### PR TITLE
fix(features): apply_blocked true quando GCAL_CLIENT != 'google'

### DIFF
--- a/v2/backend/apps/core/views_health.py
+++ b/v2/backend/apps/core/views_health.py
@@ -53,13 +53,18 @@ def features(request):
         "apply_blocked": true,
         "ENVIRONMENT": "staging"
     }
+
+    Security: apply_blocked is true when GCAL_CLIENT != "google"
+    to prevent accidental calendar operations with fake client.
     """
     gcal_client = os.getenv("GCAL_CLIENT", "fake")
-    preview_only = os.getenv("PREVIEW_ONLY", "false").lower() == "true"
     environment = os.getenv("ENVIRONMENT", "dev")
+
+    # Security: block apply operations when not using real Google Calendar client
+    apply_blocked = gcal_client != "google"
 
     return JsonResponse({
         "GCAL_CLIENT": gcal_client,
-        "apply_blocked": preview_only,
+        "apply_blocked": apply_blocked,
         "ENVIRONMENT": environment,
     })


### PR DESCRIPTION
## Objetivo
Corrigir lógica de `apply_blocked` no endpoint `/api/features/` para bloquear operações quando `GCAL_CLIENT != "google"`.

## Problema Anterior
- `apply_blocked` estava vinculado a `PREVIEW_ONLY`
- Não havia proteção baseada no tipo de client (fake vs google)

## Mudanças
```python
# Antes (ERRADO)
apply_blocked = preview_only

# Depois (CORRETO - segurança)
apply_blocked = gcal_client != "google"
```

## Comportamento
| GCAL_CLIENT | apply_blocked | Descrição |
|-------------|---------------|-----------|
| `fake` (padrão) | `true` | 🔒 Bloqueia apply (segurança) |
| `google` | `false` | ✅ Permite apply (produção) |

## Aceite
- ✅ Commit atômico (1 arquivo, 7 linhas alteradas)
- 🔲 Após restart: `curl http://localhost:8002/api/features/` retorna:
  ```json
  {
    "GCAL_CLIENT": "fake",
    "apply_blocked": true,
    "ENVIRONMENT": "dev"
  }
  ```

## Refs
- Achado: `V2-AUDITORIA-GERAL-20251017.md` - F-003
- Tarefa: Pós-auditoria #2/5
- Base: PR #5 (deps/v2-add-django-redis)