### PR TITLE
ops(celery): add Celery app configuration

### DIFF
--- a/v2/backend/config/__init__.py
+++ b/v2/backend/config/__init__.py
@@ -1,1 +1,12 @@
-# Config package
+"""
+AS v2 — Config Package
+
+Expõe a aplicação Celery para que possa ser descoberta automaticamente
+quando Django é iniciado.
+
+Isso permite que tasks sejam descobertos e registrados corretamente.
+"""
+
+from .celery import app as celery_app
+
+__all__ = ("celery_app",)

--- a/v2/backend/config/celery.py
+++ b/v2/backend/config/celery.py
@@ -1,0 +1,40 @@
+"""
+AS v2 — Celery App Configuration
+
+Configuração da aplicação Celery para tarefas assíncronas:
+- Broker: Redis (CELERY_BROKER_URL)
+- Backend: Redis (CELERY_RESULT_BACKEND)
+- Autodiscovery: apps.core.tasks
+- Timezone: America/Fortaleza
+
+Comandos:
+- Worker: celery -A config worker -l info
+- Beat: celery -A config beat -l info
+"""
+
+from __future__ import annotations
+
+import os
+
+from celery import Celery
+
+# Define Django settings module
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+
+# Create Celery app
+app = Celery("config")
+
+# Load config from Django settings (namespace CELERY_*)
+app.config_from_object("django.conf:settings", namespace="CELERY")
+
+# Auto-discover tasks in all installed apps (ex: apps.core.tasks)
+app.autodiscover_tasks()
+
+
+@app.task(bind=True)
+def debug_task(self):
+    """
+    Debug task for testing Celery setup.
+    Usage: from config.celery import debug_task; debug_task.delay()
+    """
+    print(f"Request: {self.request!r}")


### PR DESCRIPTION
## 🎯 Objetivo

Habilitar Celery no backend v2 para suportar tarefas assíncronas (ex: sincronização Google Calendar via beat).

## 📝 Alterações

### Arquivos criados/modificados:

1. **`config/celery.py`** (novo)
   - Celery app com broker/backend Redis
   - Auto-discovery de tasks em `apps.core.tasks`
   - Timezone `America/Fortaleza`
   - Debug task para testes

2. **`config/__init__.py`** (atualizado)
   - Expõe `celery_app` para autodiscovery do Django
   - Permite que tasks sejam registrados automaticamente

## ✅ Validação

### Pré-requisitos:
- Containers `worker` e `beat` devem estar definidos no `docker-compose.yml`
- Redis deve estar rodando e acessível

### Comandos de validação:
```bash
# Subir worker/beat (se existirem)
docker compose -p aprender_v2 -f infra/docker-compose.yml up -d worker beat

# Verificar logs
docker compose -p aprender_v2 -f infra/docker-compose.yml logs --tail=200 worker
docker compose -p aprender_v2 -f infra/docker-compose.yml logs --tail=200 beat
```

### Critérios de aceite:
- ✅ Worker conecta ao Redis sem erros
- ✅ Worker exibe "ready" nos logs
- ✅ Beat lista schedule configurado (ex: `gcal-sync-every-5-minutes`)
- ✅ Sem erros de import ou configuração

## 🔗 Referências

- **Auditoria:** V2-AUDITORIA-GERAL-20251017.md
- **Stack:** `aprender_v2` (porta 8002)
- **Broker:** Redis (`redis://redis:6379/0`)

## ⚠️ Observações

- **Não altera Compose:** Worker/beat já devem estar no docker-compose.yml
- **Não aplica migrations:** Celery puro, sem mudanças no banco
- **Stack não é derrubado:** Apenas código Python alterado