### PR TITLE
fix(ci): use PR base SHA in ban-v1 workflow

### DIFF
--- a/.github/workflows/ban-v1.yml
+++ b/.github/workflows/ban-v1.yml
@@ -19,8 +19,14 @@ jobs:
       - name: Collect changed files
         id: diff
         run: |
-          git fetch origin main --depth=1
-          BASE=$(git merge-base HEAD origin/main)
+          # Use PR base SHA when available (in pull_request events)
+          # Fall back to merge-base for push events
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+          else
+            git fetch origin main --depth=1
+            BASE=$(git merge-base HEAD origin/main)
+          fi
           echo "base_commit=$BASE" >> "$GITHUB_OUTPUT"
           git diff --name-only "$BASE"...HEAD > ../changed.txt
       - name: Forbid legacy edits


### PR DESCRIPTION
## Problema

Workflow `ban-v1` falhava em PRs com erro:
```
fatal: Not a valid object name
error: Process completed with exit code 1
```

## Causa Raiz

`git merge-base HEAD origin/main` falhava quando:
- PR branch não tinha histórico compartilhado com main
- Repository era shallow clone (padrão em GitHub Actions)
- Branch criada de outro ponto que não main

## Solução

Usar `github.event.pull_request.base.sha` para eventos de PR:
- ✅ Sempre disponível em pull_request events
- ✅ Não depende de histórico Git completo
- ✅ Mais robusto que merge-base
- ⏸️ Fallback para merge-base em push events (mantido)

## Mudanças

```.github/workflows/ban-v1.yml```
- Linha 22-31: Detecta tipo de evento (`pull_request` vs `push`)
- Se PR: usa `github.event.pull_request.base.sha`
- Se push: usa `git merge-base` (comportamento original)

## Validações

- ✅ Sintaxe YAML válida
- ✅ Lógica condicional testada
- ✅ Compatível com push events (não quebra)
- ✅ v2-only (nenhuma mudança em archive/)

## Impacto

- 🔧 Corrige falhas em checks de PRs
- 🚀 PRs novos agora passarão no `guard` check
- ✅ Sem breaking changes

## Evidências

Diff salvo em: `v2/.agents/outbox/ci_fixes.diff`

## Refs

- Correção pós-auditoria de CI
- Parte da consolidação v2-only (Fase B)