### PR TITLE
feat(pre-agenda): publicação em massa via /pre-agenda (Controle)

### DIFF
--- a/v2/backend/apps/core/tests/test_gcal_publish_batch.py
+++ b/v2/backend/apps/core/tests/test_gcal_publish_batch.py
@@ -1,0 +1,435 @@
+"""
+Testes para endpoint POST /api/gcal/publish-batch/ (Fase 2)
+
+Cenários:
+- 202 com IDs aprovados → queued=N, errors=[]
+- Mistura com pendente → pendente em errors
+- apply_blocked exigido quando GCAL_CLIENT != 'google' e dry_run=false
+- RBAC: 403 para usuário sem Controle/Super
+"""
+
+import os
+from unittest.mock import patch, MagicMock
+
+import pytest
+from django.contrib.auth.models import Group
+from rest_framework.test import APIClient
+
+from apps.core.models import Usuario, Solicitacao, Projeto, Municipio, TipoEvento
+
+
+@pytest.fixture
+def api_client():
+    """Cliente API para testes."""
+    return APIClient()
+
+
+@pytest.fixture
+def grupo_controle(db):
+    """Cria grupo Controle."""
+    return Group.objects.create(name='Controle')
+
+
+@pytest.fixture
+def usuario_controle(db, grupo_controle):
+    """Cria usuário com grupo Controle."""
+    user = Usuario.objects.create_user(
+        username='controle_user',
+        email='controle@test.com',
+        password='testpass123',
+        cpf='12345678901'  # CPF único
+    )
+    user.groups.add(grupo_controle)
+    return user
+
+
+@pytest.fixture
+def usuario_comum(db):
+    """Cria usuário sem permissões especiais."""
+    return Usuario.objects.create_user(
+        username='comum_user',
+        email='comum@test.com',
+        password='testpass123',
+        cpf='98765432109'  # CPF único diferente
+    )
+
+
+@pytest.fixture
+def projeto(db):
+    """Cria projeto de teste."""
+    return Projeto.objects.create(
+        nome='Projeto Teste',
+        codigo='PROJ001',
+        fluxo='SUPER'
+    )
+
+
+@pytest.fixture
+def municipio(db):
+    """Cria município de teste."""
+    return Municipio.objects.create(
+        nome='Fortaleza',
+        uf='CE',
+        ibge_code='2304400'
+    )
+
+
+@pytest.fixture
+def tipo_evento(db):
+    """Cria tipo de evento de teste."""
+    return TipoEvento.objects.create(
+        nome='Formação'
+    )
+
+
+@pytest.fixture
+def solicitacao_aprovada(db, usuario_controle, projeto, municipio, tipo_evento):
+    """Cria solicitação aprovada."""
+    return Solicitacao.objects.create(
+        usuario=usuario_controle,
+        projeto=projeto,
+        municipio=municipio,
+        tipo_evento=tipo_evento,
+        inicio='2025-11-15T08:00:00-03:00',
+        fim='2025-11-15T12:00:00-03:00',
+        status='aprovado',
+        gcal_status='NONE'
+    )
+
+
+@pytest.fixture
+def solicitacao_pendente(db, usuario_controle, projeto, municipio, tipo_evento):
+    """Cria solicitação pendente."""
+    return Solicitacao.objects.create(
+        usuario=usuario_controle,
+        projeto=projeto,
+        municipio=municipio,
+        tipo_evento=tipo_evento,
+        inicio='2025-11-16T08:00:00-03:00',
+        fim='2025-11-16T12:00:00-03:00',
+        status='pendente',
+        gcal_status='NONE'
+    )
+
+
+@pytest.mark.django_db
+class TestGCalPublishBatchEndpoint:
+    """Testes do endpoint POST /api/gcal/publish-batch/."""
+
+    @patch('apps.core.tasks.task_publish_solicitacao_to_gcal')
+    @patch.dict(os.environ, {'GCAL_CLIENT': 'google'})
+    def test_batch_publish_aprovados_sucesso(
+        self,
+        mock_task,
+        api_client,
+        usuario_controle,
+        solicitacao_aprovada
+    ):
+        """
+        Cenário: 2 IDs aprovados com GCAL_CLIENT=google
+        Espera: 202 com queued=2, errors=[]
+        """
+        # Criar segunda solicitação aprovada
+        sol2 = Solicitacao.objects.create(
+            usuario=usuario_controle,
+            projeto=solicitacao_aprovada.projeto,
+            municipio=solicitacao_aprovada.municipio,
+            tipo_evento=solicitacao_aprovada.tipo_evento,
+            inicio='2025-11-17T08:00:00-03:00',
+            fim='2025-11-17T12:00:00-03:00',
+            status='aprovado',
+            gcal_status='NONE'
+        )
+
+        # Mock task
+        mock_task.delay = MagicMock()
+
+        # Autenticar
+        api_client.force_authenticate(user=usuario_controle)
+
+        # Request
+        response = api_client.post(
+            '/api/gcal/publish-batch/',
+            {
+                'solicitacao_ids': [solicitacao_aprovada.id, sol2.id],
+                'dry_run': False,
+                'apply_blocked': False
+            },
+            format='json'
+        )
+
+        # Asserts
+        assert response.status_code == 202
+        data = response.json()
+        assert data['queued'] == 2
+        assert data['errors'] == []
+        assert data['dry_run'] is False
+        assert data['apply_blocked'] is False
+
+        # Verificar task foi chamada 2x
+        assert mock_task.delay.call_count == 2
+
+        # Verificar gcal_status foi atualizado para PENDING
+        solicitacao_aprovada.refresh_from_db()
+        sol2.refresh_from_db()
+        assert solicitacao_aprovada.gcal_status == 'PENDING'
+        assert sol2.gcal_status == 'PENDING'
+
+    @patch('apps.core.tasks.task_publish_solicitacao_to_gcal')
+    @patch.dict(os.environ, {'GCAL_CLIENT': 'google'})
+    def test_batch_publish_mistura_aprovado_pendente(
+        self,
+        mock_task,
+        api_client,
+        usuario_controle,
+        solicitacao_aprovada,
+        solicitacao_pendente
+    ):
+        """
+        Cenário: 1 aprovado + 1 pendente
+        Espera: queued=1, errors=[{id: pendente, detail: "..."}]
+        """
+        # Mock task
+        mock_task.delay = MagicMock()
+
+        # Autenticar
+        api_client.force_authenticate(user=usuario_controle)
+
+        # Request
+        response = api_client.post(
+            '/api/gcal/publish-batch/',
+            {
+                'solicitacao_ids': [solicitacao_aprovada.id, solicitacao_pendente.id],
+                'dry_run': False,
+                'apply_blocked': False
+            },
+            format='json'
+        )
+
+        # Asserts
+        assert response.status_code == 202
+        data = response.json()
+        assert data['queued'] == 1
+        assert len(data['errors']) == 1
+
+        # Verificar erro do pendente
+        error = data['errors'][0]
+        assert error['id'] == solicitacao_pendente.id
+        assert 'aprovado' in error['detail']
+        assert 'pendente' in error['detail']
+
+        # Task chamada apenas 1x (aprovado)
+        assert mock_task.delay.call_count == 1
+
+        # Aprovado marcado como PENDING
+        solicitacao_aprovada.refresh_from_db()
+        assert solicitacao_aprovada.gcal_status == 'PENDING'
+
+        # Pendente não mudou
+        solicitacao_pendente.refresh_from_db()
+        assert solicitacao_pendente.gcal_status == 'NONE'
+
+    @patch.dict(os.environ, {'GCAL_CLIENT': 'fake'})
+    def test_batch_publish_requer_apply_blocked_quando_fake(
+        self,
+        api_client,
+        usuario_controle,
+        solicitacao_aprovada
+    ):
+        """
+        Cenário: GCAL_CLIENT=fake + dry_run=false + apply_blocked=false
+        Espera: errors com mensagem sobre apply_blocked
+        """
+        # Autenticar
+        api_client.force_authenticate(user=usuario_controle)
+
+        # Request SEM apply_blocked
+        response = api_client.post(
+            '/api/gcal/publish-batch/',
+            {
+                'solicitacao_ids': [solicitacao_aprovada.id],
+                'dry_run': False,
+                'apply_blocked': False
+            },
+            format='json'
+        )
+
+        # Asserts
+        assert response.status_code == 202
+        data = response.json()
+        assert data['queued'] == 0
+        assert len(data['errors']) == 1
+
+        error = data['errors'][0]
+        assert error['id'] == solicitacao_aprovada.id
+        assert 'GCAL_CLIENT=fake' in error['detail']
+        assert 'apply_blocked=true' in error['detail']
+
+    @patch('apps.core.tasks.task_publish_solicitacao_to_gcal')
+    @patch.dict(os.environ, {'GCAL_CLIENT': 'fake'})
+    def test_batch_publish_com_apply_blocked_true(
+        self,
+        mock_task,
+        api_client,
+        usuario_controle,
+        solicitacao_aprovada
+    ):
+        """
+        Cenário: GCAL_CLIENT=fake + apply_blocked=true
+        Espera: queued=1 (permite com fake client quando apply_blocked=true)
+        """
+        # Mock task
+        mock_task.delay = MagicMock()
+
+        # Autenticar
+        api_client.force_authenticate(user=usuario_controle)
+
+        # Request COM apply_blocked=true
+        response = api_client.post(
+            '/api/gcal/publish-batch/',
+            {
+                'solicitacao_ids': [solicitacao_aprovada.id],
+                'dry_run': False,
+                'apply_blocked': True
+            },
+            format='json'
+        )
+
+        # Asserts
+        assert response.status_code == 202
+        data = response.json()
+        assert data['queued'] == 1
+        assert data['errors'] == []
+        assert data['apply_blocked'] is True
+
+        # Task chamada
+        assert mock_task.delay.call_count == 1
+
+    def test_batch_publish_rbac_403_sem_permissao(
+        self,
+        api_client,
+        usuario_comum,
+        solicitacao_aprovada
+    ):
+        """
+        Cenário: Usuário sem grupo Controle/Super
+        Espera: 403 Forbidden
+        """
+        # Autenticar com usuário comum
+        api_client.force_authenticate(user=usuario_comum)
+
+        # Request
+        response = api_client.post(
+            '/api/gcal/publish-batch/',
+            {
+                'solicitacao_ids': [solicitacao_aprovada.id],
+                'dry_run': False,
+                'apply_blocked': False
+            },
+            format='json'
+        )
+
+        # Assert: 403 Forbidden
+        assert response.status_code == 403
+
+    def test_batch_publish_array_vazio(
+        self,
+        api_client,
+        usuario_controle
+    ):
+        """
+        Cenário: solicitacao_ids vazio
+        Espera: 400 Bad Request
+        """
+        # Autenticar
+        api_client.force_authenticate(user=usuario_controle)
+
+        # Request com array vazio
+        response = api_client.post(
+            '/api/gcal/publish-batch/',
+            {
+                'solicitacao_ids': [],
+                'dry_run': False
+            },
+            format='json'
+        )
+
+        # Assert: 400
+        assert response.status_code == 400
+        assert 'não-vazio' in response.json()['detail']
+
+    @patch('apps.core.tasks.task_publish_solicitacao_to_gcal')
+    @patch.dict(os.environ, {'GCAL_CLIENT': 'google'})
+    def test_batch_publish_dry_run_nao_persiste(
+        self,
+        mock_task,
+        api_client,
+        usuario_controle,
+        solicitacao_aprovada
+    ):
+        """
+        Cenário: dry_run=true
+        Espera: queued=1 mas gcal_status NÃO muda e task NÃO é chamada
+        """
+        # Mock task
+        mock_task.delay = MagicMock()
+
+        # Autenticar
+        api_client.force_authenticate(user=usuario_controle)
+
+        # Request com dry_run=true
+        response = api_client.post(
+            '/api/gcal/publish-batch/',
+            {
+                'solicitacao_ids': [solicitacao_aprovada.id],
+                'dry_run': True,
+                'apply_blocked': False
+            },
+            format='json'
+        )
+
+        # Asserts
+        assert response.status_code == 202
+        data = response.json()
+        assert data['queued'] == 1
+        assert data['dry_run'] is True
+
+        # Task NÃO foi chamada
+        mock_task.delay.assert_not_called()
+
+        # gcal_status NÃO mudou
+        solicitacao_aprovada.refresh_from_db()
+        assert solicitacao_aprovada.gcal_status == 'NONE'
+
+    def test_batch_publish_id_inexistente(
+        self,
+        api_client,
+        usuario_controle
+    ):
+        """
+        Cenário: ID que não existe
+        Espera: errors com "não encontrada"
+        """
+        # Autenticar
+        api_client.force_authenticate(user=usuario_controle)
+
+        # Request com ID inexistente
+        response = api_client.post(
+            '/api/gcal/publish-batch/',
+            {
+                'solicitacao_ids': [99999],
+                'dry_run': False,
+                'apply_blocked': False
+            },
+            format='json'
+        )
+
+        # Asserts
+        assert response.status_code == 202
+        data = response.json()
+        assert data['queued'] == 0
+        assert len(data['errors']) == 1
+
+        error = data['errors'][0]
+        assert error['id'] == 99999
+        assert 'não encontrada' in error['detail']

--- a/v2/backend/apps/core/urls.py
+++ b/v2/backend/apps/core/urls.py
@@ -38,6 +38,7 @@ from .views_gcal_dashboard import (
     GCalStatusSummaryView,
     GCalListView,
     GCalDriftView,
+    GCalPublishBatchView,
 )
 from .views_lookup import (
     MunicipioLookup,
@@ -141,10 +142,11 @@ urlpatterns = [
     ),
     # Pré-agenda
     path("pre-agenda/", PreAgendaListView.as_view(), name="pre-agenda"),
-    # GCal Dashboard (PR14 - Ajustes pós-merge)
+    # GCal Dashboard (PR14 - Ajustes pós-merge + Fase 2 batch publish)
     path("gcal/status-summary/", GCalStatusSummaryView.as_view(), name="gcal-status-summary"),
     path("gcal/list/", GCalListView.as_view(), name="gcal-list"),
     path("gcal/drift/", GCalDriftView.as_view(), name="gcal-drift"),
+    path("gcal/publish-batch/", GCalPublishBatchView.as_view(), name="gcal-publish-batch"),
     # Metrics and Reports
     path("metrics/map/", metrics_map, name="metrics-map"),
     path("reports/status-counts/", reports_status_counts, name="reports-status-counts"),

--- a/v2/backend/apps/core/views_gcal_dashboard.py
+++ b/v2/backend/apps/core/views_gcal_dashboard.py
@@ -1,19 +1,22 @@
 """
-GCal Dashboard Views (PR14 - Ajustes pós-merge)
+GCal Dashboard Views (PR14 - Ajustes pós-merge + Fase 2 batch publish)
 
-3 endpoints para painel de publicação com contrato padronizado:
+4 endpoints para painel de publicação com contrato padronizado:
 - GET /api/gcal/status-summary/ - resumo de contadores
 - GET /api/gcal/list/ - listagem com filtros
 - GET /api/gcal/drift/ - detecção de drift
+- POST /api/gcal/publish-batch/ - publicação em massa (Fase 2)
 
 Todos restritos a grupos Controle/Superintendência.
 Suportam filtros: date_from, date_to, sector, q, status (gcal_status).
 
-Nota: Publicação de eventos no Google Calendar ocorre exclusivamente via
-página /pre-agenda através do botão "Publicar" (POST /api/solicitacoes/{id}/publish/).
+Nota: Publicação de eventos no Google Calendar ocorre via página /pre-agenda:
+- Individual: botão "Publicar" (POST /api/solicitacoes/{id}/publish/)
+- Em massa: botão "Publicar Selecionados" (POST /api/gcal/publish-batch/)
 """
 
 import logging
+import os
 from datetime import date
 
 from django.db.models import Count, Q
@@ -250,3 +253,122 @@ class GCalDriftView(APIView):
             'count': len(drift_items),
             'items': drift_items
         })
+
+
+class GCalPublishBatchView(APIView):
+    """
+    POST /api/gcal/publish-batch/
+
+    Publicação em massa de solicitações aprovadas no Google Calendar.
+    Restrict: Controle/Superintendência
+
+    Request Body:
+    {
+        "solicitacao_ids": [123, 456, 789],  // Array de IDs
+        "dry_run": false,                     // Opcional (default: false)
+        "apply_blocked": false                // Opcional (default: false)
+    }
+
+    Response 202 Accepted:
+    {
+        "queued": 2,                          // Quantidade enfileirada
+        "errors": [                           // Lista de erros
+            {
+                "id": 789,
+                "detail": "Status deve ser 'aprovado' (atual: pendente)"
+            }
+        ],
+        "dry_run": false,
+        "apply_blocked": false
+    }
+
+    Regras:
+    - Apenas solicitações com status='aprovado' são processadas
+    - Se GCAL_CLIENT != "google" e dry_run=false e apply_blocked=false → erro
+    - Válidas: marca gcal_status=PENDING e enfileira task Celery
+    - Inválidas: retorna em 'errors' com motivo
+    """
+    permission_classes = [IsAuthenticated, IsControleOrSuper]
+
+    def post(self, request):
+        # Parse request body
+        solicitacao_ids = request.data.get('solicitacao_ids', [])
+        dry_run = request.data.get('dry_run', False)
+        apply_blocked = request.data.get('apply_blocked', False)
+
+        # Validação: array de IDs obrigatório
+        if not isinstance(solicitacao_ids, list) or not solicitacao_ids:
+            return Response(
+                {'detail': 'solicitacao_ids deve ser um array não-vazio de IDs'},
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        # Buscar solicitações
+        solicitacoes = Solicitacao.objects.filter(id__in=solicitacao_ids).select_related(
+            'projeto', 'municipio'
+        )
+
+        # Verificar GCAL_CLIENT
+        gcal_client = os.getenv('GCAL_CLIENT', 'fake')
+
+        queued = []
+        errors = []
+
+        for sol_id in solicitacao_ids:
+            # Verificar se existe
+            sol = next((s for s in solicitacoes if s.id == sol_id), None)
+            if not sol:
+                errors.append({
+                    'id': sol_id,
+                    'detail': 'Solicitação não encontrada'
+                })
+                continue
+
+            # Validar status='aprovado'
+            if sol.status != 'aprovado':
+                errors.append({
+                    'id': sol_id,
+                    'detail': f"Status deve ser 'aprovado' (atual: {sol.status})"
+                })
+                continue
+
+            # Validar apply_blocked com GCAL_CLIENT
+            if gcal_client != 'google' and not dry_run and not apply_blocked:
+                errors.append({
+                    'id': sol_id,
+                    'detail': f'GCAL_CLIENT={gcal_client} (não-google) requer dry_run=true ou apply_blocked=true'
+                })
+                continue
+
+            # Válida: marcar como PENDING e enfileirar
+            if not dry_run:
+                sol.gcal_status = Solicitacao.GCalStatus.PENDING
+                sol.save(update_fields=['gcal_status', 'updated_at'])
+
+                # Importar e enfileirar task Celery
+                try:
+                    from .tasks import task_publish_solicitacao_to_gcal
+                    task_publish_solicitacao_to_gcal.delay(
+                        solicitacao_id=sol.id,
+                        dry_run=dry_run,
+                        apply_blocked=apply_blocked
+                    )
+                    queued.append(sol.id)
+                    logger.info(f"Batch publish queued: solicitacao_id={sol.id}, dry_run={dry_run}")
+                except Exception as e:
+                    logger.error(f"Failed to queue solicitacao_id={sol.id}: {e}")
+                    errors.append({
+                        'id': sol.id,
+                        'detail': f'Erro ao enfileirar task: {str(e)}'
+                    })
+            else:
+                # Dry-run: apenas simula
+                queued.append(sol.id)
+                logger.info(f"Batch publish dry-run: solicitacao_id={sol.id}")
+
+        return Response({
+            'queued': len(queued),
+            'errors': errors,
+            'dry_run': dry_run,
+            'apply_blocked': apply_blocked
+        }, status=status.HTTP_202_ACCEPTED)

--- a/v2/docs/GUIDE_GCAL.md
+++ b/v2/docs/GUIDE_GCAL.md
@@ -209,7 +209,229 @@ GET /api/solicitacoes/
    - Coluna dedicada "Reunião"
    - Botão "Entrar" ou "-" se não houver link
 
-## 5. Comandos Úteis
+## 5. Publicação em Massa via Pré-agenda
+
+### Visão Geral
+
+A funcionalidade de publicação em massa permite que usuários com perfil **Controle** ou **Superintendência** publiquem múltiplas solicitações aprovadas no Google Calendar de uma só vez, através da página `/pre-agenda`.
+
+### Endpoint: POST /api/gcal/publish-batch/
+
+#### Request
+
+```bash
+POST /api/gcal/publish-batch/
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{
+  "solicitacao_ids": [123, 456, 789],  # Array de IDs (obrigatório)
+  "dry_run": false,                     # Simulação? (opcional, default: false)
+  "apply_blocked": false                # Forçar com fake client? (opcional, default: false)
+}
+```
+
+#### Response 202 Accepted
+
+```json
+{
+  "queued": 2,                          // Quantidade enfileirada com sucesso
+  "errors": [                           // Lista de erros (um por ID que falhou)
+    {
+      "id": 789,
+      "detail": "Status deve ser 'aprovado' (atual: pendente)"
+    }
+  ],
+  "dry_run": false,
+  "apply_blocked": false
+}
+```
+
+#### Regras de Validação
+
+1. **Array de IDs obrigatório**: `solicitacao_ids` deve ser um array não-vazio
+2. **Status aprovado**: Apenas solicitações com `status='aprovado'` são processadas
+3. **GCAL_CLIENT validation**:
+   - Se `GCAL_CLIENT != "google"` AND `dry_run=false` AND `apply_blocked=false` → erro
+   - Para testes com fake client: usar `apply_blocked=true`
+4. **RBAC**: Apenas usuários dos grupos **Controle** ou **Superintendência** podem chamar
+
+#### Comportamento
+
+Para cada ID na lista:
+
+1. **Busca a solicitação** no banco
+2. **Valida status='aprovado'**
+3. **Valida GCAL_CLIENT** (ou `apply_blocked=true`)
+4. Se válida:
+   - Marca `gcal_status=PENDING`
+   - Enfileira task Celery `task_publish_solicitacao_to_gcal`
+   - Adiciona ID ao array `queued`
+5. Se inválida:
+   - Adiciona objeto `{id, detail}` ao array `errors`
+
+### UI: Pré-agenda com Multi-select
+
+**Localização**: `/pre-agenda` (menu lateral → "Pré-agenda")
+
+**Features**:
+
+1. **Checkboxes na tabela**: Permite selecionar múltiplas linhas
+   - Eventos com `gcal_status='PUBLISHED'` ficam desabilitados (não podem ser republicados)
+
+2. **Botão "Publicar Selecionados (N)"**: Aparece no topo da tabela quando N > 0
+   - Abre modal de confirmação
+   - Mostra quantidade selecionada
+   - Se `GCAL_CLIENT != "google"`: exibe aviso sobre modo fake
+
+3. **Modal de Resultado**: Após publicação, exibe:
+   - ✅ Contador de eventos enfileirados (verde)
+   - ⚠️ Lista de erros (se houver), com ID e mensagem detalhada
+
+4. **Auto-reload**: Tabela recarrega após publicação para atualizar `gcal_status`
+
+### Exemplo de Uso
+
+#### Cenário 1: Publicação bem-sucedida (todos aprovados)
+
+```bash
+# Request
+POST /api/gcal/publish-batch/
+{
+  "solicitacao_ids": [101, 102, 103],
+  "dry_run": false,
+  "apply_blocked": false
+}
+
+# Response 202
+{
+  "queued": 3,
+  "errors": [],
+  "dry_run": false,
+  "apply_blocked": false
+}
+```
+
+**UI exibe**: "3 evento(s) enfileirado(s) para publicação!" (success message)
+
+#### Cenário 2: Misto de aprovados e pendentes
+
+```bash
+# Request
+POST /api/gcal/publish-batch/
+{
+  "solicitacao_ids": [101, 102, 999],  # 999 está pendente
+  "dry_run": false,
+  "apply_blocked": false
+}
+
+# Response 202
+{
+  "queued": 2,
+  "errors": [
+    {
+      "id": 999,
+      "detail": "Status deve ser 'aprovado' (atual: pendente)"
+    }
+  ],
+  "dry_run": false,
+  "apply_blocked": false
+}
+```
+
+**UI exibe**: "2 enfileirado(s), 1 erro(s)" (warning message) + modal com lista de erros
+
+#### Cenário 3: GCAL_CLIENT=fake sem apply_blocked
+
+```bash
+# Ambiente: GCAL_CLIENT=fake
+POST /api/gcal/publish-batch/
+{
+  "solicitacao_ids": [101],
+  "dry_run": false,
+  "apply_blocked": false  # ❌ Não permitido com fake client
+}
+
+# Response 202
+{
+  "queued": 0,
+  "errors": [
+    {
+      "id": 101,
+      "detail": "GCAL_CLIENT=fake (não-google) requer dry_run=true ou apply_blocked=true"
+    }
+  ],
+  "dry_run": false,
+  "apply_blocked": false
+}
+```
+
+**Solução**: Usar `apply_blocked=true` para testes com fake client:
+
+```bash
+POST /api/gcal/publish-batch/
+{
+  "solicitacao_ids": [101],
+  "dry_run": false,
+  "apply_blocked": true  # ✅ Permite publicação com fake client
+}
+
+# Response 202
+{
+  "queued": 1,
+  "errors": [],
+  "dry_run": false,
+  "apply_blocked": true
+}
+```
+
+### Testes Backend
+
+```bash
+# Rodar todos os testes de batch publish
+docker compose exec web pytest apps/core/tests/test_gcal_publish_batch.py -v
+
+# 8 cenários cobertos:
+# 1. test_batch_publish_aprovados_sucesso - Todos aprovados → queued=N
+# 2. test_batch_publish_mistura_aprovado_pendente - Misto → errors para pendentes
+# 3. test_batch_publish_requer_apply_blocked_quando_fake - GCAL_CLIENT validation
+# 4. test_batch_publish_com_apply_blocked_true - Forçar com fake client
+# 5. test_batch_publish_rbac_403_sem_permissao - RBAC enforcement
+# 6. test_batch_publish_array_vazio - Validação array vazio → 400
+# 7. test_batch_publish_dry_run_nao_persiste - Dry-run não persiste
+# 8. test_batch_publish_id_inexistente - IDs não encontrados → errors
+```
+
+### Monitoramento
+
+**Logs Celery** (worker):
+
+```bash
+docker compose logs -f worker --tail=50
+```
+
+Busque por:
+- `Batch publish queued: solicitacao_id=123, dry_run=false`
+- `Batch publish dry-run: solicitacao_id=123`
+
+**Banco de Dados**:
+
+```sql
+-- Ver solicitações em fila (PENDING)
+SELECT id, inicio, municipio_id, gcal_status, updated_at
+FROM core_solicitacao
+WHERE gcal_status = 'PENDING'
+ORDER BY updated_at DESC;
+
+-- Ver publicações recentes
+SELECT id, inicio, municipio_id, gcal_status, external_event_id, meet_link
+FROM core_solicitacao
+WHERE gcal_status = 'PUBLISHED'
+  AND updated_at > NOW() - INTERVAL '1 hour'
+ORDER BY updated_at DESC;
+```
+
+## 6. Comandos Úteis
 
 ### Preview (GET /preview-gcal/)
 
@@ -315,5 +537,9 @@ logger.info(f"GCal response: {result}")
 
 ## 8. Histórico
 
-- **PR19** (RF05/RF06): Implementação inicial
+- **PR19** (RF05/RF06): Implementação inicial de integração Google Calendar + Meet
 - **2025-10-23**: Guia criado
+- **feat/preagenda-bulk-publish** (Fase 2): Publicação em massa via `/pre-agenda`
+  - Endpoint POST `/api/gcal/publish-batch/`
+  - UI com multi-select e botão "Publicar Selecionados"
+  - 8 testes backend cobrindo validações e RBAC

--- a/v2/frontend/src/api/availability.js
+++ b/v2/frontend/src/api/availability.js
@@ -116,3 +116,12 @@ export async function getMonthly(params) {
   const url = buildUrl('/availability/monthly/', params);
   return await fetchAPI(url);
 }
+
+/**
+ * Busca feature flags do sistema.
+ *
+ * @returns {Promise<object>} Feature flags { apply_blocked, GCAL_CLIENT, PREVIEW_ONLY, ... }
+ */
+export async function getFeatures() {
+  return await fetchAPI('/features/');
+}

--- a/v2/frontend/src/pages/PreAgenda/PreAgendaPage.jsx
+++ b/v2/frontend/src/pages/PreAgenda/PreAgendaPage.jsx
@@ -39,7 +39,8 @@ import {
 import dayjs from 'dayjs';
 
 import { listSolicitacoes, previewSolicitacao, publishSolicitacao } from '../../api/solicitacoes';
-import { getStatusSummary } from '../../api/gcal';
+import { getStatusSummary, publishBatch } from '../../api/gcal';
+import { getFeatures } from '../../api/availability';
 
 const { Title, Text } = Typography;
 const { RangePicker } = DatePicker;
@@ -65,6 +66,15 @@ export default function PreAgendaPage() {
 
   const [previewVisible, setPreviewVisible] = useState(false);
   const [previewData, setPreviewData] = useState(null);
+
+  // Multi-select state
+  const [selectedRowKeys, setSelectedRowKeys] = useState([]);
+  const [batchPublishing, setBatchPublishing] = useState(false);
+  const [batchResultVisible, setBatchResultVisible] = useState(false);
+  const [batchResult, setBatchResult] = useState({ queued: 0, errors: [] });
+
+  // Feature flags
+  const [features, setFeatures] = useState({ apply_blocked: false });
 
   const loadData = useCallback(async () => {
     try {
@@ -100,6 +110,19 @@ export default function PreAgendaPage() {
     loadData();
   }, [loadData]);
 
+  // Carregar feature flags
+  useEffect(() => {
+    const loadFeatures = async () => {
+      try {
+        const data = await getFeatures();
+        setFeatures(data);
+      } catch (error) {
+        console.error('Erro ao carregar features:', error);
+      }
+    };
+    loadFeatures();
+  }, []);
+
   const handlePreview = async (id) => {
     try {
       const data = await previewSolicitacao(id);
@@ -127,6 +150,60 @@ export default function PreAgendaPage() {
         }
       },
     });
+  };
+
+  const handleBatchPublish = () => {
+    if (selectedRowKeys.length === 0) {
+      message.warning('Selecione ao menos uma solicitação');
+      return;
+    }
+
+    const content = features.apply_blocked
+      ? `Publicar ${selectedRowKeys.length} evento(s) no Google Calendar?\n\nNota: GCAL_CLIENT está em modo "${features.GCAL_CLIENT}" - operações serão simuladas.`
+      : `Publicar ${selectedRowKeys.length} evento(s) no Google Calendar?`;
+
+    Modal.confirm({
+      title: 'Confirmar Publicação em Massa',
+      content,
+      okText: 'Publicar Selecionados',
+      okType: 'primary',
+      cancelText: 'Cancelar',
+      onOk: async () => {
+        try {
+          setBatchPublishing(true);
+          const result = await publishBatch({
+            solicitacao_ids: selectedRowKeys,
+            dry_run: false,
+            apply_blocked: features.apply_blocked,
+          });
+
+          setBatchResult(result);
+          setBatchResultVisible(true);
+
+          // Limpar seleção e recarregar
+          setSelectedRowKeys([]);
+          loadData();
+
+          if (result.errors.length === 0) {
+            message.success(`${result.queued} evento(s) enfileirado(s) para publicação!`);
+          } else {
+            message.warning(`${result.queued} enfileirado(s), ${result.errors.length} erro(s)`);
+          }
+        } catch (error) {
+          message.error('Erro ao publicar em massa: ' + error.message);
+        } finally {
+          setBatchPublishing(false);
+        }
+      },
+    });
+  };
+
+  const rowSelection = {
+    selectedRowKeys,
+    onChange: (keys) => setSelectedRowKeys(keys),
+    getCheckboxProps: (record) => ({
+      disabled: record.gcal_status === 'PUBLISHED',
+    }),
   };
 
   const columns = [
@@ -271,12 +348,29 @@ export default function PreAgendaPage() {
         </Card>
 
         {/* Tabela */}
-        <Card>
+        <Card
+          title={
+            <Space>
+              <span>Eventos Aprovados</span>
+              {selectedRowKeys.length > 0 && (
+                <Button
+                  type="primary"
+                  icon={<CloudUploadOutlined />}
+                  onClick={handleBatchPublish}
+                  loading={batchPublishing}
+                >
+                  Publicar Selecionados ({selectedRowKeys.length})
+                </Button>
+              )}
+            </Space>
+          }
+        >
           <Table
             columns={columns}
             dataSource={rows}
             loading={loading}
             rowKey="id"
+            rowSelection={rowSelection}
             pagination={{
               total,
               pageSize: 20,
@@ -301,6 +395,49 @@ export default function PreAgendaPage() {
         <pre style={{ maxHeight: 500, overflow: 'auto', backgroundColor: '#f5f5f5', padding: 12 }}>
           {JSON.stringify(previewData, null, 2)}
         </pre>
+      </Modal>
+
+      {/* Modal Resultado Batch */}
+      <Modal
+        title="Resultado da Publicação em Massa"
+        open={batchResultVisible}
+        onCancel={() => setBatchResultVisible(false)}
+        footer={[
+          <Button key="close" type="primary" onClick={() => setBatchResultVisible(false)}>
+            Fechar
+          </Button>,
+        ]}
+        width={700}
+      >
+        <Space direction="vertical" style={{ width: '100%' }}>
+          <Statistic
+            title="Enfileirados para Publicação"
+            value={batchResult.queued}
+            valueStyle={{ color: '#52c41a' }}
+          />
+
+          {batchResult.errors && batchResult.errors.length > 0 && (
+            <>
+              <Alert
+                message={`${batchResult.errors.length} erro(s) encontrado(s)`}
+                type="warning"
+                showIcon
+              />
+              <div style={{ maxHeight: 300, overflow: 'auto' }}>
+                {batchResult.errors.map((err, idx) => (
+                  <Alert
+                    key={idx}
+                    message={`ID ${err.id}`}
+                    description={err.detail}
+                    type="error"
+                    showIcon
+                    style={{ marginBottom: 8 }}
+                  />
+                ))}
+              </div>
+            </>
+          )}
+        </Space>
       </Modal>
     </div>
   );


### PR DESCRIPTION
## Resumo

Implementa publicação em massa de solicitações aprovadas no Google Calendar via página **Pré-agenda**, restrita a usuários com perfil **Controle** ou **Superintendência**.

## Mudanças

### Backend

**Endpoint**: `POST /api/gcal/publish-batch/`

- ✅ Valida `status='aprovado'` por item
- ✅ Controla `apply_blocked` quando `GCAL_CLIENT != 'google'`
- ✅ Marca `gcal_status=PENDING` e enfileira tasks Celery
- ✅ Resposta estruturada: `{ queued, errors: [{ id, detail }], dry_run, apply_blocked }`
- ✅ RBAC: `IsControleOrSuper`

**Arquivos**:
- `v2/backend/apps/core/views_gcal_dashboard.py` (+117 linhas)
- `v2/backend/apps/core/urls.py` (rota)

### Frontend

**Página**: `/pre-agenda` (PreAgendaPage.jsx)

- ✅ Multi-seleção na tabela (checkboxes)
- ✅ Botão "Publicar Selecionados (N)" (aparece quando N > 0)
- ✅ Modal de confirmação com aviso sobre `GCAL_CLIENT` fake
- ✅ Leitura de `/api/features/` para obter `apply_blocked`
- ✅ Modal de resultado com contador `queued` e lista de erros
- ✅ Auto-reload e limpeza da seleção

**Arquivos**:
- `v2/frontend/src/pages/PreAgenda/PreAgendaPage.jsx` (+95 linhas)
- `v2/frontend/src/api/availability.js` (função `getFeatures`)

### Testes

**Arquivo**: `v2/backend/apps/core/tests/test_gcal_publish_batch.py` (436 linhas, 8 cenários)

1. ✅ `test_batch_publish_aprovados_sucesso` - Todos aprovados → queued=N
2. ✅ `test_batch_publish_mistura_aprovado_pendente` - Misto → errors para pendentes
3. ✅ `test_batch_publish_requer_apply_blocked_quando_fake` - GCAL_CLIENT validation
4. ✅ `test_batch_publish_com_apply_blocked_true` - Forçar com fake client
5. ✅ `test_batch_publish_rbac_403_sem_permissao` - RBAC enforcement
6. ✅ `test_batch_publish_array_vazio` - Array vazio → 400
7. ✅ `test_batch_publish_dry_run_nao_persiste` - Dry-run não persiste
8. ✅ `test_batch_publish_id_inexistente` - IDs não encontrados → errors

**Status**: 8/8 passando ✅

### Documentação

**Arquivo**: `v2/docs/GUIDE_GCAL.md`

- ✅ Seção "5. Publicação em Massa via Pré-agenda" (+222 linhas)
- ✅ Request/response com exemplos
- ✅ Regras de validação
- ✅ 3 cenários de uso (todos aprovados, misto, GCAL_CLIENT=fake)
- ✅ Comandos de teste e monitoramento
- ✅ Histórico atualizado

## Governança GCal

Após merge desta PR + PR #31 (Fase 1):

- ✅ **Única via de criação no GCal**: página `/pre-agenda` (individual + massa)
- ✅ **Reapply removido** (Fase 1)
- ⏳ **Auto-apply do Celery** será desativado em PR separado (próximo tópico)

## Observações

- **Auto-apply do Celery**: Será tratado em PR separado com flag `FEATURE_AUTO_APPLY_ENABLED=false`
- **Rebase**: Se PR #31 não tiver sido mergeada, rebasear após merge para evitar conflitos em `urls.py` e `views_gcal_dashboard.py`

## Validação

```bash
# Testes backend (8/8 passando)
docker compose exec web pytest apps/core/tests/test_gcal_publish_batch.py -v

# Verificar endpoint presente
docker compose exec web python manage.py show_urls | grep gcal/publish-batch

# UI: Acessar /pre-agenda, selecionar eventos, clicar "Publicar Selecionados"
```

## Estatísticas

- **Linhas de código**: +940 (backend + frontend + testes + docs)
- **Testes**: 8 cenários, 100% passando
- **Documentação**: +222 linhas
- **Arquivos modificados**: 6
