### PR TITLE
feat(auth): login por CPF (sem alterar username) + placeholder 'CPF'

### DIFF
--- a/v2/backend/apps/core/auth_backends.py
+++ b/v2/backend/apps/core/auth_backends.py
@@ -1,0 +1,69 @@
+"""
+Custom authentication backends for Aprender Sistema v2.
+
+Implements CPF-based authentication alongside username authentication.
+"""
+
+import re
+from django.contrib.auth import get_user_model
+from django.contrib.auth.backends import ModelBackend
+
+
+User = get_user_model()
+
+
+class CPFOrUsernameBackend(ModelBackend):
+    """
+    Authentication backend that accepts CPF or username.
+
+    Login flow:
+    1. Remove punctuation from input (dots, hyphens)
+    2. If result is 11 digits → try CPF lookup
+    3. Otherwise → try username lookup
+    4. Validate password and user_can_authenticate
+
+    Examples:
+        - "123.456.789-01" → CPF lookup
+        - "12345678901" → CPF lookup
+        - "joao" → username lookup
+        - "joao@example.com" → username lookup (not email)
+    """
+
+    def authenticate(self, request, username=None, password=None, **kwargs):
+        """
+        Authenticate user by CPF or username.
+
+        Args:
+            request: HTTP request object
+            username: CPF (with/without mask) or username
+            password: User password
+            **kwargs: Additional authentication parameters
+
+        Returns:
+            Usuario instance if authentication succeeds, None otherwise
+        """
+        if username is None or password is None:
+            return None
+
+        # Remove punctuation (dots, hyphens, spaces)
+        clean_input = re.sub(r'[.\-\s]', '', username)
+
+        # Try CPF if input is 11 digits
+        if clean_input.isdigit() and len(clean_input) == 11:
+            try:
+                user = User.objects.get(cpf=clean_input)
+            except User.DoesNotExist:
+                # CPF not found, return None
+                return None
+        else:
+            # Try username lookup
+            try:
+                user = User.objects.get(username=username)
+            except User.DoesNotExist:
+                return None
+
+        # Validate password and user status
+        if user.check_password(password) and self.user_can_authenticate(user):
+            return user
+
+        return None

--- a/v2/backend/config/settings.py
+++ b/v2/backend/config/settings.py
@@ -92,6 +92,15 @@ INSTALLED_APPS = [
 AUTH_USER_MODEL = "core.Usuario"
 
 # ================================================================
+# AUTHENTICATION BACKENDS
+# ================================================================
+# Custom backend: permite login por CPF ou username
+AUTHENTICATION_BACKENDS = [
+    "apps.core.auth_backends.CPFOrUsernameBackend",  # Custom: CPF or username
+    "django.contrib.auth.backends.ModelBackend",     # Fallback: default Django
+]
+
+# ================================================================
 # MIDDLEWARE
 # ================================================================
 MIDDLEWARE = [

--- a/v2/frontend/src/pages/Auth/LoginPage.jsx
+++ b/v2/frontend/src/pages/Auth/LoginPage.jsx
@@ -2,7 +2,8 @@
  * Página de Login - AS v2
  *
  * Design baseado em: paginadelogin/screen.png
- * - Login com username/senha
+ * - Login com CPF (com/sem máscara) ou username + senha
+ * - Backend aceita CPF ou username no mesmo campo
  * - Link "Esqueci a senha?"
  * - Link "Cadastre-se" (futuro)
  * - Layout centralizado e clean
@@ -65,15 +66,15 @@ export default function LoginPage({ onLoginSuccess }) {
           size="large"
         >
           <Form.Item
-            label="Nome de usuário"
+            label="CPF ou usuário"
             name="username"
             rules={[
-              { required: true, message: 'Por favor, insira seu nome de usuário!' }
+              { required: true, message: 'Por favor, insira seu CPF ou usuário!' }
             ]}
           >
             <Input
               prefix={<UserOutlined style={{ color: 'rgba(0,0,0,.25)' }} />}
-              placeholder="Seu nome de usuário"
+              placeholder="CPF (com ou sem máscara) ou usuário"
             />
           </Form.Item>
 


### PR DESCRIPTION
Backend aceita username ou CPF no mesmo campo; sem migrations. Placeholder do front atualizado para 'CPF'.

**Backend Changes:**
- `CPFOrUsernameBackend` in `apps/core/auth_backends.py`
- Regex removes punctuation: `r'[.\-\s]'`
- 11 digits → CPF lookup, else username lookup
- Added to `AUTHENTICATION_BACKENDS`

**Frontend Changes:**
- Updated label: 'CPF ou usuário'
- Updated placeholder: 'CPF (com ou sem máscara) ou usuário'

**Testing:**
No migrations required. Backend handles both CPF (123.456.789-01 or 12345678901) and username (joao) in same field.