### PR TITLE
fix: corrigir período no wizard de nova solicitação

### DIFF
--- a/v2/frontend/src/pages/Solicitacoes/NewSolicitacaoWizard.jsx
+++ b/v2/frontend/src/pages/Solicitacoes/NewSolicitacaoWizard.jsx
@@ -55,6 +55,7 @@ const { TextArea } = Input;
 const { Title, Text } = Typography;
 const { Step } = Steps;
 
+const RANGE_TIMEZONE = 'America/Fortaleza';
 
 export default function NewSolicitacaoWizard() {
   const navigate = useNavigate();
@@ -82,6 +83,43 @@ export default function NewSolicitacaoWizard() {
     // PR19: Modalidade online/presencial
     is_online: false,
   });
+
+  // Handler para DateTimeRange: converte {date, start, end} para ISO UTC
+  const handleRangeChange = (range) => {
+    if (!range || !range.date || !range.start || !range.end) {
+      // Se faltar dados, limpar os campos
+      setFormData(prev => ({ ...prev, inicio: null, fim: null }));
+      return;
+    }
+
+    try {
+      // Combinar date + hora usando timezone America/Fortaleza
+      const dateStr = range.date; // formato YYYY-MM-DD
+      const startTime = range.start; // formato HH:mm
+      const endTime = range.end; // formato HH:mm
+
+      // Criar dayjs objects em America/Fortaleza e converter para ISO UTC
+      const inicioLocal = dayjs.tz(`${dateStr} ${startTime}`, RANGE_TIMEZONE);
+      const fimLocal = dayjs.tz(`${dateStr} ${endTime}`, RANGE_TIMEZONE);
+
+      const isoInicio = inicioLocal.utc().format();
+      const isoFim = fimLocal.utc().format();
+
+      setFormData(prev => ({ ...prev, inicio: isoInicio, fim: isoFim }));
+    } catch (error) {
+      console.error('Erro ao converter data/hora:', error);
+      setFormData(prev => ({ ...prev, inicio: null, fim: null }));
+    }
+  };
+
+  // Derivar rangeValue de formData.inicio/fim para o componente DateTimeRange
+  const rangeValue = formData.inicio && formData.fim
+    ? {
+        date: dayjs(formData.inicio).tz(RANGE_TIMEZONE).format('YYYY-MM-DD'),
+        start: dayjs(formData.inicio).tz(RANGE_TIMEZONE).format('HH:mm'),
+        end: dayjs(formData.fim).tz(RANGE_TIMEZONE).format('HH:mm'),
+      }
+    : { date: '', start: '', end: '' };
 
   // Navegação entre passos
   const next = () => {
@@ -244,10 +282,9 @@ export default function NewSolicitacaoWizard() {
           <DateTimeRange
             labelStart="Data/Hora Início"
             labelEnd="Data/Hora Fim"
-            nameStart="inicio"
-            nameEnd="fim"
             required
-            onChange={(inicio, fim) => setFormData({ ...formData, inicio, fim })}
+            value={rangeValue}
+            onChange={handleRangeChange}
           />
         </>
       ),
@@ -399,7 +436,7 @@ export default function NewSolicitacaoWizard() {
             </Descriptions.Item>
             <Descriptions.Item label="Período">
               {formData.inicio && formData.fim
-                ? `${dayjs(formData.inicio).format('DD/MM/YYYY HH:mm')} - ${dayjs(formData.fim).format('DD/MM/YYYY HH:mm')}`
+                ? `${dayjs(formData.inicio).tz(RANGE_TIMEZONE).format('DD/MM/YYYY HH:mm')} - ${dayjs(formData.fim).tz(RANGE_TIMEZONE).format('DD/MM/YYYY HH:mm')}`
                 : 'Não informado'}
             </Descriptions.Item>
             <Descriptions.Item label="Formadores">


### PR DESCRIPTION
## Descrição do Bug

No wizard de Nova Solicitação, mesmo preenchendo a data/hora de início e fim, o passo de confirmação exibia "Período: Não informado" e o submit falhava com erro "Por favor, selecione data/hora de início e fim".

## Causa Raiz

O componente `DateTimeRange` retorna a estrutura `{date, start, end}`, mas o handler `onChange` anterior estava esperando dois parâmetros separados `(inicio, fim)`. Isso resultava em valores `undefined` sendo salvos em `formData.inicio` e `formData.fim`.

## Solução

1. **Criada constante** `RANGE_TIMEZONE = 'America/Fortaleza'` para uso consistente
2. **Criada função** `handleRangeChange(range)` que:
   - Recebe `{date, start, end}` do DateTimeRange
   - Combina data + hora usando `dayjs.tz()` em America/Fortaleza
   - Converte para ISO UTC e grava em `formData.inicio/fim`
   - Trata casos de dados incompletos zerando os campos
3. **Derivado** `rangeValue` de `formData.inicio/fim` para alimentar o DateTimeRange com valores existentes
4. **Atualizado** DateTimeRange para usar `value={rangeValue}` e `onChange={handleRangeChange}`
5. **Removidos** `nameStart` e `nameEnd` (não usados pelo componente)
6. **Formatação** do período no resumo agora usa `dayjs.tz(RANGE_TIMEZONE)` para exibição correta

## Validação Manual

✅ Preenchimento de data/hora agora persiste corretamente
✅ Passo de confirmação exibe o período formatado (ex: "15/01/2025 09:00 - 15/01/2025 12:00")
✅ Submit envia `inicio` e `fim` em formato ISO UTC
✅ Backend recebe e processa corretamente as datas

## Arquivos Alterados

- `v2/frontend/src/pages/Solicitacoes/NewSolicitacaoWizard.jsx`

## Testes

Testado manualmente:
1. Acessar wizard de Nova Solicitação
2. Preencher todos os campos obrigatórios incluindo data/hora
3. Avançar até passo de confirmação
4. Verificar que período está exibido corretamente
5. Confirmar solicitação
6. Verificar que solicitação foi criada com sucesso no backend