### PR TITLE
test: CSV path robusto (fluxo por projeto)

### DIFF
--- a/v2/backend/apps/core/tests/test_fluxo_por_projeto.py
+++ b/v2/backend/apps/core/tests/test_fluxo_por_projeto.py
@@ -314,7 +314,12 @@ class TestFluxoPorProjeto(TestCase):
         Testa que o comando seed_projetos_fluxo_from_csv funciona.
         """
         from django.core.management import call_command
+        from django.conf import settings
+        from pathlib import Path
         from io import StringIO
+
+        # Path absoluto do CSV (não depende do CWD)
+        csv_path = Path(settings.BASE_DIR) / "apps/core/data/projetos_fluxo.csv"
 
         # Criar projeto para atualizar
         projeto_teste = Projeto.objects.create(
@@ -327,6 +332,7 @@ class TestFluxoPorProjeto(TestCase):
         out = StringIO()
         call_command(
             "seed_projetos_fluxo_from_csv",
+            f"--csv={csv_path}",
             "--dry-run",
             "--verbose",
             stdout=out,
@@ -341,7 +347,7 @@ class TestFluxoPorProjeto(TestCase):
         self.assertEqual(projeto_teste.fluxo, "NAO_SUPER")
 
         # Executar sem dry-run
-        call_command("seed_projetos_fluxo_from_csv")
+        call_command("seed_projetos_fluxo_from_csv", f"--csv={csv_path}")
 
         # Verificar que foi atualizado
         projeto_teste.refresh_from_db()


### PR DESCRIPTION
Ajuste só de teste; sem mudanças em produção.

## Problema
Teste `test_comando_seed_atualiza_fluxo_projetos` falhava no CI porque o comando `seed_projetos_fluxo_from_csv` dependia do CWD (current working directory) para localizar o CSV.

## Solução
Modificado `test_fluxo_por_projeto.py` para passar path absoluto via `--csv` usando `Path(settings.BASE_DIR) / 'apps/core/data/projetos_fluxo.csv'`.

## Mudanças
- **Apenas no teste**: Adicionado path explícito nas chamadas `call_command()`
- **Nenhuma mudança** em código de produção

## Testes
✅ `test_comando_seed_atualiza_fluxo_projetos` passando (antes: FAILED)

Refs: Issue #77 (CSV path robusto)