### PR TITLE
ci/docs: cobertura de testes (pytest-cov + Codecov) + badge

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,7 +48,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r v2/backend/requirements.txt
-        pip install pytest pytest-django
+        pip install pytest pytest-django pytest-cov
 
     - name: Set up environment variables
       run: |
@@ -98,7 +98,17 @@ jobs:
         mkdir -p "$GITHUB_WORKSPACE/v2/backend/out_etl"
         mkdir -p "$GITHUB_WORKSPACE/v2/backend/data/csv-import"
 
-    - name: Run tests
+    - name: Run tests with coverage
       run: |
         cd v2/backend
-        pytest -q --tb=short
+        pytest -q --tb=short --cov=apps --cov-report=xml --cov-report=term --cov-fail-under=80
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v4
+      with:
+        file: ./v2/backend/coverage.xml
+        flags: backend
+        name: backend-coverage
+        fail_ci_if_error: false
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Aprender Sistema
 
+[![CI](https://github.com/matheusnorjosa/aprender_sistema/actions/workflows/ci.yaml/badge.svg)](https://github.com/matheusnorjosa/aprender_sistema/actions/workflows/ci.yaml)
+[![codecov](https://codecov.io/gh/matheusnorjosa/aprender_sistema/branch/main/graph/badge.svg)](https://codecov.io/gh/matheusnorjosa/aprender_sistema)
+
 Este repositório armazena apenas a estrutura **v2** do Sistema Aprender.
 Todo o código/documentação da versão anterior (v1) foi movido para
 `archive/v1_legado/` e permanece somente para consulta histórica.


### PR DESCRIPTION
## Objetivo

Adicionar análise de cobertura de testes e badges de qualidade no README.

Resolve #84

## Mudanças

### 1. CI Workflow ()

- ✅ Instalação de 
- ✅ Execução de testes com 
- ✅ Threshold mínimo: **80%** (`--cov-fail-under=80`)
- ✅ Upload automático para Codecov via `codecov/codecov-action@v4`

### 2. README.md

- ✅ Badge de CI status
- ✅ Badge de cobertura Codecov

## Benefícios

- 📊 Visibilidade de áreas não testadas
- 🛡️ Prevenir regressão de cobertura
- ✨ Badges de qualidade no repositório

## Configuração Necessária

**Antes do merge**, configurar no repositório:

1. **Codecov Integration**: https://codecov.io/gh/matheusnorjosa/aprender_sistema
2. **Secret**: Adicionar `CODECOV_TOKEN` em Settings → Secrets → Actions

## Baseline Atual

- **817 testes passando**
- **Cobertura**: Será medida no primeiro run pós-merge

## Checklist

- [x] pytest-cov instalado
- [x] CI configurado com --cov
- [x] Upload para Codecov
- [x] Badges adicionados no README
- [ ] CODECOV_TOKEN configurado (requer admin)