### PR TITLE
feat(gcal): Dashboard metrics/list (backend) — Sprint 5

### DIFF
--- a/v2/backend/apps/core/tests/test_gcal_dashboard_metrics.py
+++ b/v2/backend/apps/core/tests/test_gcal_dashboard_metrics.py
@@ -1,0 +1,374 @@
+"""
+Testes Sprint 5 - Dashboard/Monitoring (Backend)
+
+Cobertura:
+- GET /api/gcal/dashboard/metrics/ - métricas + recent_errors com filtros start/end
+- GET /api/gcal/dashboard/events/ - lista paginada com filtros status/start/end
+
+100% fake/mocked, sem rede real.
+"""
+
+import pytest
+from datetime import date, timedelta
+from django.contrib.auth.models import Group
+from django.utils import timezone
+from rest_framework.test import APIClient
+from rest_framework import status as http_status
+
+from apps.core.models import Usuario, Solicitacao, Municipio, Projeto, TipoEvento
+
+
+@pytest.fixture
+def usuario_controle():
+    """Usuário do grupo Controle"""
+    user = Usuario.objects.create_user(
+        username="controle_sprint5",
+        email="controle_sprint5@test.com",
+        password="testpass",
+        cpf="11111111111",
+    )
+    grupo, _ = Group.objects.get_or_create(name="Controle")
+    user.groups.add(grupo)
+    return user
+
+
+@pytest.fixture
+def municipio():
+    """Município de teste"""
+    return Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
+
+
+@pytest.fixture
+def projeto():
+    """Projeto de teste"""
+    return Projeto.objects.create(nome="Projeto Sprint5", codigo="SP5", fluxo="SUPER", ativo=True)
+
+
+@pytest.fixture
+def tipo_evento():
+    """Tipo de evento de teste"""
+    return TipoEvento.objects.create(nome="Formação Sprint5")
+
+
+def create_solicitacao(usuario, municipio, projeto, tipo_evento, gcal_status, data_offset_days, gcal_last_error=""):
+    """Helper para criar solicitação com status e data específicos"""
+    now = timezone.now()
+    inicio = now + timedelta(days=data_offset_days)
+    fim = inicio + timedelta(hours=3)
+
+    sol = Solicitacao.objects.create(
+        usuario=usuario,
+        municipio=municipio,
+        projeto=projeto,
+        tipo_evento=tipo_evento,
+        tipo="evento",
+        inicio=inicio,
+        fim=fim,
+        status="aprovado",
+        gcal_status=gcal_status,
+    )
+
+    # Setar erro se fornecido
+    if gcal_last_error:
+        sol.gcal_last_error = gcal_last_error
+        sol.save(update_fields=['gcal_last_error'])
+
+    return sol
+
+
+@pytest.mark.django_db
+class TestDashboardMetrics:
+    """Testes para GET /api/gcal/dashboard/metrics/"""
+
+    def test_metrics_counts_all_statuses(self, usuario_controle, municipio, projeto, tipo_evento):
+        """
+        Caso 1: Metrics deve retornar counts para NONE/PENDING/PUBLISHED/ERROR
+        """
+        # Criar solicitações com diferentes status
+        create_solicitacao(usuario_controle, municipio, projeto, tipo_evento, Solicitacao.GCalStatus.NONE, 1)
+        create_solicitacao(usuario_controle, municipio, projeto, tipo_evento, Solicitacao.GCalStatus.NONE, 2)
+        create_solicitacao(usuario_controle, municipio, projeto, tipo_evento, Solicitacao.GCalStatus.PENDING, 3)
+        create_solicitacao(usuario_controle, municipio, projeto, tipo_evento, Solicitacao.GCalStatus.PUBLISHED, 4)
+        create_solicitacao(usuario_controle, municipio, projeto, tipo_evento, Solicitacao.GCalStatus.PUBLISHED, 5)
+        create_solicitacao(usuario_controle, municipio, projeto, tipo_evento, Solicitacao.GCalStatus.PUBLISHED, 6)
+        create_solicitacao(usuario_controle, municipio, projeto, tipo_evento, Solicitacao.GCalStatus.ERROR, 7, "Erro teste")
+
+        client = APIClient()
+        client.force_authenticate(user=usuario_controle)
+
+        response = client.get("/api/gcal/dashboard/metrics/")
+
+        assert response.status_code == http_status.HTTP_200_OK
+        data = response.data
+
+        # Validar estrutura
+        assert 'counts' in data
+        assert 'recent_errors' in data
+        assert 'window' in data
+
+        # Validar counts
+        counts = data['counts']
+        assert counts['NONE'] == 2
+        assert counts['PENDING'] == 1
+        assert counts['PUBLISHED'] == 3
+        assert counts['ERROR'] == 1
+
+    def test_metrics_recent_errors_top_5(self, usuario_controle, municipio, projeto, tipo_evento):
+        """
+        Caso 2: recent_errors deve retornar top 5 erros ordenados por updated_at desc
+        """
+        # Criar 7 solicitações com erro (deve retornar apenas 5 mais recentes)
+        for i in range(7):
+            create_solicitacao(
+                usuario_controle, municipio, projeto, tipo_evento,
+                Solicitacao.GCalStatus.ERROR, i, f"Erro {i}"
+            )
+
+        client = APIClient()
+        client.force_authenticate(user=usuario_controle)
+
+        response = client.get("/api/gcal/dashboard/metrics/")
+
+        assert response.status_code == http_status.HTTP_200_OK
+        recent_errors = response.data['recent_errors']
+
+        # Deve retornar apenas 5
+        assert len(recent_errors) == 5
+
+        # Validar estrutura de cada erro
+        for error in recent_errors:
+            assert 'id' in error
+            assert 'summary' in error
+            assert 'gcal_last_error' in error
+            assert 'updated_at' in error
+
+    def test_metrics_window_filter_start_end(self, usuario_controle, municipio, projeto, tipo_evento):
+        """
+        Caso 3: Filtros start/end devem filtrar por data do evento
+        """
+        today = date.today()
+
+        # Dentro da janela
+        create_solicitacao(usuario_controle, municipio, projeto, tipo_evento, Solicitacao.GCalStatus.NONE, 5)
+        create_solicitacao(usuario_controle, municipio, projeto, tipo_evento, Solicitacao.GCalStatus.PUBLISHED, 10)
+
+        # Fora da janela (antes)
+        create_solicitacao(usuario_controle, municipio, projeto, tipo_evento, Solicitacao.GCalStatus.NONE, -10)
+
+        # Fora da janela (depois)
+        create_solicitacao(usuario_controle, municipio, projeto, tipo_evento, Solicitacao.GCalStatus.PUBLISHED, 50)
+
+        client = APIClient()
+        client.force_authenticate(user=usuario_controle)
+
+        start = (today + timedelta(days=1)).isoformat()
+        end = (today + timedelta(days=15)).isoformat()
+
+        response = client.get(f"/api/gcal/dashboard/metrics/?start={start}&end={end}")
+
+        assert response.status_code == http_status.HTTP_200_OK
+        data = response.data
+
+        # Apenas 2 eventos dentro da janela
+        total = sum(data['counts'].values())
+        assert total == 2
+
+        # Validar window retornado
+        assert data['window']['start'] == start
+        assert data['window']['end'] == end
+
+    def test_metrics_requires_authentication(self, usuario_controle, municipio, projeto, tipo_evento):
+        """
+        Caso 4: Endpoint exige autenticação
+
+        Nota: DRF retorna 403 (Forbidden) quando permission classes são checadas
+        antes de autenticação. Ambos 401 e 403 indicam acesso negado corretamente.
+        """
+        client = APIClient()
+
+        response = client.get("/api/gcal/dashboard/metrics/")
+
+        # DRF pode retornar 403 ao invés de 401 com IsControleOrSuper + IsAuthenticated
+        assert response.status_code in [http_status.HTTP_401_UNAUTHORIZED, http_status.HTTP_403_FORBIDDEN]
+
+    def test_metrics_requires_controle_or_super(self, municipio, projeto, tipo_evento):
+        """
+        Caso 5: Endpoint exige permissão Controle ou Superintendência
+        """
+        # Usuário sem grupo Controle/Super
+        user = Usuario.objects.create_user(
+            username="coordenador_sprint5",
+            email="coordenador@test.com",
+            password="testpass",
+            cpf="22222222222",
+        )
+        grupo_coord, _ = Group.objects.get_or_create(name="Coordenador")
+        user.groups.add(grupo_coord)
+
+        client = APIClient()
+        client.force_authenticate(user=user)
+
+        response = client.get("/api/gcal/dashboard/metrics/")
+
+        assert response.status_code == http_status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+class TestDashboardEvents:
+    """Testes para GET /api/gcal/dashboard/events/"""
+
+    def test_events_pagination_default(self, usuario_controle, municipio, projeto, tipo_evento):
+        """
+        Caso 1: Paginação padrão (20 itens por página)
+        """
+        # Criar 25 solicitações
+        for i in range(25):
+            create_solicitacao(usuario_controle, municipio, projeto, tipo_evento, Solicitacao.GCalStatus.PUBLISHED, i)
+
+        client = APIClient()
+        client.force_authenticate(user=usuario_controle)
+
+        response = client.get("/api/gcal/dashboard/events/")
+
+        assert response.status_code == http_status.HTTP_200_OK
+        data = response.data
+
+        # Estrutura paginada
+        assert 'count' in data
+        assert 'next' in data
+        assert 'previous' in data
+        assert 'results' in data
+
+        # Deve retornar 20 itens (página 1)
+        assert len(data['results']) == 20
+        assert data['count'] == 25
+        assert data['next'] is not None
+        assert data['previous'] is None
+
+    def test_events_pagination_custom_page_size(self, usuario_controle, municipio, projeto, tipo_evento):
+        """
+        Caso 2: page_size customizado
+        """
+        # Criar 15 solicitações
+        for i in range(15):
+            create_solicitacao(usuario_controle, municipio, projeto, tipo_evento, Solicitacao.GCalStatus.PUBLISHED, i)
+
+        client = APIClient()
+        client.force_authenticate(user=usuario_controle)
+
+        response = client.get("/api/gcal/dashboard/events/?page_size=5")
+
+        assert response.status_code == http_status.HTTP_200_OK
+        data = response.data
+
+        # Deve retornar 5 itens
+        assert len(data['results']) == 5
+        assert data['count'] == 15
+        assert data['next'] is not None
+
+    def test_events_filter_by_status(self, usuario_controle, municipio, projeto, tipo_evento):
+        """
+        Caso 3: Filtro por gcal_status
+        """
+        create_solicitacao(usuario_controle, municipio, projeto, tipo_evento, Solicitacao.GCalStatus.NONE, 1)
+        create_solicitacao(usuario_controle, municipio, projeto, tipo_evento, Solicitacao.GCalStatus.NONE, 2)
+        create_solicitacao(usuario_controle, municipio, projeto, tipo_evento, Solicitacao.GCalStatus.PUBLISHED, 3)
+        create_solicitacao(usuario_controle, municipio, projeto, tipo_evento, Solicitacao.GCalStatus.ERROR, 4, "Erro")
+
+        client = APIClient()
+        client.force_authenticate(user=usuario_controle)
+
+        # Filtrar apenas NONE
+        response = client.get("/api/gcal/dashboard/events/?status=NONE")
+
+        assert response.status_code == http_status.HTTP_200_OK
+        assert len(response.data['results']) == 2
+
+        # Filtrar apenas ERROR
+        response = client.get("/api/gcal/dashboard/events/?status=ERROR")
+
+        assert response.status_code == http_status.HTTP_200_OK
+        assert len(response.data['results']) == 1
+
+    def test_events_filter_by_date_window(self, usuario_controle, municipio, projeto, tipo_evento):
+        """
+        Caso 4: Filtro por janela de datas (start/end)
+        """
+        today = date.today()
+
+        # Dentro da janela
+        create_solicitacao(usuario_controle, municipio, projeto, tipo_evento, Solicitacao.GCalStatus.PUBLISHED, 5)
+        create_solicitacao(usuario_controle, municipio, projeto, tipo_evento, Solicitacao.GCalStatus.PUBLISHED, 10)
+
+        # Fora da janela
+        create_solicitacao(usuario_controle, municipio, projeto, tipo_evento, Solicitacao.GCalStatus.PUBLISHED, -10)
+        create_solicitacao(usuario_controle, municipio, projeto, tipo_evento, Solicitacao.GCalStatus.PUBLISHED, 50)
+
+        client = APIClient()
+        client.force_authenticate(user=usuario_controle)
+
+        start = (today + timedelta(days=1)).isoformat()
+        end = (today + timedelta(days=15)).isoformat()
+
+        response = client.get(f"/api/gcal/dashboard/events/?start={start}&end={end}")
+
+        assert response.status_code == http_status.HTTP_200_OK
+        # Apenas 2 eventos dentro da janela
+        assert len(response.data['results']) == 2
+
+    def test_events_ordered_by_updated_at_desc(self, usuario_controle, municipio, projeto, tipo_evento):
+        """
+        Caso 5: Ordenação por updated_at desc (mais recentes primeiro)
+        """
+        # Criar solicitações em ordem
+        sol1 = create_solicitacao(usuario_controle, municipio, projeto, tipo_evento, Solicitacao.GCalStatus.PUBLISHED, 1)
+        sol2 = create_solicitacao(usuario_controle, municipio, projeto, tipo_evento, Solicitacao.GCalStatus.PUBLISHED, 2)
+        sol3 = create_solicitacao(usuario_controle, municipio, projeto, tipo_evento, Solicitacao.GCalStatus.PUBLISHED, 3)
+
+        client = APIClient()
+        client.force_authenticate(user=usuario_controle)
+
+        response = client.get("/api/gcal/dashboard/events/")
+
+        assert response.status_code == http_status.HTTP_200_OK
+        results = response.data['results']
+
+        # Mais recente primeiro
+        assert results[0]['id'] == sol3.id
+        assert results[1]['id'] == sol2.id
+        assert results[2]['id'] == sol1.id
+
+    def test_events_requires_authentication(self):
+        """
+        Caso 6: Endpoint exige autenticação
+
+        Nota: DRF retorna 403 (Forbidden) quando permission classes são checadas
+        antes de autenticação. Ambos 401 e 403 indicam acesso negado corretamente.
+        """
+        client = APIClient()
+
+        response = client.get("/api/gcal/dashboard/events/")
+
+        # DRF pode retornar 403 ao invés de 401 com IsControleOrSuper + IsAuthenticated
+        assert response.status_code in [http_status.HTTP_401_UNAUTHORIZED, http_status.HTTP_403_FORBIDDEN]
+
+    def test_events_requires_controle_or_super(self):
+        """
+        Caso 7: Endpoint exige permissão Controle ou Superintendência
+        """
+        # Usuário sem grupo Controle/Super
+        user = Usuario.objects.create_user(
+            username="formador_sprint5",
+            email="formador@test.com",
+            password="testpass",
+            cpf="33333333333",
+        )
+        grupo_formador, _ = Group.objects.get_or_create(name="Formador")
+        user.groups.add(grupo_formador)
+
+        client = APIClient()
+        client.force_authenticate(user=user)
+
+        response = client.get("/api/gcal/dashboard/events/")
+
+        assert response.status_code == http_status.HTTP_403_FORBIDDEN

--- a/v2/backend/apps/core/urls.py
+++ b/v2/backend/apps/core/urls.py
@@ -39,6 +39,8 @@ from .views_gcal_dashboard import (
     GCalListView,
     GCalDriftView,
     GCalPublishBatchView,
+    DashboardMetricsView,
+    DashboardEventsView,
 )
 from .views_gcal import gcal_calendars, gcal_health
 from .views_lookup import (
@@ -161,6 +163,9 @@ urlpatterns = [
     path("gcal/list/", GCalListView.as_view(), name="gcal-list"),
     path("gcal/drift/", GCalDriftView.as_view(), name="gcal-drift"),
     path("gcal/publish-batch/", GCalPublishBatchView.as_view(), name="gcal-publish-batch"),
+    # Sprint 5 - Dashboard/Monitoring
+    path("gcal/dashboard/metrics/", DashboardMetricsView.as_view(), name="gcal-dashboard-metrics"),
+    path("gcal/dashboard/events/", DashboardEventsView.as_view(), name="gcal-dashboard-events"),
     # GCal Endpoints (Sprint 2 - Issue #65)
     path("gcal/calendars/", gcal_calendars, name="gcal-calendars"),
     path("gcal/health/", gcal_health, name="gcal-health"),

--- a/v2/backend/apps/core/views_gcal_dashboard.py
+++ b/v2/backend/apps/core/views_gcal_dashboard.py
@@ -1,11 +1,15 @@
 """
-GCal Dashboard Views (PR14 - Ajustes pós-merge + Fase 2 batch publish)
+GCal Dashboard Views (PR14 - Ajustes pós-merge + Fase 2 batch publish + Sprint 5)
 
-3 endpoints para painel de publicação com contrato padronizado:
+Endpoints para painel de publicação com contrato padronizado:
 - GET /api/gcal/status-summary/ - resumo de contadores
 - GET /api/gcal/list/ - listagem com filtros
 - GET /api/gcal/drift/ - detecção de drift
 - POST /api/gcal/publish-batch/ - publicação em massa (Fase 2)
+
+Sprint 5 - Dashboard/Monitoring:
+- GET /api/gcal/dashboard/metrics/ - métricas + recent_errors (com start/end)
+- GET /api/gcal/dashboard/events/ - lista paginada (DRF PageNumberPagination)
 
 Todos restritos a grupos Controle/Superintendência.
 Suportam filtros: date_from, date_to, sector, q, status (gcal_status).
@@ -17,11 +21,12 @@ Nota: Publicação de eventos no Google Calendar ocorre via página /pre-agenda:
 
 import logging
 import os
-from datetime import date
+from datetime import date, datetime
 
 from django.db.models import Count, Q
 from django.utils import timezone
 from rest_framework import status
+from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -372,3 +377,194 @@ class GCalPublishBatchView(APIView):
             'dry_run': dry_run,
             'apply_blocked': apply_blocked
         }, status=status.HTTP_202_ACCEPTED)
+
+
+# ================================================================
+# Sprint 5 - Dashboard/Monitoring
+# ================================================================
+
+class DashboardMetricsView(APIView):
+    """
+    GET /api/gcal/dashboard/metrics/
+
+    Retorna métricas de publicação GCal com erros recentes.
+
+    Query params:
+    - start (ISO date): Filtro início >= start (formato: YYYY-MM-DD)
+    - end (ISO date): Filtro início <= end (formato: YYYY-MM-DD)
+
+    Response:
+    {
+        "counts": {
+            "NONE": 10,
+            "PENDING": 2,
+            "PUBLISHED": 150,
+            "ERROR": 1
+        },
+        "recent_errors": [
+            {
+                "id": 789,
+                "summary": "Fortaleza - CE Fundamental I Online [ACERTA]",
+                "gcal_last_error": "500 Internal Server Error",
+                "updated_at": "2025-11-08T10:30:00Z"
+            },
+            ...
+        ],
+        "window": {
+            "start": "2025-10-01",
+            "end": "2025-11-30"
+        }
+    }
+
+    Permissions: IsControleOrSuper
+    """
+    permission_classes = [IsAuthenticated, IsControleOrSuper]
+
+    def get(self, request):
+        # Base queryset: apenas solicitações aprovadas
+        qs = Solicitacao.objects.filter(status='aprovado')
+
+        # Parse filtros de janela (start/end)
+        start_param = request.query_params.get('start')
+        end_param = request.query_params.get('end')
+
+        start_date = None
+        end_date = None
+
+        if start_param:
+            try:
+                start_date = date.fromisoformat(start_param)
+                qs = qs.filter(inicio__date__gte=start_date)
+            except (ValueError, TypeError):
+                pass
+
+        if end_param:
+            try:
+                end_date = date.fromisoformat(end_param)
+                qs = qs.filter(inicio__date__lte=end_date)
+            except (ValueError, TypeError):
+                pass
+
+        # Contadores por gcal_status
+        summary = qs.values('gcal_status').annotate(count=Count('id'))
+        counts = {item['gcal_status']: item['count'] for item in summary}
+
+        # Garantir todas as chaves existem
+        for status_key in ['NONE', 'PENDING', 'PUBLISHED', 'ERROR']:
+            if status_key not in counts:
+                counts[status_key] = 0
+
+        # Recent errors (top 5, ordenados por updated_at desc)
+        error_qs = qs.filter(gcal_status=Solicitacao.GCalStatus.ERROR).select_related(
+            'municipio', 'projeto'
+        ).order_by('-updated_at')[:5]
+
+        recent_errors = []
+        for s in error_qs:
+            # Gerar summary simples para exibição
+            municipio_nome = s.municipio.nome if s.municipio else ''
+            municipio_uf = s.municipio.uf if s.municipio else ''
+            projeto_nome = s.projeto.nome if s.projeto else ''
+            summary_text = f"{municipio_nome} - {municipio_uf} {projeto_nome}" if municipio_nome else f"Solicitação #{s.id}"
+
+            recent_errors.append({
+                'id': s.id,
+                'summary': summary_text.strip(),
+                'gcal_last_error': s.gcal_last_error or '',
+                'updated_at': s.updated_at.isoformat() if s.updated_at else None
+            })
+
+        return Response({
+            'counts': counts,
+            'recent_errors': recent_errors,
+            'window': {
+                'start': start_date.isoformat() if start_date else None,
+                'end': end_date.isoformat() if end_date else None
+            }
+        })
+
+
+class DashboardEventsPagination(PageNumberPagination):
+    """Paginação customizada para dashboard events"""
+    page_size = 20
+    page_size_query_param = 'page_size'
+    max_page_size = 100
+
+
+class DashboardEventsView(APIView):
+    """
+    GET /api/gcal/dashboard/events/
+
+    Lista paginada de eventos com campos GCal essenciais.
+
+    Query params:
+    - status: Filtro por gcal_status (NONE/PENDING/PUBLISHED/ERROR)
+    - start (ISO date): Filtro início >= start (formato: YYYY-MM-DD)
+    - end (ISO date): Filtro início <= end (formato: YYYY-MM-DD)
+    - page: Número da página (default: 1)
+    - page_size: Itens por página (default: 20, max: 100)
+
+    Response:
+    {
+        "count": 150,
+        "next": "http://localhost:8000/api/gcal/dashboard/events/?page=2",
+        "previous": null,
+        "results": [
+            {
+                "id": 123,
+                "summary": "...",
+                "gcal_status": "PUBLISHED",
+                "gcal_last_error": "",
+                "gcal_last_sync_at": "2025-11-08T10:00:00Z",
+                ...
+            },
+            ...
+        ]
+    }
+
+    Permissions: IsControleOrSuper
+    """
+    permission_classes = [IsAuthenticated, IsControleOrSuper]
+
+    def get(self, request):
+        # Base queryset: apenas aprovadas
+        qs = Solicitacao.objects.filter(status='aprovado').select_related(
+            'usuario', 'municipio', 'tipo_evento', 'projeto'
+        )
+
+        # Filtro por status
+        status_param = request.query_params.get('status')
+        if status_param:
+            qs = qs.filter(gcal_status=status_param)
+
+        # Filtro por janela (start/end)
+        start_param = request.query_params.get('start')
+        if start_param:
+            try:
+                start_date = date.fromisoformat(start_param)
+                qs = qs.filter(inicio__date__gte=start_date)
+            except (ValueError, TypeError):
+                pass
+
+        end_param = request.query_params.get('end')
+        if end_param:
+            try:
+                end_date = date.fromisoformat(end_param)
+                qs = qs.filter(inicio__date__lte=end_date)
+            except (ValueError, TypeError):
+                pass
+
+        # Ordenação: updated_at desc (mais recentes primeiro)
+        qs = qs.order_by('-updated_at', '-id')
+
+        # Paginação DRF
+        paginator = DashboardEventsPagination()
+        page = paginator.paginate_queryset(qs, request)
+
+        if page is not None:
+            serializer = SolicitacaoSerializer(page, many=True)
+            return paginator.get_paginated_response(serializer.data)
+
+        # Fallback sem paginação (não deveria acontecer)
+        serializer = SolicitacaoSerializer(qs, many=True)
+        return Response(serializer.data)


### PR DESCRIPTION
## Sprint 5 - Dashboard/Monitoring (Etapa 1 - Backend)

### Endpoints Implementados

#### 1. GET /api/gcal/dashboard/metrics/?start=&end=
Retorna métricas de publicação GCal com erros recentes:
- **counts**: Contadores por gcal_status (NONE/PENDING/PUBLISHED/ERROR)
- **recent_errors**: Top 5 erros mais recentes (id, summary, gcal_last_error, updated_at)
- **window**: Janela de datas aplicada (start/end ISO format)

Filtros:
- `start` (ISO date): Filtro início >= start
- `end` (ISO date): Filtro início <= end

#### 2. GET /api/gcal/dashboard/events/?status=&start=&end=&page=&page_size=
Lista paginada de eventos com campos GCal essenciais:
- Paginação DRF (default: 20 itens/página, max: 100)
- Ordenação: updated_at desc (mais recentes primeiro)

Filtros:
- `status`: gcal_status (NONE/PENDING/PUBLISHED/ERROR)
- `start`/`end`: Janela de datas (ISO format)
- `page`: Número da página
- `page_size`: Itens por página (max: 100)

### Permissions
- `IsAuthenticated` + `IsControleOrSuper`

### Testes
✅ **12/12 testes passando** (`test_gcal_dashboard_metrics.py`):
- 5 testes /metrics: counts, recent_errors, filtros, autenticação
- 7 testes /events: paginação, filtros, ordenação, autenticação
- 100% fake/mocked, sem rede real
- Conforme Testing Policy (BASE_DIR, sem "/app")

### Arquivos
- `v2/backend/apps/core/views_gcal_dashboard.py`: DashboardMetricsView, DashboardEventsView
- `v2/backend/apps/core/urls.py`: Rotas adicionadas
- `v2/backend/apps/core/tests/test_gcal_dashboard_metrics.py`: Novo arquivo de testes (348 linhas)

### Próximos Passos (Etapa 2 - Frontend)
- Branch `feat/dashboard-ui` (após merge deste PR)
- Nova rota "/dashboard/gcal"
- Cards com counters + tabela com paginação
- Filtros por status e período