### PR TITLE
docs: GCal Dashboard (rota, RBAC, endpoints)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,23 @@ Para políticas e práticas de testes (RBAC, Celery flags, OAuth fixtures, paths
 
 Baseline CI: **809 passed, 27 skipped, 6 warnings**
 
+### 📊 GCal Dashboard
+
+**Rota**: `/dashboard/gcal`
+**Permissões**: Grupos "Controle" ou "Superintendência" (ou superuser)
+
+Dashboard de monitoramento da sincronização com Google Calendar:
+- **4 Cards de Contagem**: Status de publicação (NONE/PENDING/PUBLISHED/ERROR)
+- **Filtros**: Período (date range) e status
+- **Tabela Paginada**: Lista de eventos com ordenação e filtros
+- **Alertas de Erros**: Top 5 erros recentes
+
+**Endpoints Backend**:
+- `GET /api/gcal/dashboard/metrics/?start=&end=` - Métricas + erros recentes
+- `GET /api/gcal/dashboard/events/?status=&start=&end=&page=&page_size=` - Lista paginada
+
+**Testes**: 12/12 passando em `v2/backend/apps/core/tests/test_gcal_dashboard_metrics.py`
+
 ## Legado (v1)
 
 O material arquivado tem README próprio em `archive/v1_legado/README.md`.


### PR DESCRIPTION
## Documentação GCal Dashboard

Adiciona seção concisa ao README.md descrevendo o Dashboard GCal implementado na Sprint 5.

### Conteúdo Adicionado

**Rota**: `/dashboard/gcal`
**Permissões**: Grupos "Controle" ou "Superintendência" (ou superuser)

**Features Documentadas**:
- 4 Cards de Contagem (NONE/PENDING/PUBLISHED/ERROR)
- Filtros (período + status)
- Tabela paginada com ordenação
- Alertas de erros recentes (top 5)

**Endpoints Backend**:
- `GET /api/gcal/dashboard/metrics/?start=&end=`
- `GET /api/gcal/dashboard/events/?status=&start=&end=&page=&page_size=`

**Referência a Testes**: 12/12 passando em `test_gcal_dashboard_metrics.py`

### Integração

A seção foi inserida após "Testing Policy" e antes de "Legado (v1)", mantendo a estrutura concisa e direta do README.

### PRs Relacionados

- PR #91 (Backend - Mergeado)
- PR #92 (Frontend - Mergeado)
- Issue #68 (Sprint 5 - Fechada)

### Mudanças

- `README.md`: +17 linhas (seção 'GCal Dashboard')