### PR TITLE
feat(gcal): Export CSV/JSON no Dashboard GCal (Issue #96)

### DIFF
--- a/v2/backend/apps/core/tests/test_gcal_export.py
+++ b/v2/backend/apps/core/tests/test_gcal_export.py
@@ -1,0 +1,303 @@
+"""
+Testes para Issue #96 - Export CSV/JSON no Dashboard GCal
+
+Endpoint: GET /api/gcal/dashboard/events/export/
+
+Testes obrigatórios:
+1. test_export_requires_authentication → 403 anônimo
+2. test_export_requires_controle_or_super → 403 para perfil não Controle/Super
+3. test_export_csv_headers_and_rows → 200, CSV com BOM, cabeçalhos exatos, linhas
+4. test_export_json_structure → 200, JSON com {count, results}, filtros
+5. test_export_filters_respected → start/end/status filtram corretamente
+"""
+
+import csv
+import io
+import json
+from datetime import date, datetime, timedelta
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+from rest_framework.test import APIClient
+
+from apps.core.models import (
+    Solicitacao,
+    Municipio,
+    Projeto,
+    TipoEvento,
+    Usuario,
+)
+
+User = get_user_model()
+
+
+class TestGCalExport(TestCase):
+    """
+    Testes para export CSV/JSON do Dashboard GCal (Issue #96)
+    """
+
+    def setUp(self):
+        """Setup comum para todos os testes"""
+        # Criar grupos
+        self.grupo_controle, _ = Group.objects.get_or_create(name='Controle')
+        self.grupo_super, _ = Group.objects.get_or_create(name='Superintendência')
+        self.grupo_coordenador, _ = Group.objects.get_or_create(name='Coordenador')
+
+        # Criar usuários (Usuario é o User customizado com cpf obrigatório)
+        self.user_controle = User.objects.create_user(
+            username='controle_user',
+            password='testpass123',
+            cpf='11111111111'  # CPF único para evitar constraint violation
+        )
+        self.user_controle.groups.add(self.grupo_controle)
+
+        self.user_super = User.objects.create_user(
+            username='super_user',
+            password='testpass123',
+            cpf='22222222222'  # CPF único
+        )
+        self.user_super.groups.add(self.grupo_super)
+
+        self.user_coordenador = User.objects.create_user(
+            username='coordenador_user',
+            password='testpass123',
+            cpf='33333333333'  # CPF único
+        )
+        self.user_coordenador.groups.add(self.grupo_coordenador)
+
+        # Criar dados de teste
+        self.municipio = Municipio.objects.create(
+            nome='Fortaleza',
+            uf='CE'
+        )
+
+        self.projeto = Projeto.objects.create(
+            nome='ACERTA',
+            fluxo='SUPER'
+        )
+
+        self.tipo_evento = TipoEvento.objects.create(
+            nome='Fundamental I Online'
+        )
+
+        # Criar solicitações aprovadas com gcal_status diferentes
+        self.sol_published = Solicitacao.objects.create(
+            status='aprovado',
+            inicio=timezone.now() + timedelta(days=1),
+            fim=timezone.now() + timedelta(days=1, hours=2),
+            municipio=self.municipio,
+            projeto=self.projeto,
+            tipo_evento=self.tipo_evento,
+            usuario=self.user_controle,
+            coordenador=self.user_coordenador,
+            gcal_status=Solicitacao.GCalStatus.PUBLISHED,
+            external_event_id='asv2-123',
+            meet_link='https://meet.google.com/abc-def-ghi'
+        )
+
+        self.sol_error = Solicitacao.objects.create(
+            status='aprovado',
+            inicio=timezone.now() + timedelta(days=2),
+            fim=timezone.now() + timedelta(days=2, hours=2),
+            municipio=self.municipio,
+            projeto=self.projeto,
+            tipo_evento=self.tipo_evento,
+            usuario=self.user_controle,
+            coordenador=self.user_coordenador,
+            gcal_status=Solicitacao.GCalStatus.ERROR,
+            gcal_last_error='500 Internal Server Error'
+        )
+
+        self.sol_none = Solicitacao.objects.create(
+            status='aprovado',
+            inicio=timezone.now() + timedelta(days=3),
+            fim=timezone.now() + timedelta(days=3, hours=2),
+            municipio=self.municipio,
+            projeto=self.projeto,
+            tipo_evento=self.tipo_evento,
+            usuario=self.user_controle,
+            coordenador=self.user_coordenador,
+            gcal_status=Solicitacao.GCalStatus.NONE
+        )
+
+        # Cliente API
+        self.client = APIClient()
+        self.url = reverse('core:gcal-dashboard-events-export')
+
+    def test_export_requires_authentication(self):
+        """
+        Teste 1: Export deve retornar 403 para usuário anônimo
+        """
+        self.client.logout()
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_export_requires_controle_or_super(self):
+        """
+        Teste 2: Export deve retornar 403 para perfil não Controle/Super
+        """
+        self.client.force_authenticate(user=self.user_coordenador)
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, 403)
+
+    def test_export_csv_headers_and_rows(self):
+        """
+        Teste 3: Export CSV deve ter:
+        - Status 200
+        - Content-Type: text/csv; charset=utf-8
+        - BOM UTF-8
+        - Cabeçalhos exatos
+        - Linhas com dados corretos
+        """
+        self.client.force_authenticate(user=self.user_controle)
+        response = self.client.get(self.url, {'export_format': 'csv'})
+
+        # Verificar status
+        self.assertEqual(response.status_code, 200)
+
+        # Verificar Content-Type
+        self.assertEqual(response['Content-Type'], 'text/csv; charset=utf-8')
+
+        # Verificar Content-Disposition
+        self.assertIn('attachment', response['Content-Disposition'])
+        self.assertIn('gcal_events_', response['Content-Disposition'])
+
+        # Verificar BOM UTF-8
+        content = response.content.decode('utf-8')
+        self.assertTrue(content.startswith('\ufeff'))
+
+        # Parse CSV
+        csv_content = content.lstrip('\ufeff')
+        reader = csv.reader(io.StringIO(csv_content))
+        rows = list(reader)
+
+        # Verificar cabeçalhos (ordem exata da especificação)
+        expected_headers = [
+            'id',
+            'municipio',
+            'projeto',
+            'tipo_evento',
+            'inicio',
+            'fim',
+            'usuario',
+            'coordenador',
+            'fluxo',
+            'gcal_status',
+            'external_event_id',
+            'gcal_last_sync_at',
+            'gcal_last_error',
+            'meet_link',
+            'gcal_payload_hash',
+            'updated_at'
+        ]
+        self.assertEqual(rows[0], expected_headers)
+
+        # Verificar presença de linhas de dados (pelo menos 3 solicitações)
+        self.assertGreaterEqual(len(rows), 4)  # 1 header + 3 data rows
+
+        # Verificar conteúdo de uma linha (sol_published)
+        # Encontrar linha com ID correto
+        data_rows = rows[1:]
+        sol_pub_row = None
+        for row in data_rows:
+            if row[0] == str(self.sol_published.id):
+                sol_pub_row = row
+                break
+
+        self.assertIsNotNone(sol_pub_row)
+        self.assertEqual(sol_pub_row[1], 'Fortaleza')  # municipio
+        self.assertEqual(sol_pub_row[2], 'ACERTA')  # projeto
+        self.assertEqual(sol_pub_row[3], 'Fundamental I Online')  # tipo_evento
+        self.assertEqual(sol_pub_row[6], 'controle_user')  # usuario
+        self.assertEqual(sol_pub_row[7], 'coordenador_user')  # coordenador
+        self.assertEqual(sol_pub_row[8], 'SUPER')  # fluxo
+        self.assertEqual(sol_pub_row[9], 'PUBLISHED')  # gcal_status
+        self.assertEqual(sol_pub_row[10], 'asv2-123')  # external_event_id
+        self.assertIn('meet.google.com', sol_pub_row[13])  # meet_link
+
+    def test_export_json_structure(self):
+        """
+        Teste 4: Export JSON deve ter:
+        - Status 200
+        - Content-Type: application/json
+        - Estrutura {count, results}
+        - Respeitando filtros
+        """
+        self.client.force_authenticate(user=self.user_super)
+        response = self.client.get(self.url, {'export_format': 'json'})
+
+        # Verificar status
+        self.assertEqual(response.status_code, 200)
+
+        # Verificar Content-Type
+        self.assertEqual(response['Content-Type'], 'application/json')
+
+        # Parse JSON
+        data = response.json()
+
+        # Verificar estrutura
+        self.assertIn('count', data)
+        self.assertIn('results', data)
+        self.assertEqual(data['count'], len(data['results']))
+
+        # Verificar que tem pelo menos 3 solicitações
+        self.assertGreaterEqual(data['count'], 3)
+
+        # Verificar estrutura de um resultado
+        first_result = data['results'][0]
+        self.assertIn('id', first_result)
+        self.assertIn('gcal_status', first_result)
+        self.assertIn('municipio', first_result)
+        self.assertIn('projeto', first_result)
+
+    def test_export_filters_respected(self):
+        """
+        Teste 5: Filtros (status, start, end) devem ser respeitados
+        """
+        self.client.force_authenticate(user=self.user_controle)
+
+        # Teste filtro por status=ERROR
+        response = self.client.get(self.url, {'export_format': 'json', 'status': 'ERROR'})
+        data = response.json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(data['count'], 1)
+        self.assertEqual(data['results'][0]['gcal_status'], 'ERROR')
+
+        # Teste filtro por status=PUBLISHED
+        response = self.client.get(self.url, {'export_format': 'json', 'status': 'PUBLISHED'})
+        data = response.json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(data['count'], 1)
+        self.assertEqual(data['results'][0]['gcal_status'], 'PUBLISHED')
+
+        # Teste filtro por start (apenas eventos futuros +2 dias)
+        start_date = (timezone.now() + timedelta(days=2)).strftime('%Y-%m-%d')
+        response = self.client.get(self.url, {'export_format': 'json', 'start': start_date})
+        data = response.json()
+        self.assertEqual(response.status_code, 200)
+        # Deve retornar sol_error e sol_none (2 eventos)
+        self.assertEqual(data['count'], 2)
+
+        # Teste filtro por end (apenas eventos até +1 dia)
+        end_date = (timezone.now() + timedelta(days=1)).strftime('%Y-%m-%d')
+        response = self.client.get(self.url, {'export_format': 'json', 'end': end_date})
+        data = response.json()
+        self.assertEqual(response.status_code, 200)
+        # Deve retornar apenas sol_published (1 evento)
+        self.assertEqual(data['count'], 1)
+
+        # Teste combinação de filtros (status + start + end)
+        response = self.client.get(self.url, {
+            'export_format': 'json',
+            'status': 'PUBLISHED',
+            'start': (timezone.now() + timedelta(days=0)).strftime('%Y-%m-%d'),
+            'end': (timezone.now() + timedelta(days=1)).strftime('%Y-%m-%d')
+        })
+        data = response.json()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(data['count'], 1)
+        self.assertEqual(data['results'][0]['id'], self.sol_published.id)

--- a/v2/backend/apps/core/urls.py
+++ b/v2/backend/apps/core/urls.py
@@ -41,6 +41,7 @@ from .views_gcal_dashboard import (
     GCalPublishBatchView,
     DashboardMetricsView,
     DashboardEventsView,
+    DashboardEventsExportView,
     GCalBatchReapplyView,
     GCalBatchResyncView,
 )
@@ -172,6 +173,8 @@ urlpatterns = [
     # Sprint 5 - Dashboard/Monitoring
     path("gcal/dashboard/metrics/", DashboardMetricsView.as_view(), name="gcal-dashboard-metrics"),
     path("gcal/dashboard/events/", DashboardEventsView.as_view(), name="gcal-dashboard-events"),
+    # Issue #96 - Export CSV/JSON
+    path("gcal/dashboard/events/export/", DashboardEventsExportView.as_view(), name="gcal-dashboard-events-export"),
     # Issue #95 - Batch Reapply/Resync
     path("gcal/dashboard/batch/reapply/", GCalBatchReapplyView.as_view(), name="gcal-batch-reapply"),
     path("gcal/dashboard/batch/resync/", GCalBatchResyncView.as_view(), name="gcal-batch-resync"),

--- a/v2/backend/apps/core/views_gcal_dashboard.py
+++ b/v2/backend/apps/core/views_gcal_dashboard.py
@@ -25,12 +25,14 @@ from django.db.models import QuerySet
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+import csv
 import logging
 import os
 from datetime import date, datetime
 
 from django.conf import settings
 from django.db.models import Count, Q
+from django.http import HttpResponse
 from django.utils import timezone
 from rest_framework import status
 from rest_framework.pagination import PageNumberPagination
@@ -878,3 +880,146 @@ class GCalBatchResyncView(APIView):
             'dry_run': dry_run,
             'apply_blocked': apply_blocked
         }, status=status.HTTP_202_ACCEPTED)
+
+
+# ================================================================
+# Issue #96 - Export CSV/JSON
+# ================================================================
+
+class DashboardEventsExportView(APIView):
+    """
+    GET /api/gcal/dashboard/events/export/
+
+    Exporta eventos do Dashboard GCal em CSV ou JSON.
+
+    Query params:
+    - status: Filtro por gcal_status (NONE/PENDING/PUBLISHED/ERROR)
+    - start (ISO date): Filtro início >= start (formato: YYYY-MM-DD)
+    - end (ISO date): Filtro início <= end (formato: YYYY-MM-DD)
+    - format: csv|json (default: csv)
+
+    CSV Response:
+    - Content-Type: text/csv; charset=utf-8
+    - Content-Disposition: attachment; filename=gcal_events_{YYYYMMDD}.csv
+    - BOM UTF-8 para compatibilidade Excel
+    - Separador ","
+    - Datas em ISO 8601
+
+    JSON Response:
+    - Content-Type: application/json
+    - Estrutura: {count, results} (sem paginação)
+
+    Permissions: IsControleOrSuper
+    """
+    permission_classes = [IsAuthenticated, IsControleOrSuper]
+
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response | HttpResponse:
+        # Base queryset: apenas aprovadas, com select_related igual ao DashboardEventsView
+        qs = Solicitacao.objects.filter(status='aprovado').select_related(
+            'usuario', 'municipio', 'tipo_evento', 'projeto', 'coordenador'
+        )
+
+        # Aplicar mesmos filtros do DashboardEventsView
+        status_param = request.query_params.get('status')
+        if status_param:
+            qs = qs.filter(gcal_status=status_param)
+
+        start_param = request.query_params.get('start')
+        if start_param:
+            try:
+                start_date = date.fromisoformat(start_param)
+                qs = qs.filter(inicio__date__gte=start_date)
+            except (ValueError, TypeError):
+                pass
+
+        end_param = request.query_params.get('end')
+        if end_param:
+            try:
+                end_date = date.fromisoformat(end_param)
+                qs = qs.filter(inicio__date__lte=end_date)
+            except (ValueError, TypeError):
+                pass
+
+        # Ordenação: updated_at desc (mesma do DashboardEventsView)
+        qs = qs.order_by('-updated_at', '-id')
+
+        # Determinar formato (default: csv)
+        # Usamos 'export_format' em vez de 'format' para evitar conflito com DRF content negotiation
+        export_format = request.query_params.get('export_format', request.query_params.get('format', 'csv')).lower()
+
+        if export_format == 'json':
+            return self._export_json(qs)
+        else:
+            return self._export_csv(qs)
+
+    def _export_csv(self, qs: QuerySet[Solicitacao]) -> HttpResponse:
+        """Exporta queryset como CSV com BOM UTF-8 para Excel"""
+        # Gerar nome do arquivo com timestamp
+        today = date.today().strftime('%Y%m%d')
+        filename = f'gcal_events_{today}.csv'
+
+        # Criar response com Content-Type e Content-Disposition
+        response = HttpResponse(content_type='text/csv; charset=utf-8')
+        response['Content-Disposition'] = f'attachment; filename="{filename}"'
+
+        # Escrever BOM UTF-8 para compatibilidade Excel
+        response.write('\ufeff')
+
+        # Criar writer CSV
+        writer = csv.writer(response)
+
+        # Escrever cabeçalhos (ordem definida na especificação)
+        writer.writerow([
+            'id',
+            'municipio',
+            'projeto',
+            'tipo_evento',
+            'inicio',
+            'fim',
+            'usuario',
+            'coordenador',
+            'fluxo',
+            'gcal_status',
+            'external_event_id',
+            'gcal_last_sync_at',
+            'gcal_last_error',
+            'meet_link',
+            'gcal_payload_hash',
+            'updated_at'
+        ])
+
+        # Escrever linhas
+        for s in qs.iterator():
+            # Determinar fluxo (SUPER ou NAO_SUPER)
+            fluxo = s.projeto.fluxo if s.projeto else ''
+
+            writer.writerow([
+                s.id,
+                s.municipio.nome if s.municipio else '',
+                s.projeto.nome if s.projeto else '',
+                s.tipo_evento.nome if s.tipo_evento else '',
+                s.inicio.isoformat() if s.inicio else '',
+                s.fim.isoformat() if s.fim else '',
+                s.usuario.username if s.usuario else '',
+                s.coordenador.username if s.coordenador else '',
+                fluxo,
+                s.gcal_status,
+                s.external_event_id or '',
+                s.gcal_last_sync_at.isoformat() if s.gcal_last_sync_at else '',
+                s.gcal_last_error or '',
+                s.meet_link or '',
+                s.gcal_payload_hash or '',
+                s.updated_at.isoformat() if s.updated_at else ''
+            ])
+
+        return response
+
+    def _export_json(self, qs: QuerySet[Solicitacao]) -> Response:
+        """Exporta queryset como JSON com estrutura {count, results}"""
+        # Serializar sem paginação (exporta tudo filtrado)
+        serializer = SolicitacaoSerializer(qs, many=True)
+
+        return Response({
+            'count': len(serializer.data),
+            'results': serializer.data
+        })

--- a/v2/frontend/src/pages/Dashboards/GCalDashboardPage.jsx
+++ b/v2/frontend/src/pages/Dashboards/GCalDashboardPage.jsx
@@ -24,6 +24,8 @@ import {
   Tooltip,
   Alert,
   Skeleton,
+  Button,
+  Dropdown,
 } from 'antd';
 import {
   CheckCircleOutlined,
@@ -33,6 +35,8 @@ import {
   SyncOutlined,
   ExclamationCircleOutlined,
   ReloadOutlined,
+  DownloadOutlined,
+  DownOutlined,
 } from '@ant-design/icons';
 import dayjs from 'dayjs';
 
@@ -167,6 +171,42 @@ export default function GCalDashboardPage() {
     loadEvents(pagination.current, pagination.pageSize);
   };
 
+  const handleExport = (format) => {
+    // Construir URL de export com os mesmos filtros ativos
+    const params = new URLSearchParams();
+    params.append('export_format', format);
+
+    if (dateRange && dateRange[0] && dateRange[1]) {
+      params.append('start', dateRange[0].format('YYYY-MM-DD'));
+      params.append('end', dateRange[1].format('YYYY-MM-DD'));
+    }
+
+    if (statusFilter) {
+      params.append('status', statusFilter);
+    }
+
+    // Abrir URL em nova aba (download automático via Content-Disposition)
+    const exportUrl = `/api/gcal/dashboard/events/export/?${params}`;
+    window.open(exportUrl, '_blank');
+    message.success(`Exportação ${format.toUpperCase()} iniciada!`);
+  };
+
+  // Menu items para dropdown de Export
+  const exportMenuItems = [
+    {
+      key: 'csv',
+      label: 'Exportar CSV',
+      icon: <DownloadOutlined />,
+      onClick: () => handleExport('csv'),
+    },
+    {
+      key: 'json',
+      label: 'Exportar JSON',
+      icon: <DownloadOutlined />,
+      onClick: () => handleExport('json'),
+    },
+  ];
+
   const columns = [
     {
       title: 'ID',
@@ -278,6 +318,11 @@ export default function GCalDashboardPage() {
               spin={loading || tableLoading}
             />
           </Tooltip>
+          <Dropdown menu={{ items: exportMenuItems }} placement="bottomRight">
+            <Button icon={<DownloadOutlined />}>
+              Exportar <DownOutlined />
+            </Button>
+          </Dropdown>
         </Space>
       </Card>
 


### PR DESCRIPTION
## 📋 Resumo

Implementa exportação de eventos do Dashboard GCal em formatos **CSV** e **JSON**, permitindo que usuários com perfil Controle/Superintendência exportem dados filtrados para análise externa.

Closes #96

## 🎯 Funcionalidades Implementadas

### Backend (Django/DRF)

**Novo Endpoint:**
```
GET /api/gcal/dashboard/events/export/
```

**Query Parameters:**
- `export_format`: `csv` | `json` (default: `csv`)
- `status`: Filtro por `gcal_status` (NONE/PENDING/PUBLISHED/ERROR)
- `start`: Data início (YYYY-MM-DD)
- `end`: Data fim (YYYY-MM-DD)

**CSV Response:**
- ✅ Content-Type: `text/csv; charset=utf-8`
- ✅ Content-Disposition: `attachment; filename=gcal_events_{YYYYMMDD}.csv`
- ✅ **BOM UTF-8** para compatibilidade Excel
- ✅ 16 colunas em ordem exata (id, municipio, projeto, tipo_evento, inicio, fim, usuario, coordenador, fluxo, gcal_status, external_event_id, gcal_last_sync_at, gcal_last_error, meet_link, gcal_payload_hash, updated_at)

**JSON Response:**
- ✅ Content-Type: `application/json`
- ✅ Estrutura: `{count, results}` (sem paginação)
- ✅ Usa `SolicitacaoSerializer` (mesma estrutura do endpoint `/events/`)

**Permissions:**
- ✅ `IsAuthenticated` + `IsControleOrSuper`

### Frontend (React + Ant Design)

**Componente Atualizado:** `GCalDashboardPage.jsx`

- ✅ Botão "Exportar" com dropdown (CSV/JSON)
- ✅ Respeita filtros ativos (dateRange, statusFilter)
- ✅ Download automático via `window.open()`
- ✅ Feedback visual com `message.success()`

## 🔧 Fix Técnico

**Problema identificado:** Query param `format` conflitava com DRF content negotiation
- `format=csv` retornava **404** (DRF tentava usar como format suffix)
- `format=json` funcionava (JSON é renderer padrão)

**Solução:** Renomeado para `export_format`
- Backend aceita ambos `export_format` e `format` (backward compatibility)
- Frontend e testes atualizados para `export_format`

## ✅ Testes

**Arquivo:** `v2/backend/apps/core/tests/test_gcal_export.py` (304 linhas, **5 testes**)

```bash
✅ test_export_requires_authentication
   → 403 para usuário anônimo

✅ test_export_requires_controle_or_super
   → 403 para perfil não-autorizado (Coordenador)

✅ test_export_csv_headers_and_rows
   → 200, BOM UTF-8, cabeçalhos exatos, linhas com dados corretos

✅ test_export_json_structure
   → 200, estrutura {count, results}

✅ test_export_filters_respected
   → Filtros status/start/end funcionam corretamente
```

**Resultado:**
```
======================== 5 passed, 5 warnings in 13.20s ========================
```

## 📁 Arquivos Modificados

**Backend:**
- ✏️ `v2/backend/apps/core/views_gcal_dashboard.py` (+135 linhas)
- ✏️ `v2/backend/apps/core/urls.py` (+1 linha)
- ➕ `v2/backend/apps/core/tests/test_gcal_export.py` (+304 linhas)

**Frontend:**
- ✏️ `v2/frontend/src/pages/Dashboards/GCalDashboardPage.jsx` (+24 linhas)

**Total:** +464 linhas adicionadas

## 🧪 Test Plan

### Validação Automática (CI)
- [x] 5/5 testes unitários passando
- [ ] Lint frontend (4 warnings pré-existentes, não relacionados)
- [ ] Build Docker (aguardando CI)

### Validação Manual
1. **Autenticação:**
   - [ ] Acesso anônimo → 403
   - [ ] Perfil Coordenador → 403
   - [ ] Perfil Controle → 200
   - [ ] Perfil Superintendência → 200

2. **Export CSV:**
   - [ ] Download automático (attachment)
   - [ ] Abrir no Excel: encoding correto (acentos visíveis)
   - [ ] Cabeçalhos em português
   - [ ] Dados corretos em cada coluna

3. **Export JSON:**
   - [ ] Estrutura `{count, results}`
   - [ ] Download automático

4. **Filtros:**
   - [ ] Status: apenas eventos com status selecionado
   - [ ] Date range: apenas eventos no período
   - [ ] Combinação de filtros funciona

## 🔄 Checklist PR

- [x] Código implementado e testado
- [x] 5/5 testes obrigatórios passando
- [x] Frontend atualizado (botão Exportar)
- [x] Commit message seguindo convenção
- [x] Branch nomeado corretamente
- [ ] CI verde (aguardando)
- [ ] Review aprovado
- [ ] Merge para main

## 📚 Documentação

**Uso via Frontend:**
1. Acessar `/dashboards/gcal`
2. Aplicar filtros desejados (período, status)
3. Clicar em "Exportar" > escolher formato (CSV ou JSON)
4. Download inicia automaticamente

**Uso via API:**
```bash
# CSV com filtros
GET /api/gcal/dashboard/events/export/?export_format=csv&status=ERROR&start=2025-01-01&end=2025-01-31

# JSON sem filtros (todos os eventos aprovados)
GET /api/gcal/dashboard/events/export/?export_format=json
```