### PR TITLE
ci: Enable Pyright type checking on main (strict mode)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,10 +37,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up Python 3.11
+    - name: Set up Python 3.12
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: '3.12'
         cache: 'pip'
         cache-dependency-path: 'v2/backend/requirements.txt'
 
@@ -48,6 +48,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r v2/backend/requirements.txt
+        pip install -r v2/backend/requirements-dev.txt
         pip install pytest pytest-django pytest-cov
 
     - name: Set up environment variables
@@ -71,6 +72,12 @@ jobs:
         echo "ETL_OUTPUT_DIR=${{ github.workspace }}/v2/backend/out_etl" >> $GITHUB_ENV
         echo "ETL_DATA_DIR=${{ github.workspace }}/v2/backend/data/csv-import" >> $GITHUB_ENV
         echo "PYTHONDONTWRITEBYTECODE=1" >> $GITHUB_ENV
+
+    - name: Type check with Pyright
+      run: |
+        cd v2/backend
+        pyright apps/core apps/dat_ingest config
+      continue-on-error: false
 
     - name: Validate test paths (no /app hardcoded)
       run: |


### PR DESCRIPTION
## Problema

Type hints foram implementados em 8 PRs (#108-#116, ~18k linhas, 42 arquivos), mas **NÃO estavam sendo validados** no CI principal:

- ❌ CI do main (`ci.yaml`) não roda Pyright
- ❌ CI usava Python 3.11 (type hints requerem 3.12)
- ❌ `requirements-dev.txt` não instalado (onde está `pyright==1.1.382`)
- ❌ PRs podem ter erros de tipo e serem mergeados

**Evidência**: PR #116 (último PR de type hints) só executou workflow "tests", sem validação de tipos.

## Solução

Este PR completa o ciclo de implementação de type hints habilitando validação obrigatória no CI:

### Mudanças em `.github/workflows/ci.yaml`:

1. **Python 3.11 → 3.12** (linha 40-43)
   - Suporte a PEP 695 (type aliases modernos)
   - Compatível com Pyright strict mode

2. **Install requirements-dev.txt** (linha 51)
   - Inclui `pyright==1.1.382`
   - Outras ferramentas de desenvolvimento

3. **Novo step: Type check with Pyright** (linhas 76-80)
   - Roda ANTES dos testes (validação de tipos é pré-requisito)
   - `continue-on-error: false` → **bloqueia merge se houver erros**
   - Escopos: `apps/core`, `apps/dat_ingest`, `config`

## Impacto

✅ **Positivo**:
- Type hints agora são enforçados automaticamente
- Previne regressões de tipo em PRs futuros
- Detecta bugs em dev (antes de chegar em prod)
- Melhora qualidade do código e autocomplete

⚠️ **Risco**:
- CI pode falhar se houver erros de tipo ocultos no código atual
- Se falhar: corrigir erros ANTES de merge deste PR

## Testes

Este PR em si NÃO adiciona testes, mas **valida** a implementação de type hints existente ao rodar Pyright pela primeira vez no CI principal.

**Resultado esperado**: ✅ CI verde (0 erros Pyright) = type hints corretos

## Checklist

- [x] Python 3.11 → 3.12
- [x] requirements-dev.txt instalado
- [x] Step de Pyright adicionado (ANTES de tests)
- [x] `continue-on-error: false` (bloqueia CI)
- [x] Commit message segue convenção

## Referências

- PRs de Type Hints: #108, #109, #110, #111, #112, #113, #114, #115, #116
- Documento de validação: `VALIDACAO_TYPE_HINTS.md`
- Pyright config: `v2/backend/pyproject.toml`

## Nota

Este PR completa a **Etapa 2** do plano de validação. Se CI passar, proceder com **Etapa 3** (remover `continue-on-error: true` do `v2-ci.yml`).