### PR TITLE
perf(ci): otimizar tempo de execução com pytest-xdist e cache melhorado

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,14 +42,16 @@ jobs:
       with:
         python-version: '3.12'
         cache: 'pip'
-        cache-dependency-path: 'v2/backend/requirements.txt'
+        cache-dependency-path: |
+          v2/backend/requirements.txt
+          v2/backend/requirements-dev.txt
 
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -r v2/backend/requirements.txt
         pip install -r v2/backend/requirements-dev.txt
-        pip install pytest pytest-django pytest-cov
+        pip install pytest pytest-django pytest-cov pytest-xdist
 
     - name: Set up environment variables
       run: |
@@ -108,7 +110,7 @@ jobs:
     - name: Run tests with coverage
       run: |
         cd v2/backend
-        pytest -q --tb=short --cov=apps --cov-report=xml --cov-report=term --cov-fail-under=80
+        pytest -n auto -q --tb=short --cov=apps --cov-report=xml --cov-report=term --cov-fail-under=80
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4


### PR DESCRIPTION
## Objetivo
Reduzir tempo de CI de **5-6 minutos** para **2-3 minutos** (~40-50% mais rápido)

## Mudanças Implementadas

### 1. Paralelização de Testes com pytest-xdist ⚡
- Adiciona `pytest-xdist` às dependências CI
- Usa flag `-n auto` para detectar CPUs disponíveis automaticamente
- Distribui 892 testes entre workers paralelos
- Mantém coverage reporting funcionando corretamente

**Linha modificada:**
```yaml
pytest -n auto -q --tb=short --cov=apps --cov-report=xml --cov-report=term --cov-fail-under=80
```

### 2. Cache Pip Melhorado 💾
- Expande `cache-dependency-path` para incluir ambos:
  - `v2/backend/requirements.txt`
  - `v2/backend/requirements-dev.txt`
- Evita reinstalação desnecessária de pyright, pytest-xdist, etc
- Reduz tempo de "Install dependencies"

**Antes:**
```yaml
cache-dependency-path: 'v2/backend/requirements.txt'
```

**Depois:**
```yaml
cache-dependency-path: |
  v2/backend/requirements.txt
  v2/backend/requirements-dev.txt
```

## Impacto Esperado

| Fase | Antes | Depois | Ganho |
|------|-------|--------|-------|
| Install deps | ~30-45s | ~15-20s | 50% |
| Run tests | ~4min | ~2-2.5min | 40% |
| **Total CI** | **5-6min** | **2.5-3min** | **~45%** |

## Validação

- ✅ Mudanças seguem [pytest-xdist docs](https://pytest-xdist.readthedocs.io/)
- ✅ Coverage reporting compatível com paralelização
- ✅ Cache strategy seguindo [setup-python best practices](https://github.com/actions/setup-python#caching-packages-dependencies)
- ⏳ Aguardando CI run para confirmar redução de tempo

## Contexto

Follow-up da conversa sobre performance CI após fechamento do PR #125. Implementa otimizações 1 e 2 discutidas com o usuário.

**Referências:**
- Issue #124 (discussion)
- PR #125 (context)