### PR TITLE
fix(frontend): menu link colors and HomePage adjustments

### DIFF
--- a/v2/frontend/src/App.css
+++ b/v2/frontend/src/App.css
@@ -6,3 +6,25 @@
   margin: 0;
   padding: 0;
 }
+
+/* Fix: Links dentro do Menu dark devem ter cor branca */
+.ant-menu-dark .ant-menu-item a,
+.ant-menu-dark .ant-menu-submenu-title a {
+  color: rgba(255, 255, 255, 0.65) !important;
+  text-decoration: none;
+}
+
+.ant-menu-dark .ant-menu-item-selected a,
+.ant-menu-dark .ant-menu-item:hover a {
+  color: #fff !important;
+}
+
+/* Fix específico: Badge dentro de Link no Menu dark */
+.ant-menu-dark .ant-menu-item a .ant-badge {
+  color: rgba(255, 255, 255, 0.65) !important;
+}
+
+.ant-menu-dark .ant-menu-item-selected a .ant-badge,
+.ant-menu-dark .ant-menu-item:hover a .ant-badge {
+  color: #fff !important;
+}

--- a/v2/frontend/src/pages/Home/HomePage.jsx
+++ b/v2/frontend/src/pages/Home/HomePage.jsx
@@ -106,11 +106,12 @@ export default function HomePage() {
   const isAdmin = user?.is_superuser || user?.groups?.includes('Superintendência') || user?.groups?.includes('Gerência');
   const isManager = user?.groups?.includes('Controle') || user?.groups?.includes('Gerência');
   const isCoordenador = user?.groups?.includes('Coordenador') || user?.groups?.includes('DAT');
+  const canDAT = user?.is_superuser || user?.groups?.includes('DAT');
 
   return (
     <div style={{ padding: '24px' }}>
       <div style={{ marginBottom: 32 }}>
-        <Title level={2}>Home</Title>
+        <Title level={2}>Página Inicial</Title>
         <Text type="secondary">
           Atalhos e KPIs resumidos para suas tarefas diárias.
         </Text>
@@ -123,15 +124,16 @@ export default function HomePage() {
             Acesso Administrativo
           </Title>
           <Row gutter={[16, 16]}>
-            <Col xs={24} sm={12} md={8}>
-              <AccessCard
-                icon={<UserOutlined />}
-                title="Gerenciamento de Usuários"
-                description="Gerenciar usuários, grupos e permissões."
-                link="/admin/usuarios"
-                disabled={true}
-              />
-            </Col>
+            {canDAT && (
+              <Col xs={24} sm={12} md={8}>
+                <AccessCard
+                  icon={<UserOutlined />}
+                  title="Gerenciamento de Usuários"
+                  description="Gerenciar usuários, grupos e permissões."
+                  link="/admin-dat/usuarios"
+                />
+              </Col>
+            )}
             <Col xs={24} sm={12} md={8}>
               <AccessCard
                 icon={<SettingOutlined />}
@@ -147,7 +149,6 @@ export default function HomePage() {
                 title="Análises"
                 description="Visualizar relatórios detalhados e métricas do sistema."
                 link="/dashboards"
-                disabled={true}
               />
             </Col>
           </Row>


### PR DESCRIPTION
## 🎨 Correções de UI/UX

### Mudanças

1. **Menu Lateral (Dark Theme)**
   - Corrigida cor dos links dentro do menu dark (branco em vez de preto)
   - Aplicado !important para sobrescrever estilos padrão do Ant Design
   - Inclui suporte para Badge dentro de Link

2. **HomePage (Página Inicial)**
   - Alterado título de "Home" para "Página Inicial" (conformidade PT-BR)
   - Habilitado card "Gerenciamento de Usuários" com guard `canDAT`
   - Habilitado card "Análises" com link para /dashboards

### Arquivos Modificados

- `v2/frontend/src/App.css` (24 linhas CSS)
- `v2/frontend/src/pages/Home/HomePage.jsx` (ajustes de permissões)

### Conformidade

- ✅ **ISO 9241-110**: Controle explícito (cards visíveis apenas para perfis autorizados)
- ✅ **RBAC**: Guards `canDAT` e `isManager` respeitados

### Screenshots

**Antes**: Link do menu com fonte preta (ilegível)
**Depois**: Link do menu com fonte branca (legível)

**Antes**: "Home" (inglês)
**Depois**: "Página Inicial" (português)

### Testes

- ✅ Testes manuais em http://localhost:5173
- ✅ Verificado comportamento em diferentes perfis (DAT, Manager, Coordenador)
- ✅ Build frontend sem erros

---

**Tipo**: Fix (UI/UX)
**Prioridade**: Baixa (correções estéticas)
**Esforço**: 30 minutos