### PR TITLE
chore: remove GAP-004 dead code from views.py

### DIFF
--- a/v2/backend/apps/core/views.py
+++ b/v2/backend/apps/core/views.py
@@ -58,7 +58,6 @@ from .serializers import (
     UsuarioOptionSerializer,
 )
 from .services.availability_service import check_conflicts
-# from .services.import_compras import import_compras_from_file  # TODO: service depende de modelo Compra (GAP-004)
 
 # Logger estruturado para auditoria
 logger = logging.getLogger(__name__)
@@ -916,50 +915,6 @@ class AuditLogViewSet(viewsets.ReadOnlyModelViewSet):
     search_fields = ["action", "model_name"]
     ordering_fields = ["created_at", "action", "id"]
     ordering = ["-created_at"]
-
-
-# TODO(GAP-004): ImportComprasView requer import_compras_from_file não implementado
-class ImportComprasView(APIView):
-    """
-    Endpoint de importação de Compras via CSV/XLSX.
-
-    POST /api/import/compras/
-    Content-Type: multipart/form-data
-    Body: file (CSV ou XLSX)
-    Query params: dry_run=true (opcional, para validação sem salvar)
-
-    Permissões: Controle ou DAT
-
-    Retorna:
-        {
-            "success": true,
-            "result": {
-                "inserted": int,
-                "updated": int,
-                "skipped": int,
-                "rejected": int,
-                "errors": [str]
-            }
-        }
-
-    Observações:
-    - Idempotência via external_hash (SHA256)
-    - Auto-cria Município e Projeto se não existirem
-    - Transacional: rollback em caso de erro crítico
-    - Salva resultado em out/etl/last_run.json
-    - Cria entrada em AuditLog
-
-    NOTA: Temporariamente desabilitado até implementação de import_compras_from_file
-    """
-
-    permission_classes = [IsControleOrDAT]
-
-    def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
-        # TODO(GAP-004): Implementar import_compras_from_file antes de habilitar
-        return Response(
-            {"detail": "Import de compras temporariamente desabilitado (GAP-004)"},
-            status=status.HTTP_501_NOT_IMPLEMENTED
-        )
 
 
 # ==========================


### PR DESCRIPTION
## Summary

This PR removes dead code identified during comprehensive system audit (GAP-004).

### Dead Code Removed from `apps/core/views.py`

**Removed:**
- Line 61: Commented import `# from .services.import_compras import import_compras_from_file`
- Lines 920-962: `ImportComprasView` stub class returning HTTP 501

**Reason for Removal:**
- Real `ImportComprasView` implementation exists in `apps/core/views_controle_imports.py`
- Real `import_compras_from_file` function exists in `apps/core/services/controle_imports.py`
- Stub was never used (registered endpoints point to working implementation)

**Not Removed (Active Code):**
- `CompraViewSet` (lines 762-794) - Tested in test_admin_api.py::TestCompraAPI (8 tests)
- `UsuarioAdminViewSet` (lines 797-871) - Tested in test_admin_api.py::TestUsuarioAdminAPI (6 tests)
- Both classes are registered in urls.py and actively used

## Test Plan

✅ **All regression tests pass (41/41):**

```bash
# Test suite 1: Admin API endpoints
pytest apps/core/tests/test_admin_api.py -v
# Result: 31 passed in 32.29s

# Test suite 2: Import compras functionality
pytest apps/core/tests/test_import_compras.py -v
# Result: 10 passed in 14.31s
```

**Tests verify:**
- CompraViewSet CRUD operations (8 tests)
- UsuarioAdminViewSet CRUD operations (6 tests)
- import_compras_from_file functionality (10 tests)

## Impact

- **-45 lines** of dead code removed (1 file changed, 45 deletions)
- **No functional changes** - only cleanup
- **All endpoints remain operational** - verified by tests

## Checklist

- [x] Removed GAP-004 dead code (commented import + stub class)
- [x] Verified CompraViewSet and UsuarioAdminViewSet are active (not removed)
- [x] Ran regression tests: test_admin_api.py (31/31 passed)
- [x] Ran regression tests: test_import_compras.py (10/10 passed)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)