### PR TITLE
docs: add pytest best practices + healthcheck alternatives analysis

### DIFF
--- a/v2/README.md
+++ b/v2/README.md
@@ -130,6 +130,30 @@ make coverage
 
 **Meta de cobertura**: 90%+ (crítico: 100%)
 
+### ⚠️ Pytest Best Practices
+
+**IMPORTANTE**: Execute pytest apenas **UMA vez por sessão** para evitar race conditions no banco de teste.
+
+```bash
+# ✅ Correto - Execução única
+make test
+# ou
+docker compose exec web pytest apps/core
+
+# ❌ Errado - Múltiplas execuções simultâneas
+pytest apps/core & pytest apps/dat_ingest  # Pode causar erro de DB
+
+# ✅ Alternativa - Use --reuse-db para execuções repetidas
+docker compose exec web pytest apps/core --reuse-db
+```
+
+**Por quê?** Múltiplos processos pytest tentam criar o mesmo banco de teste (`test_aprender_db`) simultaneamente, causando erro:
+```
+django.db.utils.IntegrityError: duplicate key value violates unique constraint "pg_database_datname_index"
+```
+
+📖 **Detalhes**: [docs/TESTING_RACE_CONDITION.md](docs/TESTING_RACE_CONDITION.md)
+
 ---
 
 ## 🔄 ETL (Migração de Dados)

--- a/v2/docs/REDIS_EXPORTER_HEALTHCHECK.md
+++ b/v2/docs/REDIS_EXPORTER_HEALTHCHECK.md
@@ -1,0 +1,199 @@
+# Redis Exporter Healthcheck Analysis
+
+## Current Status (2025-11-25)
+
+**Decision**: Healthcheck removed from `redis_exporter` service in docker-compose.yml.
+
+**Reason**: Image `oliver006/redis_exporter:v1.62.0` is scratch-based (no shell, no utilities).
+
+## Alternatives Considered
+
+### Option 1: Remove Healthcheck (CHOSEN ✅)
+
+**Implementation**: Already applied in PR #204
+
+```yaml
+redis_exporter:
+  image: oliver006/redis_exporter:v1.62.0
+  # ...
+  # Note: Healthcheck removed - scratch-based image has no shell/wget.
+  # Service health monitored by Prometheus scrape (http://localhost:9121/metrics)
+```
+
+**Pros**:
+- ✅ No false "unhealthy" status
+- ✅ Prometheus already monitors exporter health via scrape
+- ✅ Simpler configuration
+
+**Cons**:
+- ⚠️ Docker Compose doesn't report health status
+
+**Monitoring**: Prometheus scrape success/failure indicates health.
+
+### Option 2: Use Alpine-based Image
+
+**Implementation**:
+```yaml
+redis_exporter:
+  image: oliver006/redis_exporter:alpine  # If available
+  healthcheck:
+    test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:9121/metrics"]
+    interval: 30s
+    timeout: 10s
+    retries: 3
+    start_period: 10s
+```
+
+**Pros**:
+- ✅ Would have shell/wget for healthcheck
+
+**Cons**:
+- ❌ No official alpine-based image for redis_exporter
+- ❌ Larger image size
+- ❌ Unnecessary complexity
+
+**Status**: Not recommended (no official alpine variant)
+
+### Option 3: Custom Healthcheck with curl/wget Container
+
+**Implementation**:
+```yaml
+redis_exporter:
+  image: oliver006/redis_exporter:v1.62.0
+  healthcheck:
+    test: ["CMD-SHELL", "timeout 5 nc -z localhost 9121"]
+    interval: 30s
+    timeout: 10s
+    retries: 3
+```
+
+**Pros**:
+- ✅ Would check if port is listening
+
+**Cons**:
+- ❌ `nc` (netcat) also not available in scratch image
+- ❌ Only checks TCP, not actual HTTP endpoint
+
+**Status**: Not feasible (scratch image has no utilities)
+
+### Option 4: Sidecar Container for Healthcheck
+
+**Implementation**:
+```yaml
+redis_exporter_healthcheck:
+  image: busybox:latest
+  depends_on:
+    - redis_exporter
+  command: |
+    sh -c 'while true; do
+      wget -q --spider http://redis_exporter:9121/metrics || exit 1;
+      sleep 30;
+    done'
+  restart: unless-stopped
+```
+
+**Pros**:
+- ✅ Would provide health monitoring
+
+**Cons**:
+- ❌ Adds unnecessary container
+- ❌ Overly complex for simple monitoring
+- ❌ Prometheus already does this job
+
+**Status**: Not recommended (unnecessary complexity)
+
+### Option 5: Docker Compose Depends_on with Healthcheck in Prometheus
+
+**Implementation**:
+```yaml
+prometheus:
+  # ...
+  healthcheck:
+    test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://redis_exporter:9121/metrics"]
+    interval: 30s
+    timeout: 10s
+    retries: 3
+  depends_on:
+    redis_exporter:
+      condition: service_started  # Not service_healthy
+
+redis_exporter:
+  # No healthcheck needed
+```
+
+**Pros**:
+- ✅ Prometheus validates exporter availability during startup
+
+**Cons**:
+- ❌ Couples Prometheus healthcheck with redis_exporter availability
+- ❌ Prometheus image may not have wget either
+
+**Status**: Not recommended (tight coupling)
+
+## Monitoring Strategy (CHOSEN)
+
+### Prometheus Scrape Monitoring
+
+**How it works**:
+1. Prometheus scrapes `http://redis_exporter:9121/metrics` every 15-30s
+2. If scrape fails, Prometheus marks target as DOWN
+3. Grafana dashboards show target availability
+
+**Query to check exporter health**:
+```promql
+up{job="redis_exporter"}
+```
+
+**Alert rule example**:
+```yaml
+groups:
+  - name: redis_exporter
+    rules:
+      - alert: RedisExporterDown
+        expr: up{job="redis_exporter"} == 0
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Redis Exporter is down"
+          description: "Redis Exporter has been down for more than 2 minutes"
+```
+
+### Manual Health Verification
+
+```bash
+# Check if exporter is running
+docker compose ps redis_exporter
+# Expected: Up (not unhealthy)
+
+# Check if metrics endpoint responds
+curl http://localhost:9121/metrics
+# Expected: HTTP 200 with Prometheus metrics
+
+# Check specific metric
+curl -s http://localhost:9121/metrics | grep redis_up
+# Expected: redis_up 1
+```
+
+## Conclusion
+
+**Best approach**: Remove Docker healthcheck, rely on Prometheus scrape monitoring.
+
+**Rationale**:
+- Prometheus is the proper monitoring tool for this use case
+- Docker healthcheck with scratch image is impossible without workarounds
+- Adding complexity (sidecar, alpine image) provides minimal benefit
+- Current solution is industry-standard for Prometheus exporters
+
+## References
+
+- Issue identified: Audit 2025-11-25
+- Solution applied: PR #204 (d40f968)
+- Image documentation: https://hub.docker.com/r/oliver006/redis_exporter
+- Scratch image limitations: https://docs.docker.com/develop/develop-images/baseimages/#create-a-simple-parent-image-using-scratch
+
+## Related Documentation
+
+- `v2/infra/docker-compose.yml` - Redis exporter configuration
+- `v2/infra/prometheus.yml` - Prometheus scrape config
+- `v2/docs/OBSERVABILITY.md` - MP1 monitoring setup


### PR DESCRIPTION
## Summary

Follow-up documentation after PR #204, adding pytest best practices to README and comprehensive healthcheck alternatives analysis.

## Changes

### 1. README.md: Pytest Best Practices Section

Added warning section after test coverage info to prevent test database race conditions.

**Content**:
```markdown
### ⚠️ Pytest Best Practices

**IMPORTANTE**: Execute pytest apenas **UMA vez por sessão** para evitar race conditions no banco de teste.

✅ Correto: make test (single execution)
❌ Errado: pytest apps/core & pytest apps/dat_ingest (parallel)
✅ Alternativa: pytest --reuse-db
```

**Why important**: 
- Prevents `IntegrityError: duplicate key "test_aprender_db" already exists`
- Reduces developer confusion when encountering race condition
- Links to detailed documentation (TESTING_RACE_CONDITION.md)

### 2. docs/REDIS_EXPORTER_HEALTHCHECK.md: Comprehensive Analysis

Documents 5 alternatives considered for redis_exporter healthcheck:

1. **Remove healthcheck (CHOSEN ✅)**
   - Pros: No false unhealthy, Prometheus monitors
   - Cons: Docker doesn't report health

2. **Use Alpine-based image**
   - Pros: Would have shell/wget
   - Cons: No official alpine variant, larger image

3. **Custom healthcheck with netcat**
   - Cons: netcat not available in scratch image

4. **Sidecar container**
   - Cons: Unnecessary complexity, Prometheus does this

5. **Prometheus validates exporter**
   - Cons: Tight coupling

**Monitoring Strategy Documented**:
- Prometheus scrape query: `up{job="redis_exporter"}`
- Alert rule example provided
- Manual verification commands included

## Benefits

- **Developer Experience**: Prevents confusion with test errors
- **Documentation**: Explains infrastructure decisions with evidence
- **Institutional Knowledge**: Preserves analysis for future reference
- **Best Practices**: Guides correct pytest usage

## Files Changed

```
v2/README.md                               | 24 ++++
v2/docs/REDIS_EXPORTER_HEALTHCHECK.md      | 199 +++++++++++++++++++
2 files changed, 223 insertions(+)
```

## Testing

### Pytest Documentation
```bash
# Single run: should pass
docker compose exec web pytest apps/core/tests/test_config_api.py
# ✅ 6 passed

# Parallel runs: reproduces error (as documented)
pytest apps/core/tests/test_config_api.py & pytest apps/core/tests/test_config_api.py
# ❌ IntegrityError (expected)

# With --reuse-db: should work
docker compose exec web pytest apps/core --reuse-db
# ✅ Works without DB recreation
```

### Redis Exporter Verification
```bash
# Check service status
docker compose ps redis_exporter
# Up (no longer shows unhealthy)

# Check metrics endpoint
curl http://localhost:9121/metrics | grep redis_up
# redis_up 1 ✅
```

## Related PRs

- #203: Removed GAP-004 dead code
- #204: Documented race condition + removed healthcheck

## Checklist

- [x] Added pytest best practices to README with examples
- [x] Documented 5 healthcheck alternatives with pros/cons
- [x] Explained monitoring strategy (Prometheus scrape)
- [x] Provided manual verification commands
- [x] Linked to detailed documentation (TESTING_RACE_CONDITION.md)
- [x] No functional changes (documentation only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)