### PR TITLE
chore(backend): Phase 2 cleanup - logging, TODOs, DEBUG comments

### DIFF
--- a/v2/backend/apps/core/services/gcal/sync.py
+++ b/v2/backend/apps/core/services/gcal/sync.py
@@ -266,7 +266,6 @@ def upsert_one(
 
             if not dry_run:
                 try:
-                    # DEBUG: Log payload antes de enviar
                     logger.debug(
                         f"🔍 GCal INSERT #{s.id} - calendar_id={calendar_id}, "
                         f"event_id={deterministic_eid}, payload={payload}"

--- a/v2/backend/apps/core/services/gcal_oauth_client.py
+++ b/v2/backend/apps/core/services/gcal_oauth_client.py
@@ -255,7 +255,6 @@ class OAuthCalendarClient(CalendarClientAdapter):
         # Garantir que o payload tenha o event_id
         body = {**payload, "id": event_id}
 
-        # DEBUG: Log body antes de enviar
         logger.debug(
             f"🔍 OAuthClient.insert() - calendar_id={calendar_id}, "
             f"event_id={event_id}, body_has_id={'id' in body}, body_id={body.get('id')}"

--- a/v2/backend/apps/core/tasks.py
+++ b/v2/backend/apps/core/tasks.py
@@ -15,11 +15,14 @@ Agendamento via CELERY_BEAT_SCHEDULE no settings.py:
 from __future__ import annotations
 
 import json
+import logging
 from io import StringIO
 from typing import Any
 
 from celery import shared_task  # type: ignore[attr-defined]
 from django.core.management import call_command
+
+logger = logging.getLogger(__name__)
 
 
 @shared_task(bind=True)
@@ -34,27 +37,26 @@ def debug_task(self: Any) -> str:
     Returns:
         str: "ok"
     """
-    print(f"Request: {self.request!r}")
+    logger.debug(f"Request: {self.request!r}")
     return "ok"
 
 
 @shared_task
 def gcal_sync_task() -> None:
     """
-    Tarefa stub para sincronização futura com Google Calendar.
+    DEPRECATED: Tarefa stub para sincronização com Google Calendar.
 
-    TODO: Implementar lógica de sincronização.
+    Esta task não está em uso. A sincronização real é feita via:
+    - preview_then_apply_gcal (Celery beat automático)
+    - task_publish_solicitacao_to_gcal (publicação individual)
+    - /pre-agenda UI (governança manual)
 
-    Possíveis implementações:
-    - Sincronizar eventos pendentes
-    - Atualizar eventos modificados
-    - Remover eventos cancelados
-    - Integrar com preview_then_apply_gcal
+    Mantida para backwards compatibility. Não implementar lógica aqui.
 
     Returns:
-        dict: Resultado da sincronização (quando implementado)
+        None
     """
-    # TODO: Implementar lógica de sincronização
+    logger.warning("gcal_sync_task is deprecated and does nothing. Use preview_then_apply_gcal instead.")
     pass
 
 

--- a/v2/backend/apps/core/views_oauth.py
+++ b/v2/backend/apps/core/views_oauth.py
@@ -490,7 +490,6 @@ def google_oauth_list_calendars(request: Request) -> Response:
         logger.info(
             f"📅 Listed {len(calendars)} calendars for {request.user.username}"
         )
-        # DEBUG: Log calendar details
         for cal in calendars:
             logger.info(
                 f"  📅 {cal['summary']}: id={cal['id']}, "

--- a/v2/backend/apps/dat_ingest/services/parse_fluir.py
+++ b/v2/backend/apps/dat_ingest/services/parse_fluir.py
@@ -21,14 +21,16 @@ Estrutura esperada (aba "Acompanhamento"):
 
 # pyright: reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportCallIssue=false, reportGeneralTypeIssues=false, reportArgumentType=false, reportOptionalMemberAccess=false
 
+import hashlib
+import logging
+from datetime import datetime, time as dtime, timedelta
 from pathlib import Path
 from typing import Any
-from datetime import datetime, time as dtime, timedelta
-import hashlib
 
 import pandas as pd
 from zoneinfo import ZoneInfo
 
+logger = logging.getLogger(__name__)
 
 FORTALEZA_TZ = ZoneInfo("America/Fortaleza")
 
@@ -160,7 +162,7 @@ def parse_fluir_eventos(filepath: Path) -> list[dict[str, Any]]:
 
         except Exception as e:
             # Log erro mas continua processando
-            print(f"⚠️  Erro ao processar linha {idx}: {e}")
+            logger.warning(f"Erro ao processar linha {idx}: {e}")
             continue
 
     return eventos

--- a/v2/backend/config/settings.py
+++ b/v2/backend/config/settings.py
@@ -480,8 +480,9 @@ TRAVEL_BUFFER_MINUTES = int(os.getenv("TRAVEL_BUFFER_MINUTES", "120"))
 ETL_OUTPUT_DIR = os.getenv("ETL_OUTPUT_DIR", str(BASE_DIR / "out_etl"))
 ETL_DATA_DIR = os.getenv("ETL_DATA_DIR", str(BASE_DIR / "data" / "csv-import"))
 
-# ETL: Diretório padrão para importação de arquivos (legacy, deprecado)
-# TODO: Migrar para ETL_DATA_DIR após PR #53
+# ETL: Diretório padrão para importação de arquivos (backwards compatibility)
+# NOTE: ETL_DATA_DIR é o padrão preferido. DATA_IMPORT_DIR mantido para
+# compatibilidade com management commands existentes (etl_all, etl_load_xlsx).
 DATA_IMPORT_DIR = os.getenv("DATA_IMPORT_DIR", "/app/data/csv-import")
 
 # ================================================================


### PR DESCRIPTION
## Summary

Fase 2 do plano de correções da auditoria. Corrige 3 issues de alta prioridade.

### Issue #221: Substituir print() por logger estruturado

| Arquivo | Antes | Depois |
|---------|-------|--------|
| `apps/core/tasks.py` | `print(f"Request: ...")` | `logger.debug(...)` |
| `apps/dat_ingest/services/parse_fluir.py` | `print(f"⚠️ Erro...")` | `logger.warning(...)` |

### Issue #222: Resolver TODOs pendentes

| Arquivo | Ação |
|---------|------|
| `apps/core/tasks.py` | Marcou `gcal_sync_task` como DEPRECATED (sync real via `preview_then_apply_gcal`) |
| `config/settings.py` | Converteu TODO em NOTE (DATA_IMPORT_DIR mantido para backwards compatibility) |

### Issue #223: Remover comentários DEBUG obsoletos

| Arquivo | Comentário removido |
|---------|---------------------|
| `apps/core/views_oauth.py:493` | `# DEBUG: Log calendar details` |
| `apps/core/services/gcal/sync.py:269` | `# DEBUG: Log payload antes de enviar` |
| `apps/core/services/gcal_oauth_client.py:258` | `# DEBUG: Log body antes de enviar` |

**Nota**: Os logger.debug/info calls foram mantidos - apenas os comentários `# DEBUG:` foram removidos.

## Test plan

- [x] Imports funcionam no container Docker
- [x] Código usa logging estruturado (MP2 compliant)
- [ ] CI passa (testes backend)

Closes #221, #222, #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)