### PR TITLE
refactor(infra): separate observability stack into optional compose file

### DIFF
--- a/v2/docs/OBSERVABILITY.md
+++ b/v2/docs/OBSERVABILITY.md
@@ -1,8 +1,8 @@
 # Guia de Observabilidade - AS v2 (MP1)
 
-**Data**: 2025-11-18
+**Data**: 2025-12-03
 **Status**: ✅ Implementado
-**Issue**: #165
+**Issue**: #165, #234
 
 ---
 
@@ -16,26 +16,83 @@
 4. **postgres_exporter** (v0.15.0) - Métricas PostgreSQL
 5. **redis_exporter** (v1.62.0) - Métricas Redis
 
+### Arquitetura
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    docker-compose.yml                        │
+│  (Stack Principal - sempre disponível)                      │
+│  ┌─────────┐  ┌─────────┐  ┌─────────┐  ┌─────────┐        │
+│  │   web   │  │   db    │  │  redis  │  │ worker  │        │
+│  │ :8002   │  │ :5434   │  │ :6380   │  │         │        │
+│  │/metrics │  │         │  │         │  │         │        │
+│  └─────────┘  └─────────┘  └─────────┘  └─────────┘        │
+└─────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────┐
+│              docker-compose.observability.yml                │
+│  (Stack Opcional - desenvolvimento/staging local)           │
+│  ┌─────────────┐  ┌─────────────┐  ┌─────────────────────┐ │
+│  │ prometheus  │  │   grafana   │  │ postgres_exporter   │ │
+│  │   :9090     │  │   :3000     │  │      :9187          │ │
+│  └─────────────┘  └─────────────┘  └─────────────────────┘ │
+│                                    ┌─────────────────────┐ │
+│                                    │  redis_exporter     │ │
+│                                    │      :9121          │ │
+│                                    └─────────────────────┘ │
+└─────────────────────────────────────────────────────────────┘
+```
+
 ### Portas
 
-| Serviço | Porta | URL |
-|---------|-------|-----|
-| Prometheus UI | 9090 | http://localhost:9090 |
-| Grafana UI | 3000 | http://localhost:3000 |
-| Metrics endpoint | 8002 | http://localhost:8002/metrics |
-| PostgreSQL exporter | 9187 | http://localhost:9187/metrics |
-| Redis exporter | 9121 | http://localhost:9121/metrics |
+| Serviço | Porta | URL | Arquivo |
+|---------|-------|-----|---------|
+| Metrics endpoint | 8002 | http://localhost:8002/metrics | docker-compose.yml |
+| Prometheus UI | 9090 | http://localhost:9090 | docker-compose.observability.yml |
+| Grafana UI | 3000 | http://localhost:3000 | docker-compose.observability.yml |
+| PostgreSQL exporter | 9187 | http://localhost:9187/metrics | docker-compose.observability.yml |
+| Redis exporter | 9121 | http://localhost:9121/metrics | docker-compose.observability.yml |
 
 ---
 
 ## 🚀 Quick Start
 
-### Iniciar Stack Completa
+### Stack Principal (sem observabilidade local)
 
 ```bash
 cd v2/infra
+make up
+# ou
 docker compose up -d
 ```
+
+O endpoint `/metrics` está sempre disponível para scraping externo.
+
+### Stack com Observabilidade Local
+
+```bash
+cd v2/infra
+make up-obs
+# ou
+docker compose -f docker-compose.yml -f docker-compose.observability.yml up -d
+```
+
+### Parar Serviços
+
+```bash
+make down      # Stack principal
+make down-obs  # Stack + observabilidade
+```
+
+### Produção
+
+Em produção, use o serviço de observabilidade do provedor de hospedagem:
+- **AWS**: CloudWatch
+- **GCP**: Cloud Monitoring
+- **Azure**: Azure Monitor
+- **Managed services**: Datadog, New Relic, Grafana Cloud
+
+O endpoint `/metrics` do Django permanece disponível e compatível com Prometheus.
 
 ### Acessar Dashboards
 
@@ -490,6 +547,6 @@ for sol in solicitacoes:
 
 ---
 
-**Última atualização**: 2025-11-18
+**Última atualização**: 2025-12-03
 **Responsável**: Claude Code
-**Issues**: #165 (MP1 - Prometheus + Grafana), #166 (MP2 - Structured Logging), #167 (MP3 - Sentry APM)
+**Issues**: #165 (MP1 - Prometheus + Grafana), #166 (MP2 - Structured Logging), #167 (MP3 - Sentry APM), #234 (Separar stack de observabilidade)

--- a/v2/infra/Makefile
+++ b/v2/infra/Makefile
@@ -4,10 +4,11 @@
 # Comandos unificados para operações comuns
 # ================================================================
 
-.PHONY: help build up down restart logs shell migrate test clean
+.PHONY: help build up up-obs down down-obs restart logs shell migrate test clean
 
 # Variáveis
 COMPOSE_FILE := docker-compose.yml
+COMPOSE_OBS_FILE := docker-compose.observability.yml
 SERVICE_WEB := web
 SERVICE_DB := db
 SERVICE_WORKER := worker
@@ -40,9 +41,21 @@ up:  ## Iniciar todos os serviços
 	@echo "📊 Admin: http://localhost:8000/admin"
 	@echo "🔍 API Health: http://localhost:8000/api/health/"
 
+up-obs:  ## Iniciar com stack de observabilidade (Prometheus + Grafana)
+	@echo "🚀 Iniciando serviços com observabilidade..."
+	docker compose -f $(COMPOSE_FILE) -f $(COMPOSE_OBS_FILE) up -d
+	@echo "✅ Serviços iniciados!"
+	@echo "🌐 Web: http://localhost:8000"
+	@echo "📊 Grafana: http://localhost:3000 (admin/admin)"
+	@echo "🔍 Prometheus: http://localhost:9090"
+
 down:  ## Parar todos os serviços
 	@echo "⏹️  Parando serviços..."
 	docker compose -f $(COMPOSE_FILE) down
+
+down-obs:  ## Parar serviços + observabilidade
+	@echo "⏹️  Parando serviços com observabilidade..."
+	docker compose -f $(COMPOSE_FILE) -f $(COMPOSE_OBS_FILE) down
 
 restart:  ## Reiniciar todos os serviços
 	@echo "🔄 Reiniciando serviços..."

--- a/v2/infra/docker-compose.observability.yml
+++ b/v2/infra/docker-compose.observability.yml
@@ -1,0 +1,91 @@
+# ================================================================
+# AS v2 — Observability Stack (Opcional)
+# ================================================================
+# Prometheus + Grafana + Exporters para monitoramento local
+#
+# Uso:
+#   docker compose -f docker-compose.yml -f docker-compose.observability.yml up -d
+#
+# Ou via Makefile:
+#   make up-obs
+#
+# Nota: Em produção, use o serviço de observabilidade do provedor.
+#       Este stack é para desenvolvimento/staging local.
+# ================================================================
+
+services:
+  prometheus:
+    image: prom/prometheus:v2.54.0
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--storage.tsdb.retention.time=30d'
+      - '--web.console.libraries=/usr/share/prometheus/console_libraries'
+      - '--web.console.templates=/usr/share/prometheus/consoles'
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:9090/-/healthy"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+
+  grafana:
+    image: grafana/grafana:11.2.0
+    ports:
+      - "3000:3000"
+    environment:
+      GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:-admin}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-admin}
+      GF_INSTALL_PLUGINS: ""
+      GF_AUTH_ANONYMOUS_ENABLED: "false"
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+    depends_on:
+      - prometheus
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:3000/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
+
+  postgres_exporter:
+    image: prometheuscommunity/postgres-exporter:v0.15.0
+    ports:
+      - "9187:9187"
+    environment:
+      DATA_SOURCE_NAME: "postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}?sslmode=disable"
+    depends_on:
+      - db
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:9187/metrics"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+
+  redis_exporter:
+    image: oliver006/redis_exporter:v1.62.0
+    ports:
+      - "9121:9121"
+    environment:
+      REDIS_ADDR: "redis:6379"
+    depends_on:
+      - redis
+    restart: unless-stopped
+    # Note: Healthcheck removed - scratch-based image has no shell/wget.
+    # Service health monitored by Prometheus scrape (http://localhost:9121/metrics)
+
+volumes:
+  prometheus_data:  # MP1: Prometheus metrics storage
+  grafana_data:  # MP1: Grafana dashboards and config

--- a/v2/infra/docker-compose.yml
+++ b/v2/infra/docker-compose.yml
@@ -104,83 +104,20 @@ services:
       start_period: 30s
 
   # ================================================================
-  # MP1: Observability Stack (Prometheus + Grafana + Exporters)
+  # Observability Stack (Prometheus + Grafana + Exporters)
   # ================================================================
-  prometheus:
-    image: prom/prometheus:v2.54.0
-    ports:
-      - "9090:9090"
-    volumes:
-      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
-      - prometheus_data:/prometheus
-    command:
-      - '--config.file=/etc/prometheus/prometheus.yml'
-      - '--storage.tsdb.path=/prometheus'
-      - '--storage.tsdb.retention.time=30d'
-      - '--web.console.libraries=/usr/share/prometheus/console_libraries'
-      - '--web.console.templates=/usr/share/prometheus/consoles'
-    restart: unless-stopped
-    healthcheck:
-      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:9090/-/healthy"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 10s
-
-  grafana:
-    image: grafana/grafana:11.2.0
-    ports:
-      - "3000:3000"
-    environment:
-      GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:-admin}
-      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-admin}
-      GF_INSTALL_PLUGINS: ""
-      GF_AUTH_ANONYMOUS_ENABLED: "false"
-    volumes:
-      - grafana_data:/var/lib/grafana
-      - ./grafana/provisioning:/etc/grafana/provisioning:ro
-      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
-    depends_on:
-      - prometheus
-    restart: unless-stopped
-    healthcheck:
-      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:3000/api/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 20s
-
-  postgres_exporter:
-    image: prometheuscommunity/postgres-exporter:v0.15.0
-    ports:
-      - "9187:9187"
-    environment:
-      DATA_SOURCE_NAME: "postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}?sslmode=disable"
-    depends_on:
-      - db
-    restart: unless-stopped
-    healthcheck:
-      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:9187/metrics"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 10s
-
-  redis_exporter:
-    image: oliver006/redis_exporter:v1.62.0
-    ports:
-      - "9121:9121"
-    environment:
-      REDIS_ADDR: "redis:6379"
-    depends_on:
-      - redis
-    restart: unless-stopped
-    # Note: Healthcheck removed - scratch-based image has no shell/wget.
-    # Service health monitored by Prometheus scrape (http://localhost:9121/metrics)
+  # Movido para docker-compose.observability.yml (Issue #234)
+  #
+  # Para usar localmente:
+  #   make up-obs
+  # Ou:
+  #   docker compose -f docker-compose.yml -f docker-compose.observability.yml up -d
+  #
+  # Em produção, use o serviço de observabilidade do provedor.
+  # O endpoint /metrics do Django permanece disponível para scraping.
+  # ================================================================
 
 volumes:
   db_data:
   redis_data:  # CP2: Persistência Redis (sessões)
   backup_data:  # MP5: PostgreSQL backups storage
-  prometheus_data:  # MP1: Prometheus metrics storage
-  grafana_data:  # MP1: Grafana dashboards and config


### PR DESCRIPTION
## Summary

- Move Prometheus, Grafana, and exporters to `docker-compose.observability.yml`
- Main stack (`docker-compose.yml`) now lighter (5 containers → 5 containers, no observability overhead)
- Add `make up-obs` / `make down-obs` commands for optional local observability
- Update `OBSERVABILITY.md` with new architecture diagram and usage

## Motivation

In production, the hosting provider typically offers their own observability service (CloudWatch, Cloud Monitoring, Datadog, etc.), making local Prometheus/Grafana redundant. This refactor:

1. Reduces default container count for faster startup
2. Keeps `/metrics` endpoint available for external scraping
3. Maintains full local observability when needed (`make up-obs`)

## Changes

| File | Change |
|------|--------|
| `docker-compose.yml` | Remove prometheus, grafana, exporters |
| `docker-compose.observability.yml` | New file with observability stack |
| `Makefile` | Add `up-obs`, `down-obs` commands |
| `OBSERVABILITY.md` | Update architecture and usage docs |

## Usage

```bash
# Standard (no local observability)
make up

# With local Prometheus + Grafana
make up-obs
```

## Test plan

- [ ] `make up` starts only core services (web, db, redis, worker, beat)
- [ ] `make up-obs` starts core + observability (prometheus, grafana, exporters)
- [ ] `/metrics` endpoint accessible in both modes
- [ ] Grafana dashboard loads correctly with `make up-obs`

Closes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)