### PR TITLE
fix(tests): update serializer count to 53

### DIFF
--- a/v2/backend/apps/core/tests/test_modular_serializers.py
+++ b/v2/backend/apps/core/tests/test_modular_serializers.py
@@ -167,4 +167,4 @@ class TestSerializersBackwardsCompatibility:
         """Verifica que __all__ esta definido corretamente."""
         from apps.core import serializers
         assert hasattr(serializers, "__all__")
-        assert len(serializers.__all__) == 52  # Total de serializers exportados (23 base + 20 DAT + 9 PlanoFormacoes)
+        assert len(serializers.__all__) == 53  # Total de serializers exportados (25 base + 19 DAT + 9 PlanoFormacoes)


### PR DESCRIPTION
## Summary
- Update expected serializer count from 52 to 53 in `test_modular_serializers.py`
- Accounts for new serializers added: `EventDetailSerializer`, `AuditLogTimelineSerializer`

## Test plan
- CI should pass after this fix