### PR TITLE
fix(frontend): ensure logout always completes even if API fails

### DIFF
--- a/v2/frontend/src/App.jsx
+++ b/v2/frontend/src/App.jsx
@@ -206,11 +206,15 @@ function AppContent() {
     try {
       await apiLogout();
       message.success('Logout realizado com sucesso');
+    } catch (error) {
+      // Log detalhado do erro
+      logger.error('Erro no logout:', error);
+      message.warning('Sessão encerrada localmente');
+    } finally {
+      // Sempre limpar estado local e redirecionar, mesmo se API falhar
+      setUser(null);
       // Recarregar a página para voltar para tela de login
       window.location.reload();
-    } catch (error) {
-      message.error('Erro ao fazer logout');
-      logger.error('Erro no logout:', error);
     }
   };
 

--- a/v2/frontend/src/api/auth.js
+++ b/v2/frontend/src/api/auth.js
@@ -7,7 +7,7 @@
  * - GET /api/me/ - Dados do usuário atual
  */
 
-import { fetchAPI } from './config';
+import { fetchAPI, clearCsrfCache } from './config';
 
 /**
  * Realiza login com username e senha
@@ -27,6 +27,8 @@ export async function logout() {
   const response = await fetchAPI('/auth/logout/', {
     method: 'POST',
   });
+  // Limpar cache de CSRF token após logout
+  clearCsrfCache();
   return response;
 }
 

--- a/v2/frontend/src/api/config.js
+++ b/v2/frontend/src/api/config.js
@@ -40,6 +40,13 @@ export function getCsrfToken() {
 let cachedCsrfToken = null;
 
 /**
+ * Limpa o cache de CSRF token (usar no logout).
+ */
+export function clearCsrfCache() {
+  cachedCsrfToken = null;
+}
+
+/**
  * Garante que CSRF token existe, caso contrário faz request para obtê-lo.
  *
  * Issue #135: Suporta CSRF_COOKIE_HTTPONLY=True usando endpoint /api/csrf/


### PR DESCRIPTION
## Summary

- Garante que o botão de logout sempre funciona, mesmo se a chamada à API falhar
- Adiciona padrão try-catch-finally no `handleLogout`
- Limpa cache de CSRF token após logout bem-sucedido

## Mudanças

1. **App.jsx**: `handleLogout` agora usa `finally` para sempre recarregar a página
2. **auth.js**: Chama `clearCsrfCache()` após logout bem-sucedido
3. **config.js**: Nova função `clearCsrfCache()` para limpar cache em memória

## Problema Resolvido

O botão "Sair" não funcionava quando:
- A sessão já havia expirado no servidor
- Havia erro de rede
- O token CSRF era inválido

Agora o logout **sempre** redireciona para a tela de login, mostrando:
- ✅ "Logout realizado com sucesso" - se API retornar 200
- ⚠️ "Sessão encerrada localmente" - se API falhar

## Test Plan

- [ ] Testar logout com sessão válida
- [ ] Testar logout após sessão expirar (aguardar 30min ou invalidar cookie)
- [ ] Verificar que CSRF token é limpo após logout