### PR TITLE
fix(frontend): fix CSRF errors and simplify rejection flow

### DIFF
--- a/v2/frontend/src/api/config.js
+++ b/v2/frontend/src/api/config.js
@@ -47,32 +47,11 @@ export function clearCsrfCache() {
 }
 
 /**
- * Garante que CSRF token existe, caso contrário faz request para obtê-lo.
+ * Busca um token CSRF fresco do servidor.
  *
- * Issue #135: Suporta CSRF_COOKIE_HTTPONLY=True usando endpoint /api/csrf/
- * que retorna o token no body da resposta (acessível ao JavaScript).
- *
- * Estratégia:
- * 1. Tenta ler do cookie (retrocompatibilidade se HttpOnly=False)
- * 2. Se não conseguir, usa cache em memória
- * 3. Se cache vazio, chama /api/csrf/ e lê do body da resposta
- *
- * @returns {Promise<string|null>} CSRF token
+ * @returns {Promise<string|null>} CSRF token fresco
  */
-export async function ensureCsrfToken() {
-  // Tentativa 1: Ler do cookie (retrocompatibilidade)
-  let token = getCsrfToken();
-  if (token) {
-    cachedCsrfToken = token; // Atualizar cache
-    return token;
-  }
-
-  // Tentativa 2: Usar cache em memória
-  if (cachedCsrfToken) {
-    return cachedCsrfToken;
-  }
-
-  // Tentativa 3: Obter via endpoint /api/csrf/ (Issue #135)
+async function fetchFreshCsrfToken() {
   try {
     const response = await fetch(`${API_BASE}/csrf/`, {
       method: 'GET',
@@ -81,32 +60,67 @@ export async function ensureCsrfToken() {
 
     if (response.ok) {
       const data = await response.json();
-      token = data.csrfToken;
+      const token = data.csrfToken;
 
       if (token) {
-        cachedCsrfToken = token; // Cachear em memória
+        cachedCsrfToken = token;
         return token;
       }
     }
   } catch (error) {
     logger.warn('Erro ao obter CSRF token via /api/csrf/:', error);
   }
-
-  // Fallback: retornar null e deixar request falhar com mensagem clara
   return null;
+}
+
+/**
+ * Garante que CSRF token existe, caso contrário faz request para obtê-lo.
+ *
+ * Issue #135: Suporta CSRF_COOKIE_HTTPONLY=True usando endpoint /api/csrf/
+ * que retorna o token no body da resposta (acessível ao JavaScript).
+ *
+ * Estratégia:
+ * 1. Tenta ler do cookie (retrocompatibilidade se HttpOnly=False)
+ * 2. Se não conseguir, busca token fresco do servidor
+ *
+ * @param {boolean} forceRefresh - Se true, ignora cache e busca token fresco
+ * @returns {Promise<string|null>} CSRF token
+ */
+export async function ensureCsrfToken(forceRefresh = false) {
+  // Se forceRefresh, buscar token fresco diretamente
+  if (forceRefresh) {
+    return await fetchFreshCsrfToken();
+  }
+
+  // Tentativa 1: Ler do cookie (retrocompatibilidade)
+  let token = getCsrfToken();
+  if (token) {
+    cachedCsrfToken = token; // Atualizar cache
+    return token;
+  }
+
+  // Tentativa 2: Usar cache em memória (se não muito antigo)
+  if (cachedCsrfToken) {
+    return cachedCsrfToken;
+  }
+
+  // Tentativa 3: Obter via endpoint /api/csrf/ (Issue #135)
+  return await fetchFreshCsrfToken();
 }
 
 /**
  * Wrapper genérico para fetch com autenticação, CSRF e tratamento de erros.
  *
  * Issue #135: Usa ensureCsrfToken() para suportar CSRF_COOKIE_HTTPONLY=True
+ * Retry automático: Se receber erro CSRF (403 com "CSRF"), busca token fresco e retenta.
  *
  * @param {string} url - URL relativa (ex: '/solicitacoes/') ou absoluta
  * @param {object} options - Opções do fetch (method, body, headers, etc.)
+ * @param {boolean} isRetry - Flag interna para evitar loop infinito de retry
  * @returns {Promise<object>} Response JSON
  * @throws {Error} Se request falhar ou CSRF estiver ausente
  */
-export async function fetchAPI(url, options = {}) {
+export async function fetchAPI(url, options = {}, isRetry = false) {
   const fullUrl = url.startsWith('http') ? url : `${API_BASE}${url}`;
 
   const headers = {
@@ -117,7 +131,8 @@ export async function fetchAPI(url, options = {}) {
   // Adicionar CSRF para métodos mutantes (Issue #135: usa ensureCsrfToken)
   const method = options.method?.toUpperCase() || 'GET';
   if (['POST', 'PUT', 'PATCH', 'DELETE'].includes(method)) {
-    const csrfToken = await ensureCsrfToken();
+    // Se é retry, forçar refresh do token
+    const csrfToken = await ensureCsrfToken(isRetry);
 
     if (!csrfToken) {
       logger.error('CSRF token não encontrado! Verifique se está autenticado.');
@@ -142,11 +157,18 @@ export async function fetchAPI(url, options = {}) {
   });
 
   if (!response.ok) {
+    const errorBody = await response.text();
+
+    // Detectar erro de CSRF e fazer retry com token fresco (apenas uma vez)
+    if (response.status === 403 && errorBody.includes('CSRF') && !isRetry) {
+      logger.warn('CSRF token inválido, buscando token fresco e retentando...');
+      clearCsrfCache();
+      return fetchAPI(url, options, true); // Retry com flag
+    }
+
     logger.error('=== fetchAPI ERROR ===');
     logger.error('Status:', response.status);
     logger.error('StatusText:', response.statusText);
-
-    const errorBody = await response.text();
     logger.error('Response body:', errorBody);
 
     let error;

--- a/v2/frontend/src/api/solicitacoes.js
+++ b/v2/frontend/src/api/solicitacoes.js
@@ -77,13 +77,13 @@ export async function approveSolicitacao(id, reason = '') {
  * Reprova uma solicitação pendente.
  *
  * @param {number} id - ID da solicitação
- * @param {string} reason - Motivo/justificativa (obrigatório)
+ * @param {string} reason - Motivo/justificativa (opcional)
  * @returns {Promise<object>} Solicitação atualizada
  */
-export async function rejectSolicitacao(id, reason) {
+export async function rejectSolicitacao(id, reason = '') {
   return await fetchAPI(`/solicitacoes/${id}/reject/`, {
     method: 'PATCH',
-    body: JSON.stringify({ reason }),
+    body: JSON.stringify(reason ? { reason } : {}),
   });
 }
 

--- a/v2/frontend/src/pages/Aprovacoes/ApprovalsPage.jsx
+++ b/v2/frontend/src/pages/Aprovacoes/ApprovalsPage.jsx
@@ -5,7 +5,7 @@
  * - Filtra solicitações pendentes do fluxo SUPER
  * - Botões para preview, aprovar e reprovar
  * - Modal para preview de payload JSON
- * - Modal para reprovação com justificativa obrigatória
+ * - Confirmação simples para reprovação (sem justificativa obrigatória)
  *
  * PA-06 (Política de Aprovação Manual):
  * - Botões de aprovar/reprovar aparecem para: Superintendência, DAT, e Superusuários
@@ -25,7 +25,6 @@ import {
   Typography,
   message,
   Modal,
-  Form,
   Descriptions,
   Divider,
   List,
@@ -51,7 +50,6 @@ import {
 import { getMe } from '../../api/availability';
 
 const { Title, Paragraph } = Typography;
-const { TextArea } = Input;
 
 const STATUS_COLORS = {
   pendente: 'orange',
@@ -75,10 +73,6 @@ export default function ApprovalsPage() {
 
   const [previewVisible, setPreviewVisible] = useState(false);
   const [previewData, setPreviewData] = useState(null);
-
-  const [rejectVisible, setRejectVisible] = useState(false);
-  const [rejectId, setRejectId] = useState(null);
-  const [rejectForm] = Form.useForm();
 
   // PA-06: Estado para verificar permissão do usuário (Superintendência, DAT, Superusuários)
   const [canApprove, setCanApprove] = useState(false);
@@ -148,21 +142,23 @@ export default function ApprovalsPage() {
     });
   };
 
-  const handleRejectClick = (id) => {
-    setRejectId(id);
-    setRejectVisible(true);
-    rejectForm.resetFields();
-  };
-
-  const handleRejectConfirm = async (values) => {
-    try {
-      await rejectSolicitacao(rejectId, values.reason);
-      message.success('Solicitação reprovada.');
-      setRejectVisible(false);
-      loadData();
-    } catch (error) {
-      message.error('Erro ao reprovar: ' + error.message);
-    }
+  const handleReject = (id) => {
+    Modal.confirm({
+      title: 'Confirmar Reprovação',
+      content: 'Deseja reprovar esta solicitação?',
+      okText: 'Reprovar',
+      okType: 'danger',
+      cancelText: 'Cancelar',
+      onOk: async () => {
+        try {
+          await rejectSolicitacao(id);
+          message.success('Solicitação reprovada.');
+          loadData();
+        } catch (error) {
+          message.error('Erro ao reprovar: ' + error.message);
+        }
+      },
+    });
   };
 
   // Colunas da tabela (otimizadas para caber na tela)
@@ -270,7 +266,7 @@ export default function ApprovalsPage() {
                 size="small"
                 danger
                 icon={<CloseOutlined />}
-                onClick={() => handleRejectClick(record.id)}
+                onClick={() => handleReject(record.id)}
               >
                 Reprovar
               </Button>
@@ -459,25 +455,6 @@ export default function ApprovalsPage() {
         )}
       </Modal>
 
-      {/* Modal Rejeitar */}
-      <Modal
-        title="Reprovar Solicitação"
-        open={rejectVisible}
-        onCancel={() => setRejectVisible(false)}
-        onOk={() => rejectForm.submit()}
-        okText="Reprovar"
-        okButtonProps={{ danger: true }}
-      >
-        <Form form={rejectForm} layout="vertical" onFinish={handleRejectConfirm}>
-          <Form.Item
-            label="Motivo da Reprovação"
-            name="reason"
-            rules={[{ required: true, message: 'O motivo é obrigatório' }]}
-          >
-            <TextArea rows={4} placeholder="Digite o motivo da reprovação..." />
-          </Form.Item>
-        </Form>
-      </Modal>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Corrige dois problemas na página de aprovações:

### 1. Erro de CSRF ao aprovar/reprovar
**Problema**: "CSRF Failed: CSRF token from the 'X-Csrftoken' HTTP header incorrect"

**Causa**: Token CSRF em cache estava desatualizado (após login ou rotação de sessão)

**Solução**:
- Retry automático em erros CSRF (status 403 + "CSRF" no body)
- Limpa cache e busca token fresco antes de retentar
- Adicionado parâmetro `forceRefresh` em `ensureCsrfToken()`

### 2. Modal de reprovação com campo obrigatório
**Problema**: Exigia motivo de reprovação em caixa de texto

**Solução**:
- Substituído modal de formulário por `Modal.confirm()` simples
- Mesmo padrão usado na aprovação
- Motivo agora é opcional (backend já aceitava vazio)

## Arquivos Modificados

| Arquivo | Mudança |
|---------|---------|
| `config.js` | Auto-retry CSRF, `fetchFreshCsrfToken()`, `forceRefresh` param |
| `solicitacoes.js` | `reason` agora é opcional |
| `ApprovalsPage.jsx` | Popup simples em vez de form modal |

## Test Plan

- [ ] Testar aprovação de solicitação
- [ ] Testar reprovação de solicitação (deve mostrar popup simples)
- [ ] Testar com sessão expirada (deve fazer retry com token fresco)