### PR TITLE
perf(frontend): optimize polling and table rendering (#259, #260)

### DIFF
--- a/v2/frontend/src/App.jsx
+++ b/v2/frontend/src/App.jsx
@@ -137,6 +137,7 @@ function AppContent() {
   }, [loadUser]);
 
   // Issue #97: Polling de alertas GCal (badge + toast)
+  // Issue #259: Pausar polling quando aba não está visível (Page Visibility API)
   useEffect(() => {
     // Só ativar polling para Controle (Gerentes de Controle)
     const inControle = user?.setores?.includes('Controle');
@@ -147,6 +148,7 @@ function AppContent() {
 
     const POLL_MS = 30000; // 30 segundos
     const COOLDOWN_MS = 120000; // 2 minutos de cooldown para toast
+    let intervalId = null;
 
     const fetchAlerts = async () => {
       try {
@@ -185,20 +187,50 @@ function AppContent() {
       }
     };
 
+    // Issue #259: Funções para controlar polling baseado em visibilidade
+    const startPolling = () => {
+      if (!intervalId) {
+        intervalId = setInterval(fetchAlerts, POLL_MS);
+      }
+    };
+
+    const stopPolling = () => {
+      if (intervalId) {
+        clearInterval(intervalId);
+        intervalId = null;
+      }
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.hidden) {
+        stopPolling();
+      } else {
+        // Fetch imediato ao voltar, depois retomar polling
+        fetchAlerts();
+        startPolling();
+      }
+    };
+
     // Carregar lastErrorsCount do localStorage na inicialização
     const stored = localStorage.getItem('gcalAlertsLastErrors');
     if (stored) {
       setLastErrorsCount(parseInt(stored, 10) || 0);
     }
 
-    // Fetch inicial
+    // Setup: listener de visibilidade
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    // Fetch inicial e iniciar polling se aba está visível
     fetchAlerts();
+    if (!document.hidden) {
+      startPolling();
+    }
 
-    // Polling a cada 30s
-    const intervalId = setInterval(fetchAlerts, POLL_MS);
-
-    // Cleanup: parar polling no unmount
-    return () => clearInterval(intervalId);
+    // Cleanup: parar polling e remover listener
+    return () => {
+      stopPolling();
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
   }, [user, lastErrorsCount, cooldownUntil]);
 
   if (loading) {

--- a/v2/frontend/src/pages/Aprovacoes/ApprovalsPage.jsx
+++ b/v2/frontend/src/pages/Aprovacoes/ApprovalsPage.jsx
@@ -13,7 +13,7 @@
  * - Conformidade ISO 9241-110: Controle explícito (usuário vê apenas ações permitidas)
  */
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import {
   Table,
   Card,
@@ -119,7 +119,8 @@ export default function ApprovalsPage() {
     loadUser();
   }, []);
 
-  const handlePreview = async (id) => {
+  // Issue #260: Memoizar handlers para evitar re-renderização desnecessária
+  const handlePreview = useCallback(async (id) => {
     try {
       const data = await previewSolicitacao(id);
       setPreviewData(data);
@@ -127,9 +128,9 @@ export default function ApprovalsPage() {
     } catch (error) {
       message.error('Erro ao visualizar payload: ' + error.message);
     }
-  };
+  }, []);
 
-  const handleApprove = (id) => {
+  const handleApprove = useCallback((id) => {
     Modal.confirm({
       title: 'Confirmar Aprovação',
       content: 'Deseja aprovar esta solicitação?',
@@ -146,9 +147,9 @@ export default function ApprovalsPage() {
         }
       },
     });
-  };
+  }, [loadData]);
 
-  const handleReject = (id) => {
+  const handleReject = useCallback((id) => {
     Modal.confirm({
       title: 'Confirmar Reprovação',
       content: 'Deseja reprovar esta solicitação?',
@@ -165,7 +166,7 @@ export default function ApprovalsPage() {
         }
       },
     });
-  };
+  }, [loadData]);
 
   // Handlers de operações em lote
   const handleBatchApprove = () => {
@@ -242,8 +243,8 @@ export default function ApprovalsPage() {
     ],
   } : undefined;
 
-  // Colunas da tabela (otimizadas para caber na tela)
-  const columns = [
+  // Issue #260: Memoizar columns para evitar re-renderização desnecessária da tabela
+  const columns = useMemo(() => [
     {
       title: 'Data/Horário',
       key: 'data_horario',
@@ -356,7 +357,7 @@ export default function ApprovalsPage() {
         </Space>
       ),
     },
-  ];
+  ], [handlePreview, handleApprove, handleReject, canApprove]);
 
   return (
     <div style={{ padding: '24px' }}>

--- a/v2/frontend/src/pages/PreAgenda/PreAgendaPage.jsx
+++ b/v2/frontend/src/pages/PreAgenda/PreAgendaPage.jsx
@@ -9,7 +9,7 @@
  * - Operações em lote (Reapply/Resync) via seleção múltipla
  */
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import {
   Table,
   Card,
@@ -142,7 +142,8 @@ export default function PreAgendaPage() {
     loadData();
   }, [loadData]);
 
-  const handlePreview = async (id) => {
+  // Issue #260: Memoizar handlers para evitar re-renderização desnecessária
+  const handlePreview = useCallback(async (id) => {
     try {
       const data = await previewSolicitacao(id);
       setPreviewData(data);
@@ -150,9 +151,9 @@ export default function PreAgendaPage() {
     } catch (error) {
       message.error('Erro ao visualizar payload: ' + error.message);
     }
-  };
+  }, []);
 
-  const handlePublish = (id) => {
+  const handlePublish = useCallback((id) => {
     // OAuth Phase 5: Guarda - verificar conexão Google
     if (googleStatus && !googleStatus.connected) {
       Modal.confirm({
@@ -206,9 +207,9 @@ export default function PreAgendaPage() {
         }
       },
     });
-  };
+  }, [googleStatus, loadData]);
 
-  const handleResync = (id) => {
+  const handleResync = useCallback((id) => {
     // OAuth Phase 5: Guarda - verificar conexão Google
     if (googleStatus && !googleStatus.connected) {
       Modal.confirm({
@@ -270,9 +271,9 @@ export default function PreAgendaPage() {
         }
       },
     });
-  };
+  }, [googleStatus, loadData]);
 
-  const handleCancel = (id) => {
+  const handleCancel = useCallback((id) => {
     Modal.confirm({
       title: 'Confirmar Cancelamento',
       icon: <StopOutlined style={{ color: '#ff4d4f' }} />,
@@ -297,7 +298,7 @@ export default function PreAgendaPage() {
         }
       },
     });
-  };
+  }, [loadData]);
 
   // Issue #95: Batch Reapply
   const handleBatchReapply = () => {
@@ -489,7 +490,8 @@ export default function PreAgendaPage() {
     });
   };
 
-  const columns = [
+  // Issue #260: Memoizar columns para evitar re-renderização desnecessária da tabela
+  const columns = useMemo(() => [
     {
       title: 'Data/Hora',
       dataIndex: 'inicio',
@@ -579,7 +581,7 @@ export default function PreAgendaPage() {
         );
       },
     },
-  ];
+  ], [handlePreview, handlePublish, handleResync, handleCancel]);
 
   // OAuth Phase 5: RBAC - verificar se é Controle ou Super
   const canControle = user?.is_superuser || user?.groups?.includes('Controle');


### PR DESCRIPTION
## Summary
- **Issue #259**: Pause polling when tab hidden via Page Visibility API
- **Issue #260**: Memoize columns arrays with useMemo + useCallback

## Changes
- `App.jsx`: Use `document.hidden` + `visibilitychange` event to control polling lifecycle
- `ApprovalsPage.jsx`: Wrap handlers with useCallback, columns with useMemo
- `PreAgendaPage.jsx`: Same pattern for handlers and columns

## Test plan
- [ ] Open Aprovações page, switch tabs, verify no network requests while hidden
- [ ] Return to tab, verify polling resumes
- [ ] Tables should not re-render on unrelated state changes

Fixes #259, Fixes #260