### PR TITLE
chore(backend): move ALLOWED_GROUPS to settings (#254)

### DIFF
--- a/v2/backend/apps/core/serializers/usuario.py
+++ b/v2/backend/apps/core/serializers/usuario.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
 from django.contrib.auth.password_validation import validate_password
@@ -75,8 +76,9 @@ class UsuarioAdminSerializer(serializers.ModelSerializer):
         """Return group IDs for frontend editing."""
         return [g.id for g in obj.groups.all()]
 
-    # Whitelist of allowed groups (P1.1) - incluindo Gerência
-    ALLOWED_GROUPS = {"DAT", "Controle", "Superintendência", "Coordenador", "Formador", "Gerência"}
+    # Whitelist of allowed groups (P1.1) - configurável via settings (Issue #254)
+    # Fallback para set vazio se não configurado (todos os grupos bloqueados)
+    ALLOWED_GROUPS: set[str] = getattr(settings, "ALLOWED_USER_GROUPS", set())
 
     class Meta:
         model = get_user_model()

--- a/v2/backend/config/settings.py
+++ b/v2/backend/config/settings.py
@@ -505,6 +505,33 @@ ETL_REQUIRE_ZERO_INVALID_DATES = (
 )  # Se True, aborta se houver datas/horas inválidas
 
 # ================================================================
+# RBAC: Grupos permitidos para usuários (Issue #254)
+# ================================================================
+# Lista de grupos que podem ser atribuídos a usuários via admin/API.
+# Estrutura: Setores (onde trabalha) + Funções (o que pode fazer)
+# Ref: .claude/PLANO_RBAC_SETOR_FUNCAO.md
+ALLOWED_USER_GROUPS: set[str] = {
+    # === SETORES (10) - Onde o usuário trabalha ===
+    # Gerências de projeto
+    "Superintendência",  # SUPERINTENDENCIA - Fluxo SUPER
+    "Vidas",             # GERENCIA 2 - Fluxo NAO_SUPER
+    "Fluir",             # GERENCIA 3 - Fluxo NAO_SUPER
+    "ACerta",            # GERENCIA 4 - Fluxo NAO_SUPER
+    "Brincando",         # GERENCIA 5 - Fluxo NAO_SUPER
+    "Sou da Paz",        # GERENCIA 6 - Fluxo NAO_SUPER
+    # Setores administrativos/operacionais
+    "DAT",               # Departamento de Apoio Técnico
+    "Controle",          # Setor de Controle
+    "Gerência",          # Gerência genérica
+    "Diretoria",         # Diretoria - Acesso a dashboards
+    # === FUNÇÕES (4) - O que o usuário pode fazer ===
+    "Formador",              # Visualiza grade, gerencia bloqueios pessoais
+    "Coordenador",           # Cria solicitações de eventos
+    "Apoio de Coordenação",  # Auxilia coordenação
+    "Gerente",               # Aprova/reprova, dashboards e relatórios
+}
+
+# ================================================================
 # SECURITY (Production)
 # ================================================================
 if not DEBUG:


### PR DESCRIPTION
## Summary
Move hardcoded `ALLOWED_GROUPS` from serializer to `settings.py` for better configurability.

## Changes
- **settings.py**: Add `ALLOWED_USER_GROUPS` with all 14 RBAC groups
- **serializers/usuario.py**: Read from settings instead of hardcoded set

## Before
```python
# serializers/usuario.py
ALLOWED_GROUPS = {"DAT", "Controle", "Superintendência", "Coordenador", "Formador", "Gerência"}
# Only 6 groups!
```

## After
```python
# settings.py
ALLOWED_USER_GROUPS = {
    # 10 Setores
    "Superintendência", "Vidas", "Fluir", "ACerta", "Brincando",
    "Sou da Paz", "DAT", "Controle", "Gerência", "Diretoria",
    # 4 Funções
    "Formador", "Coordenador", "Apoio de Coordenação", "Gerente",
}

# serializers/usuario.py
ALLOWED_GROUPS = getattr(settings, "ALLOWED_USER_GROUPS", set())
```

## Benefits
- New groups can be added via settings without code changes
- Better alignment with RBAC structure (10 Setores + 4 Funções)
- All existing groups now included (was missing 8 groups!)

## Test Plan
- [x] `python manage.py check` passes
- [x] 20 RBAC tests passing
- [x] Verified setting loads correctly in serializer

Closes #254