### PR TITLE
docs(compliance): update PA-02 to include DAT (#244)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -408,7 +408,8 @@ from apps.core.services.gcal.sync import apply_one_solicitacao
 Estas regras estão definidas em `.claude/CLAUDE.md` e são **imutáveis**:
 
 - **PA-01**: Sem auto-aprovação. Uma Solicitação **nunca** muda para "Aprovada" automaticamente.
-- **PA-02**: Apenas usuários com **Gerente + Superintendência** (ou superuser) podem aprovar/reprovar. Ver seção RBAC.
+- **PA-02 (Adaptada)**: Usuários com **Superintendência**, **DAT** ou **superuser** podem aprovar/reprovar.
+  - _Histórico_: Originalmente era "Gerente + Superintendência". Adaptado para incluir DAT (ver `permissions.py`).
 - **PA-03**: Integrações externas (Google Calendar, etc.) só executam **após** aprovação manual concluída.
 - **PA-04**: Toda solicitação nasce com `status = pendente`.
 - **PA-05**: Registrar usuário, data/hora e justificativa em `Aprovacao` e `LogAuditoria`.
@@ -736,8 +737,9 @@ As regras abaixo consolidam a lógica original das planilhas e devem ser aplicad
 
 ## Política de Aprovação Manual (Obrigatória)
 
-- **PA-01 — Sem auto-aprovação**: Uma `Solicitacao` **nunca** muda para “Aprovada” automaticamente, mesmo se não houver conflitos.  
-- **PA-02 — Perfil exigido**: Apenas usuários com **Gerente + Superintendência** (ou superuser) podem aprovar/reprovar. Ver seção RBAC.  
+- **PA-01 — Sem auto-aprovação**: Uma `Solicitacao` **nunca** muda para "Aprovada" automaticamente, mesmo se não houver conflitos.
+- **PA-02 — Perfil exigido (Adaptada)**: Usuários com **Superintendência**, **DAT** ou **superuser** podem aprovar/reprovar.
+  - _Histórico_: Originalmente era "Gerente + Superintendência". Adaptado para incluir DAT (ver `permissions.py`).
 - **PA-03 — Gatilhos pós-aprovação**: Integrações externas (RF05/RF06) só executam **após** aprovação manual concluída.  
 - **PA-04 — Estado inicial**: Toda solicitação nasce com `status = pendente`.  
 - **PA-05 — Auditoria**: Registrar usuário, data/hora e justificativa (quando houver) em `Aprovacao` e `LogAuditoria`.  
@@ -756,7 +758,7 @@ As regras abaixo consolidam a lógica original das planilhas e devem ser aplicad
 **Status**: Implementado e testado (5/5 testes passando)
 **Documentação Completa**: [v2/docs/IMPLEMENTACAO_PA.md](../v2/docs/IMPLEMENTACAO_PA.md)
 
-**Resumo**: PR17 implementou conformidade total com Política de Aprovação Manual (CP-02): sem auto-aprovação (PA-01), apenas Superintendência aprova (PA-02), integrações após aprovação (PA-03), AuditLog persistente (PA-05), botões ocultos (PA-06), 5 testes obrigatórios (PA-07).
+**Resumo**: PR17 implementou conformidade total com Política de Aprovação Manual (CP-02): sem auto-aprovação (PA-01), Superintendência/DAT/superuser aprovam (PA-02 Adaptada), integrações após aprovação (PA-03), AuditLog persistente (PA-05), botões ocultos (PA-06), 5 testes obrigatórios (PA-07).
 
 **Arquivos modificados**: `models.py` (Solicitacao.save), `views.py` (approve/reject + AuditLog), `test_approval_policy_PA.py` (5 testes), `ApprovalsPage.jsx` (PA-06).
 

--- a/v2/docs/IMPLEMENTACAO_PA.md
+++ b/v2/docs/IMPLEMENTACAO_PA.md
@@ -8,7 +8,7 @@
 
 PR17 implementa conformidade total com a Política de Aprovação Manual (CP-02), garantindo que:
 1. Nenhuma solicitação é auto-aprovada (PA-01)
-2. Apenas Superintendência pode aprovar/reprovar (PA-02)
+2. Superintendência, DAT ou superuser podem aprovar/reprovar (PA-02 Adaptada)
 3. Integrações externas só executam após aprovação (PA-03)
 4. Auditoria completa em AuditLog (PA-05)
 5. Botões ocultos para não-autorizados no frontend (PA-06)
@@ -105,7 +105,7 @@ test_approval_policy_PA.py::test_approval_flow_records_audit_log PASSED
 | Requisito | Status | Implementação | Arquivo |
 |-----------|--------|---------------|---------|
 | **PA-01** | ✅ | Sem auto-aprovação em `Solicitacao.save()` | `models.py:412-436` |
-| **PA-02** | ✅ | Permission class `IsSuperintendencia` + endpoints protegidos | `permissions.py`, `views.py` |
+| **PA-02 (Adaptada)** | ✅ | Permission class `IsSuperintendencia` (inclui DAT) + endpoints protegidos | `permissions.py`, `views.py` |
 | **PA-03** | ✅ | Celery task `task_publish_solicitacao_to_gcal` validado via mock | `test_approval_policy_PA.py:201-262` |
 | **PA-04** | ✅ | Campo `status` tem `default='pendente'` | `models.py:120` |
 | **PA-05** | ✅ | `AuditLog.objects.create()` em approve/reject | `views.py:165-220, 236-290` |


### PR DESCRIPTION
## Summary
Update documentation to reflect that PA-02 was adapted to include DAT in the approval permission.

## Problem
| Local | O que dizia |
|-------|-------------|
| CLAUDE.md | "Apenas **Gerente + Superintendência** podem aprovar" |
| permissions.py | "Superintendência, **DAT** e Superusuários podem aprovar" |

The code was intentionally adapted but documentation wasn't updated.

## Changes
**CLAUDE.md** (3 locations):
```markdown
# ANTES:
- **PA-02**: Apenas usuários com **Gerente + Superintendência** podem aprovar

# DEPOIS:
- **PA-02 (Adaptada)**: Usuários com **Superintendência**, **DAT** ou **superuser** podem aprovar
  - _Histórico_: Originalmente era "Gerente + Superintendência". Adaptado para incluir DAT.
```

**IMPLEMENTACAO_PA.md**:
- Updated summary and compliance table

## Why this matters
- Developers reading CLAUDE.md might think DAT cannot approve
- Could cause confusion and UX bugs (hiding buttons when shouldn't)

Closes #244