### PR TITLE
test(backend): add RBAC tests for approve/reject endpoints

### DIFF
--- a/v2/backend/apps/core/tests/test_rbac_endpoints.py
+++ b/v2/backend/apps/core/tests/test_rbac_endpoints.py
@@ -1,0 +1,292 @@
+"""
+Testes RBAC para endpoints de aprovação/reprovação.
+
+Issue #250: Garantir cobertura de testes para permissões nos endpoints:
+- POST/PATCH /api/solicitacoes/{id}/approve/
+- POST/PATCH /api/solicitacoes/{id}/reject/
+
+Complementa test_approval_policy_PA.py com cenários adicionais:
+- DAT pode aprovar (PA-02 Adaptada)
+- Usuário não autenticado recebe 401
+- Formador (sem permissão) recebe 403
+"""
+from datetime import timedelta
+from uuid import uuid4
+
+import pytest
+from django.contrib.auth.models import Group
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from apps.core.models import Municipio, Projeto, Solicitacao, TipoEvento, Usuario
+
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def grupo_superintendencia():
+    """Grupo Superintendência."""
+    grupo, _ = Group.objects.get_or_create(name="Superintendência")
+    return grupo
+
+
+@pytest.fixture
+def grupo_dat():
+    """Grupo DAT."""
+    grupo, _ = Group.objects.get_or_create(name="DAT")
+    return grupo
+
+
+@pytest.fixture
+def grupo_formador():
+    """Grupo Formador."""
+    grupo, _ = Group.objects.get_or_create(name="Formador")
+    return grupo
+
+
+@pytest.fixture
+def user_superintendencia(grupo_superintendencia):
+    """Usuário do grupo Superintendência."""
+    uid = uuid4().hex[:8]
+    user = Usuario.objects.create_user(
+        username=f"super_rbac_{uid}",
+        email=f"super_rbac_{uid}@test.com",
+        password="testpass123",
+        cpf=str(uuid4().int % 10**11).zfill(11),
+    )
+    user.groups.add(grupo_superintendencia)
+    return user
+
+
+@pytest.fixture
+def user_dat(grupo_dat):
+    """Usuário do grupo DAT."""
+    uid = uuid4().hex[:8]
+    user = Usuario.objects.create_user(
+        username=f"dat_rbac_{uid}",
+        email=f"dat_rbac_{uid}@test.com",
+        password="testpass123",
+        cpf=str(uuid4().int % 10**11).zfill(11),
+    )
+    user.groups.add(grupo_dat)
+    return user
+
+
+@pytest.fixture
+def user_formador(grupo_formador):
+    """Usuário do grupo Formador (sem permissão de aprovação)."""
+    uid = uuid4().hex[:8]
+    user = Usuario.objects.create_user(
+        username=f"formador_rbac_{uid}",
+        email=f"formador_rbac_{uid}@test.com",
+        password="testpass123",
+        cpf=str(uuid4().int % 10**11).zfill(11),
+    )
+    user.groups.add(grupo_formador)
+    return user
+
+
+@pytest.fixture
+def solicitacao_pendente(user_formador):
+    """Solicitação pendente para testes RBAC."""
+    municipio, _ = Municipio.objects.get_or_create(
+        nome="Fortaleza RBAC", defaults={"uf": "CE", "ativo": True}
+    )
+    projeto, _ = Projeto.objects.get_or_create(
+        nome="Projeto RBAC SUPER",
+        defaults={"ativo": True, "fluxo": "SUPER"},
+    )
+    tipo_evento, _ = TipoEvento.objects.get_or_create(nome="Formação RBAC")
+
+    now = timezone.now()
+    return Solicitacao.objects.create(
+        usuario=user_formador,
+        municipio=municipio,
+        projeto=projeto,
+        tipo_evento=tipo_evento,
+        inicio=now + timedelta(days=1),
+        fim=now + timedelta(days=1, hours=2),
+        status="pendente",
+    )
+
+
+class TestRBACApprovalEndpoints:
+    """Testes RBAC para endpoints /approve/ e /reject/."""
+
+    def test_unauthenticated_cannot_approve(self, solicitacao_pendente):
+        """Usuário não autenticado recebe 401 ou 403 ao tentar aprovar.
+
+        Nota: DRF pode retornar 401 ou 403 dependendo da configuração de autenticação.
+        Ambos são válidos para indicar acesso negado a usuários não autenticados.
+        """
+        client = APIClient()
+        # Não autenticar - cliente sem credenciais
+
+        response = client.patch(
+            f"/api/solicitacoes/{solicitacao_pendente.id}/approve/"
+        )
+
+        assert response.status_code in (
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        ), f"Esperado 401 ou 403, recebido {response.status_code}"
+
+    def test_unauthenticated_cannot_reject(self, solicitacao_pendente):
+        """Usuário não autenticado recebe 401 ou 403 ao tentar reprovar.
+
+        Nota: DRF pode retornar 401 ou 403 dependendo da configuração de autenticação.
+        """
+        client = APIClient()
+
+        response = client.patch(
+            f"/api/solicitacoes/{solicitacao_pendente.id}/reject/",
+            {"justificativa": "Teste"},
+        )
+
+        assert response.status_code in (
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        ), f"Esperado 401 ou 403, recebido {response.status_code}"
+
+    def test_formador_cannot_approve(self, solicitacao_pendente, user_formador):
+        """Formador recebe 403 ao tentar aprovar."""
+        client = APIClient()
+        client.force_authenticate(user=user_formador)
+
+        response = client.patch(
+            f"/api/solicitacoes/{solicitacao_pendente.id}/approve/"
+        )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN, (
+            f"Esperado 403, recebido {response.status_code}"
+        )
+
+    def test_formador_cannot_reject(self, solicitacao_pendente, user_formador):
+        """Formador recebe 403 ao tentar reprovar."""
+        client = APIClient()
+        client.force_authenticate(user=user_formador)
+
+        response = client.patch(
+            f"/api/solicitacoes/{solicitacao_pendente.id}/reject/",
+            {"justificativa": "Teste"},
+        )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN, (
+            f"Esperado 403, recebido {response.status_code}"
+        )
+
+    def test_dat_can_approve(self, solicitacao_pendente, user_dat):
+        """DAT pode aprovar (PA-02 Adaptada).
+
+        PA-02 foi adaptada para incluir DAT além de Superintendência.
+        Ver IsSuperintendencia permission class.
+        """
+        client = APIClient()
+        client.force_authenticate(user=user_dat)
+
+        response = client.patch(
+            f"/api/solicitacoes/{solicitacao_pendente.id}/approve/"
+        )
+
+        assert response.status_code in (
+            status.HTTP_200_OK,
+            status.HTTP_204_NO_CONTENT,
+        ), f"DAT deve poder aprovar, recebido {response.status_code}"
+
+        # Verificar que status mudou para aprovado
+        solicitacao_pendente.refresh_from_db()
+        assert solicitacao_pendente.status == "aprovado"
+
+    def test_dat_can_reject(self, user_dat, user_formador):
+        """DAT pode reprovar (PA-02 Adaptada)."""
+        # Criar nova solicitação para este teste
+        municipio, _ = Municipio.objects.get_or_create(
+            nome="Fortaleza RBAC", defaults={"uf": "CE", "ativo": True}
+        )
+        projeto, _ = Projeto.objects.get_or_create(
+            nome="Projeto RBAC SUPER",
+            defaults={"ativo": True, "fluxo": "SUPER"},
+        )
+        tipo_evento, _ = TipoEvento.objects.get_or_create(nome="Formação RBAC")
+
+        now = timezone.now()
+        solicitacao = Solicitacao.objects.create(
+            usuario=user_formador,
+            municipio=municipio,
+            projeto=projeto,
+            tipo_evento=tipo_evento,
+            inicio=now + timedelta(days=2),
+            fim=now + timedelta(days=2, hours=2),
+            status="pendente",
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=user_dat)
+
+        response = client.patch(
+            f"/api/solicitacoes/{solicitacao.id}/reject/",
+            {"justificativa": "Reprovado pelo DAT"},
+        )
+
+        assert response.status_code in (
+            status.HTTP_200_OK,
+            status.HTTP_204_NO_CONTENT,
+        ), f"DAT deve poder reprovar, recebido {response.status_code}"
+
+        # Verificar que status mudou para reprovado
+        solicitacao.refresh_from_db()
+        assert solicitacao.status == "reprovado"
+
+    def test_superintendencia_can_approve(
+        self, solicitacao_pendente, user_superintendencia
+    ):
+        """Superintendência pode aprovar (PA-02)."""
+        client = APIClient()
+        client.force_authenticate(user=user_superintendencia)
+
+        response = client.patch(
+            f"/api/solicitacoes/{solicitacao_pendente.id}/approve/"
+        )
+
+        assert response.status_code in (
+            status.HTTP_200_OK,
+            status.HTTP_204_NO_CONTENT,
+        ), f"Superintendência deve poder aprovar, recebido {response.status_code}"
+
+    def test_superintendencia_can_reject(self, user_superintendencia, user_formador):
+        """Superintendência pode reprovar (PA-02)."""
+        # Criar nova solicitação para este teste
+        municipio, _ = Municipio.objects.get_or_create(
+            nome="Fortaleza RBAC", defaults={"uf": "CE", "ativo": True}
+        )
+        projeto, _ = Projeto.objects.get_or_create(
+            nome="Projeto RBAC SUPER",
+            defaults={"ativo": True, "fluxo": "SUPER"},
+        )
+        tipo_evento, _ = TipoEvento.objects.get_or_create(nome="Formação RBAC")
+
+        now = timezone.now()
+        solicitacao = Solicitacao.objects.create(
+            usuario=user_formador,
+            municipio=municipio,
+            projeto=projeto,
+            tipo_evento=tipo_evento,
+            inicio=now + timedelta(days=3),
+            fim=now + timedelta(days=3, hours=2),
+            status="pendente",
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=user_superintendencia)
+
+        response = client.patch(
+            f"/api/solicitacoes/{solicitacao.id}/reject/",
+            {"justificativa": "Reprovado pela Superintendência"},
+        )
+
+        assert response.status_code in (
+            status.HTTP_200_OK,
+            status.HTTP_204_NO_CONTENT,
+        ), f"Superintendência deve poder reprovar, recebido {response.status_code}"

--- a/v2/backend/apps/core/views/solicitacao.py
+++ b/v2/backend/apps/core/views/solicitacao.py
@@ -73,11 +73,14 @@ class SolicitacaoViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self) -> QuerySet:
         """
-        Filtrar solicitações por usuário (exceto Superintendência/superuser que vê todas).
+        Filtrar solicitações por usuário.
+
+        PA-02 (Adaptada): Superintendência, DAT e superusers veem todas as solicitações.
+        Outros usuários veem apenas suas próprias solicitações.
         """
         if (
             self.request.user.is_superuser
-            or self.request.user.groups.filter(name="Superintendência").exists()
+            or self.request.user.groups.filter(name__in=["Superintendência", "DAT"]).exists()
         ):
             return Solicitacao.objects.select_related(
                 "usuario", "municipio", "tipo_evento", "projeto"

--- a/v2/backend/apps/core/views_solicitacao.py
+++ b/v2/backend/apps/core/views_solicitacao.py
@@ -94,7 +94,7 @@ class SolicitacaoViewSet(viewsets.ModelViewSet):
             )
         elif (
             self.request.user.is_superuser
-            or self.request.user.groups.filter(name__in=["Superintendência", "Controle"]).exists()
+            or self.request.user.groups.filter(name__in=["Superintendência", "Controle", "DAT"]).exists()
         ):
             qs = Solicitacao.objects.select_related(
                 "usuario", "municipio", "tipo_evento", "projeto"


### PR DESCRIPTION
## Summary

- Add `test_rbac_endpoints.py` with 8 tests for PA-02 RBAC compliance
- **Fix bug**: DAT users couldn't view solicitacoes (404 on approve/reject)

## Tests Added

| Test | Description |
|------|-------------|
| `test_unauthenticated_cannot_approve` | 401/403 for unauthenticated |
| `test_unauthenticated_cannot_reject` | 401/403 for unauthenticated |
| `test_formador_cannot_approve` | 403 for Formador |
| `test_formador_cannot_reject` | 403 for Formador |
| `test_dat_can_approve` | 200 for DAT (PA-02 Adaptada) |
| `test_dat_can_reject` | 200 for DAT (PA-02 Adaptada) |
| `test_superintendencia_can_approve` | 200 for Superintendência |
| `test_superintendencia_can_reject` | 200 for Superintendência |

## Bug Fix

The `get_queryset()` method in `views_solicitacao.py` was missing "DAT" in the groups list that can view all solicitacoes. This caused DAT users to get 404 when trying to approve/reject, even though `IsSuperintendencia` permission class allows DAT.

```diff
- or self.request.user.groups.filter(name__in=["Superintendência", "Controle"]).exists()
+ or self.request.user.groups.filter(name__in=["Superintendência", "Controle", "DAT"]).exists()
```

## Test Results

```
test_rbac_endpoints.py: 8 passed
test_approval_policy_PA.py: 6 passed
```

Closes #250