### PR TITLE
ci(backend): add coverage threshold at 85%

### DIFF
--- a/.github/workflows/v2-ci.yml
+++ b/.github/workflows/v2-ci.yml
@@ -196,7 +196,7 @@ jobs:
           echo "changed_apps=$CHANGED" >> $GITHUB_OUTPUT
           echo "📁 Apps modificadas: $CHANGED"
 
-      - name: Run Tests
+      - name: Run Tests with Coverage
         env:
           DJANGO_SETTINGS_MODULE: config.settings
           ENVIRONMENT: testing
@@ -220,8 +220,13 @@ jobs:
         run: |
           cd v2/backend
 
+          # Coverage settings (Issue #268)
+          # Phase 1: 85% threshold
+          # Phase 2: 90% threshold (after stabilization)
+          COV_OPTS="--cov=apps --cov-report=term-missing --cov-report=xml --cov-fail-under=85"
+
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "🚀 PR Mode: Smart test selection"
+            echo "🚀 PR Mode: Smart test selection with coverage"
 
             # Estratégia combinada:
             # 1. Sempre rodar testes críticos (smoke tests)
@@ -254,19 +259,19 @@ jobs:
 
               if [ -n "$APP_TESTS" ]; then
                 echo "📦 Testando apps modificadas: $CHANGED_APPS"
-                pytest -q --tb=short $SLOW_TESTS $APP_TESTS $CRITICAL_TESTS 2>/dev/null || \
-                pytest -q --tb=short $SLOW_TESTS $CRITICAL_TESTS
+                pytest -q --tb=short $COV_OPTS $SLOW_TESTS $APP_TESTS $CRITICAL_TESTS 2>/dev/null || \
+                pytest -q --tb=short $COV_OPTS $SLOW_TESTS $CRITICAL_TESTS
               else
                 echo "📦 Nenhum teste específico, rodando críticos"
-                pytest -q --tb=short $SLOW_TESTS $CRITICAL_TESTS
+                pytest -q --tb=short $COV_OPTS $SLOW_TESTS $CRITICAL_TESTS
               fi
             else
               echo "📦 Sem mudanças em apps, rodando críticos"
-              pytest -q --tb=short $CRITICAL_TESTS
+              pytest -q --tb=short $COV_OPTS $CRITICAL_TESTS
             fi
           else
-            echo "🧪 Main branch: Full test suite"
-            pytest -q --tb=short
+            echo "🧪 Main branch: Full test suite with coverage"
+            pytest -q --tb=short $COV_OPTS
           fi
 
       - name: Upload coverage reports

--- a/v2/backend/pytest.ini
+++ b/v2/backend/pytest.ini
@@ -15,3 +15,42 @@ django_db_suffix = _{worker_id}
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')
     performance: marks tests as performance tests (deselect with '-m "not performance"')
+
+# =============================================================================
+# Coverage Configuration (Issue #268)
+# Phase 1: 85% threshold (current)
+# Phase 2: 90% threshold (after stabilization)
+#
+# Modules with coverage < 85% (baseline 2025-12-29):
+# - dat_ingest/management/commands/seed_*.py (0%) - seed scripts, rarely run
+# - dat_ingest/services/parse_fluir.py (23%) - legacy parser
+# - dat_ingest/services/resolvers.py (59%) - needs more edge case tests
+# - dat_ingest/services/loaders.py (77%) - ETL loaders
+# - dat_ingest/services/parse_bloqueios.py (77%) - block parser
+# - dat_ingest/services/processors.py (80%) - ETL processors
+# - dat_ingest/views.py (81%) - API views
+# - dat_ingest/services/parse_deslocamentos.py (84%) - travel parser
+#
+# Priority for Phase 2 (90%):
+# 1. resolvers.py - core business logic
+# 2. loaders.py - data integrity
+# 3. processors.py - ETL pipeline
+# =============================================================================
+[coverage:run]
+source = apps
+branch = True
+omit =
+    */migrations/*
+    */tests/*
+    */__pycache__/*
+
+[coverage:report]
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    raise NotImplementedError
+    if TYPE_CHECKING:
+    if __name__ == .__main__.:
+fail_under = 85
+show_missing = True
+skip_covered = False


### PR DESCRIPTION
## Summary
- Configures pytest-cov with 85% coverage threshold (Phase 1)
- Updates CI workflow to enforce threshold
- Documents modules needing improvement for Phase 2 (90%)

## Changes
- `pytest.ini`: Added coverage configuration with fail_under=85
- `v2-ci.yml`: Added --cov-fail-under=85 to test runs

## Coverage Baseline (2025-12-29)
**Total: 85%** (1324 tests, 26134 statements)

### Modules < 85% (Priority for Phase 2):
| Module | Coverage | Priority |
|--------|----------|----------|
| resolvers.py | 59% | High |
| loaders.py | 77% | High |
| parse_bloqueios.py | 77% | Medium |
| processors.py | 80% | High |
| views.py | 81% | Medium |
| parse_deslocamentos.py | 84% | Low |

## Test Plan
- [x] Run tests locally with coverage (85% confirmed)
- [ ] CI passes with new threshold

Closes #268