### PR TITLE
a11y(frontend): add aria-label to icon-only buttons

### DIFF
--- a/v2/frontend/src/pages/Aprovacoes/ApprovalsPage.jsx
+++ b/v2/frontend/src/pages/Aprovacoes/ApprovalsPage.jsx
@@ -332,7 +332,7 @@ export default function ApprovalsPage() {
             size="small"
             icon={<EyeOutlined />}
             onClick={() => handlePreview(record.id)}
-            title="Preview"
+            aria-label="Visualizar preview do evento"
           />
           {/* PA-06: Botões de aprovar/reprovar para Superintendência, DAT e Superusuários */}
           {record.status === 'pendente' && canApprove ? (

--- a/v2/frontend/src/pages/DATModule/AcoesPage.jsx
+++ b/v2/frontend/src/pages/DATModule/AcoesPage.jsx
@@ -432,6 +432,7 @@ export default function AcoesPage() {
               size="small"
               icon={<EditOutlined />}
               onClick={() => handleEdit(record)}
+              aria-label="Editar ação"
             />
           </Tooltip>
           <Tooltip title="Excluir">
@@ -441,6 +442,7 @@ export default function AcoesPage() {
               danger
               icon={<DeleteOutlined />}
               onClick={() => handleDelete(record)}
+              aria-label="Excluir ação"
             />
           </Tooltip>
         </Space>

--- a/v2/frontend/src/pages/DATModule/CadastrosPage.jsx
+++ b/v2/frontend/src/pages/DATModule/CadastrosPage.jsx
@@ -483,6 +483,7 @@ export default function CadastrosPage() {
               icon={<LinkOutlined />}
               href={record.link_planilha}
               target="_blank"
+              aria-label="Abrir planilha externa"
             />
           </Tooltip>
         ) : (
@@ -502,6 +503,7 @@ export default function CadastrosPage() {
               size="small"
               icon={<EditOutlined />}
               onClick={() => handleEdit(record)}
+              aria-label="Editar cadastro"
             />
           </Tooltip>
           <Tooltip title="Excluir">
@@ -511,6 +513,7 @@ export default function CadastrosPage() {
               danger
               icon={<DeleteOutlined />}
               onClick={() => handleDelete(record)}
+              aria-label="Excluir cadastro"
             />
           </Tooltip>
         </Space>
@@ -636,6 +639,7 @@ export default function CadastrosPage() {
               icon={<LinkOutlined />}
               href={record.link_plataforma}
               target="_blank"
+              aria-label="Abrir plataforma externa"
             />
           </Tooltip>
         ) : (
@@ -655,6 +659,7 @@ export default function CadastrosPage() {
               size="small"
               icon={<EditOutlined />}
               onClick={() => handleEdit(record)}
+              aria-label="Editar avaliação"
             />
           </Tooltip>
           <Tooltip title="Excluir">
@@ -664,6 +669,7 @@ export default function CadastrosPage() {
               danger
               icon={<DeleteOutlined />}
               onClick={() => handleDelete(record)}
+              aria-label="Excluir avaliação"
             />
           </Tooltip>
         </Space>

--- a/v2/frontend/src/pages/DATModule/ComprasPage.jsx
+++ b/v2/frontend/src/pages/DATModule/ComprasPage.jsx
@@ -412,6 +412,7 @@ export default function ComprasPage() {
               size="small"
               icon={<EditOutlined />}
               onClick={() => handleEdit(record)}
+              aria-label="Editar compra"
             />
           </Tooltip>
           <Tooltip title="Excluir">
@@ -421,6 +422,7 @@ export default function ComprasPage() {
               danger
               icon={<DeleteOutlined />}
               onClick={() => handleDelete(record)}
+              aria-label="Excluir compra"
             />
           </Tooltip>
         </Space>

--- a/v2/frontend/src/pages/DATModule/CoordenadoresPage.jsx
+++ b/v2/frontend/src/pages/DATModule/CoordenadoresPage.jsx
@@ -464,6 +464,7 @@ export default function CoordenadoresPage() {
               size="small"
               icon={<EyeOutlined />}
               onClick={() => handleView(record)}
+              aria-label="Ver detalhes do coordenador"
             />
           </Tooltip>
           <Tooltip title="Editar">
@@ -472,6 +473,7 @@ export default function CoordenadoresPage() {
               size="small"
               icon={<EditOutlined />}
               onClick={() => handleEdit(record)}
+              aria-label="Editar coordenador"
             />
           </Tooltip>
           <Tooltip title="Excluir">
@@ -481,6 +483,7 @@ export default function CoordenadoresPage() {
               danger
               icon={<DeleteOutlined />}
               onClick={() => handleDelete(record)}
+              aria-label="Excluir coordenador"
             />
           </Tooltip>
         </Space>
@@ -643,6 +646,7 @@ export default function CoordenadoresPage() {
                   type={viewMode === 'cards' ? 'primary' : 'default'}
                   icon={<AppstoreOutlined />}
                   onClick={() => setViewMode('cards')}
+                  aria-label="Visualizar como cards"
                 />
               </Tooltip>
               <Tooltip title="Lista">
@@ -650,6 +654,7 @@ export default function CoordenadoresPage() {
                   type={viewMode === 'table' ? 'primary' : 'default'}
                   icon={<TableOutlined />}
                   onClick={() => setViewMode('table')}
+                  aria-label="Visualizar como lista"
                 />
               </Tooltip>
               <Tooltip title="Por Área">
@@ -657,6 +662,7 @@ export default function CoordenadoresPage() {
                   type={viewMode === 'area' ? 'primary' : 'default'}
                   icon={<BarsOutlined />}
                   onClick={() => setViewMode('area')}
+                  aria-label="Visualizar por área"
                 />
               </Tooltip>
             </Button.Group>

--- a/v2/frontend/src/pages/DATModule/DATRegistrosPage.jsx
+++ b/v2/frontend/src/pages/DATModule/DATRegistrosPage.jsx
@@ -469,6 +469,7 @@ export default function DATRegistrosPage() {
               size="small"
               icon={<EditOutlined />}
               onClick={() => handleEdit(record)}
+              aria-label="Editar registro"
             />
           </Tooltip>
           <Tooltip title="Excluir">
@@ -478,6 +479,7 @@ export default function DATRegistrosPage() {
               danger
               icon={<DeleteOutlined />}
               onClick={() => handleDelete(record)}
+              aria-label="Excluir registro"
             />
           </Tooltip>
         </Space>

--- a/v2/frontend/src/pages/DATModule/FormacoesPage.jsx
+++ b/v2/frontend/src/pages/DATModule/FormacoesPage.jsx
@@ -451,6 +451,7 @@ export default function FormacoesPage() {
               size="small"
               icon={<EditOutlined />}
               onClick={() => handleEdit(record)}
+              aria-label="Editar formação"
             />
           </Tooltip>
           <Tooltip title="Excluir">
@@ -460,6 +461,7 @@ export default function FormacoesPage() {
               danger
               icon={<DeleteOutlined />}
               onClick={() => handleDelete(record)}
+              aria-label="Excluir formação"
             />
           </Tooltip>
         </Space>

--- a/v2/frontend/src/pages/DATModule/PlanoFormacoesPage.jsx
+++ b/v2/frontend/src/pages/DATModule/PlanoFormacoesPage.jsx
@@ -469,6 +469,7 @@ export default function PlanoFormacoesPage() {
               size="small"
               icon={<InfoCircleOutlined />}
               onClick={() => handleViewDetail(record)}
+              aria-label="Ver detalhes do plano"
             />
           </Tooltip>
           <Tooltip title="Editar">
@@ -477,6 +478,7 @@ export default function PlanoFormacoesPage() {
               size="small"
               icon={<EditOutlined />}
               onClick={() => handleEdit(record)}
+              aria-label="Editar plano de formações"
             />
           </Tooltip>
           <Tooltip title="Excluir">
@@ -486,6 +488,7 @@ export default function PlanoFormacoesPage() {
               danger
               icon={<DeleteOutlined />}
               onClick={() => handleDelete(record)}
+              aria-label="Excluir plano de formações"
             />
           </Tooltip>
         </Space>

--- a/v2/frontend/src/pages/PreAgenda/PreAgendaPage.jsx
+++ b/v2/frontend/src/pages/PreAgenda/PreAgendaPage.jsx
@@ -548,14 +548,14 @@ export default function PreAgendaPage() {
               size="small"
               icon={<EyeOutlined />}
               onClick={() => handlePreview(record.id)}
-              title="Preview"
+              aria-label="Visualizar preview do evento"
             />
             <Button
               size="small"
               type="primary"
               icon={<CloudUploadOutlined />}
               onClick={() => handlePublish(record.id)}
-              title="Publicar"
+              aria-label="Publicar evento no Google Calendar"
               disabled={isPublished}
             />
             {showResync && (
@@ -564,7 +564,7 @@ export default function PreAgendaPage() {
                 type="default"
                 icon={<SyncOutlined />}
                 onClick={() => handleResync(record.id)}
-                title="Reenviar (forçar UPDATE)"
+                aria-label="Reenviar evento (forçar atualização)"
                 style={{ color: '#faad14', borderColor: '#faad14' }}
               />
             )}
@@ -574,7 +574,7 @@ export default function PreAgendaPage() {
                 danger
                 icon={<StopOutlined />}
                 onClick={() => handleCancel(record.id)}
-                title="Cancelar evento no Calendar"
+                aria-label="Cancelar evento no Google Calendar"
               />
             )}
             <MeetLink href={record.meet_link} />


### PR DESCRIPTION
## Summary
- Add `aria-label` to 28 icon-only buttons across 9 pages
- Ensures WCAG 2.1 Level A compliance (4.1.2 Name, Role, Value)

## Changes
| Page | Buttons Updated |
|------|-----------------|
| ApprovalsPage | Preview (1) |
| PreAgendaPage | Preview, Publish, Resync, Cancel (4) |
| AcoesPage | Edit, Delete (2) |
| CadastrosPage | Link, Edit, Delete × 2 tables (6) |
| ComprasPage | Edit, Delete (2) |
| CoordenadoresPage | View, Edit, Delete, View modes × 3 (6) |
| DATRegistrosPage | Edit, Delete (2) |
| FormacoesPage | Edit, Delete (2) |
| PlanoFormacoesPage | Details, Edit, Delete (3) |

## Before/After
```jsx
// Before (inaccessible)
<Button icon={<EyeOutlined />} title="Preview" />

// After (accessible)
<Button icon={<EyeOutlined />} aria-label="Visualizar preview do evento" />
```

## Test Plan
- [x] ESLint passes (0 errors)
- [ ] CI passes

Closes #262