### PR TITLE
style(frontend): replace inline styles with Tailwind classes

### DIFF
--- a/v2/frontend/src/pages/Aprovacoes/ApprovalsPage.jsx
+++ b/v2/frontend/src/pages/Aprovacoes/ApprovalsPage.jsx
@@ -253,7 +253,7 @@ export default function ApprovalsPage() {
       render: (_, record) => (
         <div>
           <div>{dayjs(record.inicio).format('DD/MM/YYYY')}</div>
-          <small style={{ color: '#666' }}>
+          <small className="text-gray-500">
             {dayjs(record.inicio).format('HH:mm')} - {dayjs(record.fim).format('HH:mm')}
           </small>
         </div>
@@ -282,8 +282,8 @@ export default function ApprovalsPage() {
       render: (_, record) => (
         <div style={{ lineHeight: 1.3 }}>
           {record.tipo && <div>{record.tipo}</div>}
-          {record.encontro && <small style={{ color: '#666' }}>{record.encontro}</small>}
-          {record.segmento && <div><small style={{ color: '#888' }}>{record.segmento}</small></div>}
+          {record.encontro && <small className="text-gray-500">{record.encontro}</small>}
+          {record.segmento && <div><small className="text-gray-400">{record.segmento}</small></div>}
           {!record.tipo && !record.encontro && !record.segmento && '-'}
         </div>
       ),

--- a/v2/frontend/src/pages/PreAgenda/PreAgendaPage.jsx
+++ b/v2/frontend/src/pages/PreAgenda/PreAgendaPage.jsx
@@ -236,7 +236,7 @@ export default function PreAgendaPage() {
       content: (
         <div>
           <p>Deseja reenviar (forçar UPDATE) este evento no Google Calendar?</p>
-          <p style={{ color: '#888', fontSize: '12px' }}>
+          <p className="text-gray-500 text-xs">
             Esta ação irá sobrescrever o evento existente com os dados atualizados.
           </p>
         </div>
@@ -281,7 +281,7 @@ export default function PreAgendaPage() {
       content: (
         <div>
           <p>Deseja cancelar este evento no Google Calendar?</p>
-          <p style={{ color: '#ff4d4f', fontWeight: 'bold', fontSize: '12px' }}>
+          <p className="text-red-500 font-bold text-xs">
             ⚠️ ATENÇÃO: Esta ação irá deletar permanentemente o evento do Calendar e limpar todos os campos relacionados (event_id, meet_link, etc.).
           </p>
         </div>
@@ -333,7 +333,7 @@ export default function PreAgendaPage() {
       content: (
         <div>
           <p>Deseja reenviar (forçar UPDATE) estes {selectedRowKeys.length} eventos no Google Calendar?</p>
-          <p style={{ color: '#888', fontSize: '12px' }}>
+          <p className="text-gray-500 text-xs">
             Esta ação irá sobrescrever os eventos existentes com os dados atualizados.
           </p>
         </div>
@@ -428,7 +428,7 @@ export default function PreAgendaPage() {
       content: (
         <div>
           <p>Deseja forçar resync (resetar hash + PENDING) destes {selectedRowKeys.length} eventos?</p>
-          <p style={{ color: '#888', fontSize: '12px' }}>
+          <p className="text-gray-500 text-xs">
             Útil para corrigir drift ou reprocessar eventos com erros.
           </p>
         </div>


### PR DESCRIPTION
## Summary
- Replace 7 inline styles with Tailwind utility classes
- Focus on text/color styles in modal dialogs

## Changes

| File | Before | After |
|------|--------|-------|
| PreAgendaPage.jsx | `style={{ color: '#ff4d4f', fontWeight: 'bold', fontSize: '12px' }}` | `className="text-red-500 font-bold text-xs"` |
| PreAgendaPage.jsx | `style={{ color: '#888', fontSize: '12px' }}` (3x) | `className="text-gray-500 text-xs"` |
| ApprovalsPage.jsx | `style={{ color: '#666' }}` | `className="text-gray-500"` |
| ApprovalsPage.jsx | `style={{ color: '#888' }}` | `className="text-gray-400"` |

## Tailwind Mapping

| Inline | Tailwind |
|--------|----------|
| `color: '#ff4d4f'` | `text-red-500` |
| `color: '#888'` | `text-gray-500` |
| `color: '#666'` | `text-gray-500` |
| `fontWeight: 'bold'` | `font-bold` |
| `fontSize: '12px'` | `text-xs` |

## Note
708 total inline styles exist in the codebase. This PR focuses on the specific cases mentioned in the issue. A broader refactor could be done incrementally.

## Test Plan
- [x] ESLint passes
- [ ] Visual appearance unchanged

Closes #263