### PR TITLE
docs: configure MkDocs for automatic documentation generation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,86 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'requirements-docs.txt'
+      - '.github/workflows/docs.yml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'requirements-docs.txt'
+  workflow_dispatch:
+
+# ================================================================
+# MkDocs Documentation Build and Deploy
+# Issue #269: Automatic documentation generation
+# ================================================================
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # ----------------------------------------------------------------
+  # Job 1: Build documentation
+  # ----------------------------------------------------------------
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-docs-${{ hashFiles('requirements-docs.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-docs-
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-docs.txt
+
+      - name: Build documentation
+        run: mkdocs build --strict
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/
+
+  # ----------------------------------------------------------------
+  # Job 2: Deploy to GitHub Pages (only on main branch push)
+  # ----------------------------------------------------------------
+  deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/api/models.md
+++ b/docs/api/models.md
@@ -1,0 +1,138 @@
+# Models
+
+Documentação dos models Django do Aprender Sistema v2.
+
+## Estrutura Modular
+
+```
+apps/core/models/
+├── __init__.py          # Re-exports
+├── usuario.py           # Usuario (custom user)
+├── projeto.py           # Projeto, Gerencia
+├── municipio.py         # Municipio, Deslocamento
+├── solicitacao.py       # Solicitacao, Participation
+├── availability.py      # AvailabilityBlock
+├── compra.py            # Compra, Produto
+├── controle.py          # AcaoControle, AcaoDAT
+├── config.py            # SystemConfig
+└── audit.py             # AuditLog
+```
+
+## Models Principais
+
+### Usuario
+
+Custom user model com RBAC.
+
+```python
+from apps.core.models import Usuario
+
+usuario = Usuario.objects.get(username='maria')
+print(usuario.setores)  # ['Superintendência']
+print(usuario.funcoes)  # ['Gerente']
+print(usuario.can_approve_super)  # True
+```
+
+### Solicitacao
+
+Representa uma solicitação de evento.
+
+```python
+from apps.core.models import Solicitacao
+
+# Criar solicitação
+sol = Solicitacao.objects.create(
+    projeto=projeto,
+    municipio=municipio,
+    inicio=datetime(2025, 1, 15, 10, 0),
+    fim=datetime(2025, 1, 15, 12, 0),
+    descricao='Formação de professores',
+    is_online=True,
+)
+
+# Status automático
+# SUPER -> 'pendente'
+# NAO_SUPER -> 'aprovado'
+```
+
+**Campos principais:**
+
+| Campo | Tipo | Descrição |
+|-------|------|-----------|
+| projeto | FK | Projeto relacionado |
+| municipio | FK | Local do evento |
+| inicio | DateTime | Início do evento |
+| fim | DateTime | Fim do evento |
+| status | Char | pendente, aprovado, reprovado |
+| is_online | Bool | Modalidade online |
+| meet_link | URL | Link do Google Meet |
+| external_event_id | Char | ID no Google Calendar |
+
+### AvailabilityBlock
+
+Bloqueios de disponibilidade de formadores.
+
+```python
+from apps.core.models import AvailabilityBlock
+
+# Bloqueio total (T)
+block = AvailabilityBlock.objects.create(
+    usuario=formador,
+    tipo='T',
+    inicio=datetime(2025, 1, 15, 0, 0),
+    fim=datetime(2025, 1, 15, 23, 59),
+    motivo='Férias',
+)
+```
+
+**Tipos:**
+
+| Código | Descrição |
+|--------|-----------|
+| T | Bloqueio total |
+| P | Bloqueio parcial |
+
+### AuditLog
+
+Log de auditoria de ações.
+
+```python
+from apps.core.models import AuditLog
+
+# Registrar ação
+AuditLog.objects.create(
+    usuario=request.user,
+    acao='APPROVE',
+    objeto_tipo='Solicitacao',
+    objeto_id=sol.id,
+    detalhes={'status_anterior': 'pendente'},
+)
+```
+
+## QuerySets Customizados
+
+### Solicitacao
+
+```python
+# Pendentes
+Solicitacao.objects.pendentes()
+
+# Aprovadas
+Solicitacao.objects.aprovadas()
+
+# Por projeto
+Solicitacao.objects.do_projeto(projeto_id)
+
+# Por período
+Solicitacao.objects.no_periodo(inicio, fim)
+```
+
+## Imports Compatíveis
+
+```python
+# Import direto (recomendado)
+from apps.core.models import Solicitacao, Usuario
+
+# Import de submódulo
+from apps.core.models.solicitacao import Solicitacao
+```

--- a/docs/api/services.md
+++ b/docs/api/services.md
@@ -1,0 +1,151 @@
+# Services
+
+Documentação dos services do Aprender Sistema v2.
+
+## Estrutura
+
+```
+apps/core/services/
+├── availability_service.py   # Verificação de conflitos (RF03)
+├── gcal/                     # Google Calendar (RF05/RF06)
+│   ├── __init__.py
+│   ├── client.py            # CalendarClientAdapter
+│   ├── payload.py           # Build event payload
+│   ├── sync.py              # Core sync operations
+│   └── types.py             # SyncOutcome, Action
+└── integrations/             # Outras integrações
+```
+
+## availability_service
+
+Verificação de conflitos de disponibilidade.
+
+### check_conflicts
+
+```python
+from apps.core.services.availability_service import check_conflicts
+
+result = check_conflicts(
+    usuario=formador,
+    inicio=datetime(2025, 1, 15, 10, 0),
+    fim=datetime(2025, 1, 15, 12, 0),
+    municipio=municipio,
+)
+
+if not result.available:
+    for conflict in result.conflicts:
+        print(f"{conflict.code}: {conflict.title}")
+        # E: Evento existente
+        # T: Bloqueio total
+        # P: Bloqueio parcial
+        # D: Deslocamento insuficiente
+        # M: Capacidade diária excedida
+```
+
+### AvailabilityResult
+
+```python
+@dataclass
+class AvailabilityResult:
+    available: bool
+    conflicts: list[ConflictDetail]
+    checked_at: datetime
+
+@dataclass
+class ConflictDetail:
+    code: str      # E, T, P, D, M, X
+    title: str     # Descrição curta
+    detail: str    # Detalhes do conflito
+    ref_id: int    # ID do objeto em conflito
+```
+
+## gcal_sync_service
+
+Sincronização com Google Calendar.
+
+### apply_one_solicitacao
+
+```python
+from apps.core.services.gcal.sync import apply_one_solicitacao
+
+outcome = apply_one_solicitacao(
+    solicitacao,
+    apply_blocked=False,
+    dry_run=False,
+)
+
+print(outcome.action)  # 'INSERT', 'UPDATE', 'NOOP'
+print(outcome.external_event_id)  # 'asv2-123'
+```
+
+### build_event_payload
+
+```python
+from apps.core.services.gcal.payload import build_event_payload
+
+payload = build_event_payload(
+    solicitacao,
+    enable_meet=True,
+)
+
+# {
+#   "summary": "...",
+#   "start": {"dateTime": "..."},
+#   "end": {"dateTime": "..."},
+#   "conferenceData": {...}  # se is_online=True
+# }
+```
+
+### resync_solicitacao
+
+```python
+from apps.core.services.gcal.sync import resync_solicitacao
+
+# Força re-sincronização
+outcome = resync_solicitacao(solicitacao, apply_blocked=False)
+```
+
+### cancel_solicitacao
+
+```python
+from apps.core.services.gcal.sync import cancel_solicitacao
+
+# Remove do Calendar
+outcome = cancel_solicitacao(solicitacao)
+# Limpa: external_event_id, meet_link, gcal_payload_hash
+```
+
+## SyncOutcome
+
+```python
+@dataclass
+class SyncOutcome:
+    action: Action  # 'INSERT', 'UPDATE', 'DELETE', 'NOOP', 'ERROR'
+    external_event_id: str | None
+    meet_link: str | None
+    error: str | None
+```
+
+## Tratamento de Erros
+
+```python
+from apps.core.services.gcal.sync import apply_one_solicitacao
+
+try:
+    outcome = apply_one_solicitacao(sol, apply_blocked=False)
+except ValueError as e:
+    # Validação falhou (status != aprovado, etc)
+    print(f"Validation error: {e}")
+except Exception as e:
+    # Erro na API do Google
+    print(f"API error: {e}")
+```
+
+## Retry com Backoff
+
+Operações GCal usam retry automático:
+
+```python
+# 3 tentativas com backoff exponencial
+# 1s -> 2s -> 4s
+```

--- a/docs/api/views.md
+++ b/docs/api/views.md
@@ -1,0 +1,151 @@
+# Views
+
+Documentação das views e endpoints do Aprender Sistema v2.
+
+## Estrutura Modular
+
+```
+apps/core/views/
+├── __init__.py          # Re-exports
+├── utils.py             # _get_client_ip, api_root
+├── solicitacao.py       # SolicitacaoViewSet
+├── availability.py      # AvailabilityBlockViewSet
+├── user.py              # CurrentUserView
+├── admin.py             # CRUD ViewSets
+└── options.py           # Dropdown options
+```
+
+## Endpoints Principais
+
+### Autenticação
+
+| Endpoint | Método | Descrição |
+|----------|--------|-----------|
+| `/api/login/` | POST | Login (username, password) |
+| `/api/logout/` | POST | Logout |
+| `/api/me/` | GET | Dados do usuário atual |
+
+### Solicitações
+
+| Endpoint | Método | Descrição |
+|----------|--------|-----------|
+| `/api/solicitacoes/` | GET | Listar solicitações |
+| `/api/solicitacoes/` | POST | Criar solicitação |
+| `/api/solicitacoes/{id}/` | GET | Detalhe |
+| `/api/solicitacoes/{id}/approve/` | POST | Aprovar |
+| `/api/solicitacoes/{id}/reject/` | POST | Reprovar |
+| `/api/solicitacoes/{id}/publish/` | POST | Publicar no GCal |
+| `/api/solicitacoes/{id}/preview-gcal/` | GET | Preview GCal |
+| `/api/solicitacoes/{id}/resync-gcal/` | POST | Resync GCal |
+| `/api/solicitacoes/{id}/cancel-gcal/` | POST | Cancelar GCal |
+
+### Disponibilidade
+
+| Endpoint | Método | Descrição |
+|----------|--------|-----------|
+| `/api/availability/check/` | GET | Verificar conflitos |
+| `/api/availability/check-many/` | POST | Verificar em lote |
+| `/api/availability/blocks/` | GET | Listar bloqueios |
+| `/api/availability/blocks/` | POST | Criar bloqueio |
+
+### Admin
+
+| Endpoint | Descrição |
+|----------|-----------|
+| `/api/municipios/` | CRUD Municípios |
+| `/api/projetos/` | CRUD Projetos |
+| `/api/usuarios/` | CRUD Usuários |
+| `/api/formadores/` | CRUD Formadores |
+
+## Permissões
+
+### Classes de Permissão
+
+```python
+from rest_framework.permissions import IsAuthenticated
+from apps.core.permissions import IsSuperintendencia, IsControleOrSuper
+
+class SolicitacaoViewSet(viewsets.ModelViewSet):
+    permission_classes = [IsAuthenticated]
+
+    @action(detail=True, methods=['post'])
+    def approve(self, request, pk=None):
+        # Apenas Superintendência
+        self.permission_classes = [IsSuperintendencia]
+```
+
+### Decorators
+
+```python
+@action(
+    detail=True,
+    methods=['post'],
+    permission_classes=[IsSuperintendencia]
+)
+def approve(self, request, pk=None):
+    ...
+```
+
+## Serializers
+
+### SolicitacaoSerializer
+
+```python
+from apps.core.serializers import SolicitacaoSerializer
+
+serializer = SolicitacaoSerializer(solicitacao)
+data = serializer.data
+# {
+#   "id": 1,
+#   "projeto": {...},
+#   "municipio": {...},
+#   "inicio": "2025-01-15T10:00:00-03:00",
+#   "fim": "2025-01-15T12:00:00-03:00",
+#   "status": "pendente",
+#   "is_online": true,
+#   "meet_link": null,
+#   ...
+# }
+```
+
+## Throttling
+
+```python
+# settings.py
+REST_FRAMEWORK = {
+    'DEFAULT_THROTTLE_RATES': {
+        'availability_check': '100/hour',
+    }
+}
+```
+
+## Paginação
+
+```python
+# settings.py
+REST_FRAMEWORK = {
+    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
+    'PAGE_SIZE': 20,
+}
+
+# Response
+{
+    "count": 100,
+    "next": "/api/solicitacoes/?page=2",
+    "previous": null,
+    "results": [...]
+}
+```
+
+## Filtros
+
+```python
+# Filtrar por status
+GET /api/solicitacoes/?status=pendente
+
+# Filtrar por projeto
+GET /api/solicitacoes/?projeto=1
+
+# Filtrar por período
+GET /api/solicitacoes/?inicio_after=2025-01-01&inicio_before=2025-01-31
+```

--- a/docs/architecture/backend.md
+++ b/docs/architecture/backend.md
@@ -1,0 +1,75 @@
+# Backend
+
+## Stack
+
+- **Python 3.12** com PEP 695 (type hints modernos)
+- **Django 5.1** com DRF
+- **Celery** para tarefas assíncronas
+- **Pyright** para type checking (strict mode)
+
+## Estrutura Modular
+
+O backend segue uma estrutura modular (PRs #213-#217):
+
+```
+apps/core/
+├── models/           # Modelos Django
+│   ├── usuario.py
+│   ├── solicitacao.py
+│   ├── availability.py
+│   └── ...
+├── serializers/      # DRF Serializers
+├── views/            # DRF ViewSets
+├── services/         # Lógica de negócio
+│   └── gcal/         # Integração Google Calendar
+└── tests/            # Testes unitários
+```
+
+## Modelos Principais
+
+### Solicitacao
+
+Representa uma solicitação de evento:
+
+```python
+class Solicitacao(models.Model):
+    projeto = models.ForeignKey(Projeto)
+    municipio = models.ForeignKey(Municipio)
+    inicio = models.DateTimeField()
+    fim = models.DateTimeField()
+    status = models.CharField()  # pendente, aprovado, reprovado
+    gcal_status = models.CharField()  # NOT_PUBLISHED, PENDING, PUBLISHED, ERROR
+```
+
+### Usuario
+
+Modelo customizado de usuário com RBAC:
+
+```python
+class Usuario(AbstractUser):
+    # Grupos: Setor + Função
+    # Setor: Superintendência, DAT, Vidas, etc.
+    # Função: Formador, Coordenador, Gerente
+```
+
+## Services
+
+A lógica de negócio está isolada em services:
+
+- `availability_service.py`: Verificação de conflitos
+- `gcal_sync_service.py`: Sincronização com Google Calendar
+- `approval_service.py`: Fluxo de aprovação
+
+## Type Hints
+
+100% do código crítico está tipado (42 arquivos, ~18,000 linhas):
+
+```python
+def check_conflicts(
+    usuario: Usuario,
+    inicio: datetime,
+    fim: datetime,
+    municipio: Municipio
+) -> AvailabilityResult:
+    ...
+```

--- a/docs/architecture/frontend.md
+++ b/docs/architecture/frontend.md
@@ -1,0 +1,62 @@
+# Frontend
+
+## Stack
+
+- **React 18** com hooks
+- **Vite** para build e dev server
+- **Ant Design** para componentes UI
+- **Tailwind CSS** para utilitários
+
+## Estrutura
+
+```
+src/
+├── pages/              # Páginas da aplicação
+│   ├── Aprovacoes/     # Tela de aprovações
+│   ├── PreAgenda/      # Pré-agenda (publicação)
+│   ├── Solicitacoes/   # Gestão de solicitações
+│   ├── Dashboards/     # Dashboards e métricas
+│   └── DATModule/      # Módulo DAT
+├── components/         # Componentes reutilizáveis
+├── api/                # Funções de chamada API
+├── hooks/              # React hooks customizados
+└── utils/              # Utilitários
+```
+
+## Páginas Principais
+
+| Rota | Descrição |
+|------|-----------|
+| `/solicitacoes` | Lista de solicitações |
+| `/solicitacoes/nova` | Nova solicitação |
+| `/aprovacoes` | Aprovação (Superintendência) |
+| `/pre-agenda` | Publicação no GCal (Controle) |
+| `/dashboards` | Dashboards e métricas |
+
+## Autenticação
+
+- Session-based authentication
+- CSRF token em todas as requisições
+- Sessão expira em 2 horas
+
+## Componentes Chave
+
+### RemoteSelect
+
+Select com busca remota para entidades:
+
+```jsx
+<RemoteSelect
+  fetchOptions={fetchMunicipios}
+  renderLabel={(item) => item.nome}
+  placeholder="Selecione um município"
+/>
+```
+
+### MeetLink
+
+Exibe link do Google Meet:
+
+```jsx
+<MeetLink href={solicitacao.meet_link} />
+```

--- a/docs/architecture/infrastructure.md
+++ b/docs/architecture/infrastructure.md
@@ -1,0 +1,61 @@
+# Infraestrutura
+
+## Docker Compose
+
+O sistema roda em containers Docker:
+
+```yaml
+services:
+  db:        # PostgreSQL 15
+  redis:     # Redis 7
+  web:       # Django + Gunicorn
+  worker:    # Celery Worker
+  beat:      # Celery Beat (scheduler)
+```
+
+## Containers
+
+### PostgreSQL
+
+- **Imagem**: postgres:15
+- **Porta**: 5433 (externa), 5432 (interna)
+- **Volume**: `pgdata` para persistência
+
+### Redis
+
+- **Imagem**: redis:7
+- **Porta**: 6379
+- **Uso**: Cache de sessões, broker Celery
+
+### Web (Django)
+
+- **Porta**: 8002
+- **Comando**: `gunicorn config.wsgi:application`
+- **Variáveis**: Via `.env`
+
+## Comandos Úteis
+
+```bash
+# Subir ambiente
+docker compose -f v2/infra/docker-compose.yml up -d
+
+# Ver logs
+docker compose -f v2/infra/docker-compose.yml logs -f web
+
+# Migrations
+docker compose -f v2/infra/docker-compose.yml exec web python manage.py migrate
+
+# Shell Django
+docker compose -f v2/infra/docker-compose.yml exec web python manage.py shell
+
+# Testes
+docker compose -f v2/infra/docker-compose.yml exec web pytest
+```
+
+## CI/CD
+
+O projeto usa GitHub Actions para CI:
+
+- **Lint**: Black, isort, flake8, Pyright
+- **Testes**: pytest com coverage (threshold 85%)
+- **Deploy**: GitHub Pages (documentação)

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,0 +1,83 @@
+# Visão Geral da Arquitetura
+
+## Diagrama de Alto Nível
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                        Frontend                              │
+│                   React + Vite + Ant Design                  │
+│                      (porta 5173)                            │
+└─────────────────────────┬───────────────────────────────────┘
+                          │ HTTP/REST
+                          ▼
+┌─────────────────────────────────────────────────────────────┐
+│                        Backend                               │
+│                  Django + DRF + Celery                       │
+│                      (porta 8002)                            │
+├─────────────────────────┬───────────────────────────────────┤
+│         API REST        │         Background Tasks           │
+│      (DRF ViewSets)     │      (Celery Workers)             │
+└─────────────────────────┴───────────────────────────────────┘
+          │                              │
+          ▼                              ▼
+┌─────────────────┐          ┌─────────────────┐
+│   PostgreSQL    │          │      Redis      │
+│   (porta 5433)  │          │   (porta 6379)  │
+│   Dados         │          │   Cache/Filas   │
+└─────────────────┘          └─────────────────┘
+```
+
+## Componentes Principais
+
+### Backend (`v2/backend/`)
+
+- **Django 5.1**: Framework web principal
+- **DRF**: API REST
+- **Celery**: Tarefas assíncronas (sync GCal, ETL)
+- **PostgreSQL**: Banco de dados relacional
+- **Redis**: Cache e broker de mensagens
+
+### Frontend (`v2/frontend/`)
+
+- **React 18**: Biblioteca UI
+- **Vite**: Build tool
+- **Ant Design**: Componentes UI
+- **Tailwind CSS**: Utilitários CSS
+
+### Infraestrutura (`v2/infra/`)
+
+- **Docker Compose**: Orquestração de containers
+- **Nginx**: Proxy reverso (produção)
+
+## Estrutura de Diretórios
+
+```
+v2/
+├── backend/
+│   ├── apps/
+│   │   ├── core/          # App principal
+│   │   │   ├── models/    # Modelos Django
+│   │   │   ├── views/     # ViewSets DRF
+│   │   │   ├── services/  # Lógica de negócio
+│   │   │   └── tests/     # Testes
+│   │   └── dat_ingest/    # ETL e importação
+│   ├── config/            # Configurações Django
+│   └── manage.py
+├── frontend/
+│   ├── src/
+│   │   ├── pages/         # Páginas React
+│   │   ├── components/    # Componentes
+│   │   ├── api/           # Chamadas API
+│   │   └── hooks/         # React hooks
+│   └── vite.config.js
+└── infra/
+    └── docker-compose.yml
+```
+
+## Fluxo de Dados
+
+1. **Usuário** interage com o **Frontend**
+2. **Frontend** faz chamadas REST ao **Backend**
+3. **Backend** processa e persiste no **PostgreSQL**
+4. **Celery** executa tarefas assíncronas (GCal sync)
+5. **Redis** gerencia cache e filas de mensagens

--- a/docs/business-rules/clausulas-petreas.md
+++ b/docs/business-rules/clausulas-petreas.md
@@ -1,0 +1,53 @@
+# Cláusulas Pétreas (CP)
+
+Regras imutáveis do sistema que não podem ser alteradas.
+
+## CP-01: REQUIRE_DOCKER=1
+
+- **v2 DEVE rodar APENAS em Docker**
+- Validação obrigatória em `config/settings.py`
+- v1 pode rodar local (legacy), mas v2 = Docker obrigatório
+
+## CP-02: Política de Aprovação Manual
+
+Ver [Política de Aprovação (PA)](politica-aprovacao.md).
+
+- Sem auto-aprovação para fluxo SUPER
+- Apenas Superintendência pode aprovar
+- Integrações só executam após aprovação
+
+## CP-03: Regras de Disponibilidade
+
+Ver [Regras de Disponibilidade (RD)](regras-disponibilidade.md).
+
+- Não-sobreposição de eventos
+- Bloqueios totais (T) e parciais (P)
+- Buffer de deslocamento (D)
+- Capacidade diária (M)
+
+## CP-04: Workflow de Sub-Agents
+
+Ordem obrigatória para agentes autônomos:
+
+1. **Entender** → Ler código, docs, issues
+2. **Planejar** → Escrever plano passo a passo
+3. **Implementar** → PRs pequenos e atômicos
+4. **Testar** → Testes unitários/integração/E2E
+5. **Infra** → Docker/CI/CD
+6. **ETL** → Importação de dados
+7. **UI/UX** → Templates/views
+
+## CP-05: Nunca Tocar v1 Sem Aprovação
+
+- v1 está congelado (tag: `v1-freeze`)
+- Mudanças exigem branch específico e aprovação
+
+## CP-06: Padrões de Commit e PR
+
+**Commits**: `<type>(<scope>): <message>`
+
+- Types: `feat`, `fix`, `chore`, `docs`, `test`, `refactor`
+
+**Branches**: `<type>/<nome>`
+
+**PRs**: Require 1+ approval, CI verde

--- a/docs/business-rules/politica-aprovacao.md
+++ b/docs/business-rules/politica-aprovacao.md
@@ -1,0 +1,65 @@
+# Política de Aprovação (PA)
+
+Regras que governam o fluxo de aprovação de solicitações.
+
+## PA-01: Sem Auto-Aprovação
+
+Uma `Solicitacao` **nunca** muda para "Aprovada" automaticamente, mesmo se não houver conflitos.
+
+!!! warning "Exceção"
+    Projetos com `fluxo='NAO_SUPER'` são auto-aprovados na criação.
+
+## PA-02: Perfil Exigido
+
+Apenas usuários com **Gerente + Superintendência** (ou superuser) podem aprovar/reprovar.
+
+```python
+can_approve_super = is_superuser OR (
+    "Gerente" IN funcoes AND "Superintendência" IN setores
+)
+```
+
+## PA-03: Gatilhos Pós-Aprovação
+
+Integrações externas (Google Calendar, Meet) só executam **após** aprovação manual concluída.
+
+## PA-04: Estado Inicial
+
+Toda solicitação nasce com `status = 'pendente'`.
+
+## PA-05: Auditoria
+
+Registrar em `AuditLog`:
+
+- Usuário que aprovou/reprovou
+- Data/hora da ação
+- Justificativa (quando houver)
+
+## PA-06: UI/UX
+
+- Botões de ação ocultos para perfis sem permissão
+- Conformidade ISO 9241-110 (controle explícito)
+
+## PA-07: Testes Obrigatórios
+
+```python
+test_never_auto_approves_on_clean_or_save
+test_only_superintendencia_can_approve_or_reject
+test_calendar_integration_not_called_before_approval
+test_approval_flow_records_audit_log
+test_non_privileged_user_gets_403_on_approval_endpoint
+```
+
+## Fluxos
+
+### SUPER (Manual)
+
+1. Coordenador cria solicitação → `status='pendente'`
+2. Superintendência aprova/reprova
+3. Se aprovado → vai para Pré-Agenda
+4. Controle publica no Google Calendar
+
+### NAO_SUPER (Auto-aprovado)
+
+1. Coordenador cria solicitação → `status='aprovado'`
+2. Vai direto para Pré-Agenda

--- a/docs/business-rules/regras-disponibilidade.md
+++ b/docs/business-rules/regras-disponibilidade.md
@@ -1,0 +1,58 @@
+# Regras de Disponibilidade (RD)
+
+Regras que governam a verificação de conflitos de agenda.
+
+## RD-01: Não-Sobreposição
+
+- Formador não pode ter dois eventos que se sobreponham
+- Caso borda: `fim == início` → **não conflita**
+- Overlap ≥ 1 minuto → **conflito**
+
+## RD-02: Bloqueio Total (T)
+
+Bloqueio marcado como **T** impede quaisquer eventos no intervalo.
+
+## RD-03: Bloqueio Parcial (P)
+
+Bloqueio **P** impede eventos dentro do subintervalo bloqueado.
+Fora do subintervalo → permitido.
+
+## RD-04: Buffer de Deslocamento (D)
+
+- Entre **municípios distintos**: tempo mínimo de deslocamento (60-120 min)
+- **Mesmo município**: buffer pode ser zero
+
+## RD-05: Capacidade Diária (M)
+
+Formador não pode ter mais de **N horas** de eventos por dia (configurável).
+
+## RD-06: Timezone
+
+- Comparações **timezone-aware** usando `America/Fortaleza`
+- Armazenar em UTC, comparar no TZ do projeto
+
+## RD-07: Prioridade de Checagem
+
+1. Bloqueios (T, P)
+2. Conflitos por eventos aprovados
+3. Buffer de deslocamento (D)
+4. Limite diário (M)
+
+## RD-08: Mensagens de Conflito
+
+Mensagens devem incluir:
+
+- Formador(es) em conflito
+- Data e intervalo (HH:MM dd/mm)
+- Tipo de conflito (E, M, D, P, T, X)
+
+## Códigos de Conflito
+
+| Código | Significado |
+|--------|-------------|
+| E | Evento existente (overlap) |
+| M | Mais de um evento (capacidade) |
+| D | Deslocamento insuficiente |
+| P | Bloqueio parcial |
+| T | Bloqueio total |
+| X | Outro conflito |

--- a/docs/business-rules/requisitos-funcionais.md
+++ b/docs/business-rules/requisitos-funcionais.md
@@ -1,0 +1,79 @@
+# Requisitos Funcionais (RF)
+
+Requisitos funcionais do sistema Aprender Sistema v2.
+
+## RF01: Autenticação
+
+- Login via username/password
+- Sessão com duração de 2 horas
+- CSRF token obrigatório em todas as requisições
+- Logout com invalidação de sessão
+
+## RF02: Solicitar Evento
+
+- Coordenador preenche formulário com:
+  - Projeto
+  - Município
+  - Data/hora início e fim
+  - Formadores participantes
+  - Modalidade (presencial/online)
+  - Descrição
+- Validação de campos obrigatórios
+- Criação com status `pendente` (SUPER) ou `aprovado` (NAO_SUPER)
+
+## RF03: Verificar Conflitos
+
+- Checagem de disponibilidade antes de criar solicitação
+- Regras implementadas (RD-01 a RD-08):
+  - Não-sobreposição de eventos
+  - Bloqueios totais (T) e parciais (P)
+  - Buffer de deslocamento entre municípios
+  - Capacidade diária por formador
+- Exibição visual de conflitos com códigos (E/M/D/P/T/X)
+
+## RF04: Aprovar/Reprovar
+
+- Apenas Superintendência pode aprovar/reprovar (fluxo SUPER)
+- Interface dedicada em `/aprovacoes`
+- Registro de justificativa em reprovações
+- AuditLog de todas as ações
+- Aprovação em lote disponível
+
+## RF05: Publicar no Google Calendar
+
+- Publicação de eventos aprovados
+- Integração via Service Account
+- Suporte a dry-run (simulação)
+- Controle de send_updates (notificações)
+- Sincronização idempotente
+
+## RF06: Gerar Link Google Meet
+
+- Geração automática para eventos online (`is_online=true`)
+- Link persistido no campo `meet_link`
+- Componente `MeetLink` para exibição e cópia
+
+## RF07: Resync/Cancel
+
+- Reenviar evento para sincronizar alterações
+- Cancelar evento (remove do Calendar)
+- Idempotência garantida (404 = sucesso)
+
+## RF08: Dashboards
+
+- Métricas de eventos por período
+- Filtros por projeto, município, status
+- Exportação de relatórios
+
+## Status de Implementação
+
+| RF | Descrição | Status |
+|----|-----------|--------|
+| RF01 | Autenticação | ✅ Implementado |
+| RF02 | Solicitar Evento | ✅ Implementado |
+| RF03 | Verificar Conflitos | ✅ Implementado |
+| RF04 | Aprovar/Reprovar | ✅ Implementado |
+| RF05 | Google Calendar | ✅ Implementado |
+| RF06 | Google Meet | ✅ Implementado |
+| RF07 | Resync/Cancel | ✅ Implementado |
+| RF08 | Dashboards | ✅ Implementado |

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -1,0 +1,50 @@
+# Configuração
+
+## Variáveis de Ambiente
+
+O sistema utiliza variáveis de ambiente para configuração. Copie o arquivo de exemplo:
+
+```bash
+cp v2/backend/.env.example v2/backend/.env
+```
+
+### Variáveis Principais
+
+| Variável | Descrição | Exemplo |
+|----------|-----------|---------|
+| `ENVIRONMENT` | Ambiente de execução | `development`, `staging`, `production` |
+| `SECRET_KEY` | Chave secreta Django | `sua-chave-secreta` |
+| `DEBUG` | Modo debug | `1` ou `0` |
+| `DB_HOST` | Host do PostgreSQL | `localhost` |
+| `DB_PORT` | Porta do PostgreSQL | `5433` |
+| `DB_NAME` | Nome do banco | `aprender_v2` |
+| `REDIS_HOST` | Host do Redis | `localhost` |
+| `REDIS_PORT` | Porta do Redis | `6379` |
+
+### Google Calendar
+
+| Variável | Descrição |
+|----------|-----------|
+| `GCAL_CLIENT` | Cliente a usar: `fake` ou `google` |
+| `GCAL_CALENDAR_ID` | ID do calendário Google |
+| `GOOGLE_SERVICE_ACCOUNT_FILE` | Caminho para credenciais |
+
+### ETL
+
+| Variável | Descrição |
+|----------|-----------|
+| `ETL_OUTPUT_DIR` | Diretório para relatórios ETL |
+| `ETL_DATA_DIR` | Diretório com arquivos CSV/Excel |
+
+## Configuração do Docker
+
+O arquivo `v2/infra/docker-compose.yml` contém toda a configuração de infraestrutura.
+
+### Portas Padrão
+
+| Serviço | Porta |
+|---------|-------|
+| PostgreSQL | 5433 |
+| Redis | 6379 |
+| Backend | 8002 |
+| Frontend | 5173 |

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -1,0 +1,59 @@
+# Instalação
+
+## Pré-requisitos
+
+- Docker e Docker Compose
+- Git
+- Node.js 18+ (para desenvolvimento frontend)
+
+## Clone do Repositório
+
+```bash
+git clone https://github.com/matheusnorjosa/aprender_sistema.git
+cd aprender_sistema
+```
+
+## Subindo o Ambiente
+
+### Backend (Docker)
+
+```bash
+cd v2
+docker compose -f infra/docker-compose.yml up -d
+```
+
+Isso irá subir:
+
+- PostgreSQL (porta 5433)
+- Redis (porta 6379)
+- Backend Django (porta 8002)
+- Celery Worker
+- Celery Beat
+
+### Frontend (Desenvolvimento)
+
+```bash
+cd v2/frontend
+npm install
+npm run dev
+```
+
+O frontend estará disponível em `http://localhost:5173`.
+
+## Verificando a Instalação
+
+```bash
+# Verificar containers
+docker compose -f v2/infra/docker-compose.yml ps
+
+# Verificar logs
+docker compose -f v2/infra/docker-compose.yml logs -f web
+
+# Acessar shell Django
+docker compose -f v2/infra/docker-compose.yml exec web python manage.py shell
+```
+
+## Próximos Passos
+
+- [Configuração](configuration.md)
+- [Quick Start](quickstart.md)

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,0 +1,49 @@
+# Quick Start
+
+Guia rápido para começar a usar o sistema.
+
+## 1. Acesse o Sistema
+
+Após a [instalação](installation.md), acesse:
+
+- **Frontend**: http://localhost:5173
+- **Backend API**: http://localhost:8002/api/
+
+## 2. Crie um Superusuário
+
+```bash
+docker compose -f v2/infra/docker-compose.yml exec web python manage.py createsuperuser
+```
+
+## 3. Acesse o Admin
+
+Acesse http://localhost:8002/admin/ com as credenciais criadas.
+
+## 4. Fluxo Básico
+
+### Criar Solicitação
+
+1. Acesse `/solicitacoes/nova`
+2. Preencha os dados do evento
+3. Selecione formadores
+4. Sistema verifica conflitos automaticamente
+5. Submeta a solicitação
+
+### Aprovar Solicitação (Superintendência)
+
+1. Acesse `/aprovacoes`
+2. Revise solicitações pendentes
+3. Aprove ou reprove com justificativa
+
+### Publicar no Google Calendar (Controle)
+
+1. Acesse `/pre-agenda`
+2. Selecione eventos aprovados
+3. Clique em "Publicar"
+4. Sistema cria evento no Google Calendar com Meet
+
+## Próximos Passos
+
+- [Arquitetura do Sistema](../architecture/overview.md)
+- [Regras de Negócio](../business-rules/clausulas-petreas.md)
+- [RBAC e Permissões](../guides/rbac.md)

--- a/docs/guides/etl.md
+++ b/docs/guides/etl.md
@@ -1,0 +1,141 @@
+# ETL e Importação de Dados
+
+Guia para importação de dados das planilhas originais.
+
+## Visão Geral
+
+O sistema possui 21 comandos ETL para importação de dados:
+
+```bash
+# Listar comandos disponíveis
+docker compose exec web python manage.py --help | grep import
+```
+
+## Comandos Principais
+
+### Usuários
+
+```bash
+python manage.py import_usuarios --dry-run
+python manage.py import_usuarios --apply
+```
+
+### Formadores
+
+```bash
+python manage.py import_formadores --dry-run
+python manage.py import_formadores --apply
+```
+
+### Municípios
+
+```bash
+python manage.py import_municipios --dry-run
+python manage.py import_municipios --apply
+```
+
+### Projetos
+
+```bash
+python manage.py import_projetos --dry-run
+python manage.py import_projetos --apply
+```
+
+### Solicitações
+
+```bash
+python manage.py import_solicitacoes --dry-run
+python manage.py import_solicitacoes --apply
+```
+
+## Princípios ETL
+
+### 1. Idempotência
+
+- Comandos podem ser executados múltiplas vezes
+- Usa `update_or_create` para evitar duplicatas
+- Chave única: campos de identificação natural
+
+### 2. Dry-Run Obrigatório
+
+```bash
+# SEMPRE rodar dry-run primeiro
+python manage.py import_dados --dry-run
+
+# Verificar output, depois aplicar
+python manage.py import_dados --apply
+```
+
+### 3. Quality Gates
+
+- Validação de campos obrigatórios
+- Normalização de dados (trim, lowercase)
+- Tratamento de valores nulos
+
+### 4. Relatórios
+
+Cada comando gera relatório JSON:
+
+```json
+{
+  "command": "import_usuarios",
+  "mode": "apply",
+  "started_at": "2025-01-15T10:00:00Z",
+  "finished_at": "2025-01-15T10:01:00Z",
+  "stats": {
+    "total_rows": 150,
+    "created": 145,
+    "updated": 5,
+    "skipped": 0,
+    "errors": 0
+  },
+  "errors": []
+}
+```
+
+## Estrutura de Arquivos
+
+```
+v2/backend/data/csv-import/
+├── Acompanhamento de Agenda _ 2025.xlsx
+├── Disponibilidade _ 2025.xlsx
+├── Planilha de Controle - 2025.xlsx
+└── Usuários.xlsx
+```
+
+## Fluxo Recomendado
+
+1. **Municípios** (sem dependências)
+2. **Projetos** (sem dependências)
+3. **Usuários** (requer grupos)
+4. **Formadores** (requer usuários)
+5. **Solicitações** (requer formadores, projetos, municípios)
+6. **Bloqueios** (requer formadores)
+
+## Troubleshooting
+
+### Erro de Encoding
+
+```bash
+# Converter arquivo para UTF-8
+iconv -f ISO-8859-1 -t UTF-8 arquivo.csv > arquivo_utf8.csv
+```
+
+### Erro de Formato de Data
+
+O sistema espera datas no formato ISO 8601 ou DD/MM/YYYY:
+
+```python
+# Formatos aceitos
+"2025-01-15"
+"2025-01-15T10:00:00"
+"15/01/2025"
+```
+
+### Linhas Ignoradas
+
+Verifique o relatório JSON para detalhes:
+
+```bash
+cat import_report_*.json | jq '.errors'
+```

--- a/docs/guides/google-calendar.md
+++ b/docs/guides/google-calendar.md
@@ -1,0 +1,123 @@
+# Guia de Integração Google Calendar
+
+Documentação completa da integração do Aprender Sistema v2 com Google Calendar API.
+
+## Visão Geral
+
+O sistema integra com Google Calendar para:
+
+- Publicação automática de eventos aprovados
+- Geração de links Google Meet para eventos online
+- Sincronização idempotente e resiliente
+
+## Configuração
+
+### 1. Criar Service Account
+
+1. Acesse [Google Cloud Console](https://console.cloud.google.com/)
+2. Crie ou selecione um projeto
+3. Ative a **Google Calendar API**
+4. Crie uma Service Account com chave JSON
+5. Compartilhe o calendário com o email da Service Account
+
+### 2. Variáveis de Ambiente
+
+```bash
+# Client: 'fake' (in-memory) ou 'google' (real API)
+GCAL_CLIENT=fake
+
+# Calendar ID
+GCAL_CALENDAR_ID=primary
+
+# Credenciais (escolha uma opção)
+GOOGLE_SERVICE_ACCOUNT_FILE=/secrets/aprender-sa-key.json
+# ou
+GOOGLE_SERVICE_ACCOUNT_JSON='{"type":"service_account",...}'
+
+# Notificações para participantes
+GCAL_SEND_UPDATES=none  # none, all, externalOnly
+```
+
+### 3. Desenvolvimento vs Produção
+
+**Desenvolvimento:**
+```bash
+GCAL_CLIENT=fake
+GCAL_SEND_UPDATES=none
+```
+
+**Produção:**
+```bash
+GCAL_CLIENT=google
+GCAL_SEND_UPDATES=externalOnly
+GOOGLE_SERVICE_ACCOUNT_FILE=/app/secrets/key.json
+```
+
+## Endpoints
+
+### Preview
+
+```bash
+GET /api/solicitacoes/{id}/preview-gcal/
+```
+
+Retorna preview do evento sem publicar.
+
+### Publicar
+
+```bash
+POST /api/solicitacoes/{id}/publish/
+{
+  "dry_run": false,
+  "apply_blocked": false
+}
+```
+
+### Resync
+
+```bash
+POST /api/solicitacoes/{id}/resync-gcal/
+```
+
+Força re-sincronização de evento já publicado.
+
+### Cancelar
+
+```bash
+POST /api/solicitacoes/{id}/cancel-gcal/
+```
+
+Remove evento do Calendar.
+
+## Modalidade (Online vs Presencial)
+
+| Campo | Valor | Comportamento |
+|-------|-------|---------------|
+| `is_online` | `false` | Evento presencial, sem Meet |
+| `is_online` | `true` | Evento online, gera Meet link |
+
+## Matriz de Comportamento
+
+| GCAL_CLIENT | apply_blocked | dry_run | Resultado |
+|-------------|---------------|---------|-----------|
+| fake | false | true | Simulação OK |
+| fake | false | false | Bloqueado (409) |
+| fake | true | false | Publica (fake) |
+| google | false | false | Publica (real) |
+
+## Troubleshooting
+
+### Erro 409 em /publish/
+
+**Causa:** `GCAL_CLIENT=fake` e `apply_blocked=false`
+
+**Solução:** Use `apply_blocked=true` para testes ou `GCAL_CLIENT=google` para produção.
+
+### meet_link não é gerado
+
+**Checklist:**
+
+- [ ] `is_online=true` na solicitação
+- [ ] `conferenceDataVersion=1` no request
+- [ ] `GCAL_CLIENT=google` configurado
+- [ ] Não é dry_run

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -1,0 +1,113 @@
+# Observabilidade
+
+Stack completa de monitoramento e logging.
+
+## Stack
+
+| Componente | Versão | Função |
+|------------|--------|--------|
+| Prometheus | 2.54.0 | Coleta de métricas |
+| Grafana | 11.2.0 | Visualização |
+| django-prometheus | 2.3.1 | Instrumentação Django |
+| postgres_exporter | 0.15.0 | Métricas PostgreSQL |
+| redis_exporter | 1.62.0 | Métricas Redis |
+| Sentry | - | APM e Error Tracking |
+
+## Quick Start
+
+### Stack Principal
+
+```bash
+cd v2/infra
+make up
+```
+
+### Stack com Observabilidade
+
+```bash
+cd v2/infra
+make up-obs
+```
+
+## Portas
+
+| Serviço | Porta | URL |
+|---------|-------|-----|
+| Django Metrics | 8002 | http://localhost:8002/metrics |
+| Prometheus | 9090 | http://localhost:9090 |
+| Grafana | 3000 | http://localhost:3000 |
+
+## Métricas Django
+
+```promql
+# Requests por segundo
+rate(django_http_requests_total_by_view_transport_method_total[1m])
+
+# Latência P99
+histogram_quantile(0.99, rate(django_http_requests_latency_seconds_by_view_method_bucket[5m]))
+
+# Taxa de erro
+sum(rate(django_http_responses_total_by_status_total{status=~"5.."}[5m]))
+```
+
+## Structured Logging
+
+### Formato JSON (Produção)
+
+```json
+{
+  "asctime": "2025-11-18T18:30:00.123456Z",
+  "levelname": "INFO",
+  "name": "apps.core.services",
+  "message": "check_conflicts called",
+  "request_id": "abc123-def456",
+  "environment": "staging",
+  "service": "web"
+}
+```
+
+### Correlation ID
+
+Cada requisição recebe `request_id` único:
+
+```bash
+# Ver header na response
+curl -i http://localhost:8002/api/solicitacoes/ | grep X-Request-ID
+
+# Filtrar logs por request_id
+docker compose logs web | jq 'select(.request_id == "abc123")'
+```
+
+## Sentry APM
+
+### Configuração
+
+```bash
+SENTRY_DSN=https://your-key@sentry.io/project-id
+SENTRY_TRACES_SAMPLE_RATE=0.1
+```
+
+### Features
+
+- Error tracking com stack traces
+- Performance monitoring
+- N+1 query detection
+- Release tracking
+- User context
+
+## Dashboard Grafana
+
+**"AS v2 - System Overview"** inclui:
+
+1. Requests/Second por endpoint
+2. Request Latency (P50/P95/P99)
+3. Error Rate (4xx/5xx)
+4. Redis Cache Hit Rate
+5. PostgreSQL Operations Rate
+6. PostgreSQL Active Connections
+
+### Acesso
+
+1. Abrir http://localhost:3000
+2. Login: `admin` / `admin`
+3. Dashboards → Aprender Sistema → AS v2 - System Overview

--- a/docs/guides/rbac.md
+++ b/docs/guides/rbac.md
@@ -1,0 +1,72 @@
+# RBAC e Permissões
+
+Sistema de permissões baseado em grupos de Setor e Função.
+
+## Conceito
+
+O sistema RBAC usa duas dimensões:
+
+- **SETOR**: Onde o usuário trabalha
+- **FUNÇÃO**: O que o usuário pode fazer
+
+## Grupos de Setor
+
+| Grupo | Descrição |
+|-------|-----------|
+| Superintendência | Setor estratégico (fluxo SUPER) |
+| Vidas | Gerência 2 - Projetos Vida |
+| Fluir | Gerência 3 - Projeto Fluir |
+| ACerta | Gerência 4 - Projetos ACerta |
+| Brincando | Gerência 5 - Brincando e Aprendendo |
+| Sou da Paz | Gerência 6 - Projeto Sou da Paz |
+| DAT | Departamento de Apoio Técnico |
+| Controle | Setor de Controle (operações) |
+| Gerência | Gerência genérica |
+
+## Grupos de Função
+
+| Grupo | Permissões |
+|-------|------------|
+| Formador | Visualiza grade, gerencia bloqueios pessoais |
+| Coordenador | Cria solicitações de eventos |
+| Apoio de Coordenação | Auxilia coordenação, visualiza solicitações |
+| Gerente | Aprova/reprova, acessa dashboards e relatórios |
+
+## Regra de Aprovação SUPER
+
+```python
+can_approve_super = is_superuser OR (
+    "Gerente" IN funcoes AND "Superintendência" IN setores
+)
+```
+
+## Exemplos
+
+| Usuário | Setor | Função | Pode Aprovar SUPER? |
+|---------|-------|--------|---------------------|
+| Maria | Superintendência | Gerente | ✅ Sim |
+| João | DAT | Gerente | ❌ Não |
+| Pedro | Superintendência | Formador | ❌ Não |
+
+## API /api/me/
+
+Retorna dados RBAC do usuário autenticado:
+
+```json
+{
+  "id": 1,
+  "username": "maria",
+  "groups": ["Superintendência", "Gerente"],
+  "setores": ["Superintendência"],
+  "funcoes": ["Gerente"],
+  "is_superuser": false,
+  "is_superintendencia": true,
+  "can_approve_super": true
+}
+```
+
+## Arquivos Principais
+
+- `apps/core/views_basic.py`: Definição de grupos e CurrentUserView
+- `apps/core/tests/test_rbac_permissions.py`: Testes unitários
+- `v2/frontend/src/pages/AdminDAT/UsuariosPage.jsx`: Interface de gestão

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,34 @@
+# Aprender Sistema v2
+
+Plataforma web para gestão de eventos, formações e solicitações do programa Aprender.
+
+## Visão Geral
+
+O **Aprender Sistema (AS) v2** substitui planilhas Google/Excel por uma plataforma web automatizada, oferecendo:
+
+- **Gestão de Solicitações**: Criação, aprovação e acompanhamento de eventos
+- **Verificação de Conflitos**: Validação automática de disponibilidade de formadores
+- **Integração Google Calendar**: Publicação automática de eventos com Google Meet
+- **RBAC Completo**: Controle de acesso baseado em Setor + Função
+- **Auditoria**: Logs completos de todas as operações
+
+## Stack Tecnológica
+
+| Camada | Tecnologias |
+|--------|-------------|
+| **Backend** | Python 3.12, Django 5.1, DRF, Celery |
+| **Frontend** | React (Vite), Tailwind CSS, Ant Design |
+| **Banco de Dados** | PostgreSQL 15 |
+| **Cache/Filas** | Redis 7 |
+| **Infraestrutura** | Docker, Docker Compose |
+
+## Links Rápidos
+
+- [Instalação](getting-started/installation.md)
+- [Arquitetura](architecture/overview.md)
+- [Regras de Negócio](business-rules/clausulas-petreas.md)
+- [API Reference](api/models.md)
+
+## Repositório
+
+[:fontawesome-brands-github: GitHub](https://github.com/matheusnorjosa/aprender_sistema){ .md-button }

--- a/docs/operations/backup.md
+++ b/docs/operations/backup.md
@@ -1,0 +1,125 @@
+# Backup
+
+Estratégias de backup para o Aprender Sistema v2.
+
+## Componentes para Backup
+
+| Componente | Frequência | Retenção |
+|------------|------------|----------|
+| PostgreSQL | Diário | 30 dias |
+| Redis | Não necessário | - |
+| Uploads | Diário | 90 dias |
+| Configurações | Por deploy | Indefinido |
+
+## PostgreSQL
+
+### Backup Manual
+
+```bash
+# Via Docker
+docker compose exec db pg_dump -U aprender aprender_db > backup_$(date +%Y%m%d).sql
+
+# Comprimido
+docker compose exec db pg_dump -U aprender aprender_db | gzip > backup_$(date +%Y%m%d).sql.gz
+```
+
+### Restore Manual
+
+```bash
+# Restaurar
+docker compose exec -T db psql -U aprender aprender_db < backup_20250115.sql
+
+# Restaurar comprimido
+gunzip -c backup_20250115.sql.gz | docker compose exec -T db psql -U aprender aprender_db
+```
+
+### Backup Automatizado
+
+```yaml
+# docker-compose.yml
+services:
+  backup:
+    image: prodrigestivill/postgres-backup-local
+    environment:
+      POSTGRES_HOST: db
+      POSTGRES_DB: aprender_db
+      POSTGRES_USER: aprender
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      SCHEDULE: "@daily"
+      BACKUP_KEEP_DAYS: 30
+    volumes:
+      - ./backups:/backups
+```
+
+## Uploads
+
+### Backup de Arquivos
+
+```bash
+# Copiar arquivos de mídia
+tar -czvf uploads_$(date +%Y%m%d).tar.gz v2/backend/media/
+```
+
+### Sync com S3
+
+```bash
+# AWS CLI
+aws s3 sync v2/backend/media/ s3://aprender-backups/media/
+```
+
+## Configurações
+
+### .env
+
+```bash
+# Copiar arquivo de configuração (sem senhas reais)
+cp .env .env.backup.$(date +%Y%m%d)
+```
+
+### Secrets
+
+Armazenar secrets de forma segura:
+
+- AWS Secrets Manager
+- HashiCorp Vault
+- Azure Key Vault
+
+## Estratégia 3-2-1
+
+- **3** cópias dos dados
+- **2** tipos de mídia diferentes
+- **1** cópia offsite
+
+### Implementação
+
+1. **Local**: Volume Docker (rápido restore)
+2. **Cloud**: S3/GCS (redundância geográfica)
+3. **Offsite**: Backup semanal em storage separado
+
+## Verificação de Backups
+
+### Teste de Restore
+
+```bash
+# Criar banco temporário
+docker compose exec db createdb -U aprender test_restore
+
+# Restaurar backup
+docker compose exec -T db psql -U aprender test_restore < backup_latest.sql
+
+# Verificar dados
+docker compose exec db psql -U aprender test_restore -c "SELECT COUNT(*) FROM core_solicitacao;"
+
+# Limpar
+docker compose exec db dropdb -U aprender test_restore
+```
+
+## Monitoramento
+
+```bash
+# Verificar tamanho dos backups
+du -sh backups/*
+
+# Listar backups por data
+ls -la backups/*.sql.gz | tail -10
+```

--- a/docs/operations/deploy.md
+++ b/docs/operations/deploy.md
@@ -1,0 +1,127 @@
+# Deploy
+
+Guia de deploy do Aprender Sistema v2.
+
+## Requisitos
+
+- Docker Engine 24+
+- Docker Compose v2
+- Git
+- 4GB RAM mínimo
+- 20GB disco
+
+## Deploy Local (Development)
+
+```bash
+# Clonar repositório
+git clone https://github.com/matheusnorjosa/aprender_sistema.git
+cd aprender_sistema
+
+# Subir ambiente
+cd v2/infra
+make up
+
+# Verificar status
+make healthz
+```
+
+## Deploy Staging
+
+```bash
+# Usar o slash command
+/deploy-staging full
+
+# Ou manualmente
+cd v2/infra
+docker compose -f docker-compose.yml -f docker-compose.staging.yml up -d
+```
+
+### Variáveis de Ambiente (Staging)
+
+```bash
+# .env.staging
+ENVIRONMENT=staging
+DEBUG=False
+SECRET_KEY=<generate-random-key>
+ALLOWED_HOSTS=staging.aprender.com.br
+
+# Database
+DB_HOST=db
+DB_PORT=5432
+DB_NAME=aprender_staging
+DB_USER=aprender
+DB_PASSWORD=<secure-password>
+
+# Redis
+REDIS_URL=redis://redis:6379/0
+
+# Google Calendar
+GCAL_CLIENT=google
+GCAL_CALENDAR_ID=<calendar-id>
+GOOGLE_SERVICE_ACCOUNT_FILE=/secrets/sa-key.json
+
+# Sentry
+SENTRY_DSN=<sentry-dsn>
+SENTRY_TRACES_SAMPLE_RATE=0.5
+```
+
+## Deploy Produção
+
+### Checklist Pré-Deploy
+
+- [ ] Testes passando (`make test`)
+- [ ] Migrations aplicadas
+- [ ] Variáveis de ambiente configuradas
+- [ ] Secrets armazenados de forma segura
+- [ ] Backup do banco realizado
+
+### Comandos
+
+```bash
+# Build e push das imagens
+docker build -t aprender-web:latest v2/backend
+docker push registry.example.com/aprender-web:latest
+
+# Deploy
+docker compose -f docker-compose.prod.yml up -d
+
+# Aplicar migrations
+docker compose exec web python manage.py migrate
+
+# Coletar static files
+docker compose exec web python manage.py collectstatic --no-input
+```
+
+## Makefile
+
+```bash
+# Comandos disponíveis
+make up          # Subir ambiente
+make down        # Parar ambiente
+make logs        # Ver logs
+make shell       # Django shell
+make test        # Rodar testes
+make migrate     # Aplicar migrations
+make healthz     # Health check
+make readyz      # Ready check
+```
+
+## Rollback
+
+```bash
+# Ver histórico de deploys
+docker compose ps --all
+
+# Voltar para versão anterior
+docker compose up -d --force-recreate web
+
+# Ou restaurar backup do banco
+docker compose exec db pg_restore -U aprender -d aprender_db backup.dump
+```
+
+## Monitoramento Pós-Deploy
+
+1. Verificar logs: `docker compose logs -f web`
+2. Verificar métricas: http://localhost:9090 (Prometheus)
+3. Verificar Sentry para erros
+4. Testar endpoints críticos

--- a/docs/operations/go-live.md
+++ b/docs/operations/go-live.md
@@ -1,0 +1,121 @@
+# Go-Live Checklist
+
+Checklist para entrada em produção do Aprender Sistema v2.
+
+## Pré-Requisitos
+
+### Infraestrutura
+
+- [ ] Servidor provisionado (4GB RAM, 20GB disco)
+- [ ] Docker Engine 24+ instalado
+- [ ] Docker Compose v2 instalado
+- [ ] Domínio configurado (DNS)
+- [ ] Certificado SSL (Let's Encrypt ou similar)
+- [ ] Firewall configurado (portas 80, 443)
+
+### Configurações
+
+- [ ] `.env` de produção configurado
+- [ ] `SECRET_KEY` gerada (única para produção)
+- [ ] `ALLOWED_HOSTS` configurado
+- [ ] `DEBUG=False`
+
+### Banco de Dados
+
+- [ ] PostgreSQL 15 configurado
+- [ ] Credenciais seguras
+- [ ] Backup automatizado
+- [ ] Migrations aplicadas
+
+### Google Calendar
+
+- [ ] Service Account criada
+- [ ] Calendário compartilhado com SA
+- [ ] `GCAL_CLIENT=google`
+- [ ] Credenciais montadas no container
+
+### Monitoramento
+
+- [ ] Sentry configurado
+- [ ] Prometheus/Grafana (opcional)
+- [ ] Alertas configurados
+
+## Deploy
+
+```bash
+# 1. Subir ambiente
+make up
+
+# 2. Verificar readiness
+make readyz
+
+# 3. Verificar health
+make healthz
+
+# 4. Bloquear v1
+make ban-v1
+```
+
+## Verificações Pós-Deploy
+
+### Funcionais
+
+- [ ] Login funciona
+- [ ] Criar solicitação funciona
+- [ ] Aprovar solicitação funciona
+- [ ] Publicar no Calendar funciona
+- [ ] Meet link é gerado
+
+### Técnicas
+
+- [ ] Logs sem erros críticos
+- [ ] Métricas coletando
+- [ ] Sentry recebendo eventos
+- [ ] HTTPS funcionando
+- [ ] CSRF funcionando
+
+### Performance
+
+- [ ] Tempo de resposta < 500ms
+- [ ] Memória estável
+- [ ] CPU estável
+
+## Rollback
+
+Se necessário reverter:
+
+```bash
+# 1. Parar v2
+docker compose down
+
+# 2. Restaurar v1 (se aplicável)
+git checkout v1-freeze
+```
+
+## Comunicação
+
+### Antes do Go-Live
+
+- [ ] Notificar stakeholders
+- [ ] Agendar janela de manutenção
+- [ ] Preparar comunicado de lançamento
+
+### Após Go-Live
+
+- [ ] Confirmar sucesso com stakeholders
+- [ ] Monitorar primeiras horas
+- [ ] Coletar feedback inicial
+
+## Contatos
+
+| Função | Responsável | Contato |
+|--------|-------------|---------|
+| Tech Lead | - | - |
+| DevOps | - | - |
+| Produto | - | - |
+
+## Histórico
+
+| Data | Versão | Status |
+|------|--------|--------|
+| - | v2.0.0 | Planejado |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,101 @@
+# MkDocs Configuration - Aprender Sistema v2
+# Issue #269: Automatic documentation generation
+
+site_name: Aprender Sistema v2
+site_description: Documentação do sistema de gestão de eventos e formações
+site_author: Equipe AS
+site_url: https://matheusnorjosa.github.io/aprender_sistema/
+
+repo_name: matheusnorjosa/aprender_sistema
+repo_url: https://github.com/matheusnorjosa/aprender_sistema
+
+theme:
+  name: material
+  language: pt-BR
+  palette:
+    - scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Modo escuro
+    - scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Modo claro
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.tabs
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - content.tabs.link
+  icon:
+    repo: fontawesome/brands/github
+
+plugins:
+  - search:
+      lang: pt
+  - mkdocstrings:
+      handlers:
+        python:
+          paths: [v2/backend]
+          options:
+            show_source: true
+            show_root_heading: true
+            heading_level: 2
+
+markdown_extensions:
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - admonition
+  - pymdownx.details
+  - tables
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md
+  - Getting Started:
+    - Instalação: getting-started/installation.md
+    - Configuração: getting-started/configuration.md
+    - Quick Start: getting-started/quickstart.md
+  - Arquitetura:
+    - Visão Geral: architecture/overview.md
+    - Backend: architecture/backend.md
+    - Frontend: architecture/frontend.md
+    - Infraestrutura: architecture/infrastructure.md
+  - Regras de Negócio:
+    - Cláusulas Pétreas (CP): business-rules/clausulas-petreas.md
+    - Política de Aprovação (PA): business-rules/politica-aprovacao.md
+    - Regras de Disponibilidade (RD): business-rules/regras-disponibilidade.md
+    - Requisitos Funcionais (RF): business-rules/requisitos-funcionais.md
+  - Guias:
+    - Google Calendar: guides/google-calendar.md
+    - RBAC e Permissões: guides/rbac.md
+    - ETL e Importação: guides/etl.md
+    - Observabilidade: guides/observability.md
+  - API Reference:
+    - Models: api/models.md
+    - Services: api/services.md
+    - Views: api/views.md
+  - Operações:
+    - Deploy: operations/deploy.md
+    - Backup: operations/backup.md
+    - Go-Live Checklist: operations/go-live.md
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/matheusnorjosa/aprender_sistema

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,10 @@
+# MkDocs Documentation Dependencies
+# Issue #269: Automatic documentation generation
+# Install: pip install -r requirements-docs.txt
+
+mkdocs>=1.6.0
+mkdocs-material>=9.5.0
+mkdocstrings[python]>=0.24.0
+
+# Optional plugins
+pymdown-extensions>=10.7.0


### PR DESCRIPTION
## Summary

Closes #269

- Configure MkDocs with Material theme for automatic documentation generation
- Create comprehensive documentation structure with 22 files
- Add GitHub Actions workflow for GitHub Pages deployment

## Documentation Structure

```
docs/
├── index.md                    # Home page
├── getting-started/            # Installation, configuration, quickstart
├── architecture/               # Backend, frontend, infrastructure
├── business-rules/             # CP, PA, RD, RF
├── guides/                     # Google Calendar, RBAC, ETL, observability
├── api/                        # Models, services, views
└── operations/                 # Deploy, backup, go-live
```

## Features

- **Material theme** with dark/light mode toggle
- **Search** with Portuguese language support
- **mkdocstrings** for Python docstring extraction
- **GitHub Pages** automatic deployment on main branch push
- **Code highlighting** with copy button

## Test Plan

- [ ] Build passes with `mkdocs build --strict`
- [ ] GitHub Actions workflow runs successfully
- [ ] Documentation deploys to GitHub Pages
- [ ] Navigation works correctly
- [ ] Search functionality works