### PR TITLE
refactor(frontend): convert margin/padding inline styles to Tailwind in DATModule

### DIFF
--- a/v2/frontend/src/pages/DATModule/AcoesPage.jsx
+++ b/v2/frontend/src/pages/DATModule/AcoesPage.jsx
@@ -451,13 +451,13 @@ export default function AcoesPage() {
   ];
 
   return (
-    <div style={{ padding: '24px', background: '#f0f2f5', minHeight: 'calc(100vh - 64px)' }}>
+    <div className="p-6 bg-gray-100" style={{ minHeight: 'calc(100vh - 64px)' }}>
       {/* Header */}
-      <div style={{ marginBottom: 24 }}>
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 8 }}>
+      <div className="mb-6">
+        <div className="flex justify-between items-start mb-2">
           <div>
-            <Title level={3} style={{ margin: 0 }}>
-              <RocketOutlined style={{ marginRight: 8 }} />
+            <Title level={3} className="m-0">
+              <RocketOutlined className="mr-2" />
               Gestão de Ações
             </Title>
             <Text type="secondary">
@@ -475,7 +475,7 @@ export default function AcoesPage() {
 
       {/* Stats Cards */}
       {stats && (
-        <Row gutter={16} style={{ marginBottom: 16 }}>
+        <Row gutter={16} className="mb-4">
           <Col xs={24} sm={12} md={6}>
             <Card>
               <Statistic
@@ -522,10 +522,10 @@ export default function AcoesPage() {
       )}
 
       {/* Filters Card */}
-      <Card style={{ marginBottom: 16 }} bodyStyle={{ paddingBottom: 12 }}>
+      <Card className="mb-4" bodyStyle={{ paddingBottom: 12 }}>
         <Row gutter={[16, 16]}>
           <Col xs={24} sm={12} md={8} lg={4}>
-            <div style={{ marginBottom: 4 }}>
+            <div className="mb-1">
               <Text type="secondary" style={{ fontSize: 12, textTransform: 'uppercase' }}>
                 Buscar
               </Text>
@@ -539,7 +539,7 @@ export default function AcoesPage() {
             />
           </Col>
           <Col xs={24} sm={12} md={8} lg={3}>
-            <div style={{ marginBottom: 4 }}>
+            <div className="mb-1">
               <Text type="secondary" style={{ fontSize: 12, textTransform: 'uppercase' }}>
                 UF
               </Text>
@@ -555,7 +555,7 @@ export default function AcoesPage() {
             />
           </Col>
           <Col xs={24} sm={12} md={8} lg={5}>
-            <div style={{ marginBottom: 4 }}>
+            <div className="mb-1">
               <Text type="secondary" style={{ fontSize: 12, textTransform: 'uppercase' }}>
                 Município
               </Text>
@@ -572,7 +572,7 @@ export default function AcoesPage() {
             />
           </Col>
           <Col xs={24} sm={12} md={8} lg={4}>
-            <div style={{ marginBottom: 4 }}>
+            <div className="mb-1">
               <Text type="secondary" style={{ fontSize: 12, textTransform: 'uppercase' }}>
                 Projeto
               </Text>
@@ -589,7 +589,7 @@ export default function AcoesPage() {
             />
           </Col>
           <Col xs={24} sm={12} md={8} lg={4}>
-            <div style={{ marginBottom: 4 }}>
+            <div className="mb-1">
               <Text type="secondary" style={{ fontSize: 12, textTransform: 'uppercase' }}>
                 Coordenador
               </Text>
@@ -606,7 +606,7 @@ export default function AcoesPage() {
             />
           </Col>
           <Col xs={24} sm={12} md={8} lg={4}>
-            <div style={{ marginBottom: 4 }}>
+            <div className="mb-1">
               <Text type="secondary" style={{ fontSize: 12, textTransform: 'uppercase' }}>
                 Status
               </Text>
@@ -625,8 +625,8 @@ export default function AcoesPage() {
             />
           </Col>
         </Row>
-        <Divider style={{ margin: '16px 0 12px' }} />
-        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
+        <Divider className="my-4 mb-3" />
+        <div className="flex justify-end gap-2">
           <Button icon={<ClearOutlined />} onClick={handleClearFilters}>
             Limpar
           </Button>
@@ -710,7 +710,7 @@ export default function AcoesPage() {
       </Card>
 
       {/* Legend */}
-      <Card style={{ marginTop: 16 }} size="small">
+      <Card className="mt-4" size="small">
         <Space size="large" wrap>
           <Text strong style={{ textTransform: 'uppercase', fontSize: 12 }}>
             Legenda:
@@ -738,7 +738,7 @@ export default function AcoesPage() {
       <Modal
         title={
           <div>
-            <Title level={4} style={{ margin: 0 }}>
+            <Title level={4} className="m-0">
               {editingAcao ? 'Editar Ação' : 'Nova Ação'}
             </Title>
             <Text type="secondary" style={{ fontSize: 13 }}>
@@ -749,7 +749,7 @@ export default function AcoesPage() {
         open={modalVisible}
         onCancel={() => setModalVisible(false)}
         footer={
-          <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+          <div className="flex justify-between">
             <div>
               {editingAcao && (
                 <Button
@@ -778,7 +778,7 @@ export default function AcoesPage() {
       >
         <Form form={form} layout="vertical" onFinish={handleSave}>
           {/* Dados Básicos */}
-          <Card size="small" title="Identificação" style={{ marginBottom: 16 }}>
+          <Card size="small" title="Identificação" className="mb-4">
             <Row gutter={16}>
               <Col xs={24} sm={12}>
                 <Form.Item
@@ -830,7 +830,7 @@ export default function AcoesPage() {
           </Card>
 
           {/* Fluxo de Status */}
-          <Card size="small" title="Fluxo de Acompanhamento" style={{ marginBottom: 16 }}>
+          <Card size="small" title="Fluxo de Acompanhamento" className="mb-4">
             <Row gutter={16}>
               {/* Carta */}
               <Col xs={24} sm={12} md={6}>

--- a/v2/frontend/src/pages/DATModule/CadastrosPage.jsx
+++ b/v2/frontend/src/pages/DATModule/CadastrosPage.jsx
@@ -681,13 +681,13 @@ export default function CadastrosPage() {
   const currentPlataforma = PLATAFORMAS[activeTab];
 
   return (
-    <div style={{ padding: '24px', background: '#f0f2f5', minHeight: 'calc(100vh - 64px)' }}>
+    <div className="p-6 bg-gray-100" style={{ minHeight: 'calc(100vh - 64px)' }}>
       {/* Header */}
-      <div style={{ marginBottom: 24 }}>
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 8 }}>
+      <div className="mb-6">
+        <div className="flex justify-between items-start mb-2">
           <div>
-            <Title level={3} style={{ margin: 0 }}>
-              <CloudServerOutlined style={{ marginRight: 8 }} />
+            <Title level={3} className="m-0">
+              <CloudServerOutlined className="mr-2" />
               Gestão de Cadastros em Plataformas
             </Title>
             <Text type="secondary">
@@ -704,7 +704,7 @@ export default function CadastrosPage() {
       </div>
 
       {/* Tabs for FORMAR / AVALIAR */}
-      <Card style={{ marginBottom: 16 }}>
+      <Card className="mb-4">
         <Tabs
           activeKey={activeTab}
           onChange={setActiveTab}
@@ -734,7 +734,7 @@ export default function CadastrosPage() {
 
         {/* Stats Cards */}
         {stats && (
-          <Row gutter={16} style={{ marginTop: 16 }}>
+          <Row gutter={16} className="mt-4">
             <Col xs={24} sm={12} md={6}>
               <Card size="small">
                 <Statistic
@@ -779,10 +779,10 @@ export default function CadastrosPage() {
       </Card>
 
       {/* Filters Card */}
-      <Card style={{ marginBottom: 16 }} bodyStyle={{ paddingBottom: 12 }}>
+      <Card className="mb-4" bodyStyle={{ paddingBottom: 12 }}>
         <Row gutter={[16, 16]}>
           <Col xs={24} sm={12} md={8} lg={5}>
-            <div style={{ marginBottom: 4 }}>
+            <div className="mb-1">
               <Text type="secondary" style={{ fontSize: 12, textTransform: 'uppercase' }}>
                 Buscar
               </Text>
@@ -796,7 +796,7 @@ export default function CadastrosPage() {
             />
           </Col>
           <Col xs={24} sm={12} md={8} lg={4}>
-            <div style={{ marginBottom: 4 }}>
+            <div className="mb-1">
               <Text type="secondary" style={{ fontSize: 12, textTransform: 'uppercase' }}>
                 Projeto
               </Text>
@@ -813,7 +813,7 @@ export default function CadastrosPage() {
             />
           </Col>
           <Col xs={24} sm={12} md={8} lg={3}>
-            <div style={{ marginBottom: 4 }}>
+            <div className="mb-1">
               <Text type="secondary" style={{ fontSize: 12, textTransform: 'uppercase' }}>
                 UF
               </Text>
@@ -829,7 +829,7 @@ export default function CadastrosPage() {
             />
           </Col>
           <Col xs={24} sm={12} md={8} lg={5}>
-            <div style={{ marginBottom: 4 }}>
+            <div className="mb-1">
               <Text type="secondary" style={{ fontSize: 12, textTransform: 'uppercase' }}>
                 Município
               </Text>
@@ -846,7 +846,7 @@ export default function CadastrosPage() {
             />
           </Col>
           <Col xs={24} sm={12} md={8} lg={4}>
-            <div style={{ marginBottom: 4 }}>
+            <div className="mb-1">
               <Text type="secondary" style={{ fontSize: 12, textTransform: 'uppercase' }}>
                 Status
               </Text>
@@ -865,8 +865,8 @@ export default function CadastrosPage() {
             />
           </Col>
         </Row>
-        <Divider style={{ margin: '16px 0 12px' }} />
-        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
+        <Divider className="my-4 mb-3" />
+        <div className="flex justify-end gap-2">
           <Button icon={<ClearOutlined />} onClick={handleClearFilters}>
             Limpar
           </Button>
@@ -921,7 +921,7 @@ export default function CadastrosPage() {
       </Card>
 
       {/* Legend */}
-      <Card style={{ marginTop: 16 }} size="small">
+      <Card className="mt-4" size="small">
         <Space size="large" wrap>
           <Text strong style={{ textTransform: 'uppercase', fontSize: 12 }}>
             Legenda (clique nos ícones para alterar):
@@ -949,7 +949,7 @@ export default function CadastrosPage() {
       <Modal
         title={
           <div>
-            <Title level={4} style={{ margin: 0 }}>
+            <Title level={4} className="m-0">
               {editingCadastro ? 'Editar Cadastro' : 'Novo Cadastro'}
             </Title>
             <Text type="secondary" style={{ fontSize: 13 }}>
@@ -960,7 +960,7 @@ export default function CadastrosPage() {
         open={modalVisible}
         onCancel={() => setModalVisible(false)}
         footer={
-          <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+          <div className="flex justify-between">
             <div>
               {editingCadastro && (
                 <Button
@@ -993,7 +993,7 @@ export default function CadastrosPage() {
           </Form.Item>
 
           {/* Identificação */}
-          <Card size="small" title="Identificação" style={{ marginBottom: 16 }}>
+          <Card size="small" title="Identificação" className="mb-4">
             <Row gutter={16}>
               <Col xs={24} sm={12}>
                 <Form.Item
@@ -1053,7 +1053,7 @@ export default function CadastrosPage() {
                   <span>Workflow FORMAR</span>
                 </Space>
               }
-              style={{ marginBottom: 16 }}
+              className="mb-4"
             >
               <Row gutter={16}>
                 <Col xs={12} sm={6}>
@@ -1102,7 +1102,7 @@ export default function CadastrosPage() {
                   <span>Workflow AVALIAR</span>
                 </Space>
               }
-              style={{ marginBottom: 16 }}
+              className="mb-4"
             >
               <Row gutter={16}>
                 <Col xs={24} sm={8}>
@@ -1143,7 +1143,7 @@ export default function CadastrosPage() {
           )}
 
           {/* Links */}
-          <Card size="small" title="Links" style={{ marginBottom: 16 }}>
+          <Card size="small" title="Links" className="mb-4">
             <Row gutter={16}>
               <Col xs={24} sm={12}>
                 <Form.Item name="link_planilha" label="Link da Planilha">

--- a/v2/frontend/src/pages/DATModule/CoordenadoresPage.jsx
+++ b/v2/frontend/src/pages/DATModule/CoordenadoresPage.jsx
@@ -626,13 +626,13 @@ export default function CoordenadoresPage() {
   );
 
   return (
-    <div style={{ padding: '24px', background: '#f0f2f5', minHeight: 'calc(100vh - 64px)' }}>
+    <div className="p-6 bg-gray-100" style={{ minHeight: 'calc(100vh - 64px)' }}>
       {/* Header */}
-      <div style={{ marginBottom: 24 }}>
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 8 }}>
+      <div className="mb-6">
+        <div className="flex justify-between items-start mb-2">
           <div>
-            <Title level={3} style={{ margin: 0 }}>
-              <TeamOutlined style={{ marginRight: 8 }} />
+            <Title level={3} className="m-0">
+              <TeamOutlined className="mr-2" />
               Gestão de Coordenadores
             </Title>
             <Text type="secondary">
@@ -676,7 +676,7 @@ export default function CoordenadoresPage() {
 
       {/* Stats Cards */}
       {stats && (
-        <Row gutter={16} style={{ marginBottom: 16 }}>
+        <Row gutter={16} className="mb-4">
           <Col xs={24} sm={12} md={6}>
             <Card>
               <Statistic
@@ -728,7 +728,7 @@ export default function CoordenadoresPage() {
       <Card style={{ marginBottom: 16 }} bodyStyle={{ paddingBottom: 12 }}>
         <Row gutter={[16, 16]} align="bottom">
           <Col xs={24} sm={12} md={8} lg={6}>
-            <div style={{ marginBottom: 4 }}>
+            <div className="mb-1">
               <Text type="secondary" style={{ fontSize: 12, textTransform: 'uppercase' }}>
                 Buscar
               </Text>
@@ -856,7 +856,7 @@ export default function CoordenadoresPage() {
       <Modal
         title={
           <div>
-            <Title level={4} style={{ margin: 0 }}>
+            <Title level={4} className="m-0">
               {editingCoordenador ? 'Editar Coordenador' : 'Novo Coordenador'}
             </Title>
             <Text type="secondary" style={{ fontSize: 13 }}>
@@ -896,7 +896,7 @@ export default function CoordenadoresPage() {
       >
         <Form form={form} layout="vertical" onFinish={handleSave}>
           {/* Dados Pessoais */}
-          <Card size="small" title="Dados Pessoais" style={{ marginBottom: 16 }}>
+          <Card size="small" title="Dados Pessoais" className="mb-4">
             <Row gutter={16}>
               <Col xs={24} sm={16}>
                 <Form.Item
@@ -946,7 +946,7 @@ export default function CoordenadoresPage() {
           </Card>
 
           {/* Contato */}
-          <Card size="small" title="Contato" style={{ marginBottom: 16 }}>
+          <Card size="small" title="Contato" className="mb-4">
             <Row gutter={16}>
               <Col xs={24} sm={12}>
                 <Form.Item
@@ -1057,7 +1057,7 @@ export default function CoordenadoresPage() {
             </div>
 
             {/* Stats */}
-            <Row gutter={16} style={{ marginBottom: 24 }}>
+            <Row gutter={16} className="mb-6">
               <Col span={8}>
                 <Card size="small">
                   <Statistic
@@ -1088,7 +1088,7 @@ export default function CoordenadoresPage() {
             </Row>
 
             {/* Carga de Trabalho */}
-            <Card size="small" title="Carga de Trabalho" style={{ marginBottom: 16 }}>
+            <Card size="small" title="Carga de Trabalho" className="mb-4">
               <Space direction="vertical" style={{ width: '100%' }}>
                 <div>
                   <Text type="secondary">Municípios: </Text>
@@ -1136,7 +1136,7 @@ export default function CoordenadoresPage() {
 
             {/* Observações */}
             {viewingCoordenador.observacoes && (
-              <Card size="small" title="Observações" style={{ marginTop: 16 }}>
+              <Card size="small" title="Observações" className="mt-4">
                 <Text>{viewingCoordenador.observacoes}</Text>
               </Card>
             )}

--- a/v2/frontend/src/pages/DATModule/DATRegistrosPage.jsx
+++ b/v2/frontend/src/pages/DATModule/DATRegistrosPage.jsx
@@ -488,12 +488,12 @@ export default function DATRegistrosPage() {
   ];
 
   return (
-    <div style={{ padding: '24px', background: '#f0f2f5', minHeight: 'calc(100vh - 64px)' }}>
+    <div className="p-6 bg-gray-100" style={{ minHeight: 'calc(100vh - 64px)' }}>
       {/* Header */}
-      <div style={{ marginBottom: 24 }}>
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: 8 }}>
+      <div className="mb-6">
+        <div className="flex justify-between items-start mb-2">
           <div>
-            <Title level={3} style={{ margin: 0 }}>
+            <Title level={3} className="m-0">
               Listagem de Registros DAT
             </Title>
             <Text type="secondary">
@@ -512,10 +512,10 @@ export default function DATRegistrosPage() {
       </div>
 
       {/* Filters Card */}
-      <Card style={{ marginBottom: 16 }} bodyStyle={{ paddingBottom: 12 }}>
+      <Card className="mb-4" bodyStyle={{ paddingBottom: 12 }}>
         <Row gutter={[16, 16]}>
           <Col xs={24} sm={12} md={8} lg={4}>
-            <div style={{ marginBottom: 4 }}>
+            <div className="mb-1">
               <Text type="secondary" style={{ fontSize: 12, textTransform: 'uppercase' }}>
                 Região
               </Text>
@@ -530,7 +530,7 @@ export default function DATRegistrosPage() {
             />
           </Col>
           <Col xs={24} sm={12} md={8} lg={3}>
-            <div style={{ marginBottom: 4 }}>
+            <div className="mb-1">
               <Text type="secondary" style={{ fontSize: 12, textTransform: 'uppercase' }}>
                 UF
               </Text>
@@ -546,7 +546,7 @@ export default function DATRegistrosPage() {
             />
           </Col>
           <Col xs={24} sm={12} md={8} lg={5}>
-            <div style={{ marginBottom: 4 }}>
+            <div className="mb-1">
               <Text type="secondary" style={{ fontSize: 12, textTransform: 'uppercase' }}>
                 Município
               </Text>
@@ -563,7 +563,7 @@ export default function DATRegistrosPage() {
             />
           </Col>
           <Col xs={24} sm={12} md={8} lg={4}>
-            <div style={{ marginBottom: 4 }}>
+            <div className="mb-1">
               <Text type="secondary" style={{ fontSize: 12, textTransform: 'uppercase' }}>
                 Projeto Geral
               </Text>
@@ -578,7 +578,7 @@ export default function DATRegistrosPage() {
             />
           </Col>
           <Col xs={24} sm={12} md={8} lg={4}>
-            <div style={{ marginBottom: 4 }}>
+            <div className="mb-1">
               <Text type="secondary" style={{ fontSize: 12, textTransform: 'uppercase' }}>
                 Usa AVALIAR
               </Text>
@@ -596,7 +596,7 @@ export default function DATRegistrosPage() {
             />
           </Col>
           <Col xs={24} sm={12} md={8} lg={4}>
-            <div style={{ marginBottom: 4 }}>
+            <div className="mb-1">
               <Text type="secondary" style={{ fontSize: 12, textTransform: 'uppercase' }}>
                 Status Geral
               </Text>
@@ -614,7 +614,7 @@ export default function DATRegistrosPage() {
             />
           </Col>
         </Row>
-        <Divider style={{ margin: '16px 0 12px' }} />
+        <Divider className="my-4 mb-3" />
         <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
           <Button icon={<ClearOutlined />} onClick={handleClearFilters}>
             Limpar
@@ -709,7 +709,7 @@ export default function DATRegistrosPage() {
       </Card>
 
       {/* Legend */}
-      <Card style={{ marginTop: 16 }} size="small">
+      <Card className="mt-4" size="small">
         <Space size="large" wrap>
           <Text strong style={{ textTransform: 'uppercase', fontSize: 12 }}>
             Legenda de Ícones:
@@ -744,7 +744,7 @@ export default function DATRegistrosPage() {
       <Modal
         title={
           <div>
-            <Title level={4} style={{ margin: 0 }}>
+            <Title level={4} className="m-0">
               {editingRegistro ? 'Editar Registro DAT' : 'Novo Registro DAT'}
             </Title>
             <Text type="secondary" style={{ fontSize: 13 }}>
@@ -784,7 +784,7 @@ export default function DATRegistrosPage() {
                 <span>Dados Básicos</span>
               </Space>
             }
-            style={{ marginBottom: 16 }}
+            className="mb-4"
           >
             <Row gutter={16}>
               <Col xs={24} sm={12} md={8}>
@@ -859,7 +859,7 @@ export default function DATRegistrosPage() {
                     <Tag color="blue">Integração</Tag>
                   </Space>
                 }
-                style={{ marginBottom: 16, height: '100%' }}
+                className="mb-4 h-full"
               >
                 <Row gutter={16}>
                   <Col span={12}>
@@ -887,7 +887,7 @@ export default function DATRegistrosPage() {
                   </Col>
                 </Row>
 
-                <Divider style={{ margin: '12px 0' }} dashed />
+                <Divider className="my-3" dashed />
 
                 <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
                   <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
@@ -936,9 +936,9 @@ export default function DATRegistrosPage() {
                   </div>
                 </div>
 
-                <Divider style={{ margin: '12px 0' }} dashed />
+                <Divider className="my-3" dashed />
 
-                <Form.Item name="obs_formar" label="Observações FORMAR" style={{ marginBottom: 0 }}>
+                <Form.Item name="obs_formar" label="Observações FORMAR" className="mb-0">
                   <Input.TextArea rows={3} placeholder="Observações sobre a integração com FORMAR..." />
                 </Form.Item>
               </Card>
@@ -959,9 +959,9 @@ export default function DATRegistrosPage() {
                     </Form.Item>
                   </div>
                 }
-                style={{ marginBottom: 16, height: '100%' }}
+                className="mb-4 h-full"
               >
-                <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+                <div className="flex flex-col gap-3">
                   {/* Alunos Recebidos */}
                   <Card size="small" style={{ background: '#fafafa' }}>
                     <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
@@ -1023,9 +1023,9 @@ export default function DATRegistrosPage() {
                   </Card>
                 </div>
 
-                <Divider style={{ margin: '12px 0' }} dashed />
+                <Divider className="my-3" dashed />
 
-                <Form.Item name="obs_avaliar" label="Observações AVALIAR" style={{ marginBottom: 0 }}>
+                <Form.Item name="obs_avaliar" label="Observações AVALIAR" className="mb-0">
                   <Input.TextArea rows={3} placeholder="Detalhes sobre a importação no AVALIAR..." />
                 </Form.Item>
               </Card>

--- a/v2/frontend/src/pages/DATModule/PlanoFormacoesPage.jsx
+++ b/v2/frontend/src/pages/DATModule/PlanoFormacoesPage.jsx
@@ -501,11 +501,11 @@ export default function PlanoFormacoesPage() {
   // ============================================================
 
   return (
-    <div style={{ padding: 24 }}>
+    <div className="p-6">
       {/* Header */}
-      <div style={{ marginBottom: 24, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+      <div className="mb-6 flex justify-between items-center">
         <div>
-          <Title level={3} style={{ margin: 0 }}>Plano de Formacoes</Title>
+          <Title level={3} className="m-0">Plano de Formacoes</Title>
           <Text type="secondary">Gestao do plano anual de formacoes por municipio e projeto</Text>
         </div>
         <Space>
@@ -540,7 +540,7 @@ export default function PlanoFormacoesPage() {
 
       {/* Stats Cards */}
       {stats && (
-        <Row gutter={16} style={{ marginBottom: 16 }}>
+        <Row gutter={16} className="mb-4">
           <Col xs={24} sm={12} md={6}>
             <Card>
               <Statistic
@@ -584,10 +584,10 @@ export default function PlanoFormacoesPage() {
       )}
 
       {/* Filters */}
-      <Card style={{ marginBottom: 16 }} bodyStyle={{ paddingBottom: 12 }}>
+      <Card className="mb-4" bodyStyle={{ paddingBottom: 12 }}>
         <Row gutter={[16, 16]}>
           <Col xs={24} sm={12} md={6} lg={4}>
-            <div style={{ marginBottom: 4 }}>
+            <div className="mb-1">
               <Text type="secondary" style={{ fontSize: 12, textTransform: 'uppercase' }}>Buscar</Text>
             </div>
             <Input.Search
@@ -599,7 +599,7 @@ export default function PlanoFormacoesPage() {
             />
           </Col>
           <Col xs={12} sm={6} md={4} lg={3}>
-            <div style={{ marginBottom: 4 }}>
+            <div className="mb-1">
               <Text type="secondary" style={{ fontSize: 12, textTransform: 'uppercase' }}>Municipio</Text>
             </div>
             <Select
@@ -614,7 +614,7 @@ export default function PlanoFormacoesPage() {
             />
           </Col>
           <Col xs={12} sm={6} md={4} lg={3}>
-            <div style={{ marginBottom: 4 }}>
+            <div className="mb-1">
               <Text type="secondary" style={{ fontSize: 12, textTransform: 'uppercase' }}>Projeto</Text>
             </div>
             <Select
@@ -629,7 +629,7 @@ export default function PlanoFormacoesPage() {
             />
           </Col>
           <Col xs={12} sm={6} md={4} lg={3}>
-            <div style={{ marginBottom: 4 }}>
+            <div className="mb-1">
               <Text type="secondary" style={{ fontSize: 12, textTransform: 'uppercase' }}>Coordenador</Text>
             </div>
             <Select
@@ -644,8 +644,8 @@ export default function PlanoFormacoesPage() {
             />
           </Col>
         </Row>
-        <Divider style={{ margin: '16px 0 12px' }} />
-        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
+        <Divider className="my-4 mb-3" />
+        <div className="flex justify-end gap-2">
           <Button icon={<ClearOutlined />} onClick={handleClearFilters}>Limpar</Button>
           <Button icon={<ReloadOutlined />} onClick={() => fetchData(1)} loading={loading}>Atualizar</Button>
           <Button type="primary" icon={<FilterOutlined />} onClick={() => fetchData(1)}>Filtrar</Button>


### PR DESCRIPTION
## Summary
- Convert common layout inline styles to Tailwind utility classes in DATModule pages
- Part of Issue #294 (margin/padding refactoring)

## Changes
5 files updated with layout conversions:
- `DATRegistrosPage.jsx`
- `AcoesPage.jsx`
- `CadastrosPage.jsx`
- `CoordenadoresPage.jsx`
- `PlanoFormacoesPage.jsx`

## Patterns Converted
| Inline Style | Tailwind Class |
|--------------|----------------|
| `padding: 24px` | `p-6` |
| `marginBottom: 24` | `mb-6` |
| `marginBottom: 16` | `mb-4` |
| `marginBottom: 8` | `mb-2` |
| `marginBottom: 4` | `mb-1` |
| `marginTop: 16` | `mt-4` |
| `margin: 0` | `m-0` |
| `margin: '16px 0 12px'` | `my-4 mb-3` |
| `display: flex, justifyContent, alignItems` | `flex justify-between items-start` |
| `gap: 8` | `gap-2` |
| `marginRight: 8` | `mr-2` |

## Test Plan
- [x] `npm run build` passes without errors
- [ ] Visual inspection of layout in browser

Partial fix for #294