### PR TITLE
refactor(frontend): convert flex layout inline styles to Tailwind (#295)

### DIFF
--- a/v2/frontend/src/App.jsx
+++ b/v2/frontend/src/App.jsx
@@ -76,13 +76,7 @@ const { Text } = Typography;
 // Componente de loading para Suspense
 function PageLoader() {
   return (
-    <div style={{
-      display: 'flex',
-      justifyContent: 'center',
-      alignItems: 'center',
-      height: '100%',
-      minHeight: '300px'
-    }}>
+    <div className="flex justify-center items-center" style={{ height: '100%', minHeight: '300px' }}>
       <Spin size="large" tip="Carregando página..." />
     </div>
   );
@@ -308,16 +302,15 @@ function AppContent() {
             }}
           >
             {/* Logo/Título */}
-            <div style={{
-              height: '64px',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              color: 'white',
-              fontSize: '22px',
-              fontWeight: 'bold',
-              borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
-            }}>
+            <div
+              className="flex items-center justify-center font-bold"
+              style={{
+                height: '64px',
+                color: 'white',
+                fontSize: '22px',
+                borderBottom: '1px solid rgba(255, 255, 255, 0.1)',
+              }}
+            >
               Aprender Sistema
             </div>
 
@@ -452,16 +445,15 @@ function AppContent() {
           {/* Layout com margem para compensar Sider fixo */}
           <Layout style={{ marginLeft: 250, minHeight: '100vh', background: isDark ? '#141414' : undefined }}>
             {/* Header com info do usuário */}
-            <Header style={{
-              background: isDark ? '#1f1f1f' : '#fff',
-              padding: '0 24px',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'flex-end',
-              borderBottom: isDark ? '1px solid #303030' : '1px solid #f0f0f0',
-              width: '100%',
-            }}>
-              <div style={{ display: 'flex', alignItems: 'center', gap: '16px', whiteSpace: 'nowrap' }}>
+            <Header
+              className="flex items-center justify-end w-full"
+              style={{
+                background: isDark ? '#1f1f1f' : '#fff',
+                padding: '0 24px',
+                borderBottom: isDark ? '1px solid #303030' : '1px solid #f0f0f0',
+              }}
+            >
+              <div className="flex items-center gap-4" style={{ whiteSpace: 'nowrap' }}>
                 {/* Toggle de tema */}
                 <Tooltip title={isDark ? 'Modo claro' : 'Modo escuro'}>
                   <Button
@@ -471,7 +463,7 @@ function AppContent() {
                     style={{ color: isDark ? '#fff' : undefined }}
                   />
                 </Tooltip>
-                <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                <div className="flex items-center gap-2">
                   <UserOutlined />
                   <Text strong>{user?.name || user?.username || 'Usuário'}</Text>
                 </div>

--- a/v2/frontend/src/pages/AdminDAT/GruposPage.jsx
+++ b/v2/frontend/src/pages/AdminDAT/GruposPage.jsx
@@ -259,7 +259,7 @@ export default function GruposPage() {
         </div>
 
         <Checkbox.Group
-          style={{ width: '100%', display: 'flex', flexDirection: 'column', gap: '8px' }}
+          className="w-full flex flex-col gap-2"
           value={selectedUsers}
           onChange={setSelectedUsers}
         >

--- a/v2/frontend/src/pages/Auth/LoginPage.jsx
+++ b/v2/frontend/src/pages/Auth/LoginPage.jsx
@@ -34,15 +34,10 @@ export default function LoginPage({ onLoginSuccess }) {
   };
 
   return (
-    <div style={{
-      minHeight: '100vh',
-      display: 'flex',
-      flexDirection: 'column',
-      alignItems: 'center',
-      justifyContent: 'flex-start',
-      paddingTop: '60px',
-      background: '#004B3D',
-    }}>
+    <div
+      className="flex flex-col items-center justify-start"
+      style={{ minHeight: '100vh', paddingTop: '60px', background: '#004B3D' }}
+    >
       {/* Logo */}
       <div style={{ marginBottom: '40px' }}>
         <img

--- a/v2/frontend/src/pages/DATModule/AcoesPage.jsx
+++ b/v2/frontend/src/pages/DATModule/AcoesPage.jsx
@@ -652,13 +652,10 @@ export default function AcoesPage() {
       >
         {/* Column Group Headers */}
         <div
+          className="flex text-xs font-semibold uppercase"
           style={{
-            display: 'flex',
             borderBottom: '1px solid #f0f0f0',
             background: '#fafafa',
-            fontSize: 12,
-            fontWeight: 600,
-            textTransform: 'uppercase',
           }}
         >
           <div

--- a/v2/frontend/src/pages/DATModule/CoordenadoresPage.jsx
+++ b/v2/frontend/src/pages/DATModule/CoordenadoresPage.jsx
@@ -779,7 +779,7 @@ export default function CoordenadoresPage() {
             />
           </Col>
           <Col flex="auto">
-            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
+            <div className="flex justify-end gap-2">
               <Button icon={<ClearOutlined />} onClick={handleClearFilters}>
                 Limpar
               </Button>
@@ -867,7 +867,7 @@ export default function CoordenadoresPage() {
         open={modalVisible}
         onCancel={() => setModalVisible(false)}
         footer={
-          <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+          <div className="flex justify-between">
             <div>
               {editingCoordenador && (
                 <Button
@@ -1011,7 +1011,7 @@ export default function CoordenadoresPage() {
         {viewingCoordenador && (
           <div>
             {/* Header */}
-            <div style={{ display: 'flex', gap: 16, marginBottom: 24 }}>
+            <div className="flex gap-4 mb-6">
               <Avatar
                 src={viewingCoordenador.foto_url}
                 size={80}

--- a/v2/frontend/src/pages/DATModule/DATRegistrosPage.jsx
+++ b/v2/frontend/src/pages/DATModule/DATRegistrosPage.jsx
@@ -615,7 +615,7 @@ export default function DATRegistrosPage() {
           </Col>
         </Row>
         <Divider className="my-4 mb-3" />
-        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8 }}>
+        <div className="flex justify-end gap-2">
           <Button icon={<ClearOutlined />} onClick={handleClearFilters}>
             Limpar
           </Button>
@@ -641,49 +641,24 @@ export default function DATRegistrosPage() {
       >
         {/* Column Group Headers */}
         <div
-          style={{
-            display: 'flex',
-            borderBottom: '1px solid #f0f0f0',
-            background: '#fafafa',
-            fontSize: 12,
-            fontWeight: 600,
-            textTransform: 'uppercase',
-          }}
+          className="flex text-xs font-semibold uppercase"
+          style={{ borderBottom: '1px solid #f0f0f0', background: '#fafafa' }}
         >
           <div
-            style={{
-              flex: '0 0 640px',
-              padding: '8px 16px',
-              borderRight: '1px solid #f0f0f0',
-              display: 'flex',
-              alignItems: 'center',
-              gap: 6,
-            }}
+            className="flex items-center gap-1.5"
+            style={{ flex: '0 0 640px', padding: '8px 16px', borderRight: '1px solid #f0f0f0' }}
           >
             <DatabaseOutlined /> Dados Básicos
           </div>
           <div
-            style={{
-              flex: '0 0 580px',
-              padding: '8px 16px',
-              borderRight: '1px solid #f0f0f0',
-              display: 'flex',
-              alignItems: 'center',
-              gap: 6,
-              color: '#1890ff',
-            }}
+            className="flex items-center gap-1.5 text-blue-500"
+            style={{ flex: '0 0 580px', padding: '8px 16px', borderRight: '1px solid #f0f0f0' }}
           >
             <BookOutlined /> Detalhes FORMAR
           </div>
           <div
-            style={{
-              flex: 1,
-              padding: '8px 16px',
-              display: 'flex',
-              alignItems: 'center',
-              gap: 6,
-              color: '#52c41a',
-            }}
+            className="flex items-center gap-1.5 text-green-500"
+            style={{ flex: 1, padding: '8px 16px' }}
           >
             <BarChartOutlined /> Detalhes AVALIAR
           </div>
@@ -755,7 +730,7 @@ export default function DATRegistrosPage() {
         open={modalVisible}
         onCancel={() => setModalVisible(false)}
         footer={
-          <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+          <div className="flex justify-between">
             <div>
               {editingRegistro && (
                 <Button danger type="text" icon={<DeleteOutlined />} onClick={() => { setModalVisible(false); handleDelete(editingRegistro); }}>
@@ -889,8 +864,8 @@ export default function DATRegistrosPage() {
 
                 <Divider className="my-3" dashed />
 
-                <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                <div className="flex flex-col gap-3">
+                  <div className="flex justify-between items-center">
                     <Form.Item name="chaves_inscricao_status" noStyle>
                       <Select
                         placeholder="Status"
@@ -905,7 +880,7 @@ export default function DATRegistrosPage() {
                     </Form.Item>
                   </div>
 
-                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                  <div className="flex justify-between items-center">
                     <Form.Item name="instrucoes_status" noStyle>
                       <Select
                         placeholder="Status"
@@ -920,7 +895,7 @@ export default function DATRegistrosPage() {
                     </Form.Item>
                   </div>
 
-                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                  <div className="flex justify-between items-center">
                     <Form.Item name="envio_codigos_status" noStyle>
                       <Select
                         placeholder="Status"
@@ -949,7 +924,7 @@ export default function DATRegistrosPage() {
               <Card
                 size="small"
                 title={
-                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', width: '100%' }}>
+                  <div className="flex justify-between items-center w-full">
                     <Space>
                       <BarChartOutlined className="text-green-500" />
                       <span>Plataforma AVALIAR</span>
@@ -964,7 +939,7 @@ export default function DATRegistrosPage() {
                 <div className="flex flex-col gap-3">
                   {/* Alunos Recebidos */}
                   <Card size="small" style={{ background: '#fafafa' }}>
-                    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                    <div className="flex justify-between items-center">
                       <Space>
                         <Form.Item name="alunos_recebidos_status" noStyle>
                           <Select
@@ -984,7 +959,7 @@ export default function DATRegistrosPage() {
 
                   {/* Alunos Validados */}
                   <Card size="small" style={{ background: '#fafafa' }}>
-                    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                    <div className="flex justify-between items-center">
                       <Space>
                         <Form.Item name="alunos_validados_status" noStyle>
                           <Select
@@ -1004,7 +979,7 @@ export default function DATRegistrosPage() {
 
                   {/* Alunos Importados */}
                   <Card size="small" style={{ background: '#fafafa' }}>
-                    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                    <div className="flex justify-between items-center">
                       <Space>
                         <Form.Item name="alunos_importados_status" noStyle>
                           <Select

--- a/v2/frontend/src/pages/MapaBrasil/MapaBrasilPage.jsx
+++ b/v2/frontend/src/pages/MapaBrasil/MapaBrasilPage.jsx
@@ -393,7 +393,7 @@ export default function MapaBrasilPage() {
   return (
     <div style={{ padding: '24px', background: '#f0f2f5', minHeight: '100vh' }}>
       {/* Header */}
-      <div style={{ marginBottom: 24, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+      <div className="mb-6 flex justify-between items-center">
         <div>
           <Title level={2} style={{ marginBottom: 0 }}>
             <EnvironmentOutlined style={{ marginRight: 8 }} />
@@ -795,7 +795,7 @@ export default function MapaBrasilPage() {
                   dataSource={Object.entries(estadosData).sort((a, b) => b[1].eventos - a[1].eventos)}
                   renderItem={([uf, data]) => (
                     <List.Item>
-                      <div style={{ width: '100%', display: 'flex', justifyContent: 'space-between' }}>
+                      <div className="w-full flex justify-between">
                         <div>
                           <Text strong>{uf}</Text>
                           <br />


### PR DESCRIPTION
## Summary
- Converts all flexbox inline styles to Tailwind CSS utility classes
- 7 files modified, removing 90 lines of inline style code and replacing with 49 lines using Tailwind classes

## Files Changed

| File | Occurrences |
|------|-------------|
| App.jsx | 5 |
| LoginPage.jsx | 1 |
| MapaBrasilPage.jsx | 2 |
| AcoesPage.jsx | 1 |
| GruposPage.jsx | 1 |
| CoordenadoresPage.jsx | 3 |
| DATRegistrosPage.jsx | 15+ |

## Conversions Applied

| Inline Style | Tailwind |
|--------------|----------|
| `display: 'flex'` | `flex` |
| `justifyContent: 'space-between'` | `justify-between` |
| `justifyContent: 'flex-end'` | `justify-end` |
| `justifyContent: 'center'` | `justify-center` |
| `alignItems: 'center'` | `items-center` |
| `flexDirection: 'column'` | `flex-col` |
| `gap: 8` | `gap-2` |
| `gap: 16` | `gap-4` |

## Test Plan
- [x] Build passes (`npm run build`)
- [ ] Visual regression test on key pages

Closes #295