### PR TITLE
refactor(frontend): convert background inline styles to Tailwind (#296)

### DIFF
--- a/v2/frontend/src/pages/AdminDAT/AdminDATHomePage.jsx
+++ b/v2/frontend/src/pages/AdminDAT/AdminDATHomePage.jsx
@@ -64,7 +64,7 @@ export default function AdminDATHomePage() {
   ];
 
   return (
-    <div style={{ padding: '24px', background: '#f0f2f5', minHeight: 'calc(100vh - 64px)' }}>
+    <div className="p-6 bg-gray-100" style={{ minHeight: 'calc(100vh - 64px)' }}>
       {/* Header */}
       <div style={{ marginBottom: '24px' }}>
         <Title level={2}>Admin DAT</Title>

--- a/v2/frontend/src/pages/Aprovacoes/ApprovalsPage.jsx
+++ b/v2/frontend/src/pages/Aprovacoes/ApprovalsPage.jsx
@@ -511,7 +511,7 @@ export default function ApprovalsPage() {
               {payload.description && (
                 <>
                   <Divider orientation="left" className="mt-4">Descrição</Divider>
-                  <Card size="small" style={{ background: '#fafafa' }}>
+                  <Card size="small" className="bg-gray-50">
                     <pre style={{
                       whiteSpace: 'pre-wrap',
                       margin: 0,

--- a/v2/frontend/src/pages/DATModule/AcoesPage.jsx
+++ b/v2/frontend/src/pages/DATModule/AcoesPage.jsx
@@ -652,11 +652,8 @@ export default function AcoesPage() {
       >
         {/* Column Group Headers */}
         <div
-          className="flex text-xs font-semibold uppercase"
-          style={{
-            borderBottom: '1px solid #f0f0f0',
-            background: '#fafafa',
-          }}
+          className="flex text-xs font-semibold uppercase bg-gray-50"
+          style={{ borderBottom: '1px solid #f0f0f0' }}
         >
           <div
             style={{

--- a/v2/frontend/src/pages/DATModule/ComprasPage.jsx
+++ b/v2/frontend/src/pages/DATModule/ComprasPage.jsx
@@ -669,7 +669,7 @@ export default function ComprasPage() {
 
             return (
               <Table.Summary fixed>
-                <Table.Summary.Row style={{ background: '#fafafa', fontWeight: 'bold' }}>
+                <Table.Summary.Row className="bg-gray-50 font-bold">
                   <Table.Summary.Cell index={0} colSpan={4}>
                     Total da Página
                   </Table.Summary.Cell>

--- a/v2/frontend/src/pages/DATModule/DATRegistrosPage.jsx
+++ b/v2/frontend/src/pages/DATModule/DATRegistrosPage.jsx
@@ -641,8 +641,8 @@ export default function DATRegistrosPage() {
       >
         {/* Column Group Headers */}
         <div
-          className="flex text-xs font-semibold uppercase"
-          style={{ borderBottom: '1px solid #f0f0f0', background: '#fafafa' }}
+          className="flex text-xs font-semibold uppercase bg-gray-50"
+          style={{ borderBottom: '1px solid #f0f0f0' }}
         >
           <div
             className="flex items-center gap-1.5"
@@ -938,7 +938,7 @@ export default function DATRegistrosPage() {
               >
                 <div className="flex flex-col gap-3">
                   {/* Alunos Recebidos */}
-                  <Card size="small" style={{ background: '#fafafa' }}>
+                  <Card size="small" className="bg-gray-50">
                     <div className="flex justify-between items-center">
                       <Space>
                         <Form.Item name="alunos_recebidos_status" noStyle>
@@ -958,7 +958,7 @@ export default function DATRegistrosPage() {
                   </Card>
 
                   {/* Alunos Validados */}
-                  <Card size="small" style={{ background: '#fafafa' }}>
+                  <Card size="small" className="bg-gray-50">
                     <div className="flex justify-between items-center">
                       <Space>
                         <Form.Item name="alunos_validados_status" noStyle>
@@ -978,7 +978,7 @@ export default function DATRegistrosPage() {
                   </Card>
 
                   {/* Alunos Importados */}
-                  <Card size="small" style={{ background: '#fafafa' }}>
+                  <Card size="small" className="bg-gray-50">
                     <div className="flex justify-between items-center">
                       <Space>
                         <Form.Item name="alunos_importados_status" noStyle>

--- a/v2/frontend/src/pages/MapaBrasil/MapaBrasilPage.jsx
+++ b/v2/frontend/src/pages/MapaBrasil/MapaBrasilPage.jsx
@@ -391,7 +391,7 @@ export default function MapaBrasilPage() {
   }, []);
 
   return (
-    <div style={{ padding: '24px', background: '#f0f2f5', minHeight: '100vh' }}>
+    <div className="p-6 bg-gray-100" style={{ minHeight: '100vh' }}>
       {/* Header */}
       <div className="mb-6 flex justify-between items-center">
         <div>


### PR DESCRIPTION
## Summary
- Final part (4/4) of inline styles refactoring series
- Converts simple background colors to Tailwind utility classes
- 6 files modified, 11 insertions, 14 deletions

## Files Changed

| File | Color | Tailwind |
|------|-------|----------|
| AdminDATHomePage.jsx | #f0f2f5 | bg-gray-100 |
| ApprovalsPage.jsx | #fafafa | bg-gray-50 |
| AcoesPage.jsx | #fafafa | bg-gray-50 |
| ComprasPage.jsx | #fafafa | bg-gray-50 |
| MapaBrasilPage.jsx | #f0f2f5 | bg-gray-100 |
| DATRegistrosPage.jsx | 4x #fafafa | bg-gray-50 |

## Exclusions (kept as inline)
- Brand colors (#004B3D, #E5EDE5)
- Status colors with borders (#f6ffed, #e6f7ff, etc.)
- Map legend colors
- Dynamic/conditional backgrounds

## Refactoring Series Complete

| PR | Issue | Description | Status |
|----|-------|-------------|--------|
| #297 | #293 | Icon colors | ✅ Merged |
| #298 | #294 | margin/padding Part 1 | ✅ Merged |
| #299 | #294 | margin/padding Part 2 | ✅ Merged |
| #300 | #295 | flex layout | ✅ Merged |
| #301 | #296 | background styles | 🔄 This PR |

## Test Plan
- [x] Build passes (`npm run build`)
- [ ] Visual regression test on key pages

Closes #296