### PR TITLE
chore: add CP-07 rule to block direct push to main

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -472,6 +472,26 @@ Ordem obrigatória de trabalho para agentes autônomos:
 - Require: 1+ approval, CI verde, branch up-to-date
 - Merge strategy: **Squash and merge** recomendado
 
+### 🚫 CP-07: Nunca Commit/Push Direto na Main
+**REGRA ABSOLUTA**: Todas as mudanças devem passar por PR.
+
+**Fluxo obrigatório:**
+1. `git checkout -b <type>/<nome>` — Criar branch
+2. Fazer commits na branch
+3. `git push -u origin <type>/<nome>` — Push da branch
+4. `gh pr create` — Abrir PR
+5. Aguardar CI verde
+6. `gh pr merge` — Merge via GitHub
+
+**PROIBIDO:**
+- ❌ `git push origin main` — Push direto na main
+- ❌ `git commit` estando na branch main — Commit na main
+- ❌ Merge local na main — Sempre via PR
+
+**Exceção única:** Hotfix crítico de segurança COM aprovação explícita do usuário na mesma mensagem.
+
+**Enforcement:** Hook em `.claude/settings.json` bloqueia `git push origin main`.
+
 ---
 
 ## ✅ SESSÃO ATUAL: Sistema Completo + Módulo DAT (Dezembro 2025)

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,16 @@
 {
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "powershell -Command \"if ($env:TOOL_INPUT -match 'push.*origin\\s+main' -or $env:TOOL_INPUT -match 'push\\s+origin\\s+main') { Write-Error 'CP-07 VIOLADO: Push direto na main bloqueado. Use branch + PR.'; exit 1 }\""
+          }
+        ]
+      }
+    ],
     "Notification": [
       {
         "matcher": "",


### PR DESCRIPTION
## Summary

Adiciona regra CP-07 às cláusulas pétreas para garantir que todas as mudanças passem por PR.

## Mudanças

### CLAUDE.md
- Nova seção **CP-07: Nunca Commit/Push Direto na Main**
- Documenta fluxo obrigatório: branch → commit → push → PR → merge
- Lista ações proibidas explicitamente
- Define exceção única (hotfix crítico com aprovação explícita)

### settings.json  
- Novo hook `PreToolUse` que intercepta comandos Bash
- Bloqueia `git push origin main` via regex PowerShell
- Retorna erro com mensagem clara: "CP-07 VIOLADO"

## Motivação

Dois commits recentes foram feitos diretamente na main:
- `ce69631` fix(security): add CSRF protection
- `8b7eb0c` refactor: replace console.warn

Este PR previne que isso aconteça novamente.

## Test plan

- [ ] Tentar `git push origin main` e verificar se hook bloqueia
- [ ] Verificar que push para outras branches funciona normalmente