### PR TITLE
perf: optimize N+1 queries in stats endpoints

### DIFF
--- a/v2/backend/apps/core/views/dat.py
+++ b/v2/backend/apps/core/views/dat.py
@@ -246,19 +246,22 @@ class DATRegistroViewSet(viewsets.ModelViewSet):
         """
         qs = self.filter_queryset(self.get_queryset())
 
-        total = qs.count()
-        completos_formar = qs.filter(
-            chaves_inscricao_status="concluido",
-            instrucoes_status="concluido",
-            envio_codigos_status="concluido",
-        ).count()
-        usa_avaliar = qs.filter(usa_avaliar=True).count()
-        completos_avaliar = qs.filter(
-            usa_avaliar=True,
-            alunos_recebidos_status="concluido",
-            alunos_validados_status="concluido",
-            alunos_importados_status="concluido",
-        ).count()
+        # Agregação em uma única query (Issue #308: fix N+1)
+        stats = qs.aggregate(
+            total=Count('id'),
+            completos_formar=Count('id', filter=Q(
+                chaves_inscricao_status="concluido",
+                instrucoes_status="concluido",
+                envio_codigos_status="concluido",
+            )),
+            usa_avaliar_count=Count('id', filter=Q(usa_avaliar=True)),
+            completos_avaliar=Count('id', filter=Q(
+                usa_avaliar=True,
+                alunos_recebidos_status="concluido",
+                alunos_validados_status="concluido",
+                alunos_importados_status="concluido",
+            )),
+        )
 
         por_uf = (
             qs.values("municipio__uf")
@@ -267,10 +270,10 @@ class DATRegistroViewSet(viewsets.ModelViewSet):
         )
 
         return Response({
-            "total": total,
-            "completos_formar": completos_formar,
-            "completos_avaliar": completos_avaliar,
-            "usa_avaliar": usa_avaliar,
+            "total": stats['total'],
+            "completos_formar": stats['completos_formar'],
+            "completos_avaliar": stats['completos_avaliar'],
+            "usa_avaliar": stats['usa_avaliar_count'],
             "por_uf": list(por_uf),
         })
 

--- a/v2/backend/apps/core/views_gcal/insights.py
+++ b/v2/backend/apps/core/views_gcal/insights.py
@@ -50,11 +50,17 @@ class SuccessRateView(APIView):
         # Reutilizar helper TZ-aware
         qs = _filter_events_queryset(request, Solicitacao.objects.all())
 
-        # Contar por gcal_status
-        published = qs.filter(gcal_status=Solicitacao.GCalStatus.PUBLISHED).count()
-        error = qs.filter(gcal_status=Solicitacao.GCalStatus.ERROR).count()
-        pending = qs.filter(gcal_status=Solicitacao.GCalStatus.PENDING).count()
-        none = qs.filter(gcal_status=Solicitacao.GCalStatus.NONE).count()
+        # Contar por gcal_status em uma única query (Issue #308: fix N+1)
+        counts = qs.aggregate(
+            published=Count('id', filter=Q(gcal_status=Solicitacao.GCalStatus.PUBLISHED)),
+            error=Count('id', filter=Q(gcal_status=Solicitacao.GCalStatus.ERROR)),
+            pending=Count('id', filter=Q(gcal_status=Solicitacao.GCalStatus.PENDING)),
+            none=Count('id', filter=Q(gcal_status=Solicitacao.GCalStatus.NONE)),
+        )
+        published = counts['published']
+        error = counts['error']
+        pending = counts['pending']
+        none = counts['none']
 
         # Calcular rate (apenas published e error contam como "tentativas")
         denom = published + error

--- a/v2/backend/apps/core/views_gcal/summary.py
+++ b/v2/backend/apps/core/views_gcal/summary.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from datetime import date
 from typing import Any
 
-from django.db.models import Count
+from django.db.models import Count, Q
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
@@ -239,21 +239,23 @@ class AlertsSummaryView(APIView):
         # Reutilizar helper TZ-aware
         qs = _filter_events_queryset(request, Solicitacao.objects.all())
 
-        # Contar por gcal_status
-        errors = qs.filter(gcal_status=Solicitacao.GCalStatus.ERROR).count()
-        pending = qs.filter(gcal_status=Solicitacao.GCalStatus.PENDING).count()
-        published = qs.filter(gcal_status=Solicitacao.GCalStatus.PUBLISHED).count()
-        none = qs.filter(gcal_status=Solicitacao.GCalStatus.NONE).count()
+        # Contar por gcal_status em uma única query (Issue #308: fix N+1)
+        counts = qs.aggregate(
+            errors=Count('id', filter=Q(gcal_status=Solicitacao.GCalStatus.ERROR)),
+            pending=Count('id', filter=Q(gcal_status=Solicitacao.GCalStatus.PENDING)),
+            published=Count('id', filter=Q(gcal_status=Solicitacao.GCalStatus.PUBLISHED)),
+            none=Count('id', filter=Q(gcal_status=Solicitacao.GCalStatus.NONE)),
+        )
 
         # Extrair janela de query params (retornar como strings ou null)
         start_param = request.query_params.get('start')
         end_param = request.query_params.get('end')
 
         return Response({
-            'errors': errors,
-            'pending': pending,
-            'published': published,
-            'none': none,
+            'errors': counts['errors'],
+            'pending': counts['pending'],
+            'published': counts['published'],
+            'none': counts['none'],
             'window': {
                 'start': start_param if start_param else None,
                 'end': end_param if end_param else None


### PR DESCRIPTION
## Summary

Otimiza endpoints de estatísticas substituindo múltiplas chamadas `.count()` por uma única `.aggregate()` com `Count` e filtros `Q`.

Closes #308

## Mudanças

### views_gcal/summary.py - AlertsSummaryView
```python
# Antes (4 queries)
errors = qs.filter(gcal_status=ERROR).count()
pending = qs.filter(gcal_status=PENDING).count()
published = qs.filter(gcal_status=PUBLISHED).count()
none = qs.filter(gcal_status=NONE).count()

# Depois (1 query)
counts = qs.aggregate(
    errors=Count('id', filter=Q(gcal_status=ERROR)),
    pending=Count('id', filter=Q(gcal_status=PENDING)),
    ...
)
```

### views_gcal/insights.py - SuccessRateView
Mesma otimização (4→1 queries)

### views/dat.py - DATRegistroViewSet.stats
Mesma otimização (4→1 queries)
- Nota: Renomeado `usa_avaliar` para `usa_avaliar_count` no aggregate para evitar conflito com campo do model

## Impacto

| Endpoint | Antes | Depois |
|----------|-------|--------|
| /api/gcal/dashboard/alerts/summary/ | 4 queries | 1 query |
| /api/gcal/dashboard/insights/success-rate/ | 4 queries | 1 query |
| /api/dat/registros/stats/ | 4 queries | 1 query |

## Test plan

- [x] `test_stats_endpoint` passa
- [x] Imports verificados via manage.py shell