### PR TITLE
chore: update CP-07 to require CI pass before merge

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -473,20 +473,21 @@ Ordem obrigatória de trabalho para agentes autônomos:
 - Merge strategy: **Squash and merge** recomendado
 
 ### 🚫 CP-07: Nunca Commit/Push Direto na Main
-**REGRA ABSOLUTA**: Todas as mudanças devem passar por PR.
+**REGRA ABSOLUTA**: Todas as mudanças devem passar por PR com CI verde.
 
 **Fluxo obrigatório:**
 1. `git checkout -b <type>/<nome>` — Criar branch
 2. Fazer commits na branch
 3. `git push -u origin <type>/<nome>` — Push da branch
 4. `gh pr create` — Abrir PR
-5. Aguardar CI verde
-6. `gh pr merge` — Merge via GitHub
+5. `gh pr checks --watch` — **⏳ AGUARDAR CI PASSAR** (obrigatório!)
+6. `gh pr merge` — Merge via GitHub (só após CI verde)
 
 **PROIBIDO:**
 - ❌ `git push origin main` — Push direto na main
 - ❌ `git commit` estando na branch main — Commit na main
 - ❌ Merge local na main — Sempre via PR
+- ❌ `gh pr merge` sem CI verde — **NUNCA** fazer merge antes do CI passar
 
 **Exceção única:** Hotfix crítico de segurança COM aprovação explícita do usuário na mesma mensagem.
 


### PR DESCRIPTION
## Summary

Atualiza CP-07 para exigir explicitamente que o CI passe antes do merge.

## Mudanças

- Adicionado passo explícito: `gh pr checks --watch`
- Adicionado à lista PROIBIDO: merge sem CI verde
- Clarificado que CI deve passar antes do merge

## Contexto

PRs anteriores (#312, #313) foram mergeados sem esperar CI passar.
Esta atualização documenta o fluxo correto.