### PR TITLE
fix(frontend): use PROXY_TARGET instead of VITE_API_URL for server proxy

### DIFF
--- a/v2/frontend/vite.config.js
+++ b/v2/frontend/vite.config.js
@@ -2,9 +2,10 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-// Backend URL - usa variável de ambiente ou fallback para localhost
+// Backend URL para proxy (servidor-side apenas)
+// PROXY_TARGET é usado apenas pelo servidor Vite, não pelo browser
 // eslint-disable-next-line no-undef
-const API_URL = process.env.VITE_API_URL || 'http://localhost:8002'
+const API_URL = process.env.PROXY_TARGET || 'http://localhost:8002'
 
 // https://vite.dev/config/
 export default defineConfig({

--- a/v2/infra/docker-compose.yml
+++ b/v2/infra/docker-compose.yml
@@ -108,7 +108,7 @@ services:
       context: ../frontend
       dockerfile: Dockerfile
     environment:
-      VITE_API_URL: http://web:8000  # Aponta para o backend interno
+      PROXY_TARGET: http://web:8000  # Proxy server-side para o backend interno
     ports:
       - "5173:5173"
     volumes:


### PR DESCRIPTION
## Summary
- Fix frontend login failing with `ERR_NAME_NOT_RESOLVED`
- `VITE_API_URL` was exposed to browser, which tried to connect to `http://web:8000` (Docker internal hostname)

## Root Cause
Variables prefixed with `VITE_` are exposed to the browser by Vite. The browser cannot resolve `web` hostname (Docker internal).

## Solution
- Rename `VITE_API_URL` to `PROXY_TARGET` (not prefixed with `VITE_`)
- This keeps the variable server-side only (Vite proxy)
- Browser uses `/api` (relative URL) which gets proxied correctly

## Files Changed
- `v2/frontend/vite.config.js` - Use `PROXY_TARGET` env var
- `v2/infra/docker-compose.yml` - Pass `PROXY_TARGET` instead of `VITE_API_URL`

## Test plan
- [x] `curl http://localhost:5173/api/` returns API response
- [x] Login with admin/admin123 works in browser
- [x] No `ERR_NAME_NOT_RESOLVED` errors in console