### PR TITLE
fix(frontend): add missing imports to DAT module pages

### DIFF
--- a/v2/frontend/src/pages/DATModule/CadastrosPage.jsx
+++ b/v2/frontend/src/pages/DATModule/CadastrosPage.jsx
@@ -42,6 +42,7 @@ import {
   CloudServerOutlined,
   BookOutlined,
   BarChartOutlined,
+  LinkOutlined,
 } from '@ant-design/icons';
 import {
   listCadastros,

--- a/v2/frontend/src/pages/DATModule/CoordenadoresPage.jsx
+++ b/v2/frontend/src/pages/DATModule/CoordenadoresPage.jsx
@@ -30,6 +30,7 @@ import {
   DatePicker,
   Collapse,
   List,
+  Switch,
 } from 'antd';
 import {
   ReloadOutlined,
@@ -47,6 +48,9 @@ import {
   ProjectOutlined,
   BarsOutlined,
   EyeOutlined,
+  CheckCircleOutlined,
+  PhoneOutlined,
+  MailOutlined,
 } from '@ant-design/icons';
 import {
   listCoordenadoresDAT,

--- a/v2/frontend/src/pages/DATModule/DATRegistrosPage.jsx
+++ b/v2/frontend/src/pages/DATModule/DATRegistrosPage.jsx
@@ -25,6 +25,7 @@ import {
   Divider,
   Row,
   Col,
+  Tag,
 } from 'antd';
 import {
   ReloadOutlined,
@@ -36,6 +37,10 @@ import {
   ClockCircleFilled,
   ExclamationCircleFilled,
   MinusCircleFilled,
+  DatabaseOutlined,
+  BookOutlined,
+  BarChartOutlined,
+  DeleteOutlined,
 } from '@ant-design/icons';
 import {
   listDATRegistros,


### PR DESCRIPTION
## Summary
- Fixed blank pages in DAT module caused by missing component imports
- Affected pages: DATRegistrosPage, CadastrosPage, CoordenadoresPage

## Changes
- **DATRegistrosPage.jsx**: Added `DatabaseOutlined`, `BookOutlined`, `BarChartOutlined`, `DeleteOutlined` icons and `Tag` component
- **CadastrosPage.jsx**: Added `LinkOutlined` icon
- **CoordenadoresPage.jsx**: Added `CheckCircleOutlined`, `PhoneOutlined`, `MailOutlined` icons and `Switch` component

## Test plan
- [x] ESLint passes on all 3 files
- [ ] Access `/dat-module/registros` - page renders correctly
- [ ] Access `/dat-module/cadastros` - page renders correctly
- [ ] Access `/dat-module/coordenadores` - page renders correctly