### PR TITLE
feat(deploy): add INCLUDE_ETL env var to exclude ETL from production

### DIFF
--- a/v2/backend/apps/core/tests/test_optional_etl.py
+++ b/v2/backend/apps/core/tests/test_optional_etl.py
@@ -1,0 +1,94 @@
+"""
+Tests for optional ETL deployment (INCLUDE_ETL setting).
+
+Verifies that:
+- INCLUDE_ETL defaults to True (backward compatibility)
+- dat_ingest is included when INCLUDE_ETL=true
+- URLs are conditionally registered
+"""
+
+import pytest
+from django.conf import settings
+
+
+class TestIncludeETLSetting:
+    """Tests for INCLUDE_ETL configuration."""
+
+    def test_include_etl_defaults_to_true(self):
+        """INCLUDE_ETL should default to True for backward compatibility."""
+        # The setting should exist
+        assert hasattr(settings, "INCLUDE_ETL")
+        # Default is True (we're running with default settings)
+        assert settings.INCLUDE_ETL is True
+
+    def test_dat_ingest_in_installed_apps_when_enabled(self):
+        """dat_ingest should be in INSTALLED_APPS when INCLUDE_ETL=true."""
+        # With default settings, dat_ingest should be included
+        if settings.INCLUDE_ETL:
+            assert "apps.dat_ingest" in settings.INSTALLED_APPS
+
+    def test_core_always_in_installed_apps(self):
+        """core app should always be in INSTALLED_APPS regardless of INCLUDE_ETL."""
+        assert "apps.core" in settings.INSTALLED_APPS
+
+    def test_core_services_available_without_dat_ingest(self):
+        """Core services (normalize, resolvers) should work without dat_ingest."""
+        # These imports should work regardless of INCLUDE_ETL
+        from apps.core.services import norm_text, resolve_municipio
+
+        # Basic functionality test
+        assert norm_text("  Test  ") == "test"
+        assert callable(resolve_municipio)
+
+
+class TestETLURLsConditional:
+    """Tests for conditional ETL URL registration."""
+
+    def test_etl_urls_registered_when_enabled(self, client):
+        """ETL endpoints should be accessible when INCLUDE_ETL=true."""
+        if not settings.INCLUDE_ETL:
+            pytest.skip("ETL not enabled")
+
+        # The etl/reports/latest/ endpoint exists in dat_ingest.urls
+        # It requires authentication, so we expect 403 (not 404)
+        response = client.get("/api/etl/reports/latest/")
+        # 403 = endpoint exists but auth required
+        # 404 = endpoint doesn't exist
+        assert response.status_code in [403, 401], (
+            f"Expected 403/401 (auth required), got {response.status_code}"
+        )
+
+    def test_core_urls_always_registered(self, client):
+        """Core endpoints should always be accessible."""
+        # healthz is always available (no auth required)
+        response = client.get("/healthz/")
+        assert response.status_code == 200
+
+        # api root requires auth (but endpoint exists)
+        response = client.get("/api/")
+        assert response.status_code in [200, 403, 401]
+
+
+class TestETLExclusionDocumentation:
+    """Documentation tests for ETL exclusion."""
+
+    def test_include_etl_env_var_documented(self):
+        """Verify the expected behavior of INCLUDE_ETL."""
+        # This test documents the expected behavior:
+        #
+        # INCLUDE_ETL=true (default):
+        #   - apps.dat_ingest in INSTALLED_APPS
+        #   - ETL management commands available
+        #   - /api/etl-reports/ endpoint available
+        #
+        # INCLUDE_ETL=false:
+        #   - apps.dat_ingest NOT in INSTALLED_APPS
+        #   - ETL management commands NOT available
+        #   - /api/etl-reports/ returns 404
+        #   - Core functionality (normalize, resolvers) still works
+        #
+        # To deploy without ETL:
+        #   docker-compose.prod.yml:
+        #     environment:
+        #       - INCLUDE_ETL=false
+        pass

--- a/v2/backend/config/settings.py
+++ b/v2/backend/config/settings.py
@@ -71,6 +71,11 @@ if ENVIRONMENT == "production":
 # ================================================================
 # INSTALLED APPS
 # ================================================================
+# ETL Module (dat_ingest) - Opcional em produção
+# Default: True (inclui ETL para manter compatibilidade)
+# Para excluir do deploy: INCLUDE_ETL=false
+INCLUDE_ETL = os.getenv("INCLUDE_ETL", "true").lower() == "true"
+
 INSTALLED_APPS = [
     # Django core
     "django.contrib.admin.apps.SimpleAdminConfig",  # Disables autodiscover (custom admin site)
@@ -87,8 +92,11 @@ INSTALLED_APPS = [
     "django_celery_results",
     # AS v2 apps
     "apps.core",
-    "apps.dat_ingest",
 ]
+
+# Incluir ETL apenas se INCLUDE_ETL=true
+if INCLUDE_ETL:
+    INSTALLED_APPS.append("apps.dat_ingest")
 
 # ================================================================
 # AUTH USER MODEL

--- a/v2/backend/config/urls.py
+++ b/v2/backend/config/urls.py
@@ -35,8 +35,13 @@ urlpatterns = [
     path("", include("django_prometheus.urls")),
     # API
     path("api/", include("apps.core.urls")),
-    path("api/", include("apps.dat_ingest.urls")),  # Fase 5: ETL Observability
 ]
+
+# Incluir URLs do ETL apenas se o app estiver instalado (INCLUDE_ETL=true)
+if "apps.dat_ingest" in settings.INSTALLED_APPS:
+    urlpatterns.append(
+        path("api/", include("apps.dat_ingest.urls")),  # Fase 5: ETL Observability
+    )
 
 # Static/Media files (development only)
 if settings.DEBUG:


### PR DESCRIPTION
## Summary

- Add `INCLUDE_ETL` environment variable to optionally exclude ETL module from production deployments
- Default: `true` (backward compatible - ETL included)
- Conditionally include `apps.dat_ingest` in `INSTALLED_APPS`
- Conditionally register `dat_ingest` URLs

## Motivation

After PR #338 (decouple-etl-shared-services), the ETL module can now be safely excluded from production deployments. This PR adds the configuration option to do so.

## Usage

To deploy **with** ETL (default):
```yaml
# No change needed, INCLUDE_ETL defaults to true
```

To deploy **without** ETL:
```yaml
environment:
  - INCLUDE_ETL=false
```

## Changes

| File | Change |
|------|--------|
| `config/settings.py` | Add `INCLUDE_ETL` env var, conditionally append `dat_ingest` |
| `config/urls.py` | Conditionally include `dat_ingest.urls` |
| `test_optional_etl.py` | 7 tests verifying behavior |

## Test plan

- [x] `INCLUDE_ETL=true` (default): dat_ingest in INSTALLED_APPS ✅
- [x] Core services (normalize, resolvers) work regardless of setting ✅
- [x] ETL URLs registered when enabled ✅
- [x] Core URLs always registered ✅
- [x] 7/7 tests passing locally ✅