### PR TITLE
feat(disponibilidade): add RBAC-based gerência filtering

### DIFF
--- a/v2/frontend/src/App.jsx
+++ b/v2/frontend/src/App.jsx
@@ -284,6 +284,8 @@ function AppContent() {
   const canDAT = user?.is_superuser || inDAT;
   // canDashboards = acesso aos dashboards (Diretoria, DAT, superuser)
   const canDashboards = user?.is_superuser || inDiretoria || inDAT;
+  // canDisponibilidade = acesso à grade mensal (todos exceto Controle)
+  const canDisponibilidade = user?.is_superuser || !inControle;
 
   return (
     <ConfigProvider locale={ptBR} theme={antThemeConfig}>
@@ -424,10 +426,12 @@ function AppContent() {
                 </SubMenu>
               )}
 
-              {/* 7. Grade Mensal */}
-              <Menu.Item key="grade-mensal" icon={<TableOutlined />}>
-                <Link to="/disponibilidade">Grade Mensal</Link>
-              </Menu.Item>
+              {/* 7. Grade Mensal (todos exceto Controle) */}
+              {canDisponibilidade && (
+                <Menu.Item key="grade-mensal" icon={<TableOutlined />}>
+                  <Link to="/disponibilidade">Grade Mensal</Link>
+                </Menu.Item>
+              )}
 
               {/* 8. Solicitações */}
               {canCoordenador && (
@@ -510,7 +514,10 @@ function AppContent() {
                     element={canDashboards ? <MapaBrasilPage /> : <Forbidden />}
                   />
 
-                  <Route path="/disponibilidade" element={<MonthlyPage />} />
+                  <Route
+                    path="/disponibilidade"
+                    element={canDisponibilidade ? <MonthlyPage /> : <Forbidden />}
+                  />
                   <Route path="/bloqueios" element={<DisponibilidadeBlocks />} />
 
                   {/* PR15: Novas rotas de solicitações */}

--- a/v2/frontend/src/pages/Disponibilidade/FiltersBar.jsx
+++ b/v2/frontend/src/pages/Disponibilidade/FiltersBar.jsx
@@ -138,10 +138,10 @@ export default function FiltersBar({ year, month, gerenciaId, sector, q, onChang
           className="w-52 px-3 py-2 text-sm border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white"
         >
           {/* Opção "Todas" apenas para Superintendência */}
-          {canSeeAll && <option value="">Todas (Superintendência)</option>}
+          {canSeeAll && <option value="">Todas</option>}
           {gerencias.map((g) => (
             <option key={g.id} value={g.id}>
-              {g.nome} ({g.nome_setor})
+              {g.nome_setor}
             </option>
           ))}
         </select>


### PR DESCRIPTION
## Summary

- Filter gerência dropdown based on user's setores (RBAC groups)
- Auto-select user's gerência on page load for non-Superintendência users
- "Todas (Superintendência)" option only visible for Superintendência/superusers
- Map RBAC group names to gerência nome_setor (Superintendência → Super)

## Behavior by Profile

| Profile | Dropdown Options | Default |
|---------|------------------|---------|
| Superintendência / superuser | All gerências + "Todas" | "Todas (Superintendência)" |
| Specific sector user (e.g., Vidas) | Only their gerência(s) | Auto-selects their gerência |

## Test plan

- [ ] Login as superuser → see all gerências + "Todas" option
- [ ] Login as Superintendência user → see all gerências + "Todas" option
- [ ] Login as Vidas user → see only GERENCIA 2 (Vidas), auto-selected
- [ ] Login as Fluir user → see only GERENCIA 3 (Fluir), auto-selected

Refs: PR #389