### PR TITLE
perf(frontend): memoize arrays and computed values (#426, #427, #428)

### DIFF
--- a/v2/frontend/src/pages/Solicitacoes/EditSolicitacaoPage.jsx
+++ b/v2/frontend/src/pages/Solicitacoes/EditSolicitacaoPage.jsx
@@ -9,7 +9,7 @@
  * - Não é possível editar solicitações reprovadas
  */
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 // antd - direct imports for tree-shaking (Issue #424)
 import Form from 'antd/es/form';
@@ -140,8 +140,8 @@ export default function EditSolicitacaoPage() {
     }
   }, [id, form]);
 
-  // Handler para DateTimeRange
-  const handleRangeChange = (range) => {
+  // Handler para DateTimeRange (Issue #428)
+  const handleRangeChange = useCallback((range) => {
     if (!range || !range.date || !range.start || !range.end) {
       setFormData(prev => ({ ...prev, inicio: null, fim: null }));
       return;
@@ -163,16 +163,19 @@ export default function EditSolicitacaoPage() {
       logger.error('Erro ao converter data/hora:', error);
       setFormData(prev => ({ ...prev, inicio: null, fim: null }));
     }
-  };
+  }, []);
 
-  // Derivar rangeValue para o componente DateTimeRange
-  const rangeValue = formData.inicio && formData.fim
-    ? {
-        date: dayjs(formData.inicio).tz(RANGE_TIMEZONE).format('YYYY-MM-DD'),
-        start: dayjs(formData.inicio).tz(RANGE_TIMEZONE).format('HH:mm'),
-        end: dayjs(formData.fim).tz(RANGE_TIMEZONE).format('HH:mm'),
-      }
-    : { date: '', start: '', end: '' };
+  // Derivar rangeValue memoizado (Issue #428)
+  const rangeValue = useMemo(() => {
+    if (!formData.inicio || !formData.fim) {
+      return { date: '', start: '', end: '' };
+    }
+    return {
+      date: dayjs(formData.inicio).tz(RANGE_TIMEZONE).format('YYYY-MM-DD'),
+      start: dayjs(formData.inicio).tz(RANGE_TIMEZONE).format('HH:mm'),
+      end: dayjs(formData.fim).tz(RANGE_TIMEZONE).format('HH:mm'),
+    };
+  }, [formData.inicio, formData.fim]);
 
   // Submit
   const handleSubmit = async () => {

--- a/v2/frontend/src/pages/Solicitacoes/MySolicitacoesPage.jsx
+++ b/v2/frontend/src/pages/Solicitacoes/MySolicitacoesPage.jsx
@@ -8,7 +8,7 @@
  * - Botão para criar nova solicitação
  */
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 // antd - direct imports for tree-shaking (Issue #424)
 import Table from 'antd/es/table';
@@ -76,11 +76,11 @@ export default function MySolicitacoesPage() {
     loadData();
   }, [loadData]);
 
-  const handleDelete = async (id) => {
+  const handleDelete = useCallback(async (id) => {
     try {
       await deleteSolicitacao(id);
       message.success('Solicitação excluída com sucesso!');
-      loadData(); // Recarrega a lista
+      loadData();
     } catch (error) {
       if (error.response?.data?.detail) {
         message.error(error.response.data.detail);
@@ -88,9 +88,10 @@ export default function MySolicitacoesPage() {
         message.error('Erro ao excluir solicitação: ' + error.message);
       }
     }
-  };
+  }, [loadData]);
 
-  const columns = [
+  // Colunas memoizadas (Issue #427)
+  const columns = useMemo(() => [
     {
       title: 'Data/Hora',
       dataIndex: 'inicio',
@@ -205,7 +206,7 @@ export default function MySolicitacoesPage() {
         );
       },
     },
-  ];
+  ], [handleDelete, navigate]);
 
   return (
     <div className="p-6">

--- a/v2/frontend/src/pages/Solicitacoes/NewSolicitacaoWizard.jsx
+++ b/v2/frontend/src/pages/Solicitacoes/NewSolicitacaoWizard.jsx
@@ -10,7 +10,7 @@
  * 4. Revisão e Confirmação
  */
 
-import { useState } from 'react';
+import { useState, useMemo, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 // antd - direct imports for tree-shaking (Issue #424)
 import Steps from 'antd/es/steps';
@@ -84,21 +84,18 @@ export default function NewSolicitacaoWizard() {
     is_online: false,
   });
 
-  // Handler para DateTimeRange: converte {date, start, end} para ISO UTC
-  const handleRangeChange = (range) => {
+  // Handler para DateTimeRange: converte {date, start, end} para ISO UTC (Issue #428)
+  const handleRangeChange = useCallback((range) => {
     if (!range || !range.date || !range.start || !range.end) {
-      // Se faltar dados, limpar os campos
       setFormData(prev => ({ ...prev, inicio: null, fim: null }));
       return;
     }
 
     try {
-      // Combinar date + hora usando timezone America/Fortaleza
-      const dateStr = range.date; // formato YYYY-MM-DD
-      const startTime = range.start; // formato HH:mm
-      const endTime = range.end; // formato HH:mm
+      const dateStr = range.date;
+      const startTime = range.start;
+      const endTime = range.end;
 
-      // Criar dayjs objects em America/Fortaleza e converter para ISO UTC
       const inicioLocal = dayjs.tz(`${dateStr} ${startTime}`, RANGE_TIMEZONE);
       const fimLocal = dayjs.tz(`${dateStr} ${endTime}`, RANGE_TIMEZONE);
 
@@ -110,16 +107,19 @@ export default function NewSolicitacaoWizard() {
       logger.error('Erro ao converter data/hora:', error);
       setFormData(prev => ({ ...prev, inicio: null, fim: null }));
     }
-  };
+  }, []);
 
-  // Derivar rangeValue de formData.inicio/fim para o componente DateTimeRange
-  const rangeValue = formData.inicio && formData.fim
-    ? {
-        date: dayjs(formData.inicio).tz(RANGE_TIMEZONE).format('YYYY-MM-DD'),
-        start: dayjs(formData.inicio).tz(RANGE_TIMEZONE).format('HH:mm'),
-        end: dayjs(formData.fim).tz(RANGE_TIMEZONE).format('HH:mm'),
-      }
-    : { date: '', start: '', end: '' };
+  // Derivar rangeValue memoizado (Issue #428)
+  const rangeValue = useMemo(() => {
+    if (!formData.inicio || !formData.fim) {
+      return { date: '', start: '', end: '' };
+    }
+    return {
+      date: dayjs(formData.inicio).tz(RANGE_TIMEZONE).format('YYYY-MM-DD'),
+      start: dayjs(formData.inicio).tz(RANGE_TIMEZONE).format('HH:mm'),
+      end: dayjs(formData.fim).tz(RANGE_TIMEZONE).format('HH:mm'),
+    };
+  }, [formData.inicio, formData.fim]);
 
   // Navegação entre passos
   const next = () => {
@@ -208,8 +208,8 @@ export default function NewSolicitacaoWizard() {
     }
   };
 
-  // Passos do wizard
-  const steps = [
+  // Passos do wizard memoizados (Issue #426)
+  const steps = useMemo(() => [
     {
       title: 'Informações Básicas',
       icon: <FileTextOutlined />,
@@ -490,7 +490,7 @@ export default function NewSolicitacaoWizard() {
         </>
       ),
     },
-  ];
+  ], [formData, rangeValue, handleRangeChange]);
 
   return (
     <div className="p-6 max-w-4xl mx-auto">


### PR DESCRIPTION
## Summary

Phase 2 of Epic #423 (React Performance Optimization) - Re-render optimization.

- **#426**: Memoize steps array in NewSolicitacaoWizard (280+ lines)
- **#427**: Memoize columns array in MySolicitacoesPage (115 lines)
- **#428**: Memoize rangeValue computation (2 files)

## Changes

| File | Change | Impact |
|------|--------|--------|
| `NewSolicitacaoWizard.jsx` | `useMemo` for steps, `useCallback` for handler | -280 lines/render |
| `MySolicitacoesPage.jsx` | `useMemo` for columns, `useCallback` for delete | -115 lines/render |
| `EditSolicitacaoPage.jsx` | `useMemo` for rangeValue | -3 dayjs calls/render |

## Technical Details

```jsx
// Before - recreated every render
const steps = [{ title: '...', content: <JSX /> }, ...];

// After - only recreates when deps change
const steps = useMemo(() => [...], [formData, rangeValue, handleRangeChange]);
```

## Verification

- [x] `npm run build` passes
- [x] `npm run lint` passes (0 errors)
- [ ] CI passes

## Test plan

- [ ] NewSolicitacaoWizard: all 4 steps work correctly
- [ ] MySolicitacoesPage: table renders, edit/delete work
- [ ] EditSolicitacaoPage: date/time picker works

## Related

- Epic: #423
- Closes #426
- Closes #427
- Closes #428