### PR TITLE
perf(api): complete query optimization (#406)

### DIFF
--- a/v2/backend/apps/core/views_availability.py
+++ b/v2/backend/apps/core/views_availability.py
@@ -57,7 +57,7 @@ class AvailabilityBlockViewSet(viewsets.ModelViewSet):
         - Outros: bloqueios de usuários da mesma gerência
     """
 
-    queryset = AvailabilityBlock.objects.all()
+    queryset = AvailabilityBlock.objects.select_related("usuario").all()
     serializer_class = AvailabilityBlockSerializer
     permission_classes = [IsAuthenticated]
 
@@ -66,20 +66,20 @@ class AvailabilityBlockViewSet(viewsets.ModelViewSet):
 
         # Privilegiados (superuser, Superintendência, Controle) veem todos
         if is_privileged_user(user):
-            return AvailabilityBlock.objects.all()
+            return AvailabilityBlock.objects.select_related("usuario").all()
 
         # Outros: bloqueios de usuários das suas gerências
         gerencias_ids = get_user_gerencias_ids(user)
         if not gerencias_ids:
             # Sem gerência, vê apenas os próprios
-            return AvailabilityBlock.objects.filter(usuario=user)
+            return AvailabilityBlock.objects.select_related("usuario").filter(usuario=user)
 
         # Usuários na mesma gerência
         usuarios_na_gerencia = EquipeGerencia.objects.filter(
             gerencia_id__in=gerencias_ids
         ).values_list("usuario_id", flat=True)
 
-        return AvailabilityBlock.objects.filter(usuario_id__in=usuarios_na_gerencia)
+        return AvailabilityBlock.objects.select_related("usuario").filter(usuario_id__in=usuarios_na_gerencia)
 
     def perform_create(self, serializer):
         """

--- a/v2/backend/apps/core/views_solicitacao.py
+++ b/v2/backend/apps/core/views_solicitacao.py
@@ -426,7 +426,7 @@ class SolicitacaoViewSet(viewsets.ModelViewSet):
 
         Estratégia: substituição completa
         - Remove formadores não presentes na nova lista
-        - Adiciona novos formadores
+        - Adiciona novos formadores com batch fetch (#406)
 
         Retorna True se houve alteração.
         """
@@ -456,19 +456,30 @@ class SolicitacaoViewSet(viewsets.ModelViewSet):
             ).delete()
             changed = True
 
-        # Adicionar formadores
-        for formador_id in to_add:
-            if formador_id:
-                try:
-                    usuario = Usuario.objects.get(id=formador_id)
-                    Participation.objects.get_or_create(
-                        solicitacao=solicitacao,
-                        usuario=usuario,
-                        defaults={'role': 'FORMADOR'}
-                    )
-                    changed = True
-                except Usuario.DoesNotExist:
-                    pass
+        # Adicionar formadores com batch fetch (#406 - Query Optimization)
+        if to_add:
+            # Batch fetch: 1 query para todos os usuários em vez de N queries
+            usuarios_map = {
+                u.id: u for u in Usuario.objects.filter(id__in=to_add)
+            }
+
+            # Bulk create participations
+            participations_to_create = [
+                Participation(
+                    solicitacao=solicitacao,
+                    usuario=usuarios_map[formador_id],
+                    role='FORMADOR'
+                )
+                for formador_id in to_add
+                if formador_id and formador_id in usuarios_map
+            ]
+
+            if participations_to_create:
+                Participation.objects.bulk_create(
+                    participations_to_create,
+                    ignore_conflicts=True
+                )
+                changed = True
 
         return changed
 


### PR DESCRIPTION
## Summary
- Add `select_related('usuario')` to `AvailabilityBlockViewSet` queryset
- Optimize `_update_formadores` with batch fetch and `bulk_create`

## Changes
1. **views_availability.py**: Added `select_related("usuario")` to all queryset calls in `AvailabilityBlockViewSet`
2. **views_solicitacao.py**: Replaced N+1 queries in `_update_formadores` with:
   - Single batch fetch: `Usuario.objects.filter(id__in=to_add)`
   - Single bulk create: `Participation.objects.bulk_create(..., ignore_conflicts=True)`

## Performance Impact
- Listing 100 availability blocks: N+1 queries → 1 query
- Adding 10 formadores: 10 queries → 2 queries

## Test plan
- [x] `test_query_optimization.py` - 4 tests pass
- [x] `test_availability_service.py` - 18 tests pass
- [x] Full core test suite - 1188 tests pass