### PR TITLE
refactor(api): remove unused over-engineered extras

### DIFF
--- a/v2/backend/apps/core/deprecation.py
+++ b/v2/backend/apps/core/deprecation.py
@@ -50,35 +50,3 @@ def deprecated_endpoint(message: str, removal_version: str = "v2") -> Callable[[
     return decorator
 
 
-def deprecated_view_class(message: str, removal_version: str = "v2") -> Callable[[type], type]:
-    """
-    Class decorator to mark API view classes as deprecated.
-
-    Wraps the dispatch method to add deprecation headers to all responses.
-
-    Usage:
-        @deprecated_view_class("Use NewView instead", removal_version="v2")
-        class OldView(APIView):
-            ...
-
-    Args:
-        message: Human-readable deprecation message
-        removal_version: API version when endpoint will be removed
-
-    Returns:
-        Decorated class that adds deprecation headers to all responses
-    """
-    def decorator(cls: type) -> type:
-        original_dispatch = cls.dispatch  # type: ignore[attr-defined]
-
-        @wraps(original_dispatch)
-        def new_dispatch(self: Any, request: Request, *args: Any, **kwargs: Any) -> Response:
-            response = original_dispatch(self, request, *args, **kwargs)
-            response["X-Deprecated"] = "true"
-            response["X-Deprecated-Message"] = message
-            response["X-Removal-Version"] = removal_version
-            return response
-
-        cls.dispatch = new_dispatch  # type: ignore[attr-defined]
-        return cls
-    return decorator

--- a/v2/backend/apps/core/pagination.py
+++ b/v2/backend/apps/core/pagination.py
@@ -39,17 +39,3 @@ class LargePagination(PageNumberPagination):
     max_page_size = 1000
 
 
-class SmallPagination(PageNumberPagination):
-    """
-    Pagination for endpoints with smaller datasets.
-
-    - Default page size: 20
-    - Max page size: 100
-    - Supports ?page_size= query param
-
-    Use for: User lists, simple lookups.
-    """
-
-    page_size = 20
-    page_size_query_param = "page_size"
-    max_page_size = 100

--- a/v2/backend/apps/core/responses.py
+++ b/v2/backend/apps/core/responses.py
@@ -87,28 +87,3 @@ class APIResponse:
             }
         )
 
-    @staticmethod
-    def counts(
-        counts: dict[str, int],
-        total: int | None = None,
-        meta: dict[str, Any] | None = None
-    ) -> Response:
-        """
-        Standardized counts response.
-
-        Response format:
-        {
-            "data": {
-                "counts": {...},
-                "total": 10
-            },
-            "meta": {...}
-        }
-        """
-        return APIResponse.success(
-            data={
-                "counts": counts,
-                "total": total if total is not None else sum(counts.values())
-            },
-            meta=meta
-        )

--- a/v2/backend/apps/core/tests/test_pagination.py
+++ b/v2/backend/apps/core/tests/test_pagination.py
@@ -223,11 +223,3 @@ class TestPaginationClasses(TestCase):
         self.assertEqual(pagination.page_size_query_param, "page_size")
         self.assertEqual(pagination.max_page_size, 1000)
 
-    def test_small_pagination_config(self) -> None:
-        """SmallPagination should have correct config."""
-        from apps.core.pagination import SmallPagination
-
-        pagination = SmallPagination()
-        self.assertEqual(pagination.page_size, 20)
-        self.assertEqual(pagination.page_size_query_param, "page_size")
-        self.assertEqual(pagination.max_page_size, 100)

--- a/v2/backend/apps/core/tests/test_response_consistency.py
+++ b/v2/backend/apps/core/tests/test_response_consistency.py
@@ -64,24 +64,6 @@ class TestAPIResponseFactory(TestCase):
 
         self.assertEqual(content["data"]["total"], 100)
 
-    def test_counts_response_format(self) -> None:
-        """APIResponse.counts should return counts and total."""
-        counts = {"a": 10, "b": 20}
-        response = APIResponse.counts(counts=counts)
-        content = response.data
-
-        self.assertIn("data", content)
-        self.assertEqual(content["data"]["counts"], counts)
-        self.assertEqual(content["data"]["total"], 30)
-
-    def test_counts_with_explicit_total(self) -> None:
-        """APIResponse.counts should use explicit total if provided."""
-        counts = {"a": 10, "b": 20}
-        response = APIResponse.counts(counts=counts, total=50)
-        content = response.data
-
-        self.assertEqual(content["data"]["total"], 50)
-
     def test_availability_response_format(self) -> None:
         """APIResponse.availability should return available and conflicts."""
         response = APIResponse.availability(ok=True, conflicts=[])

--- a/v2/backend/apps/core/tests/test_versioning.py
+++ b/v2/backend/apps/core/tests/test_versioning.py
@@ -18,7 +18,7 @@ from rest_framework.response import Response
 from rest_framework.test import APIClient
 from rest_framework.views import APIView
 
-from apps.core.deprecation import deprecated_endpoint, deprecated_view_class
+from apps.core.deprecation import deprecated_endpoint
 from apps.core.models import Usuario
 
 
@@ -109,27 +109,6 @@ class TestDeprecationDecorator(TestCase):
         self.assertEqual(response["X-Deprecated"], "true")
         self.assertEqual(response["X-Deprecated-Message"], "Use /new-endpoint/")
         self.assertEqual(response["X-Removal-Version"], "v2")
-
-    def test_deprecated_view_class_adds_headers(self) -> None:
-        """deprecated_view_class should add X-Deprecated headers."""
-        @deprecated_view_class("Use NewView", removal_version="v2")
-        class OldView(APIView):
-            permission_classes = []
-
-            def get(self, request: Request) -> Response:
-                return Response({"status": "ok"})
-
-        # Simulate request
-        from rest_framework.test import APIRequestFactory
-        factory = APIRequestFactory()
-        request = factory.get("/old/")
-        view = OldView.as_view()
-        response = view(request)
-
-        self.assertEqual(response["X-Deprecated"], "true")
-        self.assertEqual(response["X-Deprecated-Message"], "Use NewView")
-        self.assertEqual(response["X-Removal-Version"], "v2")
-
 
 class TestVersioningConfiguration(TestCase):
     """Tests for versioning DRF configuration."""

--- a/v2/backend/apps/core/views_reports.py
+++ b/v2/backend/apps/core/views_reports.py
@@ -89,14 +89,16 @@ def reports_status_counts(request: Request) -> Response:
     counts_dict = {item["status"]: item["count"] for item in counts}
 
     # Response consistency (#411)
-    return APIResponse.counts(
-        counts={
-            "pendente": counts_dict.get("pendente", 0),
-            "aprovado": counts_dict.get("aprovado", 0),
-            "reprovado": counts_dict.get("reprovado", 0),
-            "publicado": counts_dict.get("publicado", 0),
+    return APIResponse.success(
+        data={
+            "counts": {
+                "pendente": counts_dict.get("pendente", 0),
+                "aprovado": counts_dict.get("aprovado", 0),
+                "reprovado": counts_dict.get("reprovado", 0),
+                "publicado": counts_dict.get("publicado", 0),
+            },
+            "total": queryset.count(),
         },
-        total=queryset.count(),
         meta={
             "range": {
                 "start": str(start_date),


### PR DESCRIPTION
## Summary

Remove functionality that was added prematurely (YAGNI principle):

| Removed | Reason |
|---------|--------|
| `deprecated_view_class` | No deprecated views exist yet |
| `APIResponse.counts()` | Marginal benefit over `success()` |
| `SmallPagination` | Created but never used anywhere |

## Changes

- **deprecation.py**: Remove `deprecated_view_class` decorator (-33 lines)
- **responses.py**: Remove `counts()` method (-25 lines)
- **pagination.py**: Remove `SmallPagination` class (-15 lines)
- **views_reports.py**: Use `APIResponse.success()` instead of `counts()`
- **tests**: Remove tests for removed functionality

## What's kept

- `deprecated_endpoint` decorator (for function-based views)
- `APIResponse.success()`, `list()`, `availability()`
- `StandardPagination`, `LargePagination`

## Test plan

- [x] 51 affected tests pass
- [x] No functionality change (same response format maintained)