### PR TITLE
fix(auth): clear CSRF cache after login to handle token rotation

### DIFF
--- a/v2/frontend/src/api/auth.js
+++ b/v2/frontend/src/api/auth.js
@@ -11,12 +11,17 @@ import { fetchAPI, clearCsrfCache } from './config';
 
 /**
  * Realiza login com username e senha
+ *
+ * Nota: Django rotaciona o CSRF token após login bem-sucedido.
+ * Limpamos o cache para forçar obtenção de token fresco.
  */
 export async function login(username, password) {
   const response = await fetchAPI('/auth/login/', {
     method: 'POST',
     body: JSON.stringify({ username, password }),
   });
+  // Limpar cache de CSRF token após login (Django rotaciona o token)
+  clearCsrfCache();
   return response;
 }
 

--- a/v2/frontend/src/api/config.js
+++ b/v2/frontend/src/api/config.js
@@ -208,6 +208,26 @@ export async function fetchAPI(url, options = {}, isRetry = false) {
 }
 
 /**
+ * Inicializa CSRF token proativamente.
+ *
+ * Chame no início do app para garantir que o token CSRF esteja disponível
+ * antes de qualquer interação do usuário. Isso evita race conditions
+ * onde o usuário tenta fazer login antes do token estar pronto.
+ */
+export async function initCsrfToken() {
+  try {
+    await ensureCsrfToken();
+    logger.debug('CSRF token inicializado com sucesso');
+  } catch (error) {
+    logger.warn('Falha ao inicializar CSRF token:', error);
+  }
+}
+
+// Inicializar CSRF token automaticamente quando o módulo carrega
+// Isso garante que o token está disponível assim que o app iniciar
+initCsrfToken();
+
+/**
  * Helper para construir URL com query params.
  *
  * @param {string} path - Caminho relativo (ex: '/solicitacoes/')


### PR DESCRIPTION
## Summary
- Clear CSRF cache after successful login (Django rotates token)
- Initialize CSRF token proactively when app loads

## Problem
After login, Django rotates the CSRF token as a security measure. The frontend was using the old cached token, causing "CSRF token from POST incorrect" (403) errors on subsequent requests.

## Solution
1. **auth.js**: Call `clearCsrfCache()` after successful login
2. **config.js**: Add `initCsrfToken()` that runs when module loads

## Test plan
- [x] Frontend build passes
- [x] Backend CSRF tests pass (8/8)
- [ ] Manual test: Login and make a POST request