### PR TITLE
style: apply isort formatting to backend imports

### DIFF
--- a/v2/backend/apps/core/management/commands/compliance_audit.py
+++ b/v2/backend/apps/core/management/commands/compliance_audit.py
@@ -51,11 +51,7 @@ class Command(BaseCommand):
 
     def handle(self, *args: Any, **options: Any) -> None:
         """Execute compliance audit."""
-        from apps.core.models import (
-            AuditLog,
-            AvailabilityBlock,
-            Solicitacao,
-        )
+        from apps.core.models import AuditLog, AvailabilityBlock, Solicitacao
 
         days = options["days"]
         since = timezone.now() - timedelta(days=days)

--- a/v2/backend/apps/core/management/commands/lgpd_export.py
+++ b/v2/backend/apps/core/management/commands/lgpd_export.py
@@ -60,13 +60,7 @@ class Command(BaseCommand):
 
     def handle(self, *args: Any, **options: Any) -> None:
         """Execute LGPD data export."""
-        from apps.core.models import (
-            AuditLog,
-            AvailabilityBlock,
-            GoogleOAuthCredential,
-            Solicitacao,
-            Usuario,
-        )
+        from apps.core.models import AuditLog, AvailabilityBlock, GoogleOAuthCredential, Solicitacao, Usuario
 
         cpf = options.get("cpf")
         email = options.get("email")

--- a/v2/backend/apps/core/models/__init__.py
+++ b/v2/backend/apps/core/models/__init__.py
@@ -48,15 +48,7 @@ from apps.core.models.dat_formacao import DATFormacao
 from apps.core.models.dat_registro import DATRegistro
 from apps.core.models.formacao import Formacao
 from apps.core.models.integracao import GoogleOAuthCredential
-from apps.core.models.organizacao import (
-    EquipeGerencia,
-    Gerencia,
-    Municipio,
-    Produto,
-    Projeto,
-    ProjetoGeral,
-    TipoEvento,
-)
+from apps.core.models.organizacao import EquipeGerencia, Gerencia, Municipio, Produto, Projeto, ProjetoGeral, TipoEvento
 from apps.core.models.plano_formacoes import PlanoFormacoes
 from apps.core.models.prova import Prova
 from apps.core.models.solicitacao import Participation, Solicitacao

--- a/v2/backend/apps/core/serializers/dat_module/__init__.py
+++ b/v2/backend/apps/core/serializers/dat_module/__init__.py
@@ -5,22 +5,10 @@ Re-exports all DAT serializers for backward compatibility.
 Original monolithic file split into domain-specific modules.
 """
 
-from apps.core.serializers.dat_module.dat_acao import (
-    DATAcaoListSerializer,
-    DATAcaoSerializer,
-)
-from apps.core.serializers.dat_module.dat_area import (
-    DATAreaOptionSerializer,
-    DATAreaSerializer,
-)
-from apps.core.serializers.dat_module.dat_cadastro import (
-    DATCadastroListSerializer,
-    DATCadastroSerializer,
-)
-from apps.core.serializers.dat_module.dat_compra import (
-    DATCompraListSerializer,
-    DATCompraSerializer,
-)
+from apps.core.serializers.dat_module.dat_acao import DATAcaoListSerializer, DATAcaoSerializer
+from apps.core.serializers.dat_module.dat_area import DATAreaOptionSerializer, DATAreaSerializer
+from apps.core.serializers.dat_module.dat_cadastro import DATCadastroListSerializer, DATCadastroSerializer
+from apps.core.serializers.dat_module.dat_compra import DATCompraListSerializer, DATCompraSerializer
 from apps.core.serializers.dat_module.dat_coordenador import (
     DATCoordenadorListSerializer,
     DATCoordenadorOptionSerializer,

--- a/v2/backend/apps/core/serializers/plano_formacoes.py
+++ b/v2/backend/apps/core/serializers/plano_formacoes.py
@@ -15,12 +15,7 @@ from typing import Any
 
 from rest_framework import serializers  # type: ignore[attr-defined]
 
-from apps.core.models import (
-    Acompanhamento,
-    Formacao,
-    PlanoFormacoes,
-    Prova,
-)
+from apps.core.models import Acompanhamento, Formacao, PlanoFormacoes, Prova
 
 # ============================================================
 # Nested Serializers (for inline display)

--- a/v2/backend/apps/core/services/controle_acoes_import.py
+++ b/v2/backend/apps/core/services/controle_acoes_import.py
@@ -29,10 +29,7 @@ from django.db import transaction
 
 from apps.core.models import AcaoControle, Municipio, Projeto, Usuario
 from apps.core.services.normalize import norm_text
-from apps.core.services.resolvers import (
-    resolve_user_by_email,
-    resolve_user_by_name,
-)
+from apps.core.services.resolvers import resolve_user_by_email, resolve_user_by_name
 from apps.core.types import ExternalHash
 
 OUT_DIR: Path = Path(settings.BASE_DIR) / "out_etl"

--- a/v2/backend/apps/core/services/dat_cadastros_import.py
+++ b/v2/backend/apps/core/services/dat_cadastros_import.py
@@ -29,10 +29,7 @@ from django.db import transaction
 
 from apps.core.models import AcaoDAT, Municipio, Projeto, Usuario
 from apps.core.services.normalize import norm_text
-from apps.core.services.resolvers import (
-    resolve_user_by_email,
-    resolve_user_by_name,
-)
+from apps.core.services.resolvers import resolve_user_by_email, resolve_user_by_name
 from apps.core.types import ExternalHash
 
 OUT_DIR: Path = Path(settings.BASE_DIR) / "out_etl"

--- a/v2/backend/apps/core/services/gcal/__init__.py
+++ b/v2/backend/apps/core/services/gcal/__init__.py
@@ -17,9 +17,7 @@ Backwards-compatible re-exports for existing imports.
 from __future__ import annotations
 
 # Client
-from apps.core.services.gcal.client import (
-    CalendarClientAdapter,
-)
+from apps.core.services.gcal.client import CalendarClientAdapter
 
 # Payload
 from apps.core.services.gcal.payload import (
@@ -30,30 +28,16 @@ from apps.core.services.gcal.payload import (
 )
 
 # Sync operations
-from apps.core.services.gcal.sync import (
-    apply_one_solicitacao,
-    cancel_solicitacao,
-    resync_solicitacao,
-    upsert_one,
-)
+from apps.core.services.gcal.sync import apply_one_solicitacao, cancel_solicitacao, resync_solicitacao, upsert_one
 
 # Types
-from apps.core.services.gcal.types import (
-    Action,
-    SyncOutcome,
-)
+from apps.core.services.gcal.types import Action, SyncOutcome
 
 # Utils
-from apps.core.services.gcal.utils import (
-    _payload_hash,
-    _retry_with_backoff,
-)
+from apps.core.services.gcal.utils import _payload_hash, _retry_with_backoff
 
 # Validation
-from apps.core.services.gcal.validation import (
-    _event_id_for,
-    _validate_event_id,
-)
+from apps.core.services.gcal.validation import _event_id_for, _validate_event_id
 
 __all__ = [
     # Types

--- a/v2/backend/apps/core/services/gcal_oauth_client.py
+++ b/v2/backend/apps/core/services/gcal_oauth_client.py
@@ -65,10 +65,7 @@ class OAuthCalendarClient(CalendarClientAdapter):
         # Validar que credential é uma instância de GoogleOAuthCredential
         # Importar aqui para evitar circular import
         from apps.core.models import GoogleOAuthCredential
-        from apps.core.services.google_oauth import (
-            _decrypt_token,
-            refresh_access_token_safe,
-        )
+        from apps.core.services.google_oauth import _decrypt_token, refresh_access_token_safe
 
         if not isinstance(credential, GoogleOAuthCredential):
             raise TypeError(f"Expected GoogleOAuthCredential instance, got {type(credential)}")

--- a/v2/backend/apps/core/services/monthly_grid_service.py
+++ b/v2/backend/apps/core/services/monthly_grid_service.py
@@ -26,13 +26,7 @@ from typing import Any
 from django.db.models import Prefetch, Q
 from django.utils import timezone
 
-from apps.core.models import (
-    AvailabilityBlock,
-    Deslocamento,
-    Participation,
-    Solicitacao,
-    Usuario,
-)
+from apps.core.models import AvailabilityBlock, Deslocamento, Participation, Solicitacao, Usuario
 from apps.core.types import UserId
 
 

--- a/v2/backend/apps/core/services/oauth/__init__.py
+++ b/v2/backend/apps/core/services/oauth/__init__.py
@@ -7,11 +7,7 @@ Re-exports from token_manager and oauth_flow for convenience.
 
 # pyright: reportUnknownVariableType=false, reportMissingImports=false
 
-from .oauth_flow import (
-    build_authorization_url,
-    exchange_code_for_tokens,
-    validate_oauth_state,
-)
+from .oauth_flow import build_authorization_url, exchange_code_for_tokens, validate_oauth_state
 from .token_manager import (
     _get_fernet_key,
     decrypt_token,

--- a/v2/backend/apps/core/tests/test_approval_policy_PA.py
+++ b/v2/backend/apps/core/tests/test_approval_policy_PA.py
@@ -24,14 +24,7 @@ from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import (
-    AuditLog,
-    Municipio,
-    Projeto,
-    Solicitacao,
-    TipoEvento,
-    Usuario,
-)
+from apps.core.models import AuditLog, Municipio, Projeto, Solicitacao, TipoEvento, Usuario
 
 pytestmark = pytest.mark.django_db
 

--- a/v2/backend/apps/core/tests/test_auditlog_approve_reject.py
+++ b/v2/backend/apps/core/tests/test_auditlog_approve_reject.py
@@ -17,14 +17,7 @@ from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import (
-    AuditLog,
-    Municipio,
-    Projeto,
-    Solicitacao,
-    TipoEvento,
-    Usuario,
-)
+from apps.core.models import AuditLog, Municipio, Projeto, Solicitacao, TipoEvento, Usuario
 
 pytestmark = pytest.mark.django_db
 

--- a/v2/backend/apps/core/tests/test_availability_block_autoapproval.py
+++ b/v2/backend/apps/core/tests/test_availability_block_autoapproval.py
@@ -19,14 +19,7 @@ from datetime import timedelta
 from django.test import TestCase
 from django.utils import timezone
 
-from apps.core.models import (
-    AvailabilityBlock,
-    Municipio,
-    Projeto,
-    Solicitacao,
-    TipoEvento,
-    Usuario,
-)
+from apps.core.models import AvailabilityBlock, Municipio, Projeto, Solicitacao, TipoEvento, Usuario
 
 
 class TestAvailabilityBlockAutoApproval(TestCase):

--- a/v2/backend/apps/core/tests/test_availability_monthly_api.py
+++ b/v2/backend/apps/core/tests/test_availability_monthly_api.py
@@ -21,15 +21,7 @@ from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import (
-    AvailabilityBlock,
-    Municipio,
-    Participation,
-    Projeto,
-    Solicitacao,
-    TipoEvento,
-    Usuario,
-)
+from apps.core.models import AvailabilityBlock, Municipio, Participation, Projeto, Solicitacao, TipoEvento, Usuario
 
 pytestmark = pytest.mark.django_db
 

--- a/v2/backend/apps/core/tests/test_cache_availability.py
+++ b/v2/backend/apps/core/tests/test_cache_availability.py
@@ -24,14 +24,7 @@ from rest_framework.test import APIClient
 import pytest
 import pytz
 
-from apps.core.models import (
-    AvailabilityBlock,
-    Municipio,
-    Projeto,
-    Solicitacao,
-    TipoEvento,
-    Usuario,
-)
+from apps.core.models import AvailabilityBlock, Municipio, Projeto, Solicitacao, TipoEvento, Usuario
 from apps.core.services.availability_service import check_conflicts
 
 

--- a/v2/backend/apps/core/tests/test_error_handling.py
+++ b/v2/backend/apps/core/tests/test_error_handling.py
@@ -14,13 +14,7 @@ from django.test import TestCase, override_settings
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from apps.core.exceptions import (
-    APIError,
-    ConflictError,
-    NotFoundError,
-    ServiceUnavailableError,
-    ValidationAPIError,
-)
+from apps.core.exceptions import APIError, ConflictError, NotFoundError, ServiceUnavailableError, ValidationAPIError
 from apps.core.models import Usuario
 
 

--- a/v2/backend/apps/core/tests/test_fluxo_por_projeto.py
+++ b/v2/backend/apps/core/tests/test_fluxo_por_projeto.py
@@ -19,13 +19,7 @@ from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import (
-    Municipio,
-    Projeto,
-    Solicitacao,
-    TipoEvento,
-    Usuario,
-)
+from apps.core.models import Municipio, Projeto, Solicitacao, TipoEvento, Usuario
 
 
 class TestFluxoPorProjeto(TestCase):

--- a/v2/backend/apps/core/tests/test_gcal_dashboard.py
+++ b/v2/backend/apps/core/tests/test_gcal_dashboard.py
@@ -25,13 +25,7 @@ from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import (
-    Municipio,
-    Projeto,
-    Solicitacao,
-    TipoEvento,
-    Usuario,
-)
+from apps.core.models import Municipio, Projeto, Solicitacao, TipoEvento, Usuario
 
 
 @pytest.fixture

--- a/v2/backend/apps/core/tests/test_gcal_export.py
+++ b/v2/backend/apps/core/tests/test_gcal_export.py
@@ -27,13 +27,7 @@ from django.urls import reverse
 from django.utils import timezone
 from rest_framework.test import APIClient
 
-from apps.core.models import (
-    Municipio,
-    Projeto,
-    Solicitacao,
-    TipoEvento,
-    Usuario,
-)
+from apps.core.models import Municipio, Projeto, Solicitacao, TipoEvento, Usuario
 
 User = get_user_model()
 

--- a/v2/backend/apps/core/tests/test_gcal_meet_link_by_mode.py
+++ b/v2/backend/apps/core/tests/test_gcal_meet_link_by_mode.py
@@ -22,13 +22,7 @@ from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import (
-    Municipio,
-    Projeto,
-    Solicitacao,
-    TipoEvento,
-    Usuario,
-)
+from apps.core.models import Municipio, Projeto, Solicitacao, TipoEvento, Usuario
 
 
 @pytest.fixture

--- a/v2/backend/apps/core/tests/test_gcal_meet_link_persist.py
+++ b/v2/backend/apps/core/tests/test_gcal_meet_link_persist.py
@@ -20,13 +20,7 @@ from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import (
-    Municipio,
-    Projeto,
-    Solicitacao,
-    TipoEvento,
-    Usuario,
-)
+from apps.core.models import Municipio, Projeto, Solicitacao, TipoEvento, Usuario
 
 
 @pytest.fixture

--- a/v2/backend/apps/core/tests/test_gcal_publish_apply_blocked.py
+++ b/v2/backend/apps/core/tests/test_gcal_publish_apply_blocked.py
@@ -21,13 +21,7 @@ from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import (
-    Municipio,
-    Projeto,
-    Solicitacao,
-    TipoEvento,
-    Usuario,
-)
+from apps.core.models import Municipio, Projeto, Solicitacao, TipoEvento, Usuario
 
 
 def mock_task_result():

--- a/v2/backend/apps/core/tests/test_metrics_api.py
+++ b/v2/backend/apps/core/tests/test_metrics_api.py
@@ -23,15 +23,7 @@ from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import (
-    AuditLog,
-    Municipio,
-    Participation,
-    Projeto,
-    Solicitacao,
-    TipoEvento,
-    Usuario,
-)
+from apps.core.models import AuditLog, Municipio, Participation, Projeto, Solicitacao, TipoEvento, Usuario
 
 
 @pytest.fixture

--- a/v2/backend/apps/core/tests/test_modular_imports.py
+++ b/v2/backend/apps/core/tests/test_modular_imports.py
@@ -66,14 +66,7 @@ class TestModelsBackwardsCompatibility:
 
     def test_direct_import_organizacao(self) -> None:
         """Import direto: from apps.core.models.organizacao import X"""
-        from apps.core.models.organizacao import (
-            EquipeGerencia,
-            Gerencia,
-            Municipio,
-            Produto,
-            Projeto,
-            TipoEvento,
-        )
+        from apps.core.models.organizacao import EquipeGerencia, Gerencia, Municipio, Produto, Projeto, TipoEvento
 
         assert Municipio is not None
         assert Gerencia is not None

--- a/v2/backend/apps/core/tests/test_multi_sector_permissions.py
+++ b/v2/backend/apps/core/tests/test_multi_sector_permissions.py
@@ -17,12 +17,7 @@ from rest_framework.test import APIClient, APIRequestFactory
 
 import pytest
 
-from apps.core.models import (
-    AvailabilityBlock,
-    EquipeGerencia,
-    Gerencia,
-    Usuario,
-)
+from apps.core.models import AvailabilityBlock, EquipeGerencia, Gerencia, Usuario
 from apps.core.permissions import HasSectorAccess
 
 

--- a/v2/backend/apps/core/tests/test_partial_updates_and_checkview.py
+++ b/v2/backend/apps/core/tests/test_partial_updates_and_checkview.py
@@ -18,14 +18,7 @@ from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import (
-    AvailabilityBlock,
-    Municipio,
-    Projeto,
-    Solicitacao,
-    TipoEvento,
-    Usuario,
-)
+from apps.core.models import AvailabilityBlock, Municipio, Projeto, Solicitacao, TipoEvento, Usuario
 
 pytestmark = pytest.mark.django_db
 

--- a/v2/backend/apps/core/tests/test_plano_formacoes.py
+++ b/v2/backend/apps/core/tests/test_plano_formacoes.py
@@ -20,14 +20,7 @@ from django.contrib.auth import get_user_model
 
 import pytest
 
-from apps.core.models import (
-    Acompanhamento,
-    Formacao,
-    Municipio,
-    PlanoFormacoes,
-    Projeto,
-    Prova,
-)
+from apps.core.models import Acompanhamento, Formacao, Municipio, PlanoFormacoes, Projeto, Prova
 
 User = get_user_model()
 

--- a/v2/backend/apps/core/tests/test_preagenda_publish_api.py
+++ b/v2/backend/apps/core/tests/test_preagenda_publish_api.py
@@ -24,15 +24,7 @@ from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import (
-    AuditLog,
-    Municipio,
-    Participation,
-    Projeto,
-    Solicitacao,
-    TipoEvento,
-    Usuario,
-)
+from apps.core.models import AuditLog, Municipio, Participation, Projeto, Solicitacao, TipoEvento, Usuario
 from apps.core.services.gcal_sync_service import (
     apply_one_solicitacao,
     build_attendees_for_solicitacao,

--- a/v2/backend/apps/core/tests/test_query_optimization.py
+++ b/v2/backend/apps/core/tests/test_query_optimization.py
@@ -17,14 +17,7 @@ from django.test import TestCase, override_settings
 from django.test.utils import CaptureQueriesContext
 from rest_framework.test import APIClient
 
-from apps.core.models import (
-    AvailabilityBlock,
-    Municipio,
-    Participation,
-    Projeto,
-    Solicitacao,
-    TipoEvento,
-)
+from apps.core.models import AvailabilityBlock, Municipio, Participation, Projeto, Solicitacao, TipoEvento
 
 Usuario = get_user_model()
 

--- a/v2/backend/apps/core/tests/test_solicitacao_edit.py
+++ b/v2/backend/apps/core/tests/test_solicitacao_edit.py
@@ -38,15 +38,7 @@ from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import (
-    AuditLog,
-    Municipio,
-    Participation,
-    Projeto,
-    Solicitacao,
-    TipoEvento,
-    Usuario,
-)
+from apps.core.models import AuditLog, Municipio, Participation, Projeto, Solicitacao, TipoEvento, Usuario
 
 pytestmark = pytest.mark.django_db
 

--- a/v2/backend/apps/core/tests/test_solicitacao_fluxo.py
+++ b/v2/backend/apps/core/tests/test_solicitacao_fluxo.py
@@ -21,13 +21,7 @@ from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import (
-    Municipio,
-    Projeto,
-    Solicitacao,
-    TipoEvento,
-    Usuario,
-)
+from apps.core.models import Municipio, Projeto, Solicitacao, TipoEvento, Usuario
 
 
 @pytest.fixture

--- a/v2/backend/apps/core/tests/test_solicitacao_online_mode.py
+++ b/v2/backend/apps/core/tests/test_solicitacao_online_mode.py
@@ -19,13 +19,7 @@ from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import (
-    Municipio,
-    Projeto,
-    Solicitacao,
-    TipoEvento,
-    Usuario,
-)
+from apps.core.models import Municipio, Projeto, Solicitacao, TipoEvento, Usuario
 
 
 @pytest.fixture

--- a/v2/backend/apps/core/tests/test_solicitacao_pr15.py
+++ b/v2/backend/apps/core/tests/test_solicitacao_pr15.py
@@ -20,14 +20,7 @@ from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import (
-    Municipio,
-    Participation,
-    Projeto,
-    Solicitacao,
-    TipoEvento,
-    Usuario,
-)
+from apps.core.models import Municipio, Participation, Projeto, Solicitacao, TipoEvento, Usuario
 
 
 @pytest.fixture

--- a/v2/backend/apps/core/tests/test_solicitacao_serializer_meet_link.py
+++ b/v2/backend/apps/core/tests/test_solicitacao_serializer_meet_link.py
@@ -20,13 +20,7 @@ from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import (
-    Municipio,
-    Projeto,
-    Solicitacao,
-    TipoEvento,
-    Usuario,
-)
+from apps.core.models import Municipio, Projeto, Solicitacao, TipoEvento, Usuario
 
 
 @pytest.fixture

--- a/v2/backend/apps/core/tests/test_views_metrics_coverage.py
+++ b/v2/backend/apps/core/tests/test_views_metrics_coverage.py
@@ -26,14 +26,7 @@ from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import (
-    Municipio,
-    Participation,
-    Projeto,
-    Solicitacao,
-    TipoEvento,
-    Usuario,
-)
+from apps.core.models import Municipio, Participation, Projeto, Solicitacao, TipoEvento, Usuario
 
 pytestmark = pytest.mark.django_db
 

--- a/v2/backend/apps/core/tests/test_views_options.py
+++ b/v2/backend/apps/core/tests/test_views_options.py
@@ -23,15 +23,7 @@ from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import (
-    DATArea,
-    DATCoordenador,
-    Municipio,
-    Produto,
-    Projeto,
-    TipoEvento,
-    Usuario,
-)
+from apps.core.models import DATArea, DATCoordenador, Municipio, Produto, Projeto, TipoEvento, Usuario
 
 
 @pytest.fixture

--- a/v2/backend/apps/core/tests/test_views_solicitacao_coverage.py
+++ b/v2/backend/apps/core/tests/test_views_solicitacao_coverage.py
@@ -24,15 +24,7 @@ from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import (
-    AuditLog,
-    Municipio,
-    Participation,
-    Projeto,
-    Solicitacao,
-    TipoEvento,
-    Usuario,
-)
+from apps.core.models import AuditLog, Municipio, Participation, Projeto, Solicitacao, TipoEvento, Usuario
 
 
 @pytest.fixture

--- a/v2/backend/apps/core/urls.py
+++ b/v2/backend/apps/core/urls.py
@@ -9,11 +9,7 @@ from __future__ import annotations
 from django.urls import include, path
 from rest_framework.routers import DefaultRouter
 
-from drf_spectacular.views import (
-    SpectacularAPIView,
-    SpectacularRedocView,
-    SpectacularSwaggerView,
-)
+from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
 
 from .views import DATRegistroViewSet  # DAT Registros module
 from .views import GerenciaViewSet  # Issue #145
@@ -36,11 +32,7 @@ from .views import (  # DAT Module ViewSets; Plano Formacoes (novo modelo estrut
 )
 from .views.stats import HomeStatsView
 from .views_auth import csrf_token, login, logout, ping
-from .views_availability import (
-    AvailabilityBlockViewSet,
-    AvailabilityCheckManyView,
-    AvailabilityCheckView,
-)
+from .views_availability import AvailabilityBlockViewSet, AvailabilityCheckManyView, AvailabilityCheckView
 from .views_availability_monthly import MonthlyAvailabilityView
 
 # Imports de módulos isolados (GAP-001 fix)
@@ -70,12 +62,7 @@ from .views_gcal import (  # Core GCal; Dashboard views
 )
 from .views_health import features, readyz
 from .views_imports import ControleImportAcoesView, DATImportCadastrosView
-from .views_lookup import (
-    MunicipioLookup,
-    ProjetoLookup,
-    TipoEventoLookup,
-    UsuarioLookup,
-)
+from .views_lookup import MunicipioLookup, ProjetoLookup, TipoEventoLookup, UsuarioLookup
 from .views_metrics import (
     formadores_metrics,
     metrics_map,
@@ -101,12 +88,7 @@ from .views_options import (
     usuarios_options,
 )
 from .views_preagenda import PreAgendaListView
-from .views_reports import (
-    reports_by_uf,
-    reports_status_counts,
-    reports_top_projects,
-    reports_weekly_approved,
-)
+from .views_reports import reports_by_uf, reports_status_counts, reports_top_projects, reports_weekly_approved
 from .views_solicitacao import SolicitacaoViewSet
 from .views_validate import SolicitationValidateView
 

--- a/v2/backend/apps/core/views.py
+++ b/v2/backend/apps/core/views.py
@@ -23,11 +23,7 @@ from apps.core.views.admin import (
     ProjetoViewSet,
     UsuarioAdminViewSet,
 )
-from apps.core.views.availability import (
-    AvailabilityBlockViewSet,
-    AvailabilityCheckManyView,
-    AvailabilityCheckView,
-)
+from apps.core.views.availability import AvailabilityBlockViewSet, AvailabilityCheckManyView, AvailabilityCheckView
 from apps.core.views.options import (
     CoordenadorOptionViewSet,
     FormadorOptionViewSet,

--- a/v2/backend/apps/core/views/__init__.py
+++ b/v2/backend/apps/core/views/__init__.py
@@ -18,15 +18,8 @@ from apps.core.views.admin import (
     ProjetoViewSet,
     UsuarioAdminViewSet,
 )
-from apps.core.views.availability import (
-    AvailabilityBlockViewSet,
-    AvailabilityCheckManyView,
-    AvailabilityCheckView,
-)
-from apps.core.views.dat import (
-    DATRegistroViewSet,
-    ProjetoGeralViewSet,
-)
+from apps.core.views.availability import AvailabilityBlockViewSet, AvailabilityCheckManyView, AvailabilityCheckView
+from apps.core.views.dat import DATRegistroViewSet, ProjetoGeralViewSet
 from apps.core.views.dat_module import (
     DATAcaoViewSet,
     DATAreaViewSet,

--- a/v2/backend/apps/core/views/admin.py
+++ b/v2/backend/apps/core/views/admin.py
@@ -18,15 +18,7 @@ from rest_framework.response import Response
 
 from django_filters.rest_framework import DjangoFilterBackend
 
-from apps.core.models import (
-    AuditLog,
-    Compra,
-    Gerencia,
-    Municipio,
-    Produto,
-    Projeto,
-    Usuario,
-)
+from apps.core.models import AuditLog, Compra, Gerencia, Municipio, Produto, Projeto, Usuario
 from apps.core.permissions import IsControleOrDAT, IsDAT
 from apps.core.serializers import (
     AuditLogSerializer,

--- a/v2/backend/apps/core/views/dat_module.py
+++ b/v2/backend/apps/core/views/dat_module.py
@@ -30,14 +30,7 @@ from rest_framework.response import Response
 from django_filters import rest_framework as filters
 from django_filters.rest_framework import DjangoFilterBackend
 
-from apps.core.models import (
-    DATAcao,
-    DATArea,
-    DATCadastro,
-    DATCompra,
-    DATCoordenador,
-    DATFormacao,
-)
+from apps.core.models import DATAcao, DATArea, DATCadastro, DATCompra, DATCoordenador, DATFormacao
 from apps.core.permissions import IsDATOrSuper, IsSuperintendenciaOnly
 from apps.core.serializers import (
     DATAcaoListSerializer,

--- a/v2/backend/apps/core/views/plano_formacoes.py
+++ b/v2/backend/apps/core/views/plano_formacoes.py
@@ -25,12 +25,7 @@ from rest_framework.response import Response
 from django_filters import rest_framework as filters
 from django_filters.rest_framework import DjangoFilterBackend
 
-from apps.core.models import (
-    Acompanhamento,
-    Formacao,
-    PlanoFormacoes,
-    Prova,
-)
+from apps.core.models import Acompanhamento, Formacao, PlanoFormacoes, Prova
 from apps.core.permissions import IsDATOrSuper, IsSuperintendenciaOnly
 from apps.core.serializers import (
     AcompanhamentoSerializer,

--- a/v2/backend/apps/core/views_controle_dat.py
+++ b/v2/backend/apps/core/views_controle_dat.py
@@ -20,11 +20,7 @@ from rest_framework.response import Response
 
 from .models import AcaoControle, AcaoDAT
 from .permissions import IsControleOrSuper, IsDATOrSuper
-from .serializers import (
-    AcaoControleSerializer,
-    AcaoDATCreateSerializer,
-    AcaoDATSerializer,
-)
+from .serializers import AcaoControleSerializer, AcaoDATCreateSerializer, AcaoDATSerializer
 
 
 class ControleAcoesListView(generics.ListAPIView):

--- a/v2/backend/apps/core/views_gcal/__init__.py
+++ b/v2/backend/apps/core/views_gcal/__init__.py
@@ -13,11 +13,7 @@ Backwards-compatible re-exports for existing imports.
 """
 
 # Batch views
-from apps.core.views_gcal.batch import (
-    GCalBatchReapplyView,
-    GCalBatchResyncView,
-    GCalPublishBatchView,
-)
+from apps.core.views_gcal.batch import GCalBatchReapplyView, GCalBatchResyncView, GCalPublishBatchView
 
 # Detail views
 from apps.core.views_gcal.detail import (
@@ -28,31 +24,16 @@ from apps.core.views_gcal.detail import (
 )
 
 # Core GCal views (from old views_gcal.py)
-from apps.core.views_gcal.gcal import (
-    gcal_calendars,
-    gcal_health,
-)
+from apps.core.views_gcal.gcal import gcal_calendars, gcal_health
 
 # Helpers
-from apps.core.views_gcal.helpers import (
-    DashboardEventsPagination,
-    _apply_common_filters,
-    _filter_events_queryset,
-)
+from apps.core.views_gcal.helpers import DashboardEventsPagination, _apply_common_filters, _filter_events_queryset
 
 # Insights views
-from apps.core.views_gcal.insights import (
-    SuccessRateView,
-    TopInsightsView,
-)
+from apps.core.views_gcal.insights import SuccessRateView, TopInsightsView
 
 # Summary views
-from apps.core.views_gcal.summary import (
-    AlertsSummaryView,
-    DashboardMetricsView,
-    GCalListView,
-    GCalStatusSummaryView,
-)
+from apps.core.views_gcal.summary import AlertsSummaryView, DashboardMetricsView, GCalListView, GCalStatusSummaryView
 
 __all__ = [
     # Core GCal

--- a/v2/backend/apps/core/views_gcal/detail.py
+++ b/v2/backend/apps/core/views_gcal/detail.py
@@ -25,10 +25,7 @@ from apps.core.models import Solicitacao
 from apps.core.permissions import IsControleOrSuper
 from apps.core.serializers import EventDetailSerializer, SolicitacaoSerializer
 from apps.core.services.gcal import compute_payload_hash
-from apps.core.views_gcal.helpers import (
-    DashboardEventsPagination,
-    _filter_events_queryset,
-)
+from apps.core.views_gcal.helpers import DashboardEventsPagination, _filter_events_queryset
 
 
 class DashboardEventsView(APIView):

--- a/v2/backend/apps/core/views_solicitacao.py
+++ b/v2/backend/apps/core/views_solicitacao.py
@@ -21,12 +21,7 @@ from rest_framework.response import Response
 
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import (
-    OpenApiExample,
-    OpenApiParameter,
-    extend_schema,
-    extend_schema_view,
-)
+from drf_spectacular.utils import OpenApiExample, OpenApiParameter, extend_schema, extend_schema_view
 
 from .api_schemas import (
     COMMON_ERROR_RESPONSES,
@@ -51,14 +46,9 @@ from .services.solicitacao_approval import (
     batch_reject_solicitacoes,
     reject_solicitacao,
 )
-from .services.solicitacao_publish import (
-    cancel_from_gcal,
-)
+from .services.solicitacao_publish import cancel_from_gcal
 from .services.solicitacao_publish import preview_gcal as preview_gcal_service
-from .services.solicitacao_publish import (
-    publish_to_gcal,
-    resync_to_gcal,
-)
+from .services.solicitacao_publish import publish_to_gcal, resync_to_gcal
 
 logger = logging.getLogger(__name__)
 

--- a/v2/backend/apps/core/views_validate.py
+++ b/v2/backend/apps/core/views_validate.py
@@ -54,12 +54,7 @@ from rest_framework.views import APIView
 
 import pytz
 
-from apps.core.services.resolvers import (
-    resolve_municipio,
-    resolve_projeto,
-    resolve_tipo_evento,
-    resolve_user_by_email,
-)
+from apps.core.services.resolvers import resolve_municipio, resolve_projeto, resolve_tipo_evento, resolve_user_by_email
 
 from .models import Municipio, Projeto, TipoEvento
 

--- a/v2/backend/apps/dat_ingest/management/commands/etl_populate_equipe_gerencia.py
+++ b/v2/backend/apps/dat_ingest/management/commands/etl_populate_equipe_gerencia.py
@@ -22,12 +22,7 @@ from typing import Any
 from django.core.management.base import BaseCommand
 from django.db.models import Count
 
-from apps.core.models import (
-    EquipeGerencia,
-    Gerencia,
-    Participation,
-    Usuario,
-)
+from apps.core.models import EquipeGerencia, Gerencia, Participation, Usuario
 
 
 class Command(BaseCommand):

--- a/v2/backend/apps/dat_ingest/management/commands/etl_upsert_deslocamento.py
+++ b/v2/backend/apps/dat_ingest/management/commands/etl_upsert_deslocamento.py
@@ -26,10 +26,7 @@ from django.core.management.base import BaseCommand, CommandParser
 from django.db import transaction
 
 from apps.core.models import Deslocamento
-from apps.dat_ingest.services.resolvers import (
-    resolve_user_by_email,
-    resolve_user_by_name,
-)
+from apps.dat_ingest.services.resolvers import resolve_user_by_email, resolve_user_by_name
 
 
 class Command(BaseCommand):

--- a/v2/backend/apps/dat_ingest/management/commands/load_full_pipeline.py
+++ b/v2/backend/apps/dat_ingest/management/commands/load_full_pipeline.py
@@ -15,10 +15,7 @@ from django.db import transaction
 
 from apps.core.models import Municipio, Projeto, TipoEvento, Usuario
 from apps.dat_ingest.models import StgMunicipio, StgProjeto, StgTipoEvento, StgUsuario
-from apps.dat_ingest.services.loaders import (
-    extract_tipos_evento_from_agenda,
-    parse_usuarios,
-)
+from apps.dat_ingest.services.loaders import extract_tipos_evento_from_agenda, parse_usuarios
 
 
 class Command(BaseCommand):

--- a/v2/backend/apps/dat_ingest/tests/test_etl_commands_coverage.py
+++ b/v2/backend/apps/dat_ingest/tests/test_etl_commands_coverage.py
@@ -28,14 +28,7 @@ from django.core.management.base import CommandError
 
 import pytest
 
-from apps.core.models import (
-    Municipio,
-    Participation,
-    Projeto,
-    Solicitacao,
-    TipoEvento,
-    Usuario,
-)
+from apps.core.models import Municipio, Participation, Projeto, Solicitacao, TipoEvento, Usuario
 
 # =============================================================================
 # Fixtures

--- a/v2/backend/apps/dat_ingest/tests/test_processors.py
+++ b/v2/backend/apps/dat_ingest/tests/test_processors.py
@@ -13,11 +13,7 @@ import pandas as pd
 import pytest
 from openpyxl import Workbook
 
-from apps.dat_ingest.services.processors import (
-    AgendaProcessor,
-    ControleProcessor,
-    DisponibilidadeProcessor,
-)
+from apps.dat_ingest.services.processors import AgendaProcessor, ControleProcessor, DisponibilidadeProcessor
 
 
 @pytest.fixture

--- a/v2/backend/apps/dat_ingest/tests/test_super_date_parsing.py
+++ b/v2/backend/apps/dat_ingest/tests/test_super_date_parsing.py
@@ -31,10 +31,7 @@ from django.test import TestCase
 
 import pytz
 
-from apps.dat_ingest.services.parse_acompanhamento import (
-    combine_datetime,
-    parse_acompanhamento_aba,
-)
+from apps.dat_ingest.services.parse_acompanhamento import combine_datetime, parse_acompanhamento_aba
 
 
 class TestSuperDateParsing(TestCase):

--- a/v2/backend/apps/dev_tools/management/commands/seed_rbac.py
+++ b/v2/backend/apps/dev_tools/management/commands/seed_rbac.py
@@ -23,14 +23,7 @@ from django.contrib.auth.models import Group, Permission
 from django.contrib.contenttypes.models import ContentType
 from django.core.management.base import BaseCommand, CommandParser
 
-from apps.core.models import (
-    AvailabilityBlock,
-    Compra,
-    Municipio,
-    Projeto,
-    Solicitacao,
-    Usuario,
-)
+from apps.core.models import AvailabilityBlock, Compra, Municipio, Projeto, Solicitacao, Usuario
 
 GROUPS = [
     "Superintendência",

--- a/v2/backend/apps/dev_tools/tests/test_projetos_fluxo_seed.py
+++ b/v2/backend/apps/dev_tools/tests/test_projetos_fluxo_seed.py
@@ -85,9 +85,7 @@ class TestSeedProjetosFluxoFromSheets(TestCase):
         - "Novo  Lendo" → "novo lendo"
         - "Brincando & Aprendendo" → "brincando aprendendo"
         """
-        from apps.dev_tools.management.commands.seed_projetos_fluxo_from_sheets import (
-            Command,
-        )
+        from apps.dev_tools.management.commands.seed_projetos_fluxo_from_sheets import Command
 
         cmd = Command()
 


### PR DESCRIPTION
## Summary

Apply isort formatting fixes to 58 backend Python files.

### Changes
- Collapse multi-line imports into single lines where appropriate
- Reorder imports according to isort profile (black compatible)
- **-375 lines** of code (456 deletions, 81 insertions)

### Context

These changes were generated when running `isort` in the Docker container during a rebuild. They ensure consistency with the lint CI checks established in PR #492.

### Files Modified

| Category | Files |
|----------|-------|
| views | 12 |
| tests | 28 |
| services | 6 |
| serializers | 2 |
| management commands | 6 |
| models | 1 |
| urls | 1 |
| other | 2 |

## Test Plan
- [x] No functional changes (style only)
- [ ] CI passes (lint, tests)