### PR TITLE
fix(ci): use correct Docker Scout organization name

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -119,7 +119,7 @@ jobs:
         with:
           command: cves,recommendations
           image: ${{ env.BACKEND_IMAGE }}:${{ steps.version.outputs.version }}
-          organization: aprender
+          organization: norjosamatheus
           only-severities: critical,high
 
       - name: Docker Scout - Update production environment
@@ -127,7 +127,7 @@ jobs:
         with:
           command: environment
           image: ${{ env.BACKEND_IMAGE }}:${{ steps.version.outputs.version }}
-          organization: aprender
+          organization: norjosamatheus
           environment: production
 
       # =========================================================================


### PR DESCRIPTION
## Summary

Fix Docker Scout error: organization "aprender" is not enrolled.

## Problem

```
You either don't have permission to run operation on organization or organization "aprender" is not enrolled with Docker Scout
```

## Solution

Change organization from `aprender` to `norjosamatheus` (the actual Docker Hub username).

## Checklist

- [x] Follows Conventional Commits (CP-06)
- [x] No direct push to main (CP-07)