### PR TITLE
fix(ci): add git short SHA to version tag for uniqueness

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,7 +32,8 @@ jobs:
       - name: Generate version
         id: version
         run: |
-          VERSION="v$(date -u +%Y.%m.%d)"
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          VERSION="v$(date -u +%Y.%m.%d)-${SHORT_SHA}"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Generated version: $VERSION"
 


### PR DESCRIPTION
## Summary

Changes version format from `v2026.01.28` to `v2026.01.28-e80fc7e`.

## Benefits

- Allows multiple releases per day without tag conflicts
- Maps versions directly to commits for traceability
- Unique version for each release

## Example

Before: `v2026.01.28`
After: `v2026.01.28-e80fc7e`