### PR TITLE
feat(frontend): add semantic HTML to Solicitacoes and Aprovacoes pages

### DIFF
--- a/v2/frontend/src/pages/Aprovacoes/ApprovalsPage.tsx
+++ b/v2/frontend/src/pages/Aprovacoes/ApprovalsPage.tsx
@@ -385,47 +385,55 @@ export default function ApprovalsPage(): JSX.Element {
   ], [handlePreview, handleApprove, handleReject, canApprove]);
 
   return (
-    <div className="p-6">
+    <section className="p-6" aria-labelledby="aprovacoes-title">
       <Card>
         <Space direction="vertical" style={{ width: '100%' }} size="large">
-          {/* Header */}
-          <Title level={2}>Aprovações</Title>
+          {/* Header semantico */}
+          <header>
+            <Title level={2} id="aprovacoes-title">Aprovações</Title>
+          </header>
 
           {/* Filtros */}
-          <Space>
-            <Select
-              value={statusFilter}
-              onChange={setStatusFilter}
-              style={{ width: 200 }}
-              placeholder="Status"
-            >
-              <Select.Option value="pendente">Pendentes</Select.Option>
-              <Select.Option value="aprovado">Aprovadas</Select.Option>
-              <Select.Option value="reprovado">Reprovadas</Select.Option>
-            </Select>
+          <nav aria-label="Filtros de busca">
+            <Space>
+              <Select
+                value={statusFilter}
+                onChange={setStatusFilter}
+                style={{ width: 200 }}
+                placeholder="Status"
+                aria-label="Filtrar por status"
+              >
+                <Select.Option value="pendente">Pendentes</Select.Option>
+                <Select.Option value="aprovado">Aprovadas</Select.Option>
+                <Select.Option value="reprovado">Reprovadas</Select.Option>
+              </Select>
 
-            <Input.Search
-              placeholder="Buscar por município, projeto, autor..."
-              value={searchTerm}
-              onChange={(e: ChangeEvent<HTMLInputElement>) => setSearchTerm(e.target.value)}
-              onSearch={loadData}
-              style={{ width: 400 }}
-              allowClear
-            />
-          </Space>
+              <Input.Search
+                placeholder="Buscar por município, projeto, autor..."
+                value={searchTerm}
+                onChange={(e: ChangeEvent<HTMLInputElement>) => setSearchTerm(e.target.value)}
+                onSearch={loadData}
+                style={{ width: 400 }}
+                allowClear
+                aria-label="Buscar solicitacoes"
+              />
+            </Space>
+          </nav>
 
           {/* Contagem de pendentes */}
           {statusFilter === 'pendente' && total > 0 && (
-            <Paragraph>
-              <Tag color="orange">{total}</Tag> solicitações aguardando aprovação
-            </Paragraph>
+            <aside aria-label="Contador de pendentes">
+              <Paragraph>
+                <Tag color="orange">{total}</Tag> solicitações aguardando aprovação
+              </Paragraph>
+            </aside>
           )}
 
           {/* Toolbar de ações em lote (PA-06: apenas para usuários com permissão) */}
           {selectedRowKeys.length > 0 && canApprove && (
-            <div className="mb-4 p-3 bg-blue-50 rounded border border-blue-200">
+            <nav aria-label="Acoes em lote" className="mb-4 p-3 bg-blue-50 rounded border border-blue-200">
               <Space>
-                <Text strong>
+                <Text strong aria-live="polite">
                   {selectedRowKeys.length} solicitação(ões) selecionada(s)
                 </Text>
                 <Button
@@ -448,23 +456,25 @@ export default function ApprovalsPage(): JSX.Element {
                   Limpar Seleção
                 </Button>
               </Space>
-            </div>
+            </nav>
           )}
 
           {/* Tabela */}
-          <Table
-            rowSelection={rowSelection}
-            columns={columns}
-            dataSource={rows}
-            loading={loading}
-            rowKey="id"
-            scroll={{ x: 1090 }}
-            pagination={{
-              total,
-              pageSize: 20,
-              showTotal: (total) => `Total: ${total} solicitações`,
-            }}
-          />
+          <section aria-label="Lista de solicitacoes para aprovacao">
+            <Table
+              rowSelection={rowSelection}
+              columns={columns}
+              dataSource={rows}
+              loading={loading}
+              rowKey="id"
+              scroll={{ x: 1090 }}
+              pagination={{
+                total,
+                pageSize: 20,
+                showTotal: (total) => `Total: ${total} solicitações`,
+              }}
+            />
+          </section>
         </Space>
       </Card>
 
@@ -593,6 +603,6 @@ export default function ApprovalsPage(): JSX.Element {
         )}
       </Modal>
 
-    </div>
+    </section>
   );
 }

--- a/v2/frontend/src/pages/Solicitacoes/MySolicitacoesPage.tsx
+++ b/v2/frontend/src/pages/Solicitacoes/MySolicitacoesPage.tsx
@@ -263,12 +263,12 @@ export default function MySolicitacoesPage(): JSX.Element {
   ], [handleDelete, navigate]);
 
   return (
-    <div className="p-6">
+    <section className="p-6" aria-labelledby="minhas-solicitacoes-title">
       <Card>
         <Space direction="vertical" style={{ width: '100%' }} size="large">
-          {/* Header */}
-          <div className="flex justify-between items-center">
-            <Title level={2} className="m-0">
+          {/* Header semantico */}
+          <header className="flex justify-between items-center">
+            <Title level={2} className="m-0" id="minhas-solicitacoes-title">
               Minhas Solicitações
             </Title>
             <Link to="/solicitacoes/nova">
@@ -276,47 +276,53 @@ export default function MySolicitacoesPage(): JSX.Element {
                 Nova Solicitação
               </Button>
             </Link>
-          </div>
+          </header>
 
           {/* Filtros */}
-          <Space>
-            <Select
-              value={statusFilter}
-              onChange={setStatusFilter}
-              style={{ width: 200 }}
-              placeholder="Status"
-            >
-              <Select.Option value="">Todas</Select.Option>
-              <Select.Option value="pendente">Pendentes</Select.Option>
-              <Select.Option value="aprovado">Aprovadas</Select.Option>
-              <Select.Option value="reprovado">Reprovadas</Select.Option>
-            </Select>
+          <nav aria-label="Filtros de busca">
+            <Space>
+              <Select
+                value={statusFilter}
+                onChange={setStatusFilter}
+                style={{ width: 200 }}
+                placeholder="Status"
+                aria-label="Filtrar por status"
+              >
+                <Select.Option value="">Todas</Select.Option>
+                <Select.Option value="pendente">Pendentes</Select.Option>
+                <Select.Option value="aprovado">Aprovadas</Select.Option>
+                <Select.Option value="reprovado">Reprovadas</Select.Option>
+              </Select>
 
-            <Input.Search
-              placeholder="Buscar por município, projeto..."
-              value={searchTerm}
-              onChange={(e: ChangeEvent<HTMLInputElement>) => setSearchTerm(e.target.value)}
-              onSearch={loadData}
-              enterButton={<SearchOutlined />}
-              style={{ width: 300 }}
-              allowClear
-            />
-          </Space>
+              <Input.Search
+                placeholder="Buscar por município, projeto..."
+                value={searchTerm}
+                onChange={(e: ChangeEvent<HTMLInputElement>) => setSearchTerm(e.target.value)}
+                onSearch={loadData}
+                enterButton={<SearchOutlined />}
+                style={{ width: 300 }}
+                allowClear
+                aria-label="Buscar solicitacoes"
+              />
+            </Space>
+          </nav>
 
           {/* Tabela */}
-          <Table
-            columns={columns}
-            dataSource={rows}
-            loading={loading}
-            rowKey="id"
-            pagination={{
-              total,
-              pageSize: 20,
-              showTotal: (total) => `Total: ${total} solicitações`,
-            }}
-          />
+          <section aria-label="Lista de solicitacoes">
+            <Table
+              columns={columns}
+              dataSource={rows}
+              loading={loading}
+              rowKey="id"
+              pagination={{
+                total,
+                pageSize: 20,
+                showTotal: (total) => `Total: ${total} solicitações`,
+              }}
+            />
+          </section>
         </Space>
       </Card>
-    </div>
+    </section>
   );
 }

--- a/v2/frontend/src/pages/Solicitacoes/NewSolicitacaoWizard.tsx
+++ b/v2/frontend/src/pages/Solicitacoes/NewSolicitacaoWizard.tsx
@@ -542,39 +542,48 @@ export default function NewSolicitacaoWizard(): JSX.Element {
   ], [formData, rangeValue, handleRangeChange]);
 
   return (
-    <div className="p-6 max-w-4xl mx-auto">
+    <section className="p-6 max-w-4xl mx-auto" aria-labelledby="nova-solicitacao-title">
       <Card>
-        <Button
-          icon={<ArrowLeftOutlined />}
-          onClick={() => navigate('/solicitacoes/minhas')}
-          className="mb-4"
-        >
-          Voltar
-        </Button>
+        {/* Header semantico com navegacao e titulo */}
+        <header>
+          <Button
+            icon={<ArrowLeftOutlined />}
+            onClick={() => navigate('/solicitacoes/minhas')}
+            className="mb-4"
+            aria-label="Voltar para minhas solicitacoes"
+          >
+            Voltar
+          </Button>
 
-        <Title level={2} className="mb-2">Nova Solicitação</Title>
-        <Text type="secondary">Passo {currentStep + 1} de {steps.length}</Text>
+          <Title level={2} className="mb-2" id="nova-solicitacao-title">Nova Solicitação</Title>
+          <Text type="secondary" aria-live="polite">Passo {currentStep + 1} de {steps.length}</Text>
+        </header>
 
-        <Steps current={currentStep} className="mt-6 mb-8">
-          {steps.map((step, index) => (
-            <Step key={index} title={step.title} icon={step.icon} />
-          ))}
-        </Steps>
+        {/* Navegacao do wizard */}
+        <nav aria-label="Passos do wizard" className="mt-6 mb-8">
+          <Steps current={currentStep}>
+            {steps.map((step, index) => (
+              <Step key={index} title={step.title} icon={step.icon} />
+            ))}
+          </Steps>
+        </nav>
 
+        {/* Conteudo do passo atual */}
         <Form form={form} layout="vertical">
-          <div style={{ minHeight: '400px' }}>
+          <section aria-label={`Passo ${currentStep + 1}: ${steps[currentStep].title}`} style={{ minHeight: '400px' }}>
             {steps[currentStep].content}
-          </div>
+          </section>
         </Form>
 
-        <div className="mt-6 flex gap-2 justify-end">
+        {/* Footer com botoes de navegacao */}
+        <footer className="mt-6 flex gap-2 justify-end" role="navigation" aria-label="Navegacao do wizard">
           {currentStep > 0 && (
-            <Button onClick={prev}>
+            <Button onClick={prev} aria-label="Voltar para passo anterior">
               Anterior
             </Button>
           )}
           {currentStep < steps.length - 1 && (
-            <Button type="primary" onClick={next}>
+            <Button type="primary" onClick={next} aria-label="Ir para proximo passo">
               Próximo
             </Button>
           )}
@@ -583,8 +592,8 @@ export default function NewSolicitacaoWizard(): JSX.Element {
               Confirmar Solicitação
             </Button>
           )}
-        </div>
+        </footer>
       </Card>
-    </div>
+    </section>
   );
 }


### PR DESCRIPTION
## Summary

Adiciona HTML semantico as paginas de Solicitacoes e Aprovacoes:

### MySolicitacoesPage.tsx
- `<section aria-labelledby>` envolvendo a pagina
- `<header>` para titulo
- `<nav aria-label="Filtros">` para filtros
- `<section aria-label="Lista">` para tabela

### NewSolicitacaoWizard.tsx
- `<section aria-labelledby>` envolvendo a pagina
- `<header>` para navegacao e titulo
- `<nav aria-label="Passos do wizard">` para Steps
- `<section aria-label="Passo X">` para conteudo
- `<footer>` para botoes de navegacao
- `aria-live="polite"` para contador de passos

### ApprovalsPage.tsx
- `<section aria-labelledby>` envolvendo a pagina
- `<header>` para titulo
- `<nav aria-label="Filtros">` para filtros
- `<aside>` para contador de pendentes
- `<nav aria-label="Acoes em lote">` para toolbar
- `<section>` para tabela

## Test Plan

- [x] Build passa sem erros
- [ ] Navegacao por teclado funciona
- [ ] Leitor de tela identifica landmarks corretamente

## Parte do Plano

PR 2/7 da iniciativa de HTML Semantico:
1. Layout (App.tsx) - ✅ #516 merged
2. **Solicitacoes + Aprovacoes** <- Este PR
3. Disponibilidade
4. Modulo DAT
5. Dashboards
6. Componentes reutilizaveis
7. Admin + Restantes