### PR TITLE
refactor(frontend): add semantic HTML to Disponibilidade pages

### DIFF
--- a/v2/frontend/src/pages/Disponibilidade.tsx
+++ b/v2/frontend/src/pages/Disponibilidade.tsx
@@ -66,33 +66,40 @@ export default function Disponibilidade(): JSX.Element {
   }, []);
 
   return (
-    <div style={{ padding: '24px' }}>
-      <h1>Gerenciar Disponibilidade</h1>
-      <p style={{ color: '#666', marginBottom: '24px' }}>
-        Crie bloqueios de disponibilidade (Total ou Parcial) para indicar períodos em que você não estará disponível.
-      </p>
+    <section style={{ padding: '24px' }} aria-labelledby="disponibilidade-title">
+      {/* Header semantico */}
+      <header>
+        <h1 id="disponibilidade-title">Gerenciar Disponibilidade</h1>
+        <p style={{ color: '#666', marginBottom: '24px' }}>
+          Crie bloqueios de disponibilidade (Total ou Parcial) para indicar períodos em que você não estará disponível.
+        </p>
+      </header>
 
       <Row gutter={[16, 16]}>
         {/* Card de Criação */}
         <Col xs={24} lg={12}>
-          <Card title="Criar Bloqueio" bordered={false}>
-            <BlockForm onSubmit={handleCreate as unknown as (payload: { tipo: string; inicio: string; fim: string }) => Promise<void>} />
-          </Card>
+          <article aria-label="Criar novo bloqueio">
+            <Card title="Criar Bloqueio" bordered={false}>
+              <BlockForm onSubmit={handleCreate as unknown as (payload: { tipo: string; inicio: string; fim: string }) => Promise<void>} />
+            </Card>
+          </article>
         </Col>
 
         {/* Card de Listagem */}
         <Col xs={24} lg={12}>
-          <Card title="Meus Bloqueios" bordered={false}>
-            {loading ? (
-              <div style={{ textAlign: 'center', padding: '40px 0' }}>
-                <Spin size="large" tip="Carregando bloqueios..." />
-              </div>
-            ) : (
-              <MyBlocksTable blocks={blocks as unknown as Array<{ id: number; tipo: 'T' | 'P'; inicio: string; fim: string; status: 'pendente' | 'aprovado' | 'reprovado' }>} onDelete={handleDelete} loading={loading} />
-            )}
-          </Card>
+          <article aria-label="Lista de meus bloqueios">
+            <Card title="Meus Bloqueios" bordered={false}>
+              {loading ? (
+                <div style={{ textAlign: 'center', padding: '40px 0' }} role="status" aria-live="polite">
+                  <Spin size="large" tip="Carregando bloqueios..." />
+                </div>
+              ) : (
+                <MyBlocksTable blocks={blocks as unknown as Array<{ id: number; tipo: 'T' | 'P'; inicio: string; fim: string; status: 'pendente' | 'aprovado' | 'reprovado' }>} onDelete={handleDelete} loading={loading} />
+              )}
+            </Card>
+          </article>
         </Col>
       </Row>
-    </div>
+    </section>
   );
 }

--- a/v2/frontend/src/pages/Disponibilidade/MonthlyPage.tsx
+++ b/v2/frontend/src/pages/Disponibilidade/MonthlyPage.tsx
@@ -91,39 +91,43 @@ export default function MonthlyPage(): JSX.Element {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <section className="min-h-screen bg-gray-50" aria-labelledby="grade-mensal-title">
       <div className="p-6 md:p-10 space-y-6">
-        {/* Título */}
-        <div>
-          <h1 className="text-3xl font-bold text-gray-900">
+        {/* Header semantico */}
+        <header>
+          <h1 id="grade-mensal-title" className="text-3xl font-bold text-gray-900">
             Grade Mensal de Disponibilidade
           </h1>
           <p className="text-sm text-gray-600 mt-1">
             Visualize a disponibilidade mensal de formadores e coordenadores.
             Clique em uma célula para ver detalhes dos eventos.
           </p>
-        </div>
+        </header>
 
         {/* Filtros compartilhados */}
-        <FiltersBar
-          year={filters.year}
-          month={filters.month}
-          gerenciaId={filters.gerenciaId}
-          sector={filters.sector}
-          q={filters.q}
-          onChange={handleFiltersChange}
-        />
+        <nav aria-label="Filtros da grade">
+          <FiltersBar
+            year={filters.year}
+            month={filters.month}
+            gerenciaId={filters.gerenciaId}
+            sector={filters.sector}
+            q={filters.q}
+            onChange={handleFiltersChange}
+          />
+        </nav>
 
         {/* Legenda */}
-        <Legend legend={formadores.data?.legend || coordenadores.data?.legend} />
+        <aside aria-label="Legenda de cores">
+          <Legend legend={formadores.data?.legend || coordenadores.data?.legend} />
+        </aside>
 
         {/* Grades */}
         <div className="space-y-6">
             {/* Grade de Formadores */}
-            <div>
-              <div className="mb-4">
-                <h2 className="text-xl font-semibold text-gray-900">Formadores</h2>
-              </div>
+            <article aria-labelledby="formadores-heading">
+              <header className="mb-4">
+                <h2 id="formadores-heading" className="text-xl font-semibold text-gray-900">Formadores</h2>
+              </header>
 
               {formadores.loading ? (
                 <div className="bg-white rounded-lg shadow-sm p-8 text-center">
@@ -164,13 +168,13 @@ export default function MonthlyPage(): JSX.Element {
                   </p>
                 </div>
               )}
-            </div>
+            </article>
 
             {/* Grade de Coordenadores */}
-            <div>
-              <div className="mb-4">
-                <h2 className="text-xl font-semibold text-gray-900">Coordenadores</h2>
-              </div>
+            <article aria-labelledby="coordenadores-heading">
+              <header className="mb-4">
+                <h2 id="coordenadores-heading" className="text-xl font-semibold text-gray-900">Coordenadores</h2>
+              </header>
 
               {coordenadores.loading ? (
                 <div className="bg-white rounded-lg shadow-sm p-8 text-center">
@@ -211,7 +215,7 @@ export default function MonthlyPage(): JSX.Element {
                   </p>
                 </div>
               )}
-            </div>
+            </article>
         </div>
       </div>
 
@@ -223,6 +227,6 @@ export default function MonthlyPage(): JSX.Element {
         day={day}
         details={details}
       />
-    </div>
+    </section>
   );
 }


### PR DESCRIPTION
## Summary
- Add semantic HTML5 elements to Disponibilidade module pages
- Improve accessibility with proper ARIA attributes

## Changes
### Disponibilidade.tsx
- Wrap in `<section aria-labelledby="disponibilidade-title">`
- Add `<header>` with `<h1>` and description
- Use `<article aria-label>` for form and table cards

### MonthlyPage.tsx
- Wrap in `<section aria-labelledby="grade-mensal-title">`
- Add `<header>` with `<h1>` and description
- Use `<nav aria-label="Filtros da grade">` for FiltersBar
- Use `<aside aria-label="Legenda de cores">` for Legend
- Use `<article aria-labelledby>` with `<h2>` for each grid (Formadores/Coordenadores)

## Test plan
- [x] Build passes (`npm run build`)
- [ ] CI passes
- [ ] Manual test: pages render correctly
- [ ] Manual test: screen reader announces sections properly