### PR TITLE
refactor(frontend): add semantic HTML to DAT module pages

### DIFF
--- a/v2/frontend/src/pages/DATModule/AcoesPage.tsx
+++ b/v2/frontend/src/pages/DATModule/AcoesPage.tsx
@@ -491,12 +491,12 @@ export default function AcoesPage(): JSX.Element {
   ], [handleEdit, handleDelete, renderStatusIcon, calculateProgress]);
 
   return (
-    <div className="p-6 bg-gray-100" style={{ minHeight: 'calc(100vh - 64px)' }}>
+    <section className="p-6 bg-gray-100" style={{ minHeight: 'calc(100vh - 64px)' }} aria-labelledby="acoes-title">
       {/* Header */}
-      <div className="mb-6">
+      <header className="mb-6">
         <div className="flex justify-between items-start mb-2">
           <div>
-            <Title level={3} className="m-0">
+            <Title level={3} className="m-0" id="acoes-title">
               <RocketOutlined className="mr-2" />
               Gestão de Ações
             </Title>
@@ -511,7 +511,7 @@ export default function AcoesPage(): JSX.Element {
             </Button>
           </Space>
         </div>
-      </div>
+      </header>
 
       {/* Stats Cards */}
       {stats && (
@@ -562,6 +562,7 @@ export default function AcoesPage(): JSX.Element {
       )}
 
       {/* Filters Card */}
+      <nav aria-label="Filtros de busca">
       <Card className="mb-4" bodyStyle={{ paddingBottom: 12 }}>
         <Row gutter={[16, 16]}>
           <Col xs={24} sm={12} md={8} lg={4}>
@@ -678,8 +679,10 @@ export default function AcoesPage(): JSX.Element {
           </Button>
         </div>
       </Card>
+      </nav>
 
       {/* Table Card */}
+      <section aria-label="Resultados da busca">
       <Card
         bodyStyle={{ padding: 0 }}
         title={
@@ -742,8 +745,10 @@ export default function AcoesPage(): JSX.Element {
           size="middle"
         />
       </Card>
+      </section>
 
       {/* Legend */}
+      <aside aria-label="Legenda de status">
       <Card className="mt-4" size="small">
         <Space size="large" wrap>
           <Text strong style={{ textTransform: 'uppercase', fontSize: 12 }}>
@@ -767,6 +772,7 @@ export default function AcoesPage(): JSX.Element {
           </Space>
         </Space>
       </Card>
+      </aside>
 
       {/* Create/Edit Modal */}
       <Modal
@@ -974,6 +980,6 @@ export default function AcoesPage(): JSX.Element {
           </Form.Item>
         </Form>
       </Modal>
-    </div>
+    </section>
   );
 }

--- a/v2/frontend/src/pages/DATModule/CadastrosPage.tsx
+++ b/v2/frontend/src/pages/DATModule/CadastrosPage.tsx
@@ -301,12 +301,12 @@ export default function CadastrosPage(): JSX.Element {
   const currentPlataforma = PLATAFORMAS[activeTab];
 
   return (
-    <div className="p-6 bg-gray-100" style={{ minHeight: 'calc(100vh - 64px)' }}>
+    <section className="p-6 bg-gray-100" style={{ minHeight: 'calc(100vh - 64px)' }} aria-labelledby="cadastros-title">
       {/* Header */}
-      <div className="mb-6">
+      <header className="mb-6">
         <div className="flex justify-between items-start mb-2">
           <div>
-            <Title level={3} className="m-0">
+            <Title level={3} className="m-0" id="cadastros-title">
               <CloudServerOutlined className="mr-2" />
               Gestão de Cadastros em Plataformas
             </Title>
@@ -321,7 +321,7 @@ export default function CadastrosPage(): JSX.Element {
             </Button>
           </Space>
         </div>
-      </div>
+      </header>
 
       {/* Tabs for FORMAR / AVALIAR */}
       <Card className="mb-4">
@@ -399,6 +399,7 @@ export default function CadastrosPage(): JSX.Element {
       </Card>
 
       {/* Filters Card */}
+      <nav aria-label="Filtros de busca">
       <Card className="mb-4" bodyStyle={{ paddingBottom: 12 }}>
         <Row gutter={[16, 16]}>
           <Col xs={24} sm={12} md={8} lg={5}>
@@ -498,8 +499,10 @@ export default function CadastrosPage(): JSX.Element {
           </Button>
         </div>
       </Card>
+      </nav>
 
       {/* Table Card */}
+      <section aria-label="Resultados da busca">
       <Card
         bodyStyle={{ padding: 0 }}
         title={
@@ -539,8 +542,10 @@ export default function CadastrosPage(): JSX.Element {
           size="middle"
         />
       </Card>
+      </section>
 
       {/* Legend */}
+      <aside aria-label="Legenda de status">
       <Card className="mt-4" size="small">
         <Space size="large" wrap>
           <Text strong style={{ textTransform: 'uppercase', fontSize: 12 }}>
@@ -564,6 +569,7 @@ export default function CadastrosPage(): JSX.Element {
           </Space>
         </Space>
       </Card>
+      </aside>
 
       {/* Create/Edit Modal */}
       <Modal
@@ -784,6 +790,6 @@ export default function CadastrosPage(): JSX.Element {
           </Form.Item>
         </Form>
       </Modal>
-    </div>
+    </section>
   );
 }

--- a/v2/frontend/src/pages/DATModule/ComprasPage.tsx
+++ b/v2/frontend/src/pages/DATModule/ComprasPage.tsx
@@ -459,12 +459,12 @@ export default function ComprasPage(): JSX.Element {
   ], []);
 
   return (
-    <div className="p-6 bg-gray-100" style={{ minHeight: 'calc(100vh - 64px)' }}>
+    <section className="p-6 bg-gray-100" style={{ minHeight: 'calc(100vh - 64px)' }} aria-labelledby="compras-title">
       {/* Header */}
-      <div className="mb-6">
+      <header className="mb-6">
         <div className="flex justify-between items-start mb-2">
           <div>
-            <Title level={3} className="m-0">
+            <Title level={3} className="m-0" id="compras-title">
               <ShoppingCartOutlined className="mr-2" />
               Gestão de Compras/Materiais
             </Title>
@@ -479,7 +479,7 @@ export default function ComprasPage(): JSX.Element {
             </Button>
           </Space>
         </div>
-      </div>
+      </header>
 
       {/* Stats Cards */}
       {stats && (
@@ -531,6 +531,7 @@ export default function ComprasPage(): JSX.Element {
       )}
 
       {/* Filters Card */}
+      <nav aria-label="Filtros de busca">
       <Card className="mb-4" bodyStyle={{ paddingBottom: 12 }}>
         <Row gutter={[16, 16]}>
           <Col xs={24} sm={12} md={8} lg={4}>
@@ -658,8 +659,10 @@ export default function ComprasPage(): JSX.Element {
           </Button>
         </div>
       </Card>
+      </nav>
 
       {/* Table Card */}
+      <section aria-label="Resultados da busca">
       <Card
         bodyStyle={{ padding: 0 }}
         title={
@@ -723,8 +726,10 @@ export default function ComprasPage(): JSX.Element {
           }}
         />
       </Card>
+      </section>
 
       {/* Legend */}
+      <aside aria-label="Legenda de status">
       <Card className="mt-4" size="small">
         <Space size="large" wrap>
           <Text strong style={{ textTransform: 'uppercase', fontSize: 12 }}>
@@ -744,6 +749,7 @@ export default function ComprasPage(): JSX.Element {
           </Space>
         </Space>
       </Card>
+      </aside>
 
       {/* Create/Edit Modal */}
       <Modal
@@ -942,6 +948,6 @@ export default function ComprasPage(): JSX.Element {
           </Form.Item>
         </Form>
       </Modal>
-    </div>
+    </section>
   );
 }

--- a/v2/frontend/src/pages/DATModule/CoordenadoresPage.tsx
+++ b/v2/frontend/src/pages/DATModule/CoordenadoresPage.tsx
@@ -476,12 +476,12 @@ export default function CoordenadoresPage(): JSX.Element {
   );
 
   return (
-    <div className="p-6 bg-gray-100" style={{ minHeight: 'calc(100vh - 64px)' }}>
+    <section className="p-6 bg-gray-100" style={{ minHeight: 'calc(100vh - 64px)' }} aria-labelledby="coordenadores-title">
       {/* Header */}
-      <div className="mb-6">
+      <header className="mb-6">
         <div className="flex justify-between items-start mb-2">
           <div>
-            <Title level={3} className="m-0">
+            <Title level={3} className="m-0" id="coordenadores-title">
               <TeamOutlined className="mr-2" />
               Gestão de Coordenadores
             </Title>
@@ -522,7 +522,7 @@ export default function CoordenadoresPage(): JSX.Element {
             </Button>
           </Space>
         </div>
-      </div>
+      </header>
 
       {/* Stats Cards */}
       {stats && (
@@ -575,6 +575,7 @@ export default function CoordenadoresPage(): JSX.Element {
       )}
 
       {/* Filters Card */}
+      <nav aria-label="Filtros de busca">
       <Card style={{ marginBottom: 16 }} bodyStyle={{ paddingBottom: 12 }}>
         <Row gutter={[16, 16]} align="bottom">
           <Col xs={24} sm={12} md={8} lg={6}>
@@ -643,8 +644,10 @@ export default function CoordenadoresPage(): JSX.Element {
           </Col>
         </Row>
       </Card>
+      </nav>
 
       {/* Content - Cards, Table or Area View */}
+      <section aria-label="Lista de coordenadores">
       {viewMode === 'table' ? (
         <Card
           bodyStyle={{ padding: 0 }}
@@ -701,6 +704,7 @@ export default function CoordenadoresPage(): JSX.Element {
           )}
         </Card>
       )}
+      </section>
 
       {/* Create/Edit Modal */}
       <Modal
@@ -995,6 +999,6 @@ export default function CoordenadoresPage(): JSX.Element {
           </div>
         )}
       </Modal>
-    </div>
+    </section>
   );
 }

--- a/v2/frontend/src/pages/DATModule/DATRegistrosPage.tsx
+++ b/v2/frontend/src/pages/DATModule/DATRegistrosPage.tsx
@@ -288,12 +288,12 @@ export default function DATRegistrosPage(): JSX.Element {
   });
 
   return (
-    <div className="p-6 bg-gray-100" style={{ minHeight: 'calc(100vh - 64px)' }}>
+    <section className="p-6 bg-gray-100" style={{ minHeight: 'calc(100vh - 64px)' }} aria-labelledby="dat-registros-title">
       {/* Header */}
-      <div className="mb-6">
+      <header className="mb-6">
         <div className="flex justify-between items-start mb-2">
           <div>
-            <Title level={3} className="m-0">
+            <Title level={3} className="m-0" id="dat-registros-title">
               Listagem de Registros DAT
             </Title>
             <Text type="secondary">
@@ -309,9 +309,10 @@ export default function DATRegistrosPage(): JSX.Element {
             </Button>
           </Space>
         </div>
-      </div>
+      </header>
 
       {/* Filters Card */}
+      <nav aria-label="Filtros de busca">
       <Card className="mb-4" bodyStyle={{ paddingBottom: 12 }}>
         <Row gutter={[16, 16]}>
           <Col xs={24} sm={12} md={8} lg={4}>
@@ -427,8 +428,10 @@ export default function DATRegistrosPage(): JSX.Element {
           </Button>
         </div>
       </Card>
+      </nav>
 
       {/* Table Card */}
+      <section aria-label="Resultados da busca">
       <Card
         bodyStyle={{ padding: 0 }}
         title={
@@ -482,8 +485,10 @@ export default function DATRegistrosPage(): JSX.Element {
           size="middle"
         />
       </Card>
+      </section>
 
       {/* Legend */}
+      <aside aria-label="Legenda de icones">
       <Card className="mt-4" size="small">
         <Space size="large" wrap>
           <Text strong style={{ textTransform: 'uppercase', fontSize: 12 }}>
@@ -514,6 +519,7 @@ export default function DATRegistrosPage(): JSX.Element {
           </Space>
         </Space>
       </Card>
+      </aside>
 
       {/* Create/Edit Modal */}
       <Modal
@@ -808,6 +814,6 @@ export default function DATRegistrosPage(): JSX.Element {
           </Row>
         </Form>
       </Modal>
-    </div>
+    </section>
   );
 }

--- a/v2/frontend/src/pages/DATModule/FormacoesPage.tsx
+++ b/v2/frontend/src/pages/DATModule/FormacoesPage.tsx
@@ -347,12 +347,12 @@ export default function FormacoesPage(): JSX.Element {
   );
 
   return (
-    <div className="p-6 bg-gray-100" style={{ minHeight: 'calc(100vh - 64px)' }}>
+    <section className="p-6 bg-gray-100" style={{ minHeight: 'calc(100vh - 64px)' }} aria-labelledby="formacoes-title">
       {/* Header */}
-      <div className="mb-6">
+      <header className="mb-6">
         <div className="flex justify-between items-start mb-2">
           <div>
-            <Title level={3} className="m-0">
+            <Title level={3} className="m-0" id="formacoes-title">
               <CalendarOutlined className="mr-2" />
               Gestão de Formações
             </Title>
@@ -383,7 +383,7 @@ export default function FormacoesPage(): JSX.Element {
             </Button>
           </Space>
         </div>
-      </div>
+      </header>
 
       {/* Stats Cards */}
       {stats && (
@@ -431,6 +431,7 @@ export default function FormacoesPage(): JSX.Element {
       )}
 
       {/* Filters Card */}
+      <nav aria-label="Filtros de busca">
       <Card className="mb-4" bodyStyle={{ paddingBottom: 12 }}>
         <Row gutter={[16, 16]}>
           <Col xs={24} sm={12} md={6} lg={4}>
@@ -560,8 +561,10 @@ export default function FormacoesPage(): JSX.Element {
           </Button>
         </div>
       </Card>
+      </nav>
 
       {/* Content - Table or Calendar */}
+      <section aria-label="Lista de formacoes">
       {viewMode === VIEW_MODES.TABLE ? (
         <Card
           bodyStyle={{ padding: 0 }}
@@ -641,8 +644,10 @@ export default function FormacoesPage(): JSX.Element {
           />
         </Card>
       )}
+      </section>
 
       {/* Legend */}
+      <aside aria-label="Legenda de status">
       <Card className="mt-4" size="small">
         <Space size="large" wrap>
           <Text strong style={{ textTransform: 'uppercase', fontSize: 12 }}>
@@ -653,6 +658,7 @@ export default function FormacoesPage(): JSX.Element {
           ))}
         </Space>
       </Card>
+      </aside>
 
       {/* Create/Edit Modal */}
       <Modal
@@ -880,6 +886,6 @@ export default function FormacoesPage(): JSX.Element {
           </Form.Item>
         </Form>
       </Modal>
-    </div>
+    </section>
   );
 }

--- a/v2/frontend/src/pages/DATModule/PlanoFormacoesPage.tsx
+++ b/v2/frontend/src/pages/DATModule/PlanoFormacoesPage.tsx
@@ -583,11 +583,11 @@ export default function PlanoFormacoesPage(): JSX.Element {
   // ============================================================
 
   return (
-    <div className="p-6">
+    <section className="p-6" aria-labelledby="plano-formacoes-title">
       {/* Header */}
-      <div className="mb-6 flex justify-between items-center">
+      <header className="mb-6 flex justify-between items-center">
         <div>
-          <Title level={3} className="m-0">Plano de Formacoes</Title>
+          <Title level={3} className="m-0" id="plano-formacoes-title">Plano de Formacoes</Title>
           <Text type="secondary">Gestao do plano anual de formacoes por municipio e projeto</Text>
         </div>
         <Space>
@@ -618,7 +618,7 @@ export default function PlanoFormacoesPage(): JSX.Element {
             Novo Plano
           </Button>
         </Space>
-      </div>
+      </header>
 
       {/* Stats Cards */}
       {stats && (
@@ -666,6 +666,7 @@ export default function PlanoFormacoesPage(): JSX.Element {
       )}
 
       {/* Filters */}
+      <nav aria-label="Filtros de busca">
       <Card className="mb-4" bodyStyle={{ paddingBottom: 12 }}>
         <Row gutter={[16, 16]}>
           <Col xs={24} sm={12} md={6} lg={4}>
@@ -733,8 +734,10 @@ export default function PlanoFormacoesPage(): JSX.Element {
           <Button type="primary" icon={<FilterOutlined />} onClick={() => fetchData(1)}>Filtrar</Button>
         </div>
       </Card>
+      </nav>
 
       {/* Main Content */}
+      <section aria-label="Conteudo principal">
       {viewMode === 'table' && (
         <Card>
           <Table
@@ -768,6 +771,7 @@ export default function PlanoFormacoesPage(): JSX.Element {
           <Text type="secondary">Resumo por projeto em desenvolvimento...</Text>
         </Card>
       )}
+      </section>
 
       {/* Create/Edit Modal */}
       <Modal
@@ -938,6 +942,6 @@ export default function PlanoFormacoesPage(): JSX.Element {
           />
         )}
       </Modal>
-    </div>
+    </section>
   );
 }


### PR DESCRIPTION
## Summary

- Add semantic HTML elements to all 7 DAT module pages for improved accessibility
- Apply consistent pattern: `<section>` wrapper, `<header>`, `<nav>` for filters, `<section>` for content, `<aside>` for legend
- Add ARIA attributes (`aria-labelledby`, `aria-label`) for screen reader navigation

## Files Changed

| File | Changes |
|------|---------|
| DATRegistrosPage.tsx | Semantic structure + ARIA |
| AcoesPage.tsx | Semantic structure + ARIA |
| CadastrosPage.tsx | Semantic structure + ARIA |
| CoordenadoresPage.tsx | Semantic structure + ARIA |
| FormacoesPage.tsx | Semantic structure + ARIA |
| PlanoFormacoesPage.tsx | Semantic structure + ARIA |
| ComprasPage.tsx | Semantic structure + ARIA |

## Test plan

- [x] Build passes (`npm run build`)
- [ ] CI passes (lint, checklist, Lighthouse)
- [ ] Screen reader navigation works (Tab through elements)
- [ ] No visual regressions

## Related

Part of semantic HTML refactoring initiative (Phase 4/7)
- Phase 1: #516 (merged)
- Phase 2: #517 (merged)
- Phase 3: #518 (merged)
- **Phase 4: This PR**