### PR TITLE
refactor(frontend): add semantic HTML to Dashboard pages

### DIFF
--- a/v2/frontend/src/pages/Dashboards/DashboardsPage.tsx
+++ b/v2/frontend/src/pages/Dashboards/DashboardsPage.tsx
@@ -212,10 +212,10 @@ export default function DashboardsPage(): JSX.Element {
   ];
 
   return (
-    <div className="p-6">
-      <div className="mb-6 flex justify-between items-center">
+    <section className="p-6" aria-labelledby="dashboards-title">
+      <header className="mb-6 flex justify-between items-center">
         <div>
-          <Title level={2}>Dashboards e Analises</Title>
+          <Title level={2} id="dashboards-title">Dashboards e Analises</Title>
           <Text type="secondary">
             Visualize metricas detalhadas e relatorios do sistema
           </Text>
@@ -232,9 +232,10 @@ export default function DashboardsPage(): JSX.Element {
             Exportar para CSV
           </Button>
         </Space>
-      </div>
+      </header>
 
       {/* KPI Cards */}
+      <section aria-label="Indicadores principais">
       <Row gutter={[16, 16]} className="mb-6">
         <Col xs={24} sm={12} md={6}>
           <Card
@@ -300,8 +301,10 @@ export default function DashboardsPage(): JSX.Element {
           </Card>
         </Col>
       </Row>
+      </section>
 
       {/* Graficos */}
+      <section aria-label="Graficos de analise">
       <Row gutter={[16, 16]} className="mb-6">
         {/* Eventos por Fluxo */}
         <Col xs={24} md={12}>
@@ -373,8 +376,10 @@ export default function DashboardsPage(): JSX.Element {
           </Card>
         </Col>
       </Row>
+      </section>
 
       {/* Top Coordenadores */}
+      <section aria-label="Ranking de coordenadores">
       <Row gutter={[16, 16]}>
         <Col xs={24}>
           <Card
@@ -394,6 +399,7 @@ export default function DashboardsPage(): JSX.Element {
           </Card>
         </Col>
       </Row>
-    </div>
+      </section>
+    </section>
   );
 }

--- a/v2/frontend/src/pages/Dashboards/EquipeDashboardPage.tsx
+++ b/v2/frontend/src/pages/Dashboards/EquipeDashboardPage.tsx
@@ -233,11 +233,11 @@ export default function EquipeDashboardPage(): JSX.Element {
   }
 
   return (
-    <div className="p-6">
+    <section className="p-6" aria-labelledby="equipe-dashboard-title">
       {/* Header com filtro e export */}
-      <div className="mb-6 flex justify-between items-center flex-wrap gap-4">
+      <header className="mb-6 flex justify-between items-center flex-wrap gap-4">
         <div>
-          <Title level={2}>Dashboard da Equipe</Title>
+          <Title level={2} id="equipe-dashboard-title">Dashboard da Equipe</Title>
           <Text type="secondary">
             Métricas de desempenho e produtividade
           </Text>
@@ -272,7 +272,7 @@ export default function EquipeDashboardPage(): JSX.Element {
             Atualizar
           </Button>
         </Space>
-      </div>
+      </header>
 
       {loading ? (
         <div className="text-center py-16">
@@ -281,6 +281,7 @@ export default function EquipeDashboardPage(): JSX.Element {
       ) : (
         <>
           {/* SEÇÃO 1: PRODUTIVIDADE */}
+          <section aria-label="Produtividade">
           <Title level={4} className="mt-6 mb-4">
             <BarChartOutlined /> Produtividade ({productivityData?.period || '7d'})
           </Title>
@@ -328,8 +329,10 @@ export default function EquipeDashboardPage(): JSX.Element {
               </Card>
             </Col>
           </Row>
+          </section>
 
           {/* SEÇÃO 2: RANKING DE FORMADORES */}
+          <section aria-label="Ranking de formadores">
           <Title level={4} className="mt-6 mb-4">
             <TrophyOutlined /> Top 10 Formadores ({formadoresData?.period || '30d'})
           </Title>
@@ -381,8 +384,10 @@ export default function EquipeDashboardPage(): JSX.Element {
               </Card>
             </Col>
           </Row>
+          </section>
 
           {/* SEÇÃO 3: QUALIDADE */}
+          <section aria-label="Qualidade do processo">
           <Title level={4} className="mt-6 mb-4">
             <SafetyOutlined /> Qualidade do Processo ({qualityData?.period || '30d'})
           </Title>
@@ -471,6 +476,8 @@ export default function EquipeDashboardPage(): JSX.Element {
             </Col>
           </Row>
 
+          </section>
+
           {/* Footer com timestamp */}
           <Divider />
           <Text type="secondary" style={{ fontSize: '12px' }}>
@@ -478,6 +485,6 @@ export default function EquipeDashboardPage(): JSX.Element {
           </Text>
         </>
       )}
-    </div>
+    </section>
   );
 }

--- a/v2/frontend/src/pages/Dashboards/GCalDashboardPage.tsx
+++ b/v2/frontend/src/pages/Dashboards/GCalDashboardPage.tsx
@@ -650,17 +650,18 @@ export default function GCalDashboardPage(): JSX.Element {
   ], []);
 
   return (
-    <div className="p-6">
-      <div className="mb-6 flex justify-between items-center">
+    <section className="p-6" aria-labelledby="gcal-dashboard-title">
+      <header className="mb-6 flex justify-between items-center">
         <div>
-          <Title level={2}>Dashboard Google Calendar</Title>
+          <Title level={2} id="gcal-dashboard-title">Dashboard Google Calendar</Title>
           <Text type="secondary">
             Monitore métricas de publicação e sincronização de eventos
           </Text>
         </div>
-      </div>
+      </header>
 
       {/* Filtros */}
+      <nav aria-label="Filtros de busca">
       <Card
         className="mb-6"
         styles={{ body: { padding: '16px' } }}
@@ -709,8 +710,10 @@ export default function GCalDashboardPage(): JSX.Element {
           </Dropdown>
         </Space>
       </Card>
+      </nav>
 
       {/* Cards de Contagem */}
+      <section aria-label="Contagem por status">
       {loading ? (
         <Skeleton active paragraph={{ rows: 2 }} />
       ) : (
@@ -784,8 +787,10 @@ export default function GCalDashboardPage(): JSX.Element {
           )}
         </>
       )}
+      </section>
 
       {/* Insights - Success Rate + Top 5 (Issue #99) */}
+      <section aria-label="Insights e taxa de sucesso">
       {insightsLoading ? (
         <Skeleton active paragraph={{ rows: 3 }} className="mb-6" />
       ) : (
@@ -868,8 +873,10 @@ export default function GCalDashboardPage(): JSX.Element {
           </Card>
         </>
       )}
+      </section>
 
       {/* Tabela de Eventos */}
+      <section aria-label="Lista de eventos">
       <Card title="Eventos" bordered={false}>
         <Table
           dataSource={events}
@@ -885,8 +892,10 @@ export default function GCalDashboardPage(): JSX.Element {
           })}
         />
       </Card>
+      </section>
 
       {/* Drawer de Detalhes do Evento (Issue #98) */}
+      <aside aria-label="Detalhes do evento">
       <Drawer
         title={`Detalhes do Evento #${selectedEventId}`}
         placement="right"
@@ -1020,6 +1029,7 @@ export default function GCalDashboardPage(): JSX.Element {
           <Alert message="Nenhum dado disponível" type="warning" />
         )}
       </Drawer>
-    </div>
+      </aside>
+    </section>
   );
 }


### PR DESCRIPTION
## Summary

- Add semantic HTML elements to all 3 Dashboard pages for improved accessibility
- Apply consistent pattern: `<section>` wrapper, `<header>`, `<nav>` for filters, `<section>` for content areas, `<aside>` for drawers
- Add ARIA attributes (`aria-labelledby`, `aria-label`) for screen reader navigation

## Files Changed

| File | Changes |
|------|---------|
| DashboardsPage.tsx | Semantic structure + ARIA for KPIs, charts, ranking |
| GCalDashboardPage.tsx | Semantic structure + ARIA for filters, status cards, insights, events, drawer |
| EquipeDashboardPage.tsx | Semantic structure + ARIA for productivity, ranking, quality sections |

## Test plan

- [x] Build passes (`npm run build`)
- [ ] CI passes (lint, checklist, Lighthouse)
- [ ] Screen reader navigation works (Tab through elements)
- [ ] No visual regressions

## Related

Part of semantic HTML refactoring initiative (Phase 5/7)
- Phase 1: #516 (merged)
- Phase 2: #517 (merged)
- Phase 3: #518 (merged)
- Phase 4: #519 (pending CI)
- **Phase 5: This PR**