### PR TITLE
refactor(frontend): add semantic HTML to reusable components

### DIFF
--- a/v2/frontend/src/components/CoordenadoresPicker.tsx
+++ b/v2/frontend/src/components/CoordenadoresPicker.tsx
@@ -6,7 +6,7 @@
  */
 
 import { useState } from 'react';
-import { Space, Tag, AutoComplete, Spin } from 'antd';
+import { Tag, AutoComplete, Spin } from 'antd';
 import { lookupUsuarios } from '../api/lookup';
 import logger from '../utils/logger';
 import type { ID } from '../types';
@@ -105,18 +105,19 @@ export default function CoordenadoresPicker({ value = [], onChange }: Coordenado
     <div>
       {/* Tags dos coordenadores selecionados */}
       {value.length > 0 && (
-        <Space wrap className="mb-2">
+        <ul style={{ display: 'flex', flexWrap: 'wrap', gap: 8, listStyle: 'none', padding: 0, margin: '0 0 8px 0' }} aria-label="Coordenadores selecionados">
           {value.map((coord) => (
-            <Tag
-              key={coord.id}
-              closable
-              onClose={() => handleRemove(coord.id)}
-              color="green"
-            >
-              {coord.label || coord.name}
-            </Tag>
+            <li key={coord.id}>
+              <Tag
+                closable
+                onClose={() => handleRemove(coord.id)}
+                color="green"
+              >
+                {coord.label || coord.name}
+              </Tag>
+            </li>
           ))}
-        </Space>
+        </ul>
       )}
 
       {/* Autocomplete para adicionar coordenadores */}

--- a/v2/frontend/src/components/DateTimeRange.tsx
+++ b/v2/frontend/src/components/DateTimeRange.tsx
@@ -84,41 +84,53 @@ export default function DateTimeRange({ value = {}, onChange }: DateTimeRangePro
   };
 
   return (
-    <Space direction="vertical" style={{ width: '100%' }}>
-      <div>
-        <Text strong>Data:</Text>
-        <DatePicker
-          value={date}
-          onChange={handleDateChange}
-          format="DD/MM/YYYY"
-          placeholder="Selecione a data"
-          className="w-full mt-2"
-        />
-      </div>
-      <Space direction="horizontal" style={{ width: '100%' }}>
-        <div style={{ flex: 1 }}>
-          <Text strong>Início:</Text>
-          <TimePicker
-            value={start}
-            onChange={handleStartChange}
-            format="HH:mm"
-            placeholder="HH:mm"
+    <fieldset style={{ border: 'none', padding: 0, margin: 0 }}>
+      <legend className="sr-only">Data e horário do evento</legend>
+      <Space direction="vertical" style={{ width: '100%' }}>
+        <div>
+          <label htmlFor="date-picker">
+            <Text strong>Data:</Text>
+          </label>
+          <DatePicker
+            id="date-picker"
+            value={date}
+            onChange={handleDateChange}
+            format="DD/MM/YYYY"
+            placeholder="Selecione a data"
             className="w-full mt-2"
-            minuteStep={15}
           />
         </div>
-        <div style={{ flex: 1 }}>
-          <Text strong>Fim:</Text>
-          <TimePicker
-            value={end}
-            onChange={handleEndChange}
-            format="HH:mm"
-            placeholder="HH:mm"
-            className="w-full mt-2"
-            minuteStep={15}
-          />
-        </div>
+        <Space direction="horizontal" style={{ width: '100%' }}>
+          <div style={{ flex: 1 }}>
+            <label htmlFor="time-start">
+              <Text strong>Início:</Text>
+            </label>
+            <TimePicker
+              id="time-start"
+              value={start}
+              onChange={handleStartChange}
+              format="HH:mm"
+              placeholder="HH:mm"
+              className="w-full mt-2"
+              minuteStep={15}
+            />
+          </div>
+          <div style={{ flex: 1 }}>
+            <label htmlFor="time-end">
+              <Text strong>Fim:</Text>
+            </label>
+            <TimePicker
+              id="time-end"
+              value={end}
+              onChange={handleEndChange}
+              format="HH:mm"
+              placeholder="HH:mm"
+              className="w-full mt-2"
+              minuteStep={15}
+            />
+          </div>
+        </Space>
       </Space>
-    </Space>
+    </fieldset>
   );
 }

--- a/v2/frontend/src/components/FormadoresPicker.tsx
+++ b/v2/frontend/src/components/FormadoresPicker.tsx
@@ -6,7 +6,7 @@
  */
 
 import { useState } from 'react';
-import { Space, Tag, AutoComplete, Spin } from 'antd';
+import { Tag, AutoComplete, Spin } from 'antd';
 import { lookupUsuarios } from '../api/lookup';
 import logger from '../utils/logger';
 import type { ID } from '../types';
@@ -105,18 +105,19 @@ export default function FormadoresPicker({ value = [], onChange }: FormadoresPic
     <div>
       {/* Tags dos formadores selecionados */}
       {value.length > 0 && (
-        <Space wrap className="mb-2">
+        <ul style={{ display: 'flex', flexWrap: 'wrap', gap: 8, listStyle: 'none', padding: 0, margin: '0 0 8px 0' }} aria-label="Formadores selecionados">
           {value.map((formador) => (
-            <Tag
-              key={formador.id}
-              closable
-              onClose={() => handleRemove(formador.id)}
-              color="blue"
-            >
-              {formador.label || formador.name}
-            </Tag>
+            <li key={formador.id}>
+              <Tag
+                closable
+                onClose={() => handleRemove(formador.id)}
+                color="blue"
+              >
+                {formador.label || formador.name}
+              </Tag>
+            </li>
           ))}
-        </Space>
+        </ul>
       )}
 
       {/* Autocomplete para adicionar formadores */}

--- a/v2/frontend/src/components/PeoplePicker.tsx
+++ b/v2/frontend/src/components/PeoplePicker.tsx
@@ -192,20 +192,21 @@ export default function PeoplePicker({
     <Card title="Participantes" size="small">
       <Space direction="vertical" style={{ width: '100%' }} size="middle">
         {/* Formadores */}
-        <div>
-          <div className="mb-2 font-medium">Formadores:</div>
-          <Space wrap>
+        <fieldset style={{ border: 'none', padding: 0, margin: 0 }}>
+          <legend className="mb-2 font-medium">Formadores:</legend>
+          <ul style={{ display: 'flex', flexWrap: 'wrap', gap: 8, listStyle: 'none', padding: 0, margin: 0 }} aria-label="Formadores selecionados">
             {value.formadores.map((formador) => (
-              <Tag
-                key={formador.id}
-                closable
-                onClose={() => handleRemoveFormador(formador.id)}
-                color="blue"
-              >
-                {formador.label || formador.email}
-              </Tag>
+              <li key={formador.id}>
+                <Tag
+                  closable
+                  onClose={() => handleRemoveFormador(formador.id)}
+                  color="blue"
+                >
+                  {formador.label || formador.email}
+                </Tag>
+              </li>
             ))}
-          </Space>
+          </ul>
           <div className="mt-2">
             <AutoComplete
               value={formadorSearch}
@@ -224,23 +225,24 @@ export default function PeoplePicker({
               notFoundContent={loadingFormadores ? <Spin size="small" /> : null}
             />
           </div>
-        </div>
+        </fieldset>
 
         {/* Coordenadores Acompanhantes */}
-        <div>
-          <div className="mb-2 font-medium">Coordenadores Acompanhantes:</div>
-          <Space wrap>
+        <fieldset style={{ border: 'none', padding: 0, margin: 0 }}>
+          <legend className="mb-2 font-medium">Coordenadores Acompanhantes:</legend>
+          <ul style={{ display: 'flex', flexWrap: 'wrap', gap: 8, listStyle: 'none', padding: 0, margin: 0 }} aria-label="Coordenadores selecionados">
             {value.coordAcompanha.map((coord) => (
-              <Tag
-                key={coord.id}
-                closable
-                onClose={() => handleRemoveCoord(coord.id)}
-                color="green"
-              >
-                {coord.label || coord.email}
-              </Tag>
+              <li key={coord.id}>
+                <Tag
+                  closable
+                  onClose={() => handleRemoveCoord(coord.id)}
+                  color="green"
+                >
+                  {coord.label || coord.email}
+                </Tag>
+              </li>
             ))}
-          </Space>
+          </ul>
           <div className="mt-2">
             <AutoComplete
               value={coordSearch}
@@ -259,7 +261,7 @@ export default function PeoplePicker({
               notFoundContent={loadingCoord ? <Spin size="small" /> : null}
             />
           </div>
-        </div>
+        </fieldset>
       </Space>
     </Card>
   );

--- a/v2/frontend/src/components/SessionExpiryWarning.tsx
+++ b/v2/frontend/src/components/SessionExpiryWarning.tsx
@@ -86,13 +86,16 @@ export function SessionExpiryWarning({ showWarning, timeLeft, renewSession }: Se
       centered
       maskClosable={false}
       width={400}
+      aria-labelledby="session-expiry-title"
+      aria-describedby="session-expiry-description"
     >
-      <Space direction="vertical" size="large" style={{ width: '100%' }}>
+      <Space direction="vertical" size="large" style={{ width: '100%' }} role="alertdialog">
         <div style={{ textAlign: 'center' }}>
           <ClockCircleOutlined
             style={{ fontSize: 48, color: '#faad14' }}
+            aria-hidden="true"
           />
-          <Title level={4} className="mt-4">
+          <Title level={4} className="mt-4" id="session-expiry-title">
             Sua sessão está prestes a expirar
           </Title>
         </div>
@@ -111,7 +114,7 @@ export function SessionExpiryWarning({ showWarning, timeLeft, renewSession }: Se
           </div>
         </div>
 
-        <div style={{ textAlign: 'center' }}>
+        <div style={{ textAlign: 'center' }} id="session-expiry-description">
           <Text type="secondary">
             Deseja continuar conectado?
           </Text>


### PR DESCRIPTION
## Summary

- Add semantic HTML elements to 5 reusable components for improved accessibility
- Replace `<Space wrap>` with `<ul>/<li>` for tag lists
- Add `<fieldset>/<legend>` for form groupings
- Add ARIA attributes for screen reader navigation

## Files Changed

| File | Changes |
|------|---------|
| CoordenadoresPicker.tsx | `<ul>/<li>` for tags + `aria-label` |
| FormadoresPicker.tsx | `<ul>/<li>` for tags + `aria-label` |
| SessionExpiryWarning.tsx | `role="alertdialog"` + `aria-labelledby/describedby` |
| DateTimeRange.tsx | `<fieldset>/<legend>` + `<label htmlFor>` |
| PeoplePicker.tsx | `<fieldset>/<legend>` + `<ul>/<li>` for tags |

## Test plan

- [x] Build passes (`npm run build`)
- [ ] CI passes (lint, checklist, Lighthouse)
- [ ] Screen reader navigation works
- [ ] No visual regressions

## Related

Part of semantic HTML refactoring initiative (Phase 6/7)
- Phase 1: #516 (merged)
- Phase 2: #517 (merged)
- Phase 3: #518 (merged)
- Phase 4: #519 (pending CI)
- Phase 5: #520 (pending CI)
- **Phase 6: This PR**