### PR TITLE
feat(frontend): add toggle UI to Bloqueios page

### DIFF
--- a/v2/frontend/src/pages/Disponibilidade.tsx
+++ b/v2/frontend/src/pages/Disponibilidade.tsx
@@ -5,16 +5,24 @@
  * - Criar bloqueios de disponibilidade (Total ou Parcial)
  * - Listar seus bloqueios existentes
  * - Excluir bloqueios com status 'pendente'
+ * - Importar bloqueios em massa via CSV/XLSX
  */
 
 import { useState, useEffect, JSX } from 'react';
-import { Card, Row, Col, message, Spin } from 'antd';
+import { Card, Row, Col, message, Spin, Radio, Typography } from 'antd';
+import type { RadioChangeEvent } from 'antd/es/radio';
+import { StopOutlined, UploadOutlined } from '@ant-design/icons';
 import BlockForm from '../components/BlockForm';
 import MyBlocksTable from '../components/MyBlocksTable';
 import ImportUploader, { ValidationResult, ApplyResult } from '../components/ImportUploader';
 import { getBlocks, createBlock as apiCreateBlock, deleteBlock as apiDeleteBlock } from '../api/availability';
 import { importBloqueios } from '../api/ops';
 import type { ID, AvailabilityBlock, AvailabilityBlockPayload } from '../types';
+
+const { Title, Text } = Typography;
+
+/** View mode type */
+type ViewMode = 'bloqueios' | 'importar';
 
 /**
  * Converte resposta do backend para formato do ImportUploader.
@@ -62,6 +70,7 @@ function toApplyResult(response: Record<string, unknown>): ApplyResult {
 }
 
 export default function Disponibilidade(): JSX.Element {
+  const [viewMode, setViewMode] = useState<ViewMode>('bloqueios');
   const [blocks, setBlocks] = useState<AvailabilityBlock[]>([]);
   const [loading, setLoading] = useState<boolean>(false);
 
@@ -114,55 +123,105 @@ export default function Disponibilidade(): JSX.Element {
 
   return (
     <section style={{ padding: '24px' }} aria-labelledby="disponibilidade-title">
-      {/* Header semantico */}
-      <header>
-        <h1 id="disponibilidade-title">Gerenciar Disponibilidade</h1>
-        <p style={{ color: '#666', marginBottom: '24px' }}>
-          Crie bloqueios de disponibilidade (Total ou Parcial) para indicar períodos em que você não estará disponível.
-        </p>
+      {/* Header com toggle */}
+      <header style={{ marginBottom: '24px', display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+        <div>
+          <Title level={2} style={{ marginBottom: 0 }}>
+            <StopOutlined style={{ marginRight: 8 }} />
+            Gerenciar Disponibilidade
+          </Title>
+          <Text type="secondary">
+            {viewMode === 'bloqueios'
+              ? 'Crie e gerencie bloqueios de disponibilidade (Total ou Parcial)'
+              : 'Importe bloqueios em massa via arquivo CSV/XLSX'}
+          </Text>
+        </div>
+        <Radio.Group
+          value={viewMode}
+          onChange={(e: RadioChangeEvent) => setViewMode(e.target.value)}
+          buttonStyle="solid"
+        >
+          <Radio.Button value="bloqueios">Bloqueios</Radio.Button>
+          <Radio.Button value="importar">Importar</Radio.Button>
+        </Radio.Group>
       </header>
 
-      <Row gutter={[16, 16]}>
-        {/* Card de Criacao */}
-        <Col xs={24} lg={8}>
-          <article aria-label="Criar novo bloqueio">
-            <Card title="Criar Bloqueio" bordered={false}>
-              <BlockForm onSubmit={handleCreate as unknown as (payload: { tipo: string; inicio: string; fim: string }) => Promise<void>} />
-            </Card>
-          </article>
-        </Col>
+      {viewMode === 'bloqueios' ? (
+        /* View: Bloqueios (criar + listar) */
+        <Row gutter={[16, 16]}>
+          {/* Card de Criacao */}
+          <Col xs={24} lg={12}>
+            <article aria-label="Criar novo bloqueio">
+              <Card title="Criar Bloqueio" bordered={false}>
+                <BlockForm onSubmit={handleCreate as unknown as (payload: { tipo: string; inicio: string; fim: string }) => Promise<void>} />
+              </Card>
+            </article>
+          </Col>
 
-        {/* Card de Listagem */}
-        <Col xs={24} lg={8}>
-          <article aria-label="Lista de meus bloqueios">
-            <Card title="Meus Bloqueios" bordered={false}>
-              {loading ? (
-                <div style={{ textAlign: 'center', padding: '40px 0' }} role="status" aria-live="polite">
-                  <Spin size="large" tip="Carregando bloqueios..." />
-                </div>
-              ) : (
-                <MyBlocksTable blocks={blocks as unknown as Array<{ id: number; tipo: 'T' | 'P'; inicio: string; fim: string; status: 'pendente' | 'aprovado' | 'reprovado' }>} onDelete={handleDelete} loading={loading} />
-              )}
-            </Card>
-          </article>
-        </Col>
+          {/* Card de Listagem */}
+          <Col xs={24} lg={12}>
+            <article aria-label="Lista de meus bloqueios">
+              <Card title="Meus Bloqueios" bordered={false}>
+                {loading ? (
+                  <div style={{ textAlign: 'center', padding: '40px 0' }} role="status" aria-live="polite">
+                    <Spin size="large" tip="Carregando bloqueios..." />
+                  </div>
+                ) : (
+                  <MyBlocksTable blocks={blocks as unknown as Array<{ id: number; tipo: 'T' | 'P'; inicio: string; fim: string; status: 'pendente' | 'aprovado' | 'reprovado' }>} onDelete={handleDelete} loading={loading} />
+                )}
+              </Card>
+            </article>
+          </Col>
+        </Row>
+      ) : (
+        /* View: Importar em Massa */
+        <Row gutter={[16, 16]}>
+          <Col xs={24} lg={16}>
+            <article aria-label="Importar bloqueios em massa">
+              <Card
+                title={
+                  <span>
+                    <UploadOutlined style={{ marginRight: 8 }} />
+                    Importar Bloqueios em Massa
+                  </span>
+                }
+                bordered={false}
+              >
+                <ImportUploader
+                  label="Selecione o arquivo"
+                  description="CSV/XLSX com colunas: usuario, inicio, fim, tipo (T/P), motivo"
+                  onDryRun={async (file: File) => toValidationResult(await importBloqueios(file, true) as unknown as Record<string, unknown>)}
+                  onApply={async (file: File) => {
+                    const result = await importBloqueios(file, false);
+                    await fetchBlocks();
+                    return toApplyResult(result as unknown as Record<string, unknown>);
+                  }}
+                />
+              </Card>
+            </article>
+          </Col>
 
-        {/* Card de Importacao em Massa */}
-        <Col xs={24} lg={8}>
-          <article aria-label="Importar bloqueios em massa">
-            <ImportUploader
-              label="Importar Bloqueios"
-              description="CSV/XLSX com colunas: usuario, inicio, fim, tipo (T/P), motivo"
-              onDryRun={async (file: File) => toValidationResult(await importBloqueios(file, true) as unknown as Record<string, unknown>)}
-              onApply={async (file: File) => {
-                const result = await importBloqueios(file, false);
-                await fetchBlocks();
-                return toApplyResult(result as unknown as Record<string, unknown>);
-              }}
-            />
-          </article>
-        </Col>
-      </Row>
+          {/* Card de Instruções */}
+          <Col xs={24} lg={8}>
+            <Card title="Formato do Arquivo" bordered={false}>
+              <Text strong>Colunas obrigatórias:</Text>
+              <ul style={{ marginTop: 8, paddingLeft: 20 }}>
+                <li><code>usuario</code> - Nome do formador</li>
+                <li><code>inicio</code> - Data/hora início</li>
+                <li><code>fim</code> - Data/hora fim</li>
+                <li><code>tipo</code> - T (Total) ou P (Parcial)</li>
+              </ul>
+              <Text strong style={{ marginTop: 16, display: 'block' }}>Coluna opcional:</Text>
+              <ul style={{ marginTop: 8, paddingLeft: 20 }}>
+                <li><code>motivo</code> - Observação</li>
+              </ul>
+              <Text type="secondary" style={{ marginTop: 16, display: 'block', fontSize: 12 }}>
+                Formatos de data aceitos: YYYY-MM-DD, DD/MM/YYYY, ISO 8601
+              </Text>
+            </Card>
+          </Col>
+        </Row>
+      )}
     </section>
   );
 }


### PR DESCRIPTION
## Summary

- Add Map/List-style toggle to Bloqueios page (`/bloqueios`)
- Separate views: "Bloqueios" (create/list) and "Importar" (bulk upload)
- Follow same UX pattern as MapaBrasilPage for consistency

## Changes

**UI Updates:**
- Radio.Group toggle with `buttonStyle="solid"` (Bloqueios | Importar)
- Dynamic subtitle based on selected view
- Header with StopOutlined icon

**View: Bloqueios**
- 2-column layout (Create | List)
- Same functionality as before

**View: Importar**
- Dedicated ImportUploader component
- Instructions card with file format documentation

## Screenshots

Toggle similar to:
```
┌────────────────────────────────────────────────────────────┐
│  ⛔ Gerenciar Disponibilidade    [Bloqueios] [Importar]   │
│  Crie e gerencie bloqueios...                              │
└────────────────────────────────────────────────────────────┘
```

## Test plan

- [x] Frontend build succeeds
- [ ] Toggle switches between views correctly
- [ ] Bloqueios view: create and list work
- [ ] Importar view: dry-run and apply work
- [ ] Responsive on mobile

## Related

- Epic: #533
- Previous PR: #536 (added import functionality)