### PR TITLE
fix(metrics-map): corrige agregação por UF e filtros de data

### DIFF
--- a/v2/backend/apps/core/tests/test_metrics_map.py
+++ b/v2/backend/apps/core/tests/test_metrics_map.py
@@ -25,7 +25,7 @@ from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import Municipio, Projeto, Solicitacao, TipoEvento, Usuario
+from apps.core.models import Compra, Municipio, Participation, Produto, Projeto, Solicitacao, TipoEvento, Usuario
 
 pytestmark = pytest.mark.django_db
 
@@ -246,7 +246,7 @@ def test_map_metrics_superuser_allowed():
 
 
 def test_map_metrics_response_structure(user_controle, solicitacoes_variedade):
-    """Resposta tem estrutura esperada com by_municipio."""
+    """Resposta tem estrutura esperada com by_municipio e by_uf."""
     client = APIClient()
     client.force_authenticate(user=user_controle)
 
@@ -265,6 +265,19 @@ def test_map_metrics_response_structure(user_controle, solicitacoes_variedade):
     assert "totals" in data
     assert "all" in data["totals"]
     assert "by_status" in data["totals"]
+    assert "compras" in data["totals"]
+
+    # Verificar by_uf
+    assert "by_uf" in data
+    assert isinstance(data["by_uf"], list)
+    if len(data["by_uf"]) > 0:
+        uf_item = data["by_uf"][0]
+        assert "uf" in uf_item
+        assert "eventos" in uf_item
+        assert "projetos" in uf_item
+        assert "municipios" in uf_item
+        assert "coordenadores" in uf_item
+        assert "compras" in uf_item
 
     # Verificar by_municipio (não mais by_uf)
     assert "by_municipio" in data
@@ -280,6 +293,7 @@ def test_map_metrics_response_structure(user_controle, solicitacoes_variedade):
         assert "projetos" in mun
         assert "eventos" in mun
         assert "coordenadores" in mun
+        assert "compras" in mun
 
     # Verificar top_projetos
     assert "top_projetos" in data
@@ -338,6 +352,145 @@ def test_map_metrics_by_municipio_ordered_descending(user_controle, solicitacoes
     # Eventos devem estar em ordem decrescente
     for i in range(len(by_municipio) - 1):
         assert by_municipio[i]["eventos"] >= by_municipio[i + 1]["eventos"]
+
+
+def test_map_metrics_coordenadores_homonimos_nao_colidem_por_nome(user_controle):
+    """Municípios homônimos em UFs diferentes não devem compartilhar contagem de coordenadores."""
+    client = APIClient()
+    client.force_authenticate(user=user_controle)
+
+    projeto = Projeto.objects.create(nome="Projeto Homônimos", codigo="PH01", fluxo="SUPER")
+    tipo = TipoEvento.objects.create(nome="Tipo Homônimos")
+
+    municipio_ce = Municipio.objects.create(
+        nome="Santa Maria",
+        uf="CE",
+        ibge_code="2300001",
+        latitude=-3.12,
+        longitude=-39.10,
+    )
+    municipio_sp = Municipio.objects.create(
+        nome="Santa Maria",
+        uf="SP",
+        ibge_code="3500001",
+        latitude=-22.10,
+        longitude=-47.10,
+    )
+
+    criador = Usuario.objects.create_user(
+        username="criador_homonimo",
+        email="criador_homonimo@test.com",
+        password="x",
+        cpf="10101010101",
+    )
+    coord_ce = Usuario.objects.create_user(
+        username="coord_ce", email="coord_ce@test.com", password="x", cpf="20202020202"
+    )
+    coord_sp = Usuario.objects.create_user(
+        username="coord_sp", email="coord_sp@test.com", password="x", cpf="30303030303"
+    )
+
+    now = timezone.now()
+    sol_ce = Solicitacao.objects.create(
+        usuario=criador,
+        status="aprovado",
+        inicio=now,
+        fim=now + timedelta(hours=2),
+        municipio=municipio_ce,
+        projeto=projeto,
+        tipo_evento=tipo,
+    )
+    sol_sp = Solicitacao.objects.create(
+        usuario=criador,
+        status="aprovado",
+        inicio=now + timedelta(days=1),
+        fim=now + timedelta(days=1, hours=2),
+        municipio=municipio_sp,
+        projeto=projeto,
+        tipo_evento=tipo,
+    )
+
+    Participation.objects.create(solicitacao=sol_ce, usuario=coord_ce, role=Participation.Role.COORDENADOR)
+    Participation.objects.create(solicitacao=sol_sp, usuario=coord_sp, role=Participation.Role.COORDENADOR)
+
+    url = reverse("core:metrics-map")
+    res = client.get(url)
+
+    assert res.status_code == 200
+    data = res.json()
+    by_mun = {f"{m['municipio']}-{m['uf']}": m for m in data["by_municipio"]}
+
+    assert by_mun["Santa Maria-CE"]["coordenadores"] == 1
+    assert by_mun["Santa Maria-SP"]["coordenadores"] == 1
+
+
+def test_map_metrics_eventos_e_compras_separados_no_payload(user_controle):
+    """Métrica de eventos não deve ser contaminada por compras."""
+    client = APIClient()
+    client.force_authenticate(user=user_controle)
+
+    projeto = Projeto.objects.create(nome="Projeto Compras", codigo="PC01", fluxo="SUPER")
+    tipo = TipoEvento.objects.create(nome="Tipo Compras")
+    municipio = Municipio.objects.create(
+        nome="Maracanaú",
+        uf="CE",
+        ibge_code="2307650",
+        latitude=-3.88,
+        longitude=-38.62,
+    )
+
+    criador = Usuario.objects.create_user(
+        username="criador_compra", email="criador_compra@test.com", password="x", cpf="40404040404"
+    )
+    now = timezone.now()
+    Solicitacao.objects.create(
+        usuario=criador,
+        status="aprovado",
+        inicio=now,
+        fim=now + timedelta(hours=2),
+        municipio=municipio,
+        projeto=projeto,
+        tipo_evento=tipo,
+    )
+
+    produto_model = Produto.objects.create(nome="Kit Didático", codigo="KIT01", projeto=projeto)
+    Compra.objects.create(
+        codigo="COMP-001",
+        produto=produto_model,
+        projeto=projeto,
+        municipio=municipio,
+        quantidade=10,
+        data=timezone.localdate(),
+        uso="Uso 1",
+        external_hash="hash_compra_001",
+    )
+    Compra.objects.create(
+        codigo="COMP-002",
+        produto=produto_model,
+        projeto=projeto,
+        municipio=municipio,
+        quantidade=20,
+        data=timezone.localdate(),
+        uso="Uso 2",
+        external_hash="hash_compra_002",
+    )
+
+    url = reverse("core:metrics-map")
+    res = client.get(url)
+
+    assert res.status_code == 200
+    data = res.json()
+
+    assert data["totals"]["all"] == 1
+    assert data["totals"]["compras"] == 2
+
+    by_uf = next(item for item in data["by_uf"] if item["uf"] == "CE")
+    assert by_uf["eventos"] == 1
+    assert by_uf["compras"] == 2
+
+    by_mun = next(item for item in data["by_municipio"] if item["municipio"] == "Maracanaú")
+    assert by_mun["eventos"] == 1
+    assert by_mun["compras"] == 2
 
 
 # ============================================================================
@@ -421,6 +574,34 @@ def test_map_metrics_filter_combined(user_controle, solicitacoes_variedade, dado
     assert data["by_municipio"][0]["eventos"] == 3
 
 
+def test_map_metrics_filter_by_date_range(user_controle, solicitacoes_variedade):
+    """Filtro por data_inicio/data_fim deve alterar resultado de forma verificável."""
+    client = APIClient()
+    client.force_authenticate(user=user_controle)
+
+    url = reverse("core:metrics-map")
+    today = timezone.localdate()
+
+    # Janela que deve capturar somente as 2 solicitações de São Paulo (+10 e +11 dias).
+    res = client.get(
+        url,
+        {
+            "data_inicio": (today + timedelta(days=9)).isoformat(),
+            "data_fim": (today + timedelta(days=11)).isoformat(),
+        },
+    )
+    assert res.status_code == 200
+    data = res.json()
+
+    assert data["meta"]["filters"]["data_inicio"] == (today + timedelta(days=9)).isoformat()
+    assert data["meta"]["filters"]["data_fim"] == (today + timedelta(days=11)).isoformat()
+    assert data["totals"]["all"] == 2
+    assert len(data["by_municipio"]) == 1
+    assert data["by_municipio"][0]["municipio"] == "São Paulo"
+    assert data["by_municipio"][0]["uf"] == "SP"
+    assert data["by_municipio"][0]["eventos"] == 2
+
+
 # ============================================================================
 # TESTES DE VALIDAÇÃO
 # ============================================================================
@@ -450,6 +631,42 @@ def test_map_metrics_invalid_projeto_id(user_controle):
     assert "detail" in res.json()
 
 
+def test_map_metrics_invalid_data_inicio(user_controle):
+    """data_inicio inválida retorna 400."""
+    client = APIClient()
+    client.force_authenticate(user=user_controle)
+
+    url = reverse("core:metrics-map")
+    res = client.get(url, {"data_inicio": "2026/01/01"})
+
+    assert res.status_code == 400
+    assert "detail" in res.json()
+
+
+def test_map_metrics_invalid_date_range(user_controle):
+    """data_inicio > data_fim retorna 400."""
+    client = APIClient()
+    client.force_authenticate(user=user_controle)
+
+    url = reverse("core:metrics-map")
+    res = client.get(url, {"data_inicio": "2026-02-10", "data_fim": "2026-02-01"})
+
+    assert res.status_code == 400
+    assert "detail" in res.json()
+
+
+def test_map_metrics_invalid_limit(user_controle):
+    """limit inválido retorna 400."""
+    client = APIClient()
+    client.force_authenticate(user=user_controle)
+
+    url = reverse("core:metrics-map")
+    res = client.get(url, {"limit": "invalido"})
+
+    assert res.status_code == 400
+    assert "detail" in res.json()
+
+
 # ============================================================================
 # TESTES DE CASO ZERO-STATE
 # ============================================================================
@@ -467,6 +684,8 @@ def test_map_metrics_empty_database(user_controle):
     data = res.json()
 
     assert data["totals"]["all"] == 0
+    assert data["totals"]["compras"] == 0
+    assert data["by_uf"] == []
     assert data["by_municipio"] == []
     assert data["top_projetos"] == []
 

--- a/v2/backend/apps/core/tests/test_pagination.py
+++ b/v2/backend/apps/core/tests/test_pagination.py
@@ -163,15 +163,16 @@ class TestMetricsMapLimit(TestCase):
             )
 
     def test_metrics_map_default_limit(self) -> None:
-        """metrics_map should have default limit of 50."""
+        """metrics_map should not truncate by default."""
         response = self.client.get("/api/metrics/map/")
 
         self.assertEqual(response.status_code, 200)
         data = response.json()
 
         self.assertIn("meta", data)
-        self.assertEqual(data["meta"]["limit"], 50)
-        self.assertEqual(data["meta"]["max_limit"], 100)
+        self.assertIsNone(data["meta"]["limit"])
+        self.assertEqual(data["meta"]["max_limit"], 1000)
+        self.assertEqual(len(data["by_municipio"]), 20)
 
     def test_metrics_map_respects_limit_parameter(self) -> None:
         """metrics_map should respect limit parameter."""
@@ -183,24 +184,21 @@ class TestMetricsMapLimit(TestCase):
         self.assertEqual(data["meta"]["limit"], 10)
         self.assertLessEqual(len(data["by_municipio"]), 10)
 
-    def test_metrics_map_limit_capped_at_100(self) -> None:
-        """limit should be capped at max_limit (100)."""
-        response = self.client.get("/api/metrics/map/?limit=500")
+    def test_metrics_map_limit_capped_at_1000(self) -> None:
+        """limit should be capped at max_limit (1000)."""
+        response = self.client.get("/api/metrics/map/?limit=5000")
 
         self.assertEqual(response.status_code, 200)
         data = response.json()
 
-        self.assertEqual(data["meta"]["limit"], 100)
-        self.assertEqual(data["meta"]["max_limit"], 100)
+        self.assertEqual(data["meta"]["limit"], 1000)
+        self.assertEqual(data["meta"]["max_limit"], 1000)
 
-    def test_metrics_map_invalid_limit_uses_default(self) -> None:
-        """Invalid limit value should fall back to default."""
+    def test_metrics_map_invalid_limit_returns_400(self) -> None:
+        """Invalid limit value should return 400."""
         response = self.client.get("/api/metrics/map/?limit=invalid")
 
-        self.assertEqual(response.status_code, 200)
-        data = response.json()
-
-        self.assertEqual(data["meta"]["limit"], 50)
+        self.assertEqual(response.status_code, 400)
 
 
 class TestPaginationClasses(TestCase):

--- a/v2/backend/apps/core/tests/test_views_metrics_coverage.py
+++ b/v2/backend/apps/core/tests/test_views_metrics_coverage.py
@@ -424,6 +424,22 @@ class TestMetricsMapCoordinators:
         assert "coordenadores" in data
         assert len(data["coordenadores"]) >= 1
 
+    def test_coordinators_respect_date_filters(self, user_controle, solicitacoes_ce):
+        """
+        Test: Endpoint aplica filtros data_inicio/data_fim junto com UF.
+        """
+        client = APIClient()
+        client.force_authenticate(user=user_controle)
+
+        url = reverse("core:metrics-map-coordinators")
+        future_start = (timezone.localdate() + timedelta(days=365)).isoformat()
+        response = client.get(url, {"uf": "CE", "data_inicio": future_start})
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["uf"] == "CE"
+        assert data["coordenadores"] == []
+
     def test_coordinator_has_expected_structure(self, user_controle, solicitacoes_ce, coordenador_user):
         """
         Test: Each coordinator has id, nome, eventos, projetos, municipios.

--- a/v2/backend/apps/core/views/metrics/map_metrics.py
+++ b/v2/backend/apps/core/views/metrics/map_metrics.py
@@ -9,7 +9,10 @@ Extracted from views_metrics.py.
 
 from __future__ import annotations
 
-from django.db.models import Count
+from dataclasses import dataclass
+from datetime import date
+
+from django.db.models import Count, QuerySet
 from django.utils import timezone
 from rest_framework.decorators import api_view, permission_classes, throttle_classes
 from rest_framework.request import Request
@@ -17,8 +20,160 @@ from rest_framework.response import Response
 from rest_framework.throttling import ScopedRateThrottle
 
 from apps.core.exceptions import ValidationAPIError
-from apps.core.models import Participation, Solicitacao
+from apps.core.models import Compra, Participation, Solicitacao
 from apps.core.permissions import IsMapMetrics
+
+MAP_LIMIT_MAX = 1000
+VALID_STATUS_FILTERS = {"pendente", "aprovado", "reprovado"}
+
+
+@dataclass
+class MapFilterValues:
+    status: str | None = None
+    projeto_id: int | None = None
+    uf: str | None = None
+    data_inicio: date | None = None
+    data_fim: date | None = None
+
+
+def _parse_map_limit(request: Request) -> int | None:
+    """
+    Parse de limit para endpoint de mapa.
+
+    - Sem parâmetro: sem truncamento
+    - Com parâmetro: inteiro positivo, limitado a MAP_LIMIT_MAX
+    """
+    limit_param = request.query_params.get("limit")
+    if not limit_param:
+        return None
+
+    try:
+        limit = int(limit_param)
+    except (TypeError, ValueError):
+        raise ValidationAPIError(
+            message="limit deve ser um inteiro positivo",
+            field="limit",
+        ) from None
+
+    if limit < 1:
+        raise ValidationAPIError(
+            message="limit deve ser maior que zero",
+            field="limit",
+        )
+
+    return min(limit, MAP_LIMIT_MAX)
+
+
+def _parse_map_filter_values(
+    request: Request, *, require_uf: bool = False
+) -> tuple[MapFilterValues, dict[str, object]]:
+    """
+    Parse e valida filtros comuns dos endpoints de mapa.
+    """
+    filters = MapFilterValues()
+    filters_applied: dict[str, object] = {}
+
+    status_filter = request.query_params.get("status")
+    if status_filter:
+        if status_filter not in VALID_STATUS_FILTERS:
+            raise ValidationAPIError(
+                message=f"Status inválido. Valores aceitos: {', '.join(sorted(VALID_STATUS_FILTERS))}",
+                field="status",
+            )
+        filters.status = status_filter
+        filters_applied["status"] = status_filter
+
+    projeto_filter = request.query_params.get("projeto_id")
+    if projeto_filter:
+        if not projeto_filter.isdigit():
+            raise ValidationAPIError(
+                message="projeto_id deve ser um ID numérico válido",
+                field="projeto_id",
+            )
+        filters.projeto_id = int(projeto_filter)
+        filters_applied["projeto_id"] = filters.projeto_id
+
+    uf_filter = request.query_params.get("uf")
+    if uf_filter:
+        uf_normalized = uf_filter.strip().upper()
+        if len(uf_normalized) != 2 or not uf_normalized.isalpha():
+            raise ValidationAPIError(
+                message="uf deve ter 2 letras (ex: CE, SP, RJ)",
+                field="uf",
+            )
+        filters.uf = uf_normalized
+        filters_applied["uf"] = uf_normalized
+    elif require_uf:
+        raise ValidationAPIError(
+            message="Parâmetro 'uf' é obrigatório",
+            field="uf",
+        )
+
+    data_inicio_raw = request.query_params.get("data_inicio")
+    data_fim_raw = request.query_params.get("data_fim")
+
+    if data_inicio_raw:
+        try:
+            filters.data_inicio = date.fromisoformat(data_inicio_raw)
+        except ValueError:
+            raise ValidationAPIError(
+                message="data_inicio deve estar no formato YYYY-MM-DD",
+                field="data_inicio",
+            ) from None
+        filters_applied["data_inicio"] = filters.data_inicio.isoformat()
+
+    if data_fim_raw:
+        try:
+            filters.data_fim = date.fromisoformat(data_fim_raw)
+        except ValueError:
+            raise ValidationAPIError(
+                message="data_fim deve estar no formato YYYY-MM-DD",
+                field="data_fim",
+            ) from None
+        filters_applied["data_fim"] = filters.data_fim.isoformat()
+
+    if filters.data_inicio and filters.data_fim and filters.data_inicio > filters.data_fim:
+        raise ValidationAPIError(
+            message="data_inicio não pode ser maior que data_fim",
+            field="data_inicio",
+        )
+
+    return filters, filters_applied
+
+
+def _apply_filters_to_solicitacoes(
+    queryset: QuerySet[Solicitacao],
+    filters: MapFilterValues,
+) -> QuerySet[Solicitacao]:
+    """
+    Aplica filtros parseados ao queryset de solicitações (eventos).
+    """
+    if filters.status:
+        queryset = queryset.filter(status=filters.status)
+    if filters.projeto_id is not None:
+        queryset = queryset.filter(projeto_id=filters.projeto_id)
+    if filters.uf:
+        queryset = queryset.filter(municipio__uf=filters.uf)
+    if filters.data_inicio:
+        queryset = queryset.filter(inicio__date__gte=filters.data_inicio)
+    if filters.data_fim:
+        queryset = queryset.filter(inicio__date__lte=filters.data_fim)
+    return queryset
+
+
+def _apply_filters_to_compras(queryset: QuerySet[Compra], filters: MapFilterValues) -> QuerySet[Compra]:
+    """
+    Aplica filtros compatíveis ao queryset de compras.
+    """
+    if filters.projeto_id is not None:
+        queryset = queryset.filter(projeto_id=filters.projeto_id)
+    if filters.uf:
+        queryset = queryset.filter(municipio__uf=filters.uf)
+    if filters.data_inicio:
+        queryset = queryset.filter(data__gte=filters.data_inicio)
+    if filters.data_fim:
+        queryset = queryset.filter(data__lte=filters.data_fim)
+    return queryset
 
 
 @api_view(["GET"])
@@ -32,69 +187,49 @@ def metrics_map(request: Request) -> Response:
 
     Query parameters:
     - status: filtrar por status (pendente, aprovado, reprovado)
-    - projeto: filtrar por projeto ID
+    - projeto_id: filtrar por projeto ID
     - uf: filtrar por UF
+    - data_inicio: filtrar eventos/compras a partir da data (YYYY-MM-DD)
+    - data_fim: filtrar eventos/compras até a data (YYYY-MM-DD)
+    - limit: limita quantidade de municípios retornados (opcional)
 
     Response:
     {
         "meta": {
             "generated_at": "2025-10-21T...",
-            "filters": {"status": "...", "projeto": "...", "uf": "..."}
+            "filters": {
+                "status": "...",
+                "projeto_id": 1,
+                "uf": "CE",
+                "data_inicio": "2025-01-01",
+                "data_fim": "2025-01-31"
+            }
         },
         "totals": {
             "all": 100,
-            "by_status": {"pendente": 10, "aprovado": 80, "reprovado": 10}
+            "by_status": {"pendente": 10, "aprovado": 80, "reprovado": 10},
+            "compras": 25
         },
-        "by_municipio": [{"municipio": "Fortaleza", "uf": "CE", ...}, ...],
+        "by_uf": [{"uf": "CE", "eventos": 40, "compras": 12, ...}, ...],
+        "by_municipio": [{"municipio": "Fortaleza", "uf": "CE", "eventos": 10, "compras": 4, ...}, ...],
         "top_projetos": [{"nome": "Projeto A", "count": 5}, ...]
     }
 
     Permissions: IsMapMetrics (Controle, DAT, Superintendência, Gerência, Diretoria)
     """
-    queryset = Solicitacao.objects.all()
+    filters, filters_applied = _parse_map_filter_values(request)
+    limit = _parse_map_limit(request)
 
-    # Parâmetro limit com default e máximo (#408)
-    try:
-        limit = min(int(request.query_params.get("limit", 50)), 100)
-    except (ValueError, TypeError):
-        limit = 50
-
-    # Filtros opcionais
-    filters_applied = {}
-
-    status_filter = request.query_params.get("status")
-    if status_filter:
-        valid_statuses = ["pendente", "aprovado", "reprovado"]
-        if status_filter not in valid_statuses:
-            raise ValidationAPIError(
-                message=f"Status inválido. Valores aceitos: {', '.join(valid_statuses)}",
-                field="status",
-            )
-        queryset = queryset.filter(status=status_filter)
-        filters_applied["status"] = status_filter
-
-    projeto_filter = request.query_params.get("projeto_id")
-    if projeto_filter:
-        if not projeto_filter.isdigit():
-            raise ValidationAPIError(
-                message="projeto_id deve ser um ID numérico válido",
-                field="projeto_id",
-            )
-        projeto_id = int(projeto_filter)
-        queryset = queryset.filter(projeto_id=projeto_id)
-        filters_applied["projeto_id"] = projeto_id
-
-    uf_filter = request.query_params.get("uf")
-    if uf_filter:
-        queryset = queryset.filter(municipio__uf=uf_filter)
-        filters_applied["uf"] = uf_filter
+    queryset = _apply_filters_to_solicitacoes(Solicitacao.objects.all(), filters)
+    compras_queryset = _apply_filters_to_compras(Compra.objects.all(), filters)
 
     # Agregações por município (com coordenadas)
-    by_municipio = (
+    by_municipio_queryset = (
         queryset.exclude(municipio__isnull=True)
         .exclude(municipio__latitude__isnull=True)  # Apenas municípios com coordenadas
         .exclude(municipio__longitude__isnull=True)
         .values(
+            "municipio_id",
             "municipio__nome",
             "municipio__uf",
             "municipio__latitude",
@@ -104,11 +239,14 @@ def metrics_map(request: Request) -> Response:
             projetos=Count("projeto_id", distinct=True),
             eventos=Count("id"),
         )
-        .order_by("-eventos")[:limit]  # Respects limit param (#408)
+        .order_by("-eventos", "municipio__nome")
     )
 
+    if limit is not None:
+        by_municipio_queryset = by_municipio_queryset[:limit]
+
     # Contagem de coordenadores por município
-    coordenadores_por_municipio = {}
+    coordenadores_por_municipio: dict[int, int] = {}
 
     participations = (
         Participation.objects.filter(
@@ -116,16 +254,25 @@ def metrics_map(request: Request) -> Response:
             solicitacao__in=queryset,
             solicitacao__municipio__isnull=False,
         )
-        .values("solicitacao__municipio__nome")
+        .values("solicitacao__municipio_id")
         .annotate(coordenadores=Count("usuario_id", distinct=True))
     )
 
     for item in participations:
-        coordenadores_por_municipio[item["solicitacao__municipio__nome"]] = item["coordenadores"]
+        municipio_id = item["solicitacao__municipio_id"]
+        if municipio_id is not None:
+            coordenadores_por_municipio[int(municipio_id)] = int(item["coordenadores"])
+
+    compras_por_municipio: dict[int, int] = {}
+    for item in compras_queryset.exclude(municipio__isnull=True).values("municipio_id").annotate(compras=Count("id")):
+        municipio_id = item["municipio_id"]
+        if municipio_id is not None:
+            compras_por_municipio[int(municipio_id)] = int(item["compras"])
 
     # Formatar resposta com coordenadores
-    by_municipio_list = []
-    for item in by_municipio:
+    by_municipio_list: list[dict[str, object]] = []
+    for item in by_municipio_queryset:
+        municipio_id = int(item["municipio_id"])
         municipio_nome = item["municipio__nome"]
         by_municipio_list.append(
             {
@@ -135,7 +282,53 @@ def metrics_map(request: Request) -> Response:
                 "longitude": float(item["municipio__longitude"]),
                 "projetos": item["projetos"],
                 "eventos": item["eventos"],
-                "coordenadores": coordenadores_por_municipio.get(municipio_nome, 0),
+                "coordenadores": coordenadores_por_municipio.get(municipio_id, 0),
+                "compras": compras_por_municipio.get(municipio_id, 0),
+            }
+        )
+
+    by_uf_queryset = (
+        queryset.exclude(municipio__isnull=True)
+        .values("municipio__uf")
+        .annotate(
+            eventos=Count("id"),
+            projetos=Count("projeto_id", distinct=True),
+            municipios=Count("municipio_id", distinct=True),
+        )
+        .order_by("-eventos", "municipio__uf")
+    )
+
+    coordenadores_por_uf: dict[str, int] = {}
+    for item in (
+        Participation.objects.filter(
+            role=Participation.Role.COORDENADOR,
+            solicitacao__in=queryset,
+            solicitacao__municipio__isnull=False,
+        )
+        .values("solicitacao__municipio__uf")
+        .annotate(coordenadores=Count("usuario_id", distinct=True))
+    ):
+        uf = item["solicitacao__municipio__uf"]
+        if uf:
+            coordenadores_por_uf[str(uf)] = int(item["coordenadores"])
+
+    compras_por_uf: dict[str, int] = {}
+    for item in compras_queryset.exclude(municipio__isnull=True).values("municipio__uf").annotate(compras=Count("id")):
+        uf = item["municipio__uf"]
+        if uf:
+            compras_por_uf[str(uf)] = int(item["compras"])
+
+    by_uf_list: list[dict[str, object]] = []
+    for item in by_uf_queryset:
+        uf = str(item["municipio__uf"])
+        by_uf_list.append(
+            {
+                "uf": uf,
+                "eventos": int(item["eventos"]),
+                "projetos": int(item["projetos"]),
+                "municipios": int(item["municipios"]),
+                "coordenadores": coordenadores_por_uf.get(uf, 0),
+                "compras": compras_por_uf.get(uf, 0),
             }
         )
 
@@ -159,12 +352,14 @@ def metrics_map(request: Request) -> Response:
                 "generated_at": timezone.now().isoformat(),
                 "filters": filters_applied,
                 "limit": limit,
-                "max_limit": 100,
+                "max_limit": MAP_LIMIT_MAX,
             },
             "totals": {
                 "all": queryset.count(),
                 "by_status": by_status,
+                "compras": compras_queryset.count(),
             },
+            "by_uf": by_uf_list,
             "by_municipio": by_municipio_list,
             "top_projetos": top_projetos_list,
         }
@@ -186,10 +381,15 @@ def metrics_map_coordinators(request: Request) -> Response:
 
     Query parameters:
     - uf (required): UF do estado (ex: CE, SP, RJ)
+    - status: filtrar por status da solicitação (opcional)
+    - projeto_id: filtrar por projeto (opcional)
+    - data_inicio: filtrar por início >= data (YYYY-MM-DD, opcional)
+    - data_fim: filtrar por início <= data (YYYY-MM-DD, opcional)
 
     Response:
     {
         "uf": "CE",
+        "meta": {"filters": {...}},
         "coordenadores": [
             {
                 "id": 1,
@@ -204,17 +404,13 @@ def metrics_map_coordinators(request: Request) -> Response:
 
     Permissions: IsMapMetrics (Controle, DAT, Superintendência, Gerência, Diretoria)
     """
-    uf = request.query_params.get("uf")
-    if not uf:
-        raise ValidationAPIError(
-            message="Parâmetro 'uf' é obrigatório",
-            field="uf",
-        )
+    filters, filters_applied = _parse_map_filter_values(request, require_uf=True)
+    solicitacoes_filtradas = _apply_filters_to_solicitacoes(Solicitacao.objects.all(), filters)
 
     # Buscar participações de coordenadores para o estado especificado
     participations = Participation.objects.filter(
         role=Participation.Role.COORDENADOR,
-        solicitacao__municipio__uf=uf,
+        solicitacao__in=solicitacoes_filtradas,
         usuario__isnull=False,
     ).select_related("usuario", "solicitacao", "solicitacao__projeto", "solicitacao__municipio")
 
@@ -277,7 +473,10 @@ def metrics_map_coordinators(request: Request) -> Response:
 
     return Response(
         {
-            "uf": uf,
+            "uf": filters.uf,
+            "meta": {
+                "filters": filters_applied,
+            },
             "coordenadores": coordenadores_list,
         }
     )

--- a/v2/frontend/src/pages/MapaBrasil/MapaBrasilPage.tsx
+++ b/v2/frontend/src/pages/MapaBrasil/MapaBrasilPage.tsx
@@ -47,6 +47,14 @@ import 'leaflet/dist/leaflet.css';
 import api from '../../api';
 import logger from '../../utils/logger';
 import type { ID } from '../../types';
+import {
+  normalizeMapMetricsResponse,
+  type EstadoAgregadoType,
+  type EstadosDataType,
+  type MapMetricsResponse,
+  type MapQueryParams,
+  type MunicipioDataType,
+} from './mapMetrics';
 
 const { Title, Text } = Typography;
 const { Panel } = Collapse;
@@ -59,28 +67,6 @@ interface ProjetoType {
   id: ID | null;
   nome: string;
 }
-
-/** Municipio data type */
-interface MunicipioDataType {
-  municipio: string;
-  uf: string;
-  projetos: number;
-  eventos: number;
-  coordenadores: number;
-  coords: [number, number];
-}
-
-/** Estado agregado type */
-interface EstadoAgregadoType {
-  uf: string;
-  eventos: number;
-  projetos: number;
-  coordenadores: number;
-  municipios: string[];
-}
-
-/** Estados data type */
-type EstadosDataType = Record<string, EstadoAgregadoType>;
 
 /** Coordenador projeto type */
 interface CoordenadorProjetoType {
@@ -180,6 +166,7 @@ export default function MapaBrasilPage(): JSX.Element {
   const [projetos, setProjetos] = useState<ProjetoType[]>([]);
   const [coordenadoresData, setCoordenadoresData] = useState<CoordenadorDataType[]>([]);
   const [loadingCoordinators, setLoadingCoordinators] = useState<boolean>(false);
+  const [appliedMapFilters, setAppliedMapFilters] = useState<MapQueryParams>({});
 
   // Refs
   const mapRef = useRef<LeafletMap | null>(null);
@@ -248,59 +235,41 @@ export default function MapaBrasilPage(): JSX.Element {
     fetchMapData();
   }, []);
 
-  const fetchMapData = async (): Promise<void> => {
+  const buildCurrentMapParams = (): MapQueryParams => {
+    const params: MapQueryParams = {};
+    if (selectedProjeto) params.projeto_id = selectedProjeto;
+    if (dateRange?.[0]) params.data_inicio = dateRange[0].format('YYYY-MM-DD');
+    if (dateRange?.[1]) params.data_fim = dateRange[1].format('YYYY-MM-DD');
+    return params;
+  };
+
+  const fetchMapData = async (forcedParams?: MapQueryParams): Promise<void> => {
     setLoading(true);
     setError(null);
 
     try {
-      const params: Record<string, string | number> = {};
-      if (selectedProjeto) params.projeto_id = selectedProjeto;
-      if (dateRange?.[0]) params.data_inicio = dateRange[0].format('YYYY-MM-DD');
-      if (dateRange?.[1]) params.data_fim = dateRange[1].format('YYYY-MM-DD');
+      const params = forcedParams ?? buildCurrentMapParams();
 
       const response = await api.get('/metrics/map/', { params });
+      const normalized = normalizeMapMetricsResponse(response.data as MapMetricsResponse);
 
-      const municipios: MunicipioDataType[] = response.data.by_municipio.map((item: { municipio: string; uf: string; projetos: number; eventos: number; coordenadores: number; latitude: number; longitude: number }) => ({
-        municipio: item.municipio,
-        uf: item.uf,
-        projetos: item.projetos,
-        eventos: item.eventos,
-        coordenadores: item.coordenadores,
-        coords: [item.latitude, item.longitude] as [number, number],
-      }));
-
-      const estadosAgregados: EstadosDataType = {};
-      municipios.forEach(item => {
-        if (!estadosAgregados[item.uf]) {
-          estadosAgregados[item.uf] = {
-            uf: item.uf,
-            eventos: 0,
-            projetos: 0,
-            coordenadores: 0,
-            municipios: [],
-          };
-        }
-        estadosAgregados[item.uf].eventos += item.eventos;
-        estadosAgregados[item.uf].projetos += item.projetos;
-        estadosAgregados[item.uf].coordenadores += item.coordenadores;
-        estadosAgregados[item.uf].municipios.push(item.municipio);
-      });
-
-      setMunicipiosData(municipios);
-      setEstadosData(estadosAgregados);
+      setAppliedMapFilters(params);
+      setMunicipiosData(normalized.municipios);
+      setEstadosData(normalized.estados);
 
     } catch (err) {
       logger.error('Erro ao buscar dados do mapa:', err);
       setError('Erro ao carregar dados. Tente novamente.');
       message.error('Erro ao carregar dados do mapa');
       setMunicipiosData([]);
+      setEstadosData({});
     } finally {
       setLoading(false);
     }
   };
 
   // Fetch coordenadores para um estado específico
-  const fetchCoordinators = async (uf: string): Promise<void> => {
+  const fetchCoordinators = async (uf: string, filters: MapQueryParams): Promise<void> => {
     if (!uf) {
       setCoordenadoresData([]);
       return;
@@ -308,7 +277,7 @@ export default function MapaBrasilPage(): JSX.Element {
 
     setLoadingCoordinators(true);
     try {
-      const response = await api.get('/metrics/map/coordinators/', { params: { uf } });
+      const response = await api.get('/metrics/map/coordinators/', { params: { uf, ...filters } });
       setCoordenadoresData(response.data.coordenadores || []);
     } catch (err) {
       logger.error('Erro ao buscar coordenadores:', err);
@@ -321,11 +290,11 @@ export default function MapaBrasilPage(): JSX.Element {
   // Quando selectedState muda, buscar coordenadores
   useEffect(() => {
     if (selectedState) {
-      fetchCoordinators(selectedState);
+      fetchCoordinators(selectedState, appliedMapFilters);
     } else {
       setCoordenadoresData([]);
     }
-  }, [selectedState]);
+  }, [selectedState, appliedMapFilters]);
 
   const handleApplyFilters = (): void => {
     fetchMapData();
@@ -335,7 +304,7 @@ export default function MapaBrasilPage(): JSX.Element {
     setSelectedProjeto(null);
     setDateRange(null);
     setSearchTerm('');
-    fetchMapData();
+    fetchMapData({});
   };
 
   // Função para resetar a seleção do estado com zoom de volta
@@ -558,6 +527,13 @@ export default function MapaBrasilPage(): JSX.Element {
       align: 'center',
       render: (v: number) => <Tag color="purple">{v}</Tag>,
     },
+    {
+      title: 'Compras',
+      dataIndex: 'compras',
+      key: 'compras',
+      align: 'center',
+      render: (v: number) => <Tag color="orange">{v}</Tag>,
+    },
   ];
 
   // Columns for estados table
@@ -570,10 +546,10 @@ export default function MapaBrasilPage(): JSX.Element {
     },
     {
       title: 'Municípios',
-      dataIndex: 'municipios',
-      key: 'municipios',
+      dataIndex: 'municipiosTotal',
+      key: 'municipiosTotal',
       align: 'center',
-      render: (municipios: string[]) => municipios.length,
+      render: (total: number) => total,
     },
     {
       title: 'Eventos',
@@ -588,6 +564,13 @@ export default function MapaBrasilPage(): JSX.Element {
       key: 'coordenadores',
       align: 'center',
       render: (coord: number) => <Tag color="green">{coord}</Tag>,
+    },
+    {
+      title: 'Compras',
+      dataIndex: 'compras',
+      key: 'compras',
+      align: 'center',
+      render: (compras: number) => <Tag color="orange">{compras}</Tag>,
     },
   ];
 
@@ -916,25 +899,32 @@ export default function MapaBrasilPage(): JSX.Element {
               >
                 <Row gutter={[16, 16]}>
                   {/* Estatísticas em destaque */}
-                  <Col xs={8}>
+                  <Col xs={12} md={6}>
                     <Statistic
                       title="Total de Eventos"
                       value={estadosData[selectedState].eventos}
                       valueStyle={{ color: '#1890ff' }}
                     />
                   </Col>
-                  <Col xs={8}>
+                  <Col xs={12} md={6}>
                     <Statistic
                       title="Total de Projetos"
                       value={estadosData[selectedState].projetos}
                       valueStyle={{ color: '#722ed1' }}
                     />
                   </Col>
-                  <Col xs={8}>
+                  <Col xs={12} md={6}>
                     <Statistic
                       title="Coordenadores"
-                      value={coordenadoresData.length}
+                      value={estadosData[selectedState].coordenadores}
                       valueStyle={{ color: '#52c41a' }}
+                    />
+                  </Col>
+                  <Col xs={12} md={6}>
+                    <Statistic
+                      title="Compras"
+                      value={estadosData[selectedState].compras}
+                      valueStyle={{ color: '#fa8c16' }}
                     />
                   </Col>
                 </Row>
@@ -961,7 +951,7 @@ export default function MapaBrasilPage(): JSX.Element {
                 {/* Lista de municípios com eventos */}
                 <div style={{ marginBottom: 16 }}>
                   <Title level={5} style={{ marginBottom: 12 }}>
-                    Municípios com eventos ({estadosData[selectedState].municipios.length})
+                    Municípios com eventos ({estadosData[selectedState].municipiosTotal})
                   </Title>
                   <Space wrap>
                     {estadosData[selectedState].municipios.map((municipio, idx) => (
@@ -998,6 +988,7 @@ export default function MapaBrasilPage(): JSX.Element {
                       <Space>
                         <Tag color="purple">{item.projetos} projetos</Tag>
                         <Tag color="blue">{item.eventos} eventos</Tag>
+                        <Tag color="orange">{item.compras} compras</Tag>
                       </Space>
                     }
                   >
@@ -1025,11 +1016,12 @@ export default function MapaBrasilPage(): JSX.Element {
                         <div>
                           <Text strong>{uf}</Text>
                           <br />
-                          <Text type="secondary" style={{ fontSize: 12 }}>{data.municipios.length} municípios</Text>
+                          <Text type="secondary" style={{ fontSize: 12 }}>{data.municipiosTotal} municípios</Text>
                         </div>
                         <Space>
                           <Tag color="blue">{data.eventos} Eventos</Tag>
                           <Tag color="purple">{data.projetos} Projetos</Tag>
+                          <Tag color="orange">{data.compras} Compras</Tag>
                         </Space>
                       </div>
                     </List.Item>

--- a/v2/frontend/src/pages/MapaBrasil/__tests__/mapMetrics.test.ts
+++ b/v2/frontend/src/pages/MapaBrasil/__tests__/mapMetrics.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from 'vitest'
+
+import { normalizeMapMetricsResponse } from '../mapMetrics'
+
+describe('normalizeMapMetricsResponse', () => {
+  test('deve priorizar by_uf para evitar dupla agregacao no frontend', () => {
+    const payload = {
+      by_municipio: [
+        {
+          municipio: 'Fortaleza',
+          uf: 'CE',
+          projetos: 2,
+          eventos: 5,
+          coordenadores: 1,
+          compras: 2,
+          latitude: -3.71,
+          longitude: -38.54,
+        },
+        {
+          municipio: 'Sobral',
+          uf: 'CE',
+          projetos: 1,
+          eventos: 3,
+          coordenadores: 1,
+          compras: 1,
+          latitude: -3.69,
+          longitude: -40.34,
+        },
+      ],
+      by_uf: [
+        {
+          uf: 'CE',
+          eventos: 8,
+          projetos: 2,
+          coordenadores: 1,
+          municipios: 2,
+          compras: 3,
+        },
+      ],
+    }
+
+    const normalized = normalizeMapMetricsResponse(payload)
+
+    expect(normalized.estados.CE.eventos).toBe(8)
+    expect(normalized.estados.CE.projetos).toBe(2)
+    expect(normalized.estados.CE.coordenadores).toBe(1)
+    expect(normalized.estados.CE.compras).toBe(3)
+    expect(normalized.estados.CE.municipiosTotal).toBe(2)
+    expect(normalized.estados.CE.municipios).toEqual(['Fortaleza', 'Sobral'])
+  })
+
+  test('deve manter fallback para payload legado sem by_uf', () => {
+    const payload = {
+      by_municipio: [
+        {
+          municipio: 'Fortaleza',
+          uf: 'CE',
+          projetos: 2,
+          eventos: 5,
+          coordenadores: 1,
+          compras: 2,
+          latitude: -3.71,
+          longitude: -38.54,
+        },
+        {
+          municipio: 'São Paulo',
+          uf: 'SP',
+          projetos: 1,
+          eventos: 4,
+          coordenadores: 2,
+          compras: 7,
+          latitude: -23.55,
+          longitude: -46.63,
+        },
+      ],
+    }
+
+    const normalized = normalizeMapMetricsResponse(payload)
+
+    expect(normalized.estados.CE.eventos).toBe(5)
+    expect(normalized.estados.CE.compras).toBe(2)
+    expect(normalized.estados.CE.municipiosTotal).toBe(1)
+    expect(normalized.estados.SP.eventos).toBe(4)
+    expect(normalized.estados.SP.compras).toBe(7)
+    expect(normalized.estados.SP.municipiosTotal).toBe(1)
+  })
+})

--- a/v2/frontend/src/pages/MapaBrasil/mapMetrics.ts
+++ b/v2/frontend/src/pages/MapaBrasil/mapMetrics.ts
@@ -1,0 +1,120 @@
+import type { ID } from '../../types'
+
+export interface MapMunicipioMetric {
+  municipio: string
+  uf: string
+  projetos: number
+  eventos: number
+  coordenadores: number
+  compras?: number
+  latitude: number
+  longitude: number
+}
+
+export interface MapUfMetric {
+  uf: string
+  eventos: number
+  projetos: number
+  coordenadores: number
+  municipios: number
+  compras?: number
+}
+
+export interface MapMetricsResponse {
+  by_municipio: MapMunicipioMetric[]
+  by_uf?: MapUfMetric[]
+}
+
+export interface MunicipioDataType {
+  municipio: string
+  uf: string
+  projetos: number
+  eventos: number
+  coordenadores: number
+  compras: number
+  coords: [number, number]
+}
+
+export interface EstadoAgregadoType {
+  uf: string
+  eventos: number
+  projetos: number
+  coordenadores: number
+  compras: number
+  municipios: string[]
+  municipiosTotal: number
+}
+
+export type EstadosDataType = Record<string, EstadoAgregadoType>
+
+export interface MapQueryParams {
+  projeto_id?: ID
+  data_inicio?: string
+  data_fim?: string
+}
+
+export function normalizeMapMetricsResponse(response: MapMetricsResponse): {
+  municipios: MunicipioDataType[]
+  estados: EstadosDataType
+} {
+  const municipios: MunicipioDataType[] = (response.by_municipio || []).map((item) => ({
+    municipio: item.municipio,
+    uf: item.uf,
+    projetos: item.projetos,
+    eventos: item.eventos,
+    coordenadores: item.coordenadores,
+    compras: item.compras || 0,
+    coords: [item.latitude, item.longitude] as [number, number],
+  }))
+
+  const municipiosPorUf = new Map<string, Set<string>>()
+  municipios.forEach((item) => {
+    const key = item.uf
+    if (!municipiosPorUf.has(key)) {
+      municipiosPorUf.set(key, new Set())
+    }
+    municipiosPorUf.get(key)!.add(item.municipio)
+  })
+
+  const estados: EstadosDataType = {}
+  if (response.by_uf && response.by_uf.length > 0) {
+    response.by_uf.forEach((item) => {
+      const municipiosNomes = Array.from(municipiosPorUf.get(item.uf) || []).sort((a, b) => a.localeCompare(b))
+      estados[item.uf] = {
+        uf: item.uf,
+        eventos: item.eventos,
+        projetos: item.projetos,
+        coordenadores: item.coordenadores,
+        compras: item.compras || 0,
+        municipios: municipiosNomes,
+        municipiosTotal: item.municipios,
+      }
+    })
+    return { municipios, estados }
+  }
+
+  // Fallback para contratos antigos sem by_uf.
+  municipios.forEach((item) => {
+    if (!estados[item.uf]) {
+      estados[item.uf] = {
+        uf: item.uf,
+        eventos: 0,
+        projetos: 0,
+        coordenadores: 0,
+        compras: 0,
+        municipios: [],
+        municipiosTotal: 0,
+      }
+    }
+    estados[item.uf].eventos += item.eventos
+    estados[item.uf].projetos += item.projetos
+    estados[item.uf].coordenadores += item.coordenadores
+    estados[item.uf].compras += item.compras
+    if (!estados[item.uf].municipios.includes(item.municipio)) {
+      estados[item.uf].municipios.push(item.municipio)
+      estados[item.uf].municipiosTotal = estados[item.uf].municipios.length
+    }
+  })
+
+  return { municipios, estados }
+}


### PR DESCRIPTION
## Resumo
Esta entrega implementa a correção completa da issue **#613** e fecha tecnicamente as issues relacionadas **#577**, **#578** e **#579**.

### O que foi corrigido
- Backend `/api/metrics/map/`:
  - aplica `data_inicio` e `data_fim` (YYYY-MM-DD)
  - remove truncamento padrão (sem `limit` = sem corte)
  - mantém `limit` opcional com cap em `1000`
  - corrige contagem de coordenadores por município usando `municipio_id` (sem colisão por nome)
  - adiciona agregação `by_uf` como fonte de verdade para o frontend
  - separa `compras` de `eventos` no payload (`totals`, `by_uf`, `by_municipio`)
- Backend `/api/metrics/map/coordinators/`:
  - agora respeita filtros (`uf`, `status`, `projeto_id`, `data_inicio`, `data_fim`)
  - inclui `meta.filters` na resposta
- Frontend `MapaBrasilPage`:
  - passa a consumir `by_uf` do backend para evitar dupla agregação no cliente
  - mantém fallback compatível para payload legado sem `by_uf`
  - exibe `compras` separadamente de `eventos`
  - mantém filtros aplicados também na chamada de coordenadores por UF
- Testes:
  - backend: novos cenários para data range, colisão de homônimos, separação eventos/compras, novo comportamento de `limit`
  - frontend: novo teste unitário de transformação do payload (`mapMetrics`)

## Validação executada
### Backend
- `pytest apps/core/tests/test_metrics_map.py apps/core/tests/test_pagination.py -q`
- `pytest apps/core/tests/test_views_metrics_coverage.py -q`
- `black --check apps/core/views/metrics/map_metrics.py apps/core/tests/test_metrics_map.py apps/core/tests/test_pagination.py apps/core/tests/test_views_metrics_coverage.py`
- `isort --check-only apps/core/views/metrics/map_metrics.py apps/core/tests/test_metrics_map.py apps/core/tests/test_pagination.py apps/core/tests/test_views_metrics_coverage.py`
- `flake8 apps/core/views/metrics/map_metrics.py apps/core/tests/test_metrics_map.py apps/core/tests/test_pagination.py apps/core/tests/test_views_metrics_coverage.py`

### Frontend
- `vitest run src/pages/MapaBrasil/__tests__/mapMetrics.test.ts`
- `npm run typecheck`
- `npm run lint -- --max-warnings=0`

Closes #613
Closes #577
Closes #578
Closes #579
