### PR TITLE
test(e2e): atualiza rotas legadas para rotas reais do app

### DIFF
--- a/v2/frontend/e2e/dashboards.spec.ts
+++ b/v2/frontend/e2e/dashboards.spec.ts
@@ -19,7 +19,7 @@ test.describe('Dashboards', () => {
   });
 
   test('3. Dashboard GCal carrega', async ({ page }) => {
-    await page.goto('/dashboard/gcal');
+    await page.goto('/dashboards/gcal');
     await expect(page.locator('.ant-layout-content')).toBeVisible();
   });
 

--- a/v2/frontend/e2e/dat-module.spec.ts
+++ b/v2/frontend/e2e/dat-module.spec.ts
@@ -9,74 +9,69 @@ import { test, expect } from '@playwright/test';
 
 test.describe('Módulo DAT - Páginas Principais', () => {
   test('1. Admin DAT - Página inicial carrega', async ({ page }) => {
-    await page.goto('/admin-dat');
+    await page.goto('/dat/admin');
     await expect(page.locator('.ant-layout-content')).toBeVisible();
   });
 
   test('2. Importação carrega', async ({ page }) => {
-    await page.goto('/importacao');
+    await page.goto('/dat/importacao');
     await expect(page.locator('.ant-layout-content')).toBeVisible();
   });
 
   test('3. Registros de Turmas carrega', async ({ page }) => {
-    await page.goto('/dat-module/registros');
+    await page.goto('/dat/registros');
     await expect(page.locator('.ant-layout-content')).toBeVisible();
   });
 
-  test('4. Ações carrega', async ({ page }) => {
-    await page.goto('/dat-module/acoes');
+  test('4. Cadastros carrega', async ({ page }) => {
+    await page.goto('/dat/cadastros');
     await expect(page.locator('.ant-layout-content')).toBeVisible();
   });
 
-  test('5. Compras carrega', async ({ page }) => {
-    await page.goto('/dat-module/compras');
+  test('5. Coordenadores carrega', async ({ page }) => {
+    await page.goto('/dat/coordenadores');
     await expect(page.locator('.ant-layout-content')).toBeVisible();
   });
 
-  test('6. Cadastros carrega', async ({ page }) => {
-    await page.goto('/dat-module/cadastros');
+  test('6. Relatórios ETL carrega', async ({ page }) => {
+    await page.goto('/dat/etl-reports');
     await expect(page.locator('.ant-layout-content')).toBeVisible();
   });
 
-  test('7. Formações carrega', async ({ page }) => {
-    await page.goto('/dat-module/formacoes');
+  test('7. Importar Coleções carrega', async ({ page }) => {
+    await page.goto('/dat/admin/colecoes');
     await expect(page.locator('.ant-layout-content')).toBeVisible();
   });
 
-  test('8. Plano Anual carrega', async ({ page }) => {
-    await page.goto('/dat-module/plano-formacoes');
-    await expect(page.locator('.ant-layout-content')).toBeVisible();
-  });
-
-  test('9. Coordenadores carrega', async ({ page }) => {
-    await page.goto('/dat-module/coordenadores');
+  test('8. Importar Equipe-Gêrencia carrega', async ({ page }) => {
+    await page.goto('/dat/admin/equipe-gerencia');
     await expect(page.locator('.ant-layout-content')).toBeVisible();
   });
 });
 
 test.describe('Admin DAT - Subpáginas', () => {
-  test('10. Usuários carrega', async ({ page }) => {
-    await page.goto('/admin-dat/usuarios');
+  test('9. Usuários carrega', async ({ page }) => {
+    await page.goto('/dat/admin/usuarios');
     await expect(page.locator('.ant-layout-content')).toBeVisible();
   });
 
-  test('11. Municípios carrega', async ({ page }) => {
-    await page.goto('/admin-dat/municipios');
+  test('10. Municípios carrega', async ({ page }) => {
+    await page.goto('/dat/admin/municipios');
     await expect(page.locator('.ant-layout-content')).toBeVisible();
   });
 
-  test('12. Projetos carrega', async ({ page }) => {
-    await page.goto('/admin-dat/projetos');
+  test('11. Projetos carrega', async ({ page }) => {
+    await page.goto('/dat/admin/projetos');
     await expect(page.locator('.ant-layout-content')).toBeVisible();
   });
 
-  test('13. Grupos carrega', async ({ page }) => {
-    await page.goto('/admin-dat/grupos');
+  test('12. Grupos carrega', async ({ page }) => {
+    await page.goto('/dat/admin/grupos');
     await expect(page.locator('.ant-layout-content')).toBeVisible();
   });
 
-  test('14. Configurações carrega', async ({ page }) => {
-    await page.goto('/admin-dat/configuracoes');
+  test('13. Configurações carrega', async ({ page }) => {
+    await page.goto('/dat/admin/configuracoes');
     await expect(page.locator('.ant-layout-content')).toBeVisible();
   });
 });

--- a/v2/frontend/e2e/navigation.spec.ts
+++ b/v2/frontend/e2e/navigation.spec.ts
@@ -60,7 +60,7 @@ test.describe('Navegação Principal', () => {
   });
 
   test('11. Dashboard GCal carrega', async ({ page }) => {
-    await page.goto('/dashboard/gcal');
+    await page.goto('/dashboards/gcal');
     await expect(page.locator('.ant-layout-content')).toBeVisible();
   });
 
@@ -75,7 +75,7 @@ test.describe('Navegação Principal', () => {
   });
 
   test('14. Relatórios ETL carrega', async ({ page }) => {
-    await page.goto('/controle/etl-reports');
+    await page.goto('/dat/etl-reports');
     await expect(page.locator('.ant-layout-content')).toBeVisible();
   });
 });

--- a/v2/frontend/e2e/solicitacoes.spec.ts
+++ b/v2/frontend/e2e/solicitacoes.spec.ts
@@ -36,7 +36,7 @@ test.describe('Controle e Operações', () => {
   });
 
   test('6. Relatórios ETL carrega', async ({ page }) => {
-    await page.goto('/controle/etl-reports');
+    await page.goto('/dat/etl-reports');
     await expect(page.locator('.ant-layout-content')).toBeVisible();
   });
 


### PR DESCRIPTION
## Resumo
Alinha as specs Playwright com o roteamento real definido em `v2/frontend/src/App.tsx` (issue #614).

## O que mudou
- `v2/frontend/e2e/navigation.spec.ts`
  - `/dashboard/gcal` -> `/dashboards/gcal`
  - `/controle/etl-reports` -> `/dat/etl-reports`
- `v2/frontend/e2e/dashboards.spec.ts`
  - `/dashboard/gcal` -> `/dashboards/gcal`
- `v2/frontend/e2e/solicitacoes.spec.ts`
  - `/controle/etl-reports` -> `/dat/etl-reports`
- `v2/frontend/e2e/dat-module.spec.ts`
  - remove rotas legadas (`/admin-dat`, `/importacao`, `/dat-module/*`)
  - usa rotas atuais (`/dat/admin`, `/dat/importacao`, `/dat/registros`, `/dat/cadastros`, `/dat/coordenadores`, `/dat/etl-reports`, `/dat/admin/*`)

## Validação executada
- `npm run lint -- --max-warnings=0`
- `npx playwright test --list e2e/navigation.spec.ts e2e/dat-module.spec.ts e2e/dashboards.spec.ts e2e/solicitacoes.spec.ts`
- Tentativa de execução real:
  - `npm run test:e2e -- --project=chromium --reporter=line e2e/navigation.spec.ts e2e/dat-module.spec.ts e2e/dashboards.spec.ts e2e/solicitacoes.spec.ts`
  - Resultado: bloqueado por ambiente Playwright no container (erro de launch/exec do browser), tema tratado na issue #615.

Closes #614
