### PR TITLE
fix(ci): hardening de workflows com permissions mínimas e pin SHA (#632)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main, feat/dashboard-compras-etl ]
 
+permissions:
+  contents: read
+
 jobs:
   # ----------------------------------------------------------------
   # Job 1: Lint (rápido, ~1min)

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,6 +18,9 @@ on:
       - 'requirements-docs.txt'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 # ================================================================
 # MkDocs Documentation Build (validation only)
 # Issue #269: Automatic documentation generation

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -11,6 +11,9 @@ on:
     # Removed path filters for pull_request to ensure required check always runs
     # This is needed because the ruleset requires "frontend-ci" as a status check
 
+permissions:
+  contents: read
+
 jobs:
   build-lint-frontend:
     name: build/lint do frontend

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,9 @@ env:
   BACKEND_IMAGE: norjosamatheus/aprender-backend
   FRONTEND_IMAGE: norjosamatheus/aprender-frontend
 
+permissions:
+  contents: read
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -25,7 +28,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
@@ -38,7 +41,7 @@ jobs:
           echo "Generated version: $VERSION"
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
@@ -68,16 +71,16 @@ jobs:
       # Docker Hub Authentication & Build
       # =========================================================================
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ env.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
       - name: Build and push Backend image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: ./v2
           file: ./v2/infra/Dockerfile
@@ -95,7 +98,7 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
 
       - name: Build and push Frontend image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: ./v2/frontend
           file: ./v2/frontend/Dockerfile.prod
@@ -116,7 +119,7 @@ jobs:
       # Docker Scout Security Scan (Backend only - free tier limit)
       # =========================================================================
       - name: Docker Scout - Analyze Backend
-        uses: docker/scout-action@v1
+        uses: docker/scout-action@f8c776824083494ab0d56b8105ba2ca85c86e4de # v1
         with:
           command: cves,recommendations
           image: ${{ env.BACKEND_IMAGE }}:${{ steps.version.outputs.version }}
@@ -124,7 +127,7 @@ jobs:
           only-severities: critical,high
 
       - name: Docker Scout - Update production environment
-        uses: docker/scout-action@v1
+        uses: docker/scout-action@f8c776824083494ab0d56b8105ba2ca85c86e4de # v1
         with:
           command: environment
           image: ${{ env.BACKEND_IMAGE }}:${{ steps.version.outputs.version }}
@@ -158,7 +161,7 @@ jobs:
           git log --oneline --since="$(git describe --tags --abbrev=0 HEAD~1 2>/dev/null || echo '1970-01-01')" >> release_notes.md || echo "First release" >> release_notes.md
 
       - name: Create GitHub Release
-        uses: actions/create-release@v1
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -35,10 +35,10 @@ jobs:
     runs-on: ${{ vars.USE_SELF_HOSTED == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
 
@@ -62,7 +62,7 @@ jobs:
           bandit -r apps/ -f json -o bandit-report.json --skip B101,B601 -ll
 
       - name: Upload security reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: python-security-reports
@@ -79,7 +79,7 @@ jobs:
     runs-on: ${{ vars.USE_SELF_HOSTED == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Build Docker image
         run: |
@@ -87,7 +87,7 @@ jobs:
           docker build -f infra/Dockerfile -t aprender-backend:scan .
 
       - name: Run Trivy (JSON report)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@e368e328979b113139d6f9068e03accaed98a518 # 0.34.1
         with:
           image-ref: 'aprender-backend:scan'
           format: 'json'
@@ -97,7 +97,7 @@ jobs:
           severity: 'CRITICAL,HIGH,MEDIUM'
 
       - name: Run Trivy vulnerability scanner (blocking HIGH/CRITICAL)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@e368e328979b113139d6f9068e03accaed98a518 # 0.34.1
         with:
           image-ref: 'aprender-backend:scan'
           format: 'table'
@@ -107,7 +107,7 @@ jobs:
           severity: 'CRITICAL,HIGH'
 
       - name: Upload Trivy report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: trivy-report
@@ -121,10 +121,10 @@ jobs:
     runs-on: ${{ vars.USE_SELF_HOSTED == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
 
@@ -152,7 +152,7 @@ jobs:
           npm audit --omit=dev --audit-level=high
 
       - name: Upload npm audit report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: npm-audit-report
@@ -166,7 +166,7 @@ jobs:
     runs-on: ${{ vars.USE_SELF_HOSTED == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0  # Full history for secret scanning
 
@@ -201,12 +201,12 @@ jobs:
             --exit-code 1
 
       - name: Run TruffleHog
-        uses: trufflesecurity/trufflehog@main
+        uses: trufflesecurity/trufflehog@7c0734f987ad0bb30ee8da210773b800ee2016d3 # v3.93.4
         with:
           extra_args: --only-verified
 
       - name: Upload secret scan reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: secret-scan-reports


### PR DESCRIPTION
## Resumo
Implementa o hardening de workflows da issue #632 com foco em princípio do menor privilégio e redução de risco de supply chain no CI/CD.

## O que foi feito
- Adicionado bloco `permissions` explícito (read-only) em workflows principais sem definição:
  - `.github/workflows/ci.yaml`
  - `.github/workflows/frontend-ci.yml`
  - `.github/workflows/docs.yml`
  - `.github/workflows/release.yaml` (mantendo override de job com `contents: write` onde necessário)
- Pin de actions críticas por commit SHA em:
  - `.github/workflows/security-scan.yml`
  - `.github/workflows/release.yaml`
- Removidas referências mutáveis críticas (`@master`/`@main`) do `security-scan`:
  - `aquasecurity/trivy-action`
  - `trufflesecurity/trufflehog`

## Validação
- `actionlint` executado com sucesso (parser/workflow)
- Verificação adicional: não há mais `uses: ...@main|@master` em `.github/workflows`

## Observações
- O `release` continua com permissão de escrita apenas no job que cria tag/release (`contents: write`), mantendo o padrão de mínimo privilégio no restante.

Closes #632
