### PR TITLE
ci: confiabilidade com concurrency e timeout nos workflows críticos (#633)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   # ----------------------------------------------------------------
   # Job 1: Lint (rápido, ~1min)
@@ -17,6 +21,7 @@ jobs:
   lint:
     name: lint
     runs-on: ${{ vars.USE_SELF_HOSTED == 'true' && 'self-hosted' || 'ubuntu-latest' }}
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 
@@ -52,6 +57,7 @@ jobs:
   tests:
     name: tests
     runs-on: ${{ vars.USE_SELF_HOSTED == 'true' && 'self-hosted' || 'ubuntu-latest' }}
+    timeout-minutes: 35
 
     services:
       postgres:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,6 +21,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 # ================================================================
 # MkDocs Documentation Build (validation only)
 # Issue #269: Automatic documentation generation
@@ -30,6 +34,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -14,10 +14,15 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   react-doctor:
     name: react doctor quality gate
     runs-on: ${{ vars.USE_SELF_HOSTED == 'true' && 'self-hosted' || 'ubuntu-latest' }}
+    timeout-minutes: 12
 
     steps:
     - uses: actions/checkout@v4
@@ -44,6 +49,7 @@ jobs:
     name: build/lint do frontend
     runs-on: ${{ vars.USE_SELF_HOSTED == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     needs: react-doctor
+    timeout-minutes: 20
 
     defaults:
       run:
@@ -85,6 +91,7 @@ jobs:
     name: checklist tests (meta, a11y, security)
     runs-on: ${{ vars.USE_SELF_HOSTED == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     needs: build-lint-frontend
+    timeout-minutes: 25
 
     defaults:
       run:
@@ -126,6 +133,7 @@ jobs:
     runs-on: ${{ vars.USE_SELF_HOSTED == 'true' && 'self-hosted' || 'ubuntu-latest' }}
     needs: build-lint-frontend
     if: github.event_name == 'pull_request'
+    timeout-minutes: 12
 
     defaults:
       run:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -26,6 +26,10 @@ permissions:
   contents: read
   pull-requests: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   # ================================================================
   # Job 1: Python Dependency Vulnerability Scan
@@ -33,6 +37,7 @@ jobs:
   python-security:
     name: Python Dependencies
     runs-on: ${{ vars.USE_SELF_HOSTED == 'true' && 'self-hosted' || 'ubuntu-latest' }}
+    timeout-minutes: 18
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -77,6 +82,7 @@ jobs:
   container-security:
     name: Container Scan
     runs-on: ${{ vars.USE_SELF_HOSTED == 'true' && 'self-hosted' || 'ubuntu-latest' }}
+    timeout-minutes: 25
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -119,6 +125,7 @@ jobs:
   frontend-security:
     name: Frontend Dependencies
     runs-on: ${{ vars.USE_SELF_HOSTED == 'true' && 'self-hosted' || 'ubuntu-latest' }}
+    timeout-minutes: 12
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -164,6 +171,7 @@ jobs:
   secrets-scan:
     name: Secret Detection
     runs-on: ${{ vars.USE_SELF_HOSTED == 'true' && 'self-hosted' || 'ubuntu-latest' }}
+    timeout-minutes: 12
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/v2/docs/PLAN_ci_security_hardening_2026-02-23.md
+++ b/v2/docs/PLAN_ci_security_hardening_2026-02-23.md
@@ -103,6 +103,27 @@ Validação:
 
 ---
 
+### Padrão mínimo de confiabilidade de CI (Issue #633)
+
+Escopo:
+- Definir `concurrency` em workflows críticos para cancelar runs antigos de PR automaticamente.
+- Definir `timeout-minutes` explícito por job crítico para evitar execução indefinida.
+
+Padrão adotado:
+- `concurrency.group`: `${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}`
+- `cancel-in-progress`: `true` para PR (`github.event_name == 'pull_request'`)
+- `timeout-minutes` obrigatório em jobs críticos de:
+  - `.github/workflows/ci.yaml`
+  - `.github/workflows/frontend-ci.yml`
+  - `.github/workflows/security-scan.yml`
+  - `.github/workflows/docs.yml`
+
+Critério de aceite:
+- Novo push no mesmo PR cancela run anterior automaticamente.
+- Jobs críticos falham por timeout quando excedem limite definido.
+
+---
+
 ## 3) Ordem de execução (issues)
 
 1. **#627** Hardening `security-scan.yml` + trigger de PR para workflow file.
@@ -123,8 +144,10 @@ Validação:
 ## 5) Referências
 
 - Epic atual: `#620`
-- Issues deste ciclo: `#627`, `#628`, `#629`, `#630`
+- Issues deste ciclo: `#627`, `#628`, `#629`, `#630`, `#633`
 - Workflow alvo: `.github/workflows/security-scan.yml`
 - Workflow alvo: `.github/workflows/frontend-ci.yml`
+- Workflow alvo: `.github/workflows/ci.yaml`
+- Workflow alvo: `.github/workflows/docs.yml`
 - Workflow alvo: `.github/workflows/release.yaml`
 - Ruleset alvo: `Protect main` (`id: 9793909`)


### PR DESCRIPTION
## Resumo
Implementa confiabilidade de CI com `concurrency` e `timeout-minutes` nos workflows críticos.

## O que foi feito
- Adicionado `concurrency` com cancelamento em PR em:
  - `.github/workflows/ci.yaml`
  - `.github/workflows/frontend-ci.yml`
  - `.github/workflows/security-scan.yml`
  - `.github/workflows/docs.yml`
- Adicionado `timeout-minutes` explícito em todos os jobs críticos desses workflows.
- Documentado o padrão mínimo de confiabilidade no plano:
  - `v2/docs/PLAN_ci_security_hardening_2026-02-23.md`

## Padrão aplicado
- `group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}`
- `cancel-in-progress: ${{ github.event_name == 'pull_request' }}`

## Validação local
- Conferência estrutural com `rg` para `concurrency` e `timeout-minutes` nos 4 workflows alvo.
- `actionlint` não disponível no ambiente local (`command not found`), então a validação sintática final fica a cargo do CI no PR.

Closes #633
