### PR TITLE
ci(release): eliminar falso sinal de deploy no workflow (#630)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -174,7 +174,7 @@ jobs:
       # =========================================================================
       # Deployment
       # =========================================================================
-      - name: Deploy notification
+      - name: Release summary
         run: |
           echo "========================================"
           echo "Docker images published to Docker Hub!"
@@ -183,17 +183,94 @@ jobs:
           echo "Backend:  ${{ env.BACKEND_IMAGE }}:${{ steps.version.outputs.version }}"
           echo "Frontend: ${{ env.FRONTEND_IMAGE }}:${{ steps.version.outputs.version }}"
           echo ""
-          echo "To deploy, run:"
-          echo "  IMAGE_TAG=${{ steps.version.outputs.version }} docker compose -f docker-compose.prod.yml up -d"
+          echo "Deployment will now run from a configured command for '${{ github.event.inputs.environment }}'."
 
-      - name: Deploy to staging
-        if: github.event.inputs.environment == 'staging'
+      - name: Resolve deploy command (required)
+        id: resolve-deploy-command
+        env:
+          TARGET_ENV: ${{ github.event.inputs.environment }}
+          STAGING_DEPLOY_COMMAND_SECRET: ${{ secrets.STAGING_DEPLOY_COMMAND || '' }}
+          STAGING_DEPLOY_COMMAND_VAR: ${{ vars.STAGING_DEPLOY_COMMAND || '' }}
+          PRODUCTION_DEPLOY_COMMAND_SECRET: ${{ secrets.PRODUCTION_DEPLOY_COMMAND || '' }}
+          PRODUCTION_DEPLOY_COMMAND_VAR: ${{ vars.PRODUCTION_DEPLOY_COMMAND || '' }}
         run: |
-          echo "Deploying to staging environment..."
-          # Add staging deployment commands here (e.g., SSH to server, kubectl apply, etc.)
+          set -euo pipefail
 
-      - name: Deploy to production
-        if: github.event.inputs.environment == 'production'
+          DEPLOY_COMMAND=""
+          case "$TARGET_ENV" in
+            staging)
+              DEPLOY_COMMAND="$STAGING_DEPLOY_COMMAND_SECRET"
+              if [ -z "$DEPLOY_COMMAND" ]; then
+                DEPLOY_COMMAND="$STAGING_DEPLOY_COMMAND_VAR"
+              fi
+              ;;
+            production)
+              DEPLOY_COMMAND="$PRODUCTION_DEPLOY_COMMAND_SECRET"
+              if [ -z "$DEPLOY_COMMAND" ]; then
+                DEPLOY_COMMAND="$PRODUCTION_DEPLOY_COMMAND_VAR"
+              fi
+              ;;
+            *)
+              echo "Invalid environment: $TARGET_ENV" >&2
+              exit 1
+              ;;
+          esac
+
+          if [ -z "$DEPLOY_COMMAND" ]; then
+            echo "Deploy command for '$TARGET_ENV' is not configured." >&2
+            echo "Configure secret or variable: STAGING_DEPLOY_COMMAND / PRODUCTION_DEPLOY_COMMAND." >&2
+            exit 1
+          fi
+
+          echo "::add-mask::$DEPLOY_COMMAND"
+          COMMAND_HASH="$(printf '%s' "$DEPLOY_COMMAND" | sha256sum | awk '{print $1}')"
+          echo "command_hash=$COMMAND_HASH" >> "$GITHUB_OUTPUT"
+
+          delimiter="EOF_$(date +%s%N)"
+          {
+            echo "DEPLOY_COMMAND<<$delimiter"
+            echo "$DEPLOY_COMMAND"
+            echo "$delimiter"
+          } >> "$GITHUB_ENV"
+
+      - name: Execute deploy command
+        id: deploy-command
+        env:
+          TARGET_ENV: ${{ github.event.inputs.environment }}
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+          IMAGE_TAG: ${{ steps.version.outputs.version }}
+          BACKEND_IMAGE: ${{ env.BACKEND_IMAGE }}
+          FRONTEND_IMAGE: ${{ env.FRONTEND_IMAGE }}
         run: |
-          echo "Deploying to production environment..."
-          # Add production deployment commands here (e.g., SSH to server, kubectl apply, etc.)
+          set -euo pipefail
+          echo "Executing deploy for '$TARGET_ENV' with release '$RELEASE_VERSION'."
+          bash -lc "$DEPLOY_COMMAND"
+
+      - name: Generate deploy evidence
+        if: always()
+        env:
+          TARGET_ENV: ${{ github.event.inputs.environment }}
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+          DEPLOY_OUTCOME: ${{ steps.deploy-command.outcome }}
+          COMMAND_HASH: ${{ steps.resolve-deploy-command.outputs.command_hash }}
+        run: |
+          set -euo pipefail
+          {
+            echo "workflow=${{ github.workflow }}"
+            echo "run_id=${{ github.run_id }}"
+            echo "run_attempt=${{ github.run_attempt }}"
+            echo "repository=${{ github.repository }}"
+            echo "environment=$TARGET_ENV"
+            echo "release_version=$RELEASE_VERSION"
+            echo "deploy_outcome=$DEPLOY_OUTCOME"
+            echo "deploy_command_sha256=$COMMAND_HASH"
+            echo "generated_at_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          } > deploy-evidence.txt
+
+      - name: Upload deploy evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: deploy-evidence-${{ github.run_id }}
+          path: deploy-evidence.txt
+          retention-days: 30

--- a/docs/operations/deploy.md
+++ b/docs/operations/deploy.md
@@ -10,6 +10,26 @@ Guia de deploy do Aprender Sistema v2.
 - 4GB RAM mínimo
 - 20GB disco
 
+## Release via GitHub Actions
+
+Workflow: `.github/workflows/release.yaml`
+
+Comportamento atual:
+- Publica imagens Docker e executa deploy real por comando configurado para o ambiente selecionado.
+- Se não houver comando configurado, o workflow falha explicitamente (não há falso sinal de deploy concluído).
+- Gera artefato `deploy-evidence-<run_id>` com evidências da execução.
+
+Configuração obrigatória por ambiente:
+- `STAGING_DEPLOY_COMMAND` (secret ou variável de repositório)
+- `PRODUCTION_DEPLOY_COMMAND` (secret ou variável de repositório)
+
+Variáveis disponíveis para o comando:
+- `TARGET_ENV`
+- `RELEASE_VERSION`
+- `IMAGE_TAG`
+- `BACKEND_IMAGE`
+- `FRONTEND_IMAGE`
+
 ## Deploy Local (Development)
 
 ```bash


### PR DESCRIPTION
## Objetivo
Eliminar falso sinal de deploy concluído no workflow de release.

## O que foi alterado
- substituídos os passos placeholder de deploy por execução real via comando configurado por ambiente
- adicionado gate explícito: o job falha se o comando de deploy do ambiente não estiver configurado
- suporte a configuração por `secrets` ou `vars`:
  - `STAGING_DEPLOY_COMMAND`
  - `PRODUCTION_DEPLOY_COMMAND`
- adicionada evidência operacional com artefato `deploy-evidence-<run_id>` (inclui ambiente, versão e hash do comando)
- documentação atualizada em `docs/operations/deploy.md`

## Comportamento resultante
- sem comando de deploy configurado: `release` falha (sem falso verde)
- com comando configurado: `release` executa deploy real e mantém evidências

## Validação local
- parse YAML de `.github/workflows/release.yaml` validado com `python3` + `PyYAML`

Closes #630
