### PR TITLE
ci(frontend): eliminar warning de artifact ausente no checklist (#657)

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -126,6 +126,8 @@ jobs:
       with:
         name: checklist-test-results
         path: v2/frontend/test-results
+        # Checklist can pass without generating this directory (reporter=list).
+        if-no-files-found: ignore
         retention-days: 7
 
   lighthouse-ci:


### PR DESCRIPTION
## Resumo
Ajusta o upload de artifact do job `checklist-tests` para não gerar warning quando `v2/frontend/test-results` não existir em execução verde (cenário esperado com reporter `list`).

## Mudanças
- `.github/workflows/frontend-ci.yml`
  - adiciona `if-no-files-found: ignore` no step `Upload test results`

## Resultado esperado
- Remove o warning: `No files were found with the provided path: v2/frontend/test-results`
- Mantém upload quando arquivos existirem (incluindo cenários de falha com output gerado)

Closes #657
