### PR TITLE
test(checklist): centralizar mocks de auth bootstrap e remover ruído de proxy (#658)

### DIFF
--- a/v2/frontend/e2e/checklist/accessibility.spec.ts
+++ b/v2/frontend/e2e/checklist/accessibility.spec.ts
@@ -14,6 +14,7 @@
  */
 import { test, expect, Page } from '@playwright/test';
 import AxeBuilder from '@axe-core/playwright';
+import './checklist-network-mocks.setup';
 
 // Páginas para testar acessibilidade
 const PAGES_TO_TEST = [

--- a/v2/frontend/e2e/checklist/broken-links.spec.ts
+++ b/v2/frontend/e2e/checklist/broken-links.spec.ts
@@ -11,6 +11,7 @@
  * - Scripts e CSS (href/src)
  */
 import { test, expect, Page } from '@playwright/test';
+import './checklist-network-mocks.setup';
 
 interface LinkResult {
   url: string;

--- a/v2/frontend/e2e/checklist/checklist-network-mocks.setup.ts
+++ b/v2/frontend/e2e/checklist/checklist-network-mocks.setup.ts
@@ -1,0 +1,7 @@
+import { test } from '@playwright/test';
+import { mockChecklistAuthBootstrap } from './checklist-network-mocks';
+
+// Register deterministic auth/bootstrap mocks for checklist tests that use pages.
+test.beforeEach(async ({ page }) => {
+  await mockChecklistAuthBootstrap(page);
+});

--- a/v2/frontend/e2e/checklist/checklist-network-mocks.ts
+++ b/v2/frontend/e2e/checklist/checklist-network-mocks.ts
@@ -1,0 +1,21 @@
+import { Page } from '@playwright/test';
+
+export async function mockChecklistAuthBootstrap(page: Page): Promise<void> {
+  await page.route(/\/api\/csrf\/?(\?.*)?$/, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ csrfToken: 'checklist-test-csrf-token' }),
+    });
+  });
+
+  await page.route(/\/api\/me\/?(\?.*)?$/, async (route) => {
+    await route.fulfill({
+      status: 401,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        detail: 'As credenciais de autenticação não foram fornecidas.',
+      }),
+    });
+  });
+}

--- a/v2/frontend/e2e/checklist/console-errors.spec.ts
+++ b/v2/frontend/e2e/checklist/console-errors.spec.ts
@@ -6,7 +6,8 @@
  *
  * Navega pelas principais páginas e verifica se há erros no console.
  */
-import { test, expect, Page, ConsoleMessage } from '@playwright/test';
+import { test, expect, ConsoleMessage } from '@playwright/test';
+import './checklist-network-mocks.setup';
 
 // Páginas principais para testar
 const PAGES_TO_CHECK = [
@@ -49,33 +50,7 @@ function shouldIgnoreError(message: string): boolean {
   return IGNORED_ERRORS.some((ignored) => message.includes(ignored));
 }
 
-async function mockAnonymousSession(page: Page): Promise<void> {
-  // Keep console tests focused on frontend runtime behavior.
-  // Explicitly mock auth/bootstrap endpoints with robust matchers.
-  await page.route(/\/api\/csrf\/?(\?.*)?$/, async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ csrfToken: 'checklist-test-csrf-token' }),
-    });
-  });
-
-  await page.route(/\/api\/me\/?(\?.*)?$/, async (route) => {
-    await route.fulfill({
-      status: 401,
-      contentType: 'application/json',
-      body: JSON.stringify({
-        detail: 'As credenciais de autenticação não foram fornecidas.',
-      }),
-    });
-  });
-}
-
 test.describe('Checklist: Console Errors', () => {
-  test.beforeEach(async ({ page }) => {
-    await mockAnonymousSession(page);
-  });
-
   test('🔴 página inicial não deve ter erros no console', async ({ page }) => {
     const errors: string[] = [];
 

--- a/v2/frontend/e2e/checklist/meta-tags.spec.ts
+++ b/v2/frontend/e2e/checklist/meta-tags.spec.ts
@@ -9,6 +9,7 @@
  * - 🟢 Theme color
  */
 import { test, expect, Page } from '@playwright/test';
+import './checklist-network-mocks.setup';
 
 // Helper para extrair meta tags
 async function getMetaContent(page: Page, selector: string): Promise<string | null> {

--- a/v2/frontend/e2e/checklist/performance.spec.ts
+++ b/v2/frontend/e2e/checklist/performance.spec.ts
@@ -9,6 +9,7 @@
  * Usa métricas coletadas via Performance API do navegador.
  */
 import { test, expect, Page } from '@playwright/test';
+import './checklist-network-mocks.setup';
 
 // Thresholds do checklist
 const THRESHOLDS = {

--- a/v2/frontend/e2e/checklist/security-headers.spec.ts
+++ b/v2/frontend/e2e/checklist/security-headers.spec.ts
@@ -14,6 +14,7 @@
  * Este teste é mais útil em staging/produção.
  */
 import { test, expect } from '@playwright/test';
+import { mockChecklistAuthBootstrap } from './checklist-network-mocks';
 
 // Modo estrito só deve ser ativado explicitamente para ambientes com headers de produção.
 const STRICT_MODE = ['1', 'true', 'yes'].includes(
@@ -153,6 +154,10 @@ test.describe('Checklist: HTTPS', () => {
 });
 
 test.describe('Checklist: Cookies Security', () => {
+  test.beforeEach(async ({ page }) => {
+    await mockChecklistAuthBootstrap(page);
+  });
+
   test('🔴 cookies de sessão devem ter flags de segurança', async ({ page }) => {
     await page.goto('/');
 


### PR DESCRIPTION
## Resumo
Centraliza os mocks de bootstrap de autenticação do checklist (`/api/csrf` e `/api/me`) para tornar o job determinístico sem backend e reduzir ruído de proxy no Vite.

## Mudanças
- Adiciona utilitário compartilhado: `v2/frontend/e2e/checklist/checklist-network-mocks.ts`
- Adiciona setup com hook de `beforeEach`: `v2/frontend/e2e/checklist/checklist-network-mocks.setup.ts`
- Importa o setup nos specs de checklist baseados em `page`:
  - `accessibility.spec.ts`
  - `broken-links.spec.ts`
  - `console-errors.spec.ts`
  - `meta-tags.spec.ts`
  - `performance.spec.ts`
- Remove mock duplicado local em `console-errors.spec.ts`
- Em `security-headers.spec.ts`, aplica mock apenas no bloco de cookies (sem forçar browser nos testes baseados em `request`)

## Resultado esperado
- Reduz/elimina spam de `vite http proxy error` para `/api/csrf` e `/api/me` no checklist CI.
- Mantém testes do checklist independentes de backend para endpoints de bootstrap/auth.

## Validação
- `npm run lint` em `v2/frontend`: passou.
- `npm run test:checklist` local: não executável neste ambiente por dependência nativa ausente do Chromium (`libnspr4.so`).
  - A validação funcional fica coberta pelo CI do GitHub (`npx playwright install chromium --with-deps`).

Closes #658
