### PR TITLE
ci(frontend): paralelizar jobs obrigatórios sem perder gates (#645)

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -48,7 +48,6 @@ jobs:
   build-lint-frontend:
     name: "[required] build/lint do frontend"
     runs-on: ubuntu-latest
-    needs: react-doctor
     timeout-minutes: 20
 
     defaults:
@@ -90,7 +89,8 @@ jobs:
   checklist-tests:
     name: "[required] checklist tests (meta, a11y, security)"
     runs-on: ubuntu-latest
-    needs: build-lint-frontend
+    # Runs in parallel with build/lint to reduce critical path.
+    # Checklist does not consume build artifacts from build-lint-frontend.
     timeout-minutes: 25
 
     defaults:


### PR DESCRIPTION
## Resumo
- remove dependência desnecessária de build/lint em relação ao react doctor
- remove dependência desnecessária de checklist em relação ao build/lint
- mantém lighthouse dependente do build (consome artifact frontend-build)

## Resultado esperado
- mesmo conjunto de checks obrigatórios
- menor caminho crítico no frontend CI (jobs obrigatórios em paralelo)

## Validação
- sintaxe do workflow validada (yaml-ok)

Closes #645