### PR TITLE
ci(frontend): reduzir custo de checkout no React Doctor (#646)

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -27,7 +27,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        fetch-depth: 0
+        # React Doctor gate here runs full score mode (no git diff analysis),
+        # so shallow checkout is enough and faster.
+        # If diff-based React Doctor mode is introduced, switch to fetch-depth: 0.
+        fetch-depth: 1
 
     - name: Setup Node.js 20.x
       uses: actions/setup-node@v4


### PR DESCRIPTION
## Resumo
- troca checkout do job react-doctor para shallow clone (fetch-depth: 1)
- adiciona comentário técnico explicando por que clone completo não é necessário no modo atual
- documenta condição para voltar a fetch-depth: 0 se houver modo diff no React Doctor

## Validação
- workflow YAML válido (yaml-ok)
- React Doctor gate executado localmente com sucesso (score 84, mínimo 75)

Closes #646