### PR TITLE
ci(frontend): otimizar npm ci com estratégia de cache consistente (#648)

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -18,6 +18,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+env:
+  # Keep npm installs deterministic via lockfile, but reduce network overhead in CI.
+  NPM_CONFIG_PREFER_OFFLINE: 'true'
+  NPM_CONFIG_AUDIT: 'false'
+  NPM_CONFIG_FUND: 'false'
+
 jobs:
   react-doctor:
     name: "[required] react doctor quality gate"


### PR DESCRIPTION
## Resumo
- adiciona configuração global no workflow frontend-ci para npm em modo cache-friendly
- ativa prefer-offline para privilegiar cache local em todos os jobs frontend
- desativa audit e fund no CI para reduzir overhead de instalação sem alterar lockfile

## Racional
- mantém reproducibilidade com npm ci + package-lock
- reduz custo de rede em instalações repetidas entre jobs
- aplica política consistente sem introduzir serialização entre jobs

## Validação
- workflow YAML válido (yaml-ok)

Closes #648