### PR TITLE
ci(backend): experimento controlado com pytest-xdist no runner (#649)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,8 +59,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 35
     env:
-      # Controlled experiment (Issue #649): enable xdist with a fast rollback flag.
-      PYTEST_XDIST_ENABLED: '1'
+      # Controlled experiment (Issue #649): keep disabled by default after
+      # instability observed with full parallel run. Re-enable when targeted
+      # test groups are proven xdist-safe.
+      PYTEST_XDIST_ENABLED: '0'
       PYTEST_XDIST_WORKERS: 'auto'
       PYTEST_XDIST_DIST: 'loadscope'
 

--- a/v2/docs/analysis/phase-08-ci-test-optimization-plan.md
+++ b/v2/docs/analysis/phase-08-ci-test-optimization-plan.md
@@ -1,0 +1,30 @@
+# Phase 08: CI Test Optimization Plan
+
+## F2.1 - Controlled `pytest-xdist` experiment (Issue #649)
+
+### Experiment metadata
+- Date: 2026-02-24
+- PR: #665
+- Workflow run: `22366920610`
+- Job: `[required] backend tests (runner)` (`64735282997`)
+- Tested mode: `pytest -n auto --dist loadscope`
+
+### Result
+- Runtime observed: `266.36s` (`0:04:26`)
+- Test outcome: `1 failed, 1716 passed, 28 skipped`
+- Failing test: `apps/core/tests/test_config_api.py::test_config_validation`
+
+### Failure signals collected
+- Multiple unique constraint conflicts reported in Postgres logs during parallel execution.
+- Evidence indicates race/state coupling in parts of the suite under full xdist parallelism.
+
+### Decision
+- Do **not** adopt xdist as default in required backend CI yet.
+- Keep xdist toggle available in workflow for targeted follow-up experiments.
+
+### Rollback / toggle policy
+- Default (safe): `PYTEST_XDIST_ENABLED=0`
+- Controlled re-test: set `PYTEST_XDIST_ENABLED=1` in `.github/workflows/ci.yaml`
+
+### Next technical step
+- Isolate and fix stateful/non-parallel-safe tests first, then re-run the experiment.


### PR DESCRIPTION
## Resumo
- adiciona experimento controlado de xdist no job backend com flags de controle (`PYTEST_XDIST_ENABLED`, `PYTEST_XDIST_WORKERS`, `PYTEST_XDIST_DIST`)
- registra no `GITHUB_STEP_SUMMARY` modo de execucao, duracao e exit code
- aplica decisao segura: `PYTEST_XDIST_ENABLED=0` por padrao no gate requerido
- documenta evidencias e decisao em `v2/docs/analysis/phase-08-ci-test-optimization-plan.md`

## Dados do experimento
- run: `22366920610`
- job: `[required] backend tests (runner)`
- modo testado: `-n auto --dist loadscope`
- tempo observado: `266.36s`
- resultado: instavel (falha + conflitos de unicidade no Postgres)

## Decisao
- nao adotar xdist como default neste momento
- manter mecanismo de experimento pronto para nova rodada apos isolamento de testes stateful

## Validacao
- workflow YAML valido (`yaml-ok`)

Closes #649