### PR TITLE
ci(frontend): experimento controlado com checklist workers=2 (#650)

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -101,6 +101,10 @@ jobs:
     # Runs in parallel with build/lint to reduce critical path.
     # Checklist does not consume build artifacts from build-lint-frontend.
     timeout-minutes: 25
+    env:
+      # Controlled experiment (Issue #650): increase checklist concurrency.
+      # Fast rollback: set to 1 if retries/flakiness increase.
+      CHECKLIST_PLAYWRIGHT_WORKERS: '2'
 
     defaults:
       run:
@@ -123,7 +127,7 @@ jobs:
       run: npx playwright install chromium --with-deps
 
     - name: Run checklist tests
-      run: npm run test:checklist
+      run: npm run test:checklist -- --workers=${CHECKLIST_PLAYWRIGHT_WORKERS}
       env:
         # PR CI does not run behind production-grade reverse proxy headers.
         # Keep strict header assertions opt-in via STRICT_SECURITY_HEADERS=1.

--- a/v2/docs/analysis/phase-08-ci-test-optimization-plan.md
+++ b/v2/docs/analysis/phase-08-ci-test-optimization-plan.md
@@ -28,3 +28,16 @@
 
 ### Next technical step
 - Isolate and fix stateful/non-parallel-safe tests first, then re-run the experiment.
+
+## F2.2 - Controlled Playwright checklist workers experiment (Issue #650)
+
+### Experiment setup
+- Scope: checklist-only CI job (`[required] checklist tests (meta, a11y, security)`)
+- Change: run checklist with `--workers=2`
+- Control point: `CHECKLIST_PLAYWRIGHT_WORKERS` in `.github/workflows/frontend-ci.yml`
+
+### Rollback
+- Fast rollback: set `CHECKLIST_PLAYWRIGHT_WORKERS=1`
+
+### Validation target
+- Reduce checklist duration without increasing retries/flaky failures.


### PR DESCRIPTION
## Resumo
- executa checklist Playwright com `--workers=2` apenas no job `[required] checklist tests (meta, a11y, security)`
- adiciona controle de rollout via `CHECKLIST_PLAYWRIGHT_WORKERS` no workflow
- define rollback rapido (`CHECKLIST_PLAYWRIGHT_WORKERS=1`)
- registra setup/rollback no plano de fase 08 (`v2/docs/analysis/phase-08-ci-test-optimization-plan.md`)

## Escopo
- mudanca limitada ao checklist CI
- sem alterar workers globais dos demais projetos Playwright

## Validacao
- workflow YAML valido (`yaml-ok`)

Closes #650