### PR TITLE
ci(monitoring): baseline de duracao e telemetria continua (mediana/p95) (#651)

### DIFF
--- a/.github/workflows/ci-runtime-telemetry.yml
+++ b/.github/workflows/ci-runtime-telemetry.yml
@@ -1,0 +1,57 @@
+name: CI Runtime Telemetry
+
+on:
+  schedule:
+    - cron: "0 9 * * *"
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+    paths:
+      - ".github/workflows/ci-runtime-telemetry.yml"
+      - "v2/scripts/ci_runtime_telemetry.py"
+      - "v2/docs/analysis/ci-runtime-baseline.json"
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  telemetry:
+    name: "[monitoring] ci runtime baseline (median/p95)"
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Generate runtime telemetry report
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python v2/scripts/ci_runtime_telemetry.py \
+            --repo "${{ github.repository }}" \
+            --workflows "CI – Continuous Integration" "frontend-ci" "Security Scan" \
+            --runs-per-workflow 30 \
+            --required-only \
+            --baseline-json "v2/docs/analysis/ci-runtime-baseline.json" \
+            --regression-threshold-pct 35 \
+            --output-json "ci-runtime-report.json" \
+            --output-md "ci-runtime-report.md"
+
+      - name: Upload telemetry artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-runtime-telemetry
+          path: |
+            ci-runtime-report.json
+            ci-runtime-report.md
+          retention-days: 30
+
+      - name: Publish summary
+        if: always()
+        run: cat ci-runtime-report.md >> "$GITHUB_STEP_SUMMARY"

--- a/v2/docs/analysis/ci-runtime-baseline.json
+++ b/v2/docs/analysis/ci-runtime-baseline.json
@@ -1,0 +1,96 @@
+{
+  "generated_at_utc": "2026-02-24T20:09:58.022512+00:00",
+  "metrics": {
+    "CI \u2013 Continuous Integration::[required] backend tests (runner)": {
+      "max_seconds": 634.0,
+      "median_seconds": 588.0,
+      "min_seconds": 233.0,
+      "p95_seconds": 632.0,
+      "samples": 21
+    },
+    "CI \u2013 Continuous Integration::[required] backend typecheck (pyright)": {
+      "max_seconds": 78.0,
+      "median_seconds": 72.0,
+      "min_seconds": 62.0,
+      "p95_seconds": 78.0,
+      "samples": 12
+    },
+    "CI \u2013 Continuous Integration::[required] docker parity (backend)": {
+      "max_seconds": 149.0,
+      "median_seconds": 128.0,
+      "min_seconds": 118.0,
+      "p95_seconds": 135.0,
+      "samples": 21
+    },
+    "CI \u2013 Continuous Integration::[required] lint": {
+      "max_seconds": 34.0,
+      "median_seconds": 25.0,
+      "min_seconds": 20.0,
+      "p95_seconds": 28.0,
+      "samples": 21
+    },
+    "CI \u2013 Continuous Integration::[required] tests": {
+      "max_seconds": 4.0,
+      "median_seconds": 3.0,
+      "min_seconds": 2.0,
+      "p95_seconds": 4.0,
+      "samples": 21
+    },
+    "Security Scan::[required] Container Scan": {
+      "max_seconds": 167.0,
+      "median_seconds": 134.0,
+      "min_seconds": 116.0,
+      "p95_seconds": 166.0,
+      "samples": 22
+    },
+    "Security Scan::[required] Frontend Dependencies": {
+      "max_seconds": 32.0,
+      "median_seconds": 22.0,
+      "min_seconds": 19.0,
+      "p95_seconds": 25.0,
+      "samples": 22
+    },
+    "Security Scan::[required] Python Dependencies": {
+      "max_seconds": 53.0,
+      "median_seconds": 45.0,
+      "min_seconds": 39.0,
+      "p95_seconds": 53.0,
+      "samples": 22
+    },
+    "Security Scan::[required] Secret Detection": {
+      "max_seconds": 89.0,
+      "median_seconds": 17.0,
+      "min_seconds": 15.0,
+      "p95_seconds": 49.0,
+      "samples": 22
+    },
+    "frontend-ci::[required] build/lint do frontend": {
+      "max_seconds": 68.0,
+      "median_seconds": 55.0,
+      "min_seconds": 47.0,
+      "p95_seconds": 59.0,
+      "samples": 20
+    },
+    "frontend-ci::[required] checklist tests (meta, a11y, security)": {
+      "max_seconds": 488.0,
+      "median_seconds": 90.0,
+      "min_seconds": 72.0,
+      "p95_seconds": 162.0,
+      "samples": 20
+    },
+    "frontend-ci::[required] react doctor quality gate": {
+      "max_seconds": 38.0,
+      "median_seconds": 33.0,
+      "min_seconds": 28.0,
+      "p95_seconds": 36.0,
+      "samples": 20
+    }
+  },
+  "repo": "matheusnorjosa/aprender_sistema",
+  "runs_per_workflow": 30,
+  "workflows": [
+    "CI \u2013 Continuous Integration",
+    "frontend-ci",
+    "Security Scan"
+  ]
+}

--- a/v2/docs/analysis/ci-runtime-baseline.md
+++ b/v2/docs/analysis/ci-runtime-baseline.md
@@ -1,0 +1,25 @@
+# CI Runtime Telemetry
+
+- Generated at (UTC): `2026-02-24T20:09:58.022512+00:00`
+- Repo: `matheusnorjosa/aprender_sistema`
+- Workflows: `CI – Continuous Integration, frontend-ci, Security Scan`
+- Runs per workflow: `30`
+
+| Workflow | Job | Samples | Median (s) | P95 (s) | Min (s) | Max (s) |
+|---|---|---:|---:|---:|---:|---:|
+| CI – Continuous Integration | [required] backend tests (runner) | 21 | 588.0 | 632.0 | 233.0 | 634.0 |
+| CI – Continuous Integration | [required] backend typecheck (pyright) | 12 | 72.0 | 78.0 | 62.0 | 78.0 |
+| CI – Continuous Integration | [required] docker parity (backend) | 21 | 128.0 | 135.0 | 118.0 | 149.0 |
+| CI – Continuous Integration | [required] lint | 21 | 25.0 | 28.0 | 20.0 | 34.0 |
+| CI – Continuous Integration | [required] tests | 21 | 3.0 | 4.0 | 2.0 | 4.0 |
+| Security Scan | [required] Container Scan | 22 | 134.0 | 166.0 | 116.0 | 167.0 |
+| Security Scan | [required] Frontend Dependencies | 22 | 22.0 | 25.0 | 19.0 | 32.0 |
+| Security Scan | [required] Python Dependencies | 22 | 45.0 | 53.0 | 39.0 | 53.0 |
+| Security Scan | [required] Secret Detection | 22 | 17.0 | 49.0 | 15.0 | 89.0 |
+| frontend-ci | [required] build/lint do frontend | 20 | 55.0 | 59.0 | 47.0 | 68.0 |
+| frontend-ci | [required] checklist tests (meta, a11y, security) | 20 | 90.0 | 162.0 | 72.0 | 488.0 |
+| frontend-ci | [required] react doctor quality gate | 20 | 33.0 | 36.0 | 28.0 | 38.0 |
+
+## Regression Check
+
+- No p95 regressions detected against baseline threshold.

--- a/v2/docs/analysis/phase-08-ci-test-optimization-plan.md
+++ b/v2/docs/analysis/phase-08-ci-test-optimization-plan.md
@@ -41,3 +41,19 @@
 
 ### Validation target
 - Reduce checklist duration without increasing retries/flaky failures.
+
+## F3.1 - CI runtime baseline and continuous telemetry (Issue #651)
+
+### Baseline published
+- Baseline markdown: `v2/docs/analysis/ci-runtime-baseline.md`
+- Baseline data: `v2/docs/analysis/ci-runtime-baseline.json`
+- Metrics: median and p95 by required job (window: last 30 completed runs per workflow)
+
+### Continuous process
+- Script: `v2/scripts/ci_runtime_telemetry.py`
+- Workflow: `.github/workflows/ci-runtime-telemetry.yml`
+- Schedule: daily (`0 9 * * *`) + manual dispatch
+
+### Objective regression criterion
+- Compare current p95 vs baseline p95 per monitored job
+- Alert/fail threshold: `+35%` (configurable via workflow argument)

--- a/v2/scripts/ci_runtime_telemetry.py
+++ b/v2/scripts/ci_runtime_telemetry.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""Generate CI runtime telemetry (median/p95) from GitHub Actions history."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import statistics
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Dict, Iterable, List, Tuple
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+
+API_BASE = "https://api.github.com"
+
+
+@dataclass(frozen=True)
+class JobSample:
+    workflow_name: str
+    job_name: str
+    duration_seconds: float
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True, help="owner/repo")
+    parser.add_argument(
+        "--workflows",
+        nargs="+",
+        required=True,
+        help="Exact workflow names to monitor",
+    )
+    parser.add_argument(
+        "--runs-per-workflow",
+        type=int,
+        default=30,
+        help="Completed runs to inspect per workflow",
+    )
+    parser.add_argument(
+        "--required-only",
+        action="store_true",
+        help="Only include jobs with name starting with [required]",
+    )
+    parser.add_argument(
+        "--baseline-json",
+        default="",
+        help="Optional baseline json for regression detection",
+    )
+    parser.add_argument(
+        "--regression-threshold-pct",
+        type=float,
+        default=35.0,
+        help="Fail when p95 exceeds baseline by this percentage",
+    )
+    parser.add_argument("--output-json", required=True, help="Path to output json report")
+    parser.add_argument("--output-md", required=True, help="Path to output markdown report")
+    return parser.parse_args()
+
+
+def github_get(path: str, token: str, params: Dict[str, str] | None = None) -> dict:
+    query = f"?{urlencode(params)}" if params else ""
+    req = Request(f"{API_BASE}{path}{query}")
+    req.add_header("Accept", "application/vnd.github+json")
+    req.add_header("Authorization", f"Bearer {token}")
+    req.add_header("X-GitHub-Api-Version", "2022-11-28")
+    with urlopen(req, timeout=30) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def parse_ts(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def percentile(values: Iterable[float], p: float) -> float:
+    data = sorted(values)
+    if not data:
+        return 0.0
+    if len(data) == 1:
+        return data[0]
+    rank = math.ceil((p / 100.0) * len(data)) - 1
+    rank = max(0, min(rank, len(data) - 1))
+    return data[rank]
+
+
+def fetch_workflow_id(repo: str, workflow_name: str, token: str) -> int:
+    page = 1
+    while True:
+        payload = github_get(
+            f"/repos/{repo}/actions/workflows",
+            token,
+            params={"per_page": "100", "page": str(page)},
+        )
+        workflows = payload.get("workflows", [])
+        if not workflows:
+            break
+        for workflow in workflows:
+            if workflow.get("name") == workflow_name:
+                return int(workflow["id"])
+        page += 1
+    raise RuntimeError(f"Workflow not found: {workflow_name}")
+
+
+def fetch_completed_runs(repo: str, workflow_id: int, token: str, limit: int) -> List[dict]:
+    runs: List[dict] = []
+    page = 1
+    while len(runs) < limit:
+        payload = github_get(
+            f"/repos/{repo}/actions/workflows/{workflow_id}/runs",
+            token,
+            params={
+                "status": "completed",
+                "per_page": "100",
+                "page": str(page),
+            },
+        )
+        page_runs = payload.get("workflow_runs", [])
+        if not page_runs:
+            break
+        runs.extend(page_runs)
+        page += 1
+    return runs[:limit]
+
+
+def fetch_run_jobs(repo: str, run_id: int, token: str) -> List[dict]:
+    jobs: List[dict] = []
+    page = 1
+    while True:
+        payload = github_get(
+            f"/repos/{repo}/actions/runs/{run_id}/jobs",
+            token,
+            params={"per_page": "100", "page": str(page)},
+        )
+        page_jobs = payload.get("jobs", [])
+        if not page_jobs:
+            break
+        jobs.extend(page_jobs)
+        if len(page_jobs) < 100:
+            break
+        page += 1
+    return jobs
+
+
+def collect_samples(
+    repo: str,
+    workflows: List[str],
+    token: str,
+    runs_per_workflow: int,
+    required_only: bool,
+) -> List[JobSample]:
+    samples: List[JobSample] = []
+    for workflow_name in workflows:
+        workflow_id = fetch_workflow_id(repo, workflow_name, token)
+        runs = fetch_completed_runs(repo, workflow_id, token, runs_per_workflow)
+        for run in runs:
+            run_id = int(run["id"])
+            jobs = fetch_run_jobs(repo, run_id, token)
+            for job in jobs:
+                job_name = job.get("name", "")
+                if required_only and not job_name.startswith("[required]"):
+                    continue
+                started_at = job.get("started_at")
+                completed_at = job.get("completed_at")
+                if not started_at or not completed_at:
+                    continue
+                duration = (parse_ts(completed_at) - parse_ts(started_at)).total_seconds()
+                if duration < 0:
+                    continue
+                samples.append(
+                    JobSample(
+                        workflow_name=workflow_name,
+                        job_name=job_name,
+                        duration_seconds=duration,
+                    )
+                )
+    return samples
+
+
+def build_metrics(samples: List[JobSample]) -> Dict[str, dict]:
+    by_key: Dict[str, List[float]] = {}
+    for sample in samples:
+        key = f"{sample.workflow_name}::{sample.job_name}"
+        by_key.setdefault(key, []).append(sample.duration_seconds)
+
+    metrics: Dict[str, dict] = {}
+    for key, values in by_key.items():
+        values_sorted = sorted(values)
+        metrics[key] = {
+            "samples": len(values_sorted),
+            "median_seconds": round(float(statistics.median(values_sorted)), 2),
+            "p95_seconds": round(float(percentile(values_sorted, 95.0)), 2),
+            "min_seconds": round(float(values_sorted[0]), 2),
+            "max_seconds": round(float(values_sorted[-1]), 2),
+        }
+    return metrics
+
+
+def load_baseline(path: str) -> Dict[str, dict]:
+    if not path:
+        return {}
+    if not os.path.exists(path):
+        return {}
+    with open(path, "r", encoding="utf-8") as file:
+        payload = json.load(file)
+    return payload.get("metrics", {})
+
+
+def detect_regressions(
+    metrics: Dict[str, dict],
+    baseline_metrics: Dict[str, dict],
+    threshold_pct: float,
+) -> List[Tuple[str, float, float]]:
+    regressions: List[Tuple[str, float, float]] = []
+    factor = 1.0 + (threshold_pct / 100.0)
+    for key, current in metrics.items():
+        baseline = baseline_metrics.get(key)
+        if not baseline:
+            continue
+        baseline_p95 = float(baseline.get("p95_seconds", 0.0))
+        current_p95 = float(current.get("p95_seconds", 0.0))
+        if baseline_p95 <= 0.0:
+            continue
+        if current_p95 > baseline_p95 * factor:
+            regressions.append((key, baseline_p95, current_p95))
+    return regressions
+
+
+def write_json(path: str, payload: dict) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as file:
+        json.dump(payload, file, indent=2, sort_keys=True)
+        file.write("\n")
+
+
+def write_markdown(path: str, payload: dict, regressions: List[Tuple[str, float, float]]) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    lines: List[str] = []
+    lines.append("# CI Runtime Telemetry")
+    lines.append("")
+    lines.append(f"- Generated at (UTC): `{payload['generated_at_utc']}`")
+    lines.append(f"- Repo: `{payload['repo']}`")
+    lines.append(f"- Workflows: `{', '.join(payload['workflows'])}`")
+    lines.append(f"- Runs per workflow: `{payload['runs_per_workflow']}`")
+    lines.append("")
+    lines.append("| Workflow | Job | Samples | Median (s) | P95 (s) | Min (s) | Max (s) |")
+    lines.append("|---|---|---:|---:|---:|---:|---:|")
+
+    for key in sorted(payload["metrics"].keys()):
+        workflow_name, job_name = key.split("::", 1)
+        metric = payload["metrics"][key]
+        lines.append(
+            f"| {workflow_name} | {job_name} | {metric['samples']} | "
+            f"{metric['median_seconds']} | {metric['p95_seconds']} | "
+            f"{metric['min_seconds']} | {metric['max_seconds']} |"
+        )
+
+    lines.append("")
+    lines.append("## Regression Check")
+    if not regressions:
+        lines.append("")
+        lines.append("- No p95 regressions detected against baseline threshold.")
+    else:
+        lines.append("")
+        lines.append("- Regressions detected:")
+        for key, baseline_p95, current_p95 in regressions:
+            workflow_name, job_name = key.split("::", 1)
+            lines.append(
+                f"  - `{workflow_name} / {job_name}`: baseline p95={baseline_p95}s, current p95={current_p95}s"
+            )
+    lines.append("")
+
+    with open(path, "w", encoding="utf-8") as file:
+        file.write("\n".join(lines))
+
+
+def main() -> int:
+    args = parse_args()
+    token = os.environ.get("GITHUB_TOKEN", "")
+    if not token:
+        print("GITHUB_TOKEN is required", file=sys.stderr)
+        return 2
+
+    samples = collect_samples(
+        repo=args.repo,
+        workflows=args.workflows,
+        token=token,
+        runs_per_workflow=args.runs_per_workflow,
+        required_only=args.required_only,
+    )
+    metrics = build_metrics(samples)
+
+    payload = {
+        "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+        "repo": args.repo,
+        "workflows": args.workflows,
+        "runs_per_workflow": args.runs_per_workflow,
+        "metrics": metrics,
+    }
+
+    baseline_metrics = load_baseline(args.baseline_json)
+    regressions = detect_regressions(
+        metrics=metrics,
+        baseline_metrics=baseline_metrics,
+        threshold_pct=args.regression_threshold_pct,
+    )
+
+    write_json(args.output_json, payload)
+    write_markdown(args.output_md, payload, regressions)
+
+    print(f"Metrics keys: {len(metrics)}")
+    print(f"Regressions: {len(regressions)}")
+    if regressions:
+        print("p95 regression threshold exceeded for at least one monitored job", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Resumo
- publica baseline inicial de duracao CI por job requerido:
  - `v2/docs/analysis/ci-runtime-baseline.md`
  - `v2/docs/analysis/ci-runtime-baseline.json`
- adiciona script de telemetria `v2/scripts/ci_runtime_telemetry.py`
  - calcula mediana/p95 por job
  - compara p95 atual vs baseline
- adiciona workflow agendado `.github/workflows/ci-runtime-telemetry.yml`
  - execucao diaria + manual
  - upload de relatorios como artifact
  - criterio objetivo de regressao: p95 > baseline +35%
- atualiza plano fase 08 com F3.1

## Validacao local
- `python3 -m py_compile v2/scripts/ci_runtime_telemetry.py`
- `python3 ... ci_runtime_telemetry.py ...` com token -> `Metrics keys: 12`, `Regressions: 0`
- YAML dos workflows validado (`yaml-ok`)

Closes #651