### PR TITLE
ci(monitoring): corrigir falha no CI Runtime Telemetry

### DIFF
--- a/.github/workflows/ci-runtime-telemetry.yml
+++ b/.github/workflows/ci-runtime-telemetry.yml
@@ -54,4 +54,9 @@ jobs:
 
       - name: Publish summary
         if: always()
-        run: cat ci-runtime-report.md >> "$GITHUB_STEP_SUMMARY"
+        run: |
+          if [ -f ci-runtime-report.md ]; then
+            cat ci-runtime-report.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "ci-runtime-report.md not found (telemetry step failed before report generation)." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/v2/scripts/ci_runtime_telemetry.py
+++ b/v2/scripts/ci_runtime_telemetry.py
@@ -230,14 +230,18 @@ def detect_regressions(
 
 
 def write_json(path: str, payload: dict) -> None:
-    os.makedirs(os.path.dirname(path), exist_ok=True)
+    parent = os.path.dirname(path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
     with open(path, "w", encoding="utf-8") as file:
         json.dump(payload, file, indent=2, sort_keys=True)
         file.write("\n")
 
 
 def write_markdown(path: str, payload: dict, regressions: List[Tuple[str, float, float]]) -> None:
-    os.makedirs(os.path.dirname(path), exist_ok=True)
+    parent = os.path.dirname(path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
     lines: List[str] = []
     lines.append("# CI Runtime Telemetry")
     lines.append("")


### PR DESCRIPTION
## Causa raiz
O run `22368565561` falhou no job `[monitoring] ci runtime baseline (median/p95)` por `FileNotFoundError` ao escrever `ci-runtime-report.json`:
- `os.path.dirname("ci-runtime-report.json")` retorna string vazia
- `os.makedirs("")` levanta excecao

## Correcoes aplicadas
- script `v2/scripts/ci_runtime_telemetry.py`:
  - cria diretorio pai apenas quando ele existe (`if parent:`)
- workflow `.github/workflows/ci-runtime-telemetry.yml`:
  - passo `Publish summary` agora e tolerante a ausencia do arquivo de report

## Validacao
- `python3 -m py_compile v2/scripts/ci_runtime_telemetry.py`
- `python3 ... --output-json ci-runtime-report.json --output-md ci-runtime-report.md` executado com sucesso
- YAML valido (`yaml-ok`)

Refs run: https://github.com/matheusnorjosa/aprender_sistema/actions/runs/22368565561