### PR TITLE
ci(security): evitar falha do strict headers agendado sem base_url

### DIFF
--- a/.github/workflows/strict-security-headers.yml
+++ b/.github/workflows/strict-security-headers.yml
@@ -34,11 +34,13 @@ jobs:
     - name: Resolve target URL
       id: target
       env:
+        EVENT_NAME: ${{ github.event_name }}
         INPUT_BASE_URL: ${{ github.event.inputs.base_url || '' }}
         VAR_BASE_URL: ${{ vars.STRICT_SECURITY_HEADERS_BASE_URL || '' }}
         SECRET_BASE_URL: ${{ secrets.STRICT_SECURITY_HEADERS_BASE_URL || '' }}
       run: |
         set -euo pipefail
+        SKIP_RUN="0"
         TARGET_URL="$INPUT_BASE_URL"
         if [ -z "$TARGET_URL" ]; then
           TARGET_URL="$VAR_BASE_URL"
@@ -47,13 +49,23 @@ jobs:
           TARGET_URL="$SECRET_BASE_URL"
         fi
         if [ -z "$TARGET_URL" ]; then
-          echo "Missing target URL. Set workflow_dispatch input 'base_url' or configure STRICT_SECURITY_HEADERS_BASE_URL (vars/secrets)." >&2
-          exit 1
+          if [ "$EVENT_NAME" = "schedule" ]; then
+            SKIP_RUN="1"
+            echo "Scheduled run skipped: STRICT_SECURITY_HEADERS_BASE_URL is not configured." >> "$GITHUB_STEP_SUMMARY"
+            echo "::warning::Skipping strict security headers: missing STRICT_SECURITY_HEADERS_BASE_URL for scheduled run."
+          else
+            echo "Missing target URL. Set workflow_dispatch input 'base_url' or configure STRICT_SECURITY_HEADERS_BASE_URL (vars/secrets)." >&2
+            exit 1
+          fi
         fi
-        echo "::add-mask::$TARGET_URL"
+        if [ "$SKIP_RUN" = "0" ]; then
+          echo "::add-mask::$TARGET_URL"
+        fi
         echo "target_url=$TARGET_URL" >> "$GITHUB_OUTPUT"
+        echo "skip_run=$SKIP_RUN" >> "$GITHUB_OUTPUT"
 
     - name: Setup Node.js 20.x
+      if: steps.target.outputs.skip_run != '1'
       uses: actions/setup-node@v4
       with:
         node-version: '20.x'
@@ -61,12 +73,15 @@ jobs:
         cache-dependency-path: 'v2/frontend/package-lock.json'
 
     - name: Install dependencies
+      if: steps.target.outputs.skip_run != '1'
       run: npm ci
 
     - name: Install Playwright browsers
+      if: steps.target.outputs.skip_run != '1'
       run: npx playwright install chromium --with-deps
 
     - name: Run strict security headers spec
+      if: steps.target.outputs.skip_run != '1'
       run: npx playwright test e2e/checklist/security-headers.spec.ts --project=checklist
       env:
         SKIP_WEBSERVER: '1'
@@ -76,7 +91,7 @@ jobs:
 
     - name: Upload strict security headers artifacts
       uses: actions/upload-artifact@v4
-      if: always()
+      if: always() && steps.target.outputs.skip_run != '1'
       with:
         name: strict-security-headers-results
         path: |


### PR DESCRIPTION
## Contexto
O workflow **Strict Security Headers** estava falhando no `schedule` quando `STRICT_SECURITY_HEADERS_BASE_URL` não estava configurado.

Run afetado: https://github.com/matheusnorjosa/aprender_sistema/actions/runs/22382932061

## O que foi alterado
- `Resolve target URL` agora diferencia tipo de evento:
  - `workflow_dispatch`: mantém comportamento estrito (falha se URL ausente).
  - `schedule`: não falha; marca execução como `skipped` com aviso no summary.
- Adicionado output `skip_run` para controlar o restante do job.
- Steps de Node/Playwright e upload de artifacts agora executam apenas quando `skip_run != 1`.

## Resultado
- Elimina falso vermelho em execução agendada sem configuração de URL.
- Preserva falha explícita em execução manual sem parâmetro/configuração.