### PR TITLE
test(security): add IDOR regression coverage for availability-blocks

### DIFF
--- a/v2/backend/apps/core/tests/test_multi_sector_permissions.py
+++ b/v2/backend/apps/core/tests/test_multi_sector_permissions.py
@@ -283,6 +283,19 @@ class TestAvailabilityBlockViewSetMultiSector(TestCase):
             papel="FORMADOR",
         )
 
+        # Usuário par na mesma gerência (usado para validar IDOR em update/delete)
+        self.user_vidas_peer = Usuario.objects.create_user(
+            username=f"vidas_peer_{unique_suffix}",
+            email=f"vidas_peer_{unique_suffix}@test.com",
+            password="test123",
+            cpf=f"55{unique_suffix[:9]}",
+        )
+        EquipeGerencia.objects.create(
+            gerencia=self.gerencia_vidas,
+            usuario=self.user_vidas_peer,
+            papel="FORMADOR",
+        )
+
         self.user_fluir = Usuario.objects.create_user(
             username=f"fluir_block_{unique_suffix}",
             email=f"fluir_block_{unique_suffix}@test.com",
@@ -309,6 +322,13 @@ class TestAvailabilityBlockViewSetMultiSector(TestCase):
             inicio="2025-01-15T09:00:00Z",
             fim="2025-01-15T18:00:00Z",
             tipo="T",
+            status="aprovado",
+        )
+        self.block_vidas_peer = AvailabilityBlock.objects.create(
+            usuario=self.user_vidas_peer,
+            inicio="2025-01-15T10:00:00Z",
+            fim="2025-01-15T12:00:00Z",
+            tipo="P",
             status="aprovado",
         )
         self.block_fluir = AvailabilityBlock.objects.create(
@@ -370,3 +390,46 @@ class TestAvailabilityBlockViewSetMultiSector(TestCase):
         self.assertEqual(response.status_code, 201)
         self.assertEqual(response.data["usuario"], self.user_vidas.id)
         self.assertEqual(response.data["status"], "aprovado")
+
+    def test_user_cannot_update_peer_block_same_gerencia(self):
+        """
+        Usuário comum não pode editar bloqueio de terceiro (mesma gerência).
+
+        Regressão C-03 (IDOR): update deve ficar restrito ao próprio usuário,
+        exceto perfis privilegiados.
+        """
+        self.client.force_authenticate(user=self.user_vidas)
+        response = self.client.patch(
+            f"/api/availability-blocks/{self.block_vidas_peer.id}/",
+            {"motivo": "Tentativa indevida"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 404)
+
+        self.block_vidas_peer.refresh_from_db()
+        self.assertNotEqual(self.block_vidas_peer.motivo, "Tentativa indevida")
+
+    def test_user_cannot_delete_peer_block_same_gerencia(self):
+        """
+        Usuário comum não pode excluir bloqueio de terceiro (mesma gerência).
+
+        Regressão C-03 (IDOR): delete deve ficar restrito ao próprio usuário,
+        exceto perfis privilegiados.
+        """
+        self.client.force_authenticate(user=self.user_vidas)
+        response = self.client.delete(f"/api/availability-blocks/{self.block_vidas_peer.id}/")
+        self.assertEqual(response.status_code, 404)
+        self.assertTrue(AvailabilityBlock.objects.filter(id=self.block_vidas_peer.id).exists())
+
+    def test_controle_can_update_peer_block(self):
+        """Perfil Controle continua podendo editar bloqueio de terceiros."""
+        self.client.force_authenticate(user=self.user_controle)
+        response = self.client.patch(
+            f"/api/availability-blocks/{self.block_vidas_peer.id}/",
+            {"motivo": "Ajuste Controle"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200)
+
+        self.block_vidas_peer.refresh_from_db()
+        self.assertEqual(self.block_vidas_peer.motivo, "Ajuste Controle")


### PR DESCRIPTION
## Objetivo
Fechar a lacuna de validação da issue #560 (IDOR em update/delete de `availability-blocks`).

## Contexto
O `AvailabilityBlockViewSet` já restringe `update/partial_update/destroy` ao próprio usuário para perfis não privilegiados (via `get_queryset`).
Faltava cobertura de regressão explícita para garantir esse comportamento ao longo do tempo.

## Alterações
- Arquivo: `v2/backend/apps/core/tests/test_multi_sector_permissions.py`
- Adicionados cenários:
  - usuário comum **não** edita bloqueio de terceiro da mesma gerência
  - usuário comum **não** exclui bloqueio de terceiro da mesma gerência
  - usuário `Controle` **continua podendo** editar bloqueio de terceiro
- Adicionada fixture de usuário par na mesma gerência para exercitar IDOR real.

## Validação executada (Docker)
- `docker compose -f infra/docker-compose.yml exec -T web pytest apps/core/tests/test_multi_sector_permissions.py -q` -> **15 passed**
- `docker compose -f infra/docker-compose.yml exec -T web black --check apps/core/tests/test_multi_sector_permissions.py`
- `docker compose -f infra/docker-compose.yml exec -T web isort --check-only apps/core/tests/test_multi_sector_permissions.py`
- `docker compose -f infra/docker-compose.yml exec -T web flake8 apps/core/tests/test_multi_sector_permissions.py`

Closes #560
