### PR TITLE
test(backup): add regression suite for MP5 celery backups

### DIFF
--- a/v2/backend/apps/core/tests/test_tasks_mp5.py
+++ b/v2/backend/apps/core/tests/test_tasks_mp5.py
@@ -7,6 +7,8 @@ Coverage:
 - verify_backup_health healthy/degraded scenarios
 """
 
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportOptionalMemberAccess=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportMissingTypeArgument=false, reportCallIssue=false, reportIndexIssue=false, reportOperatorIssue=false, reportOptionalSubscript=false, reportUnknownLambdaType=false, reportFunctionMemberAccess=false
+
 from __future__ import annotations
 
 import subprocess
@@ -20,12 +22,12 @@ from apps.core import tasks_backup as backup_tasks
 @pytest.mark.django_db
 def test_perform_database_backup_success_parses_output(monkeypatch):
     """Task should run script with env vars and parse backup file from stdout."""
-    script = "/app/infra/scripts/backup_db.sh"
+    script_suffix = "infra/scripts/backup_db.sh"
     original_exists = Path.exists
     captured: dict[str, object] = {}
 
     def fake_exists(self: Path) -> bool:  # noqa: ANN001
-        if self.as_posix() == script:
+        if self.as_posix().endswith(script_suffix):
             return True
         return original_exists(self)
 
@@ -55,7 +57,11 @@ def test_perform_database_backup_success_parses_output(monkeypatch):
 
     cmd = captured["cmd"]
     kwargs = captured["kwargs"]
-    assert cmd == [script, "full"]
+    assert isinstance(cmd, list)
+    assert len(cmd) == 2
+    assert isinstance(cmd[0], str)
+    assert cmd[0].endswith(script_suffix)
+    assert cmd[1] == "full"
     assert isinstance(kwargs, dict)
     assert kwargs.get("check") is True
     assert kwargs.get("timeout") == 3600
@@ -75,11 +81,11 @@ def test_perform_database_backup_success_parses_output(monkeypatch):
 @pytest.mark.django_db
 def test_perform_database_backup_raises_when_script_missing(monkeypatch):
     """Task should fail fast with FileNotFoundError when script is unavailable."""
-    script = "/app/infra/scripts/backup_db.sh"
+    script_suffix = "infra/scripts/backup_db.sh"
     original_exists = Path.exists
 
     def fake_exists(self: Path) -> bool:  # noqa: ANN001
-        if self.as_posix() == script:
+        if self.as_posix().endswith(script_suffix):
             return False
         return original_exists(self)
 


### PR DESCRIPTION
## Contexto
A issue #562 descreve backup automático via Celery quebrado no Docker. No estado atual do código, os ajustes estruturais já estão presentes (`Dockerfile`, compose, script e task), mas faltava validação automatizada específica no backend.

## O que foi feito
- Adicionado teste dedicado: `v2/backend/apps/core/tests/test_tasks_mp5.py`
- Cobertura incluída:
  - `perform_database_backup` sucesso (parse de saída + invocação de script + env)
  - `perform_database_backup` falha quando script está ausente
  - `verify_backup_health` saudável com backup recente
  - `verify_backup_health` degradado sem backups
  - `verify_backup_health` degradado quando checagem S3 falha

## Validação executada (Docker)
- `docker compose -f infra/docker-compose.yml run --rm -v "$(pwd)/backend:/app" web pytest apps/core/tests/test_tasks_mp5.py -q` -> **5 passed**
- `docker compose -f infra/docker-compose.yml run --rm -v "$(pwd)/backend:/app" web black --check apps/core/tests/test_tasks_mp5.py`
- `docker compose -f infra/docker-compose.yml run --rm -v "$(pwd)/backend:/app" web isort --check-only apps/core/tests/test_tasks_mp5.py`
- `docker compose -f infra/docker-compose.yml run --rm -v "$(pwd)/backend:/app" web flake8 apps/core/tests/test_tasks_mp5.py`

## Smoke funcional (Docker)
Executado manualmente com sucesso:
- Script disponível em `worker` e `beat`: `/app/infra/scripts/backup_db.sh`
- Task executada via Django shell:
  - `perform_database_backup.run(backup_type='full')`
  - arquivo criado em `/backups/backup_full_YYYYMMDD_HHMMSS.sql.gz`

Closes #562
