### PR TITLE
ci(backend): dividir testes em jobs seriais e combinar cobertura

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -267,6 +267,7 @@ jobs:
         name: backend-coverage-core
         path: v2/backend/.coverage.core
         if-no-files-found: error
+        include-hidden-files: true
         retention-days: 7
 
   # ----------------------------------------------------------------
@@ -388,6 +389,7 @@ jobs:
         name: backend-coverage-ingest-devtools
         path: v2/backend/.coverage.ingest_devtools
         if-no-files-found: error
+        include-hidden-files: true
         retention-days: 7
 
   # ----------------------------------------------------------------


### PR DESCRIPTION
## Objetivo
Implementar a Fase 2 da issue #676 para reduzir tempo e risco operacional sem reintroduzir instabilidade de xdist.

## O que mudou
- Divide o backend em 2 jobs seriais:
  - `backend-tests-core` (`apps/core/tests`)
  - `backend-tests-ingest-devtools` (`apps/dat_ingest/tests` + `apps/dev_tools/tests`)
- Mantém o check obrigatório histórico:
  - `backend-tests` (`[required] backend tests (runner)`)
- `backend-tests` agora:
  - valida que os 2 jobs passaram
  - baixa artefatos de cobertura
  - combina cobertura com `coverage combine`
  - aplica gate único `coverage report --fail-under=80`
  - gera `coverage.xml` para Codecov

## Garantias
- Regras atuais de branch protection continuam válidas (nome do check obrigatório preservado).
- Se backend não mudou, job obrigatório continua `skipped` como no modelo da Fase 1.

Closes #676