### PR TITLE
ci(backend): add non-blocking xdist canary lane and stabilization backlog

### DIFF
--- a/.github/workflows/backend-xdist-canary.yml
+++ b/.github/workflows/backend-xdist-canary.yml
@@ -1,0 +1,221 @@
+name: Backend xdist Canary (non-blocking)
+
+on:
+  schedule:
+    - cron: "20 10 * * *"
+  workflow_dispatch:
+    inputs:
+      extra_pytest_args:
+        description: "Optional extra pytest args (example: -k test_config_validation)"
+        required: false
+        default: ""
+  push:
+    branches: [ main ]
+    paths:
+      - ".github/workflows/backend-xdist-canary.yml"
+      - "v2/scripts/xdist_canary_report.py"
+      - "docs/operations/ci-backend-xdist-canary.md"
+      - "docs/operations/ci-check-policy.md"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  xdist-canary:
+    name: "[info] backend xdist canary (w=${{ matrix.workers }},dist=${{ matrix.dist }})"
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        workers: ["2", "auto"]
+        dist: ["loadscope", "loadfile"]
+
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: test_aprender
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+      redis:
+        image: redis:7
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: |
+            v2/backend/requirements.txt
+            v2/backend/requirements-dev.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r v2/backend/requirements.txt
+          pip install -r v2/backend/requirements-dev.txt
+
+      - name: Set up environment variables
+        run: |
+          echo "DJANGO_SETTINGS_MODULE=config.settings" >> "$GITHUB_ENV"
+          echo "ENVIRONMENT=testing" >> "$GITHUB_ENV"
+          echo "DEBUG=0" >> "$GITHUB_ENV"
+          echo "SECRET_KEY=test-secret-key-for-ci-only" >> "$GITHUB_ENV"
+          echo "DB_HOST=localhost" >> "$GITHUB_ENV"
+          echo "DB_PORT=5432" >> "$GITHUB_ENV"
+          echo "DB_NAME=test_aprender" >> "$GITHUB_ENV"
+          echo "DB_USER=postgres" >> "$GITHUB_ENV"
+          echo "DB_PASSWORD=postgres" >> "$GITHUB_ENV"
+          echo "REDIS_HOST=localhost" >> "$GITHUB_ENV"
+          echo "REDIS_PORT=6379" >> "$GITHUB_ENV"
+          echo "TZ=America/Fortaleza" >> "$GITHUB_ENV"
+          echo "REQUIRE_DOCKER=0" >> "$GITHUB_ENV"
+          echo "GCAL_CLIENT=fake" >> "$GITHUB_ENV"
+          echo "GCAL_SEND_UPDATES=none" >> "$GITHUB_ENV"
+          echo "FEATURE_AUTO_APPLY_ENABLED=false" >> "$GITHUB_ENV"
+          echo "ETL_OUTPUT_DIR=${{ github.workspace }}/v2/backend/out_etl" >> "$GITHUB_ENV"
+          echo "ETL_DATA_DIR=${{ github.workspace }}/v2/backend/data/csv-import" >> "$GITHUB_ENV"
+          echo "PYTHONDONTWRITEBYTECODE=1" >> "$GITHUB_ENV"
+
+      - name: Run migrations
+        run: |
+          cd v2/backend
+          python manage.py migrate --noinput
+
+      - name: Prepare runtime dirs and symlinks
+        run: |
+          sudo mkdir -p /app
+          mkdir -p "$GITHUB_WORKSPACE/v2/backend/.agents/outbox"
+          sudo rm -rf /app/.agents || true
+          sudo ln -s "$GITHUB_WORKSPACE/v2/backend/.agents" /app/.agents
+          mkdir -p "$GITHUB_WORKSPACE/v2/backend/out_etl"
+          mkdir -p "$GITHUB_WORKSPACE/v2/backend/data/csv-import"
+
+      - name: Run xdist canary suite (non-blocking)
+        env:
+          WORKERS: ${{ matrix.workers }}
+          DIST_MODE: ${{ matrix.dist }}
+          EXTRA_PYTEST_ARGS: ${{ github.event.inputs.extra_pytest_args || '' }}
+        run: |
+          cd v2/backend
+          echo "🧪 Running xdist canary (workers=${WORKERS}, dist=${DIST_MODE})"
+          START_TS=$(date +%s)
+
+          set +e
+          pytest -q --tb=short -n "${WORKERS}" --dist "${DIST_MODE}" --max-worker-restart=0 \
+            --junitxml=xdist-canary-junit.xml ${EXTRA_PYTEST_ARGS} apps > xdist-canary-pytest.log 2>&1
+          TEST_EXIT=$?
+          set -e
+
+          END_TS=$(date +%s)
+          DURATION_SEC=$((END_TS - START_TS))
+
+          TEST_EXIT="${TEST_EXIT}" DURATION_SEC="${DURATION_SEC}" python - <<'PY'
+          import json
+          import os
+
+          payload = {
+              "workers": os.environ["WORKERS"],
+              "dist": os.environ["DIST_MODE"],
+              "exit_code": int(os.environ["TEST_EXIT"]),
+              "duration_seconds": int(os.environ["DURATION_SEC"]),
+              "repository": os.environ.get("GITHUB_REPOSITORY", ""),
+              "run_id": os.environ.get("GITHUB_RUN_ID", ""),
+              "run_attempt": os.environ.get("GITHUB_RUN_ATTEMPT", ""),
+          }
+          with open("xdist-canary-metadata.json", "w", encoding="utf-8") as file:
+              json.dump(payload, file, indent=2, sort_keys=True)
+              file.write("\n")
+          PY
+
+          tail -n 120 xdist-canary-pytest.log || true
+
+          {
+            echo "### xdist canary run"
+            echo "- workers: ${WORKERS}"
+            echo "- dist: ${DIST_MODE}"
+            echo "- duration (seconds): ${DURATION_SEC}"
+            echo "- exit code: ${TEST_EXIT}"
+            echo "- mode: non-blocking canary"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload xdist canary artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: xdist-canary-${{ matrix.workers }}w-${{ matrix.dist }}
+          path: |
+            v2/backend/xdist-canary-pytest.log
+            v2/backend/xdist-canary-junit.xml
+            v2/backend/xdist-canary-metadata.json
+          if-no-files-found: warn
+          retention-days: 30
+
+  canary-report:
+    name: "[ops] backend xdist canary summary"
+    runs-on: ubuntu-latest
+    needs:
+      - xdist-canary
+    if: always()
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Download xdist canary artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: xdist-canary-*
+          path: xdist-canary-artifacts
+
+      - name: Build consolidated canary report
+        run: |
+          python v2/scripts/xdist_canary_report.py \
+            --artifacts-dir xdist-canary-artifacts \
+            --output-json xdist-canary-report.json \
+            --output-md xdist-canary-report.md
+
+      - name: Upload consolidated report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: xdist-canary-report
+          path: |
+            xdist-canary-report.json
+            xdist-canary-report.md
+          retention-days: 30
+
+      - name: Publish summary
+        if: always()
+        run: |
+          if [ -f xdist-canary-report.md ]; then
+            cat xdist-canary-report.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "xdist-canary-report.md not found." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/docs/operations/ci-backend-xdist-canary.md
+++ b/docs/operations/ci-backend-xdist-canary.md
@@ -1,0 +1,60 @@
+# CI Backend xdist Canary (non-blocking)
+
+Este fluxo cria uma trilha de experimento para `pytest-xdist` sem alterar os gates obrigatorios de PR.
+
+## Workflow
+
+Arquivo: `.github/workflows/backend-xdist-canary.yml`
+
+Gatilhos:
+- `schedule` diario
+- `workflow_dispatch` (manual)
+- `push` em `main` para mudancas no proprio workflow/script/doc da trilha
+
+Importante:
+- Nao roda em `pull_request`.
+- Nao publica checks `[required]`.
+- Nao bloqueia merge em `main`.
+
+## Matriz de experimento
+
+Cada execucao roda a combinacao:
+- workers: `2`, `auto`
+- dist: `loadscope`, `loadfile`
+
+## Evidencias publicadas
+
+Artifacts por combinacao:
+- `xdist-canary-<workers>w-<dist>`
+- Conteudo: log pytest, junit xml, metadata da execucao
+
+Artifact consolidado:
+- `xdist-canary-report`
+- Conteudo: `xdist-canary-report.json` e `xdist-canary-report.md`
+
+O relatorio consolidado inclui:
+- testes que falharam
+- assinaturas de erro
+- frequencia de reincidencia por teste/assinatura
+
+## Backlog de estabilizacao
+
+Regra de triagem:
+- teste/assinatura com reincidencia em `2+` execucoes precisa ter issue de estabilizacao vinculada ao epic da fase (`#677`).
+
+## Criterio formal para promocao ao caminho obrigatorio
+
+Promover `xdist` para gate obrigatorio so quando TODOS os criterios abaixo forem atendidos:
+
+1. Evidencia minima de 14 dias corridos de canary (schedule diario) com dados validos.
+2. Taxa de sucesso >= 95% considerando todas as combinacoes da matriz no periodo.
+3. Nenhuma assinatura de erro recorrente (`>= 2` ocorrencias) sem issue de mitigacao aberta e com status atualizado.
+4. Nenhum teste recorrente nao paralelizavel (`>= 2` ocorrencias) sem owner definido no backlog.
+5. Dois dry-runs consecutivos em branch de experimento, reproduzindo o modo candidato do gate obrigatorio, sem falhas.
+6. Decisao registrada em issue/PR especifico antes de alterar `.github/workflows/ci.yaml`.
+
+## Rollback
+
+Se a trilha canary gerar ruido operacional, desabilitar o workflow `backend-xdist-canary.yml`.
+
+Rollback da trilha canary nao afeta os checks obrigatorios atuais.

--- a/docs/operations/ci-check-policy.md
+++ b/docs/operations/ci-check-policy.md
@@ -28,12 +28,20 @@ Estes checks não bloqueiam merge:
 
 - `[info] lighthouse CI`
 - `[info] openssf scorecard`
+- `[info] backend xdist canary (w=...,dist=...)`
 
 ## Checks operacionais
 
 Executados por `schedule` ou `workflow_dispatch`:
 
 - `[ops] strict security headers (staging/prod)`
+- `[ops] backend xdist canary summary`
+
+## Trilha Canary Backend xdist
+
+- Documento operacional: [CI Backend xdist Canary](ci-backend-xdist-canary.md)
+- Finalidade: experimentação de paralelismo (`pytest-xdist`) sem alterar o gate obrigatório.
+- Regra: findings recorrentes da trilha canary viram issues de estabilização antes de qualquer promoção para o caminho obrigatório.
 
 ## Regras de governança
 

--- a/v2/scripts/xdist_canary_report.py
+++ b/v2/scripts/xdist_canary_report.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+"""Aggregate backend xdist canary artifacts into a recurrence report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Set
+from xml.etree import ElementTree
+
+FAILED_LINE_RE = re.compile(r"^FAILED\s+(?P<test>\S+)")
+SIGNATURE_PATTERNS = [
+    re.compile(r"SessionInterrupted:[^\n]*"),
+    re.compile(r"INTERNALERROR[^\n]*"),
+    re.compile(r"Worker .* crashed[^\n]*"),
+    re.compile(r"psycopg2\.errors\.[A-Za-z_]+"),
+    re.compile(r"IntegrityError:[^\n]*"),
+    re.compile(r"UniqueViolation[^\n]*"),
+]
+
+
+@dataclass(frozen=True)
+class FailureEvent:
+    test_id: str
+    signature: str
+    source: str
+
+
+@dataclass(frozen=True)
+class CanaryRun:
+    artifact_name: str
+    workers: str
+    dist: str
+    exit_code: int
+    duration_seconds: int
+    failure_events: List[FailureEvent]
+    runtime_signatures: List[str]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--artifacts-dir",
+        default="xdist-canary-artifacts",
+        help="Directory with downloaded matrix artifacts",
+    )
+    parser.add_argument("--output-json", required=True, help="Path to output JSON report")
+    parser.add_argument("--output-md", required=True, help="Path to output Markdown report")
+    return parser.parse_args()
+
+
+def normalize_signature(text: str) -> str:
+    line = text.strip().splitlines()[0] if text.strip() else ""
+    if not line:
+        return "unknown-signature"
+    line = re.sub(r"\s+", " ", line)
+    line = re.sub(r"0x[0-9a-fA-F]+", "0x*", line)
+    line = re.sub(r"\b\d+\b", "#", line)
+    return line[:180]
+
+
+def safe_read_text(path: Path) -> str:
+    if not path.exists():
+        return ""
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+def parse_junit(path: Path) -> List[FailureEvent]:
+    if not path.exists():
+        return []
+
+    events: List[FailureEvent] = []
+    root = ElementTree.parse(path).getroot()
+
+    for testcase in root.iter("testcase"):
+        classname = testcase.attrib.get("classname", "").strip()
+        name = testcase.attrib.get("name", "").strip()
+        if classname and name:
+            test_id = f"{classname}::{name}"
+        else:
+            test_id = name or classname or "unknown-test"
+
+        for child in list(testcase):
+            tag = child.tag.lower()
+            if tag not in {"failure", "error"}:
+                continue
+            raw_message = child.attrib.get("message", "").strip()
+            body = (child.text or "").strip()
+            signature = normalize_signature(raw_message or body)
+            events.append(FailureEvent(test_id=test_id, signature=signature, source="junit"))
+
+    return events
+
+
+def parse_log(path: Path) -> tuple[Set[str], Set[str]]:
+    content = safe_read_text(path)
+    failed_tests: Set[str] = set()
+    signatures: Set[str] = set()
+
+    for raw_line in content.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+
+        failed_match = FAILED_LINE_RE.match(line)
+        if failed_match:
+            failed_tests.add(failed_match.group("test"))
+
+        for pattern in SIGNATURE_PATTERNS:
+            matched = pattern.search(line)
+            if matched:
+                signatures.add(normalize_signature(matched.group(0)))
+
+    return failed_tests, signatures
+
+
+def load_metadata(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return {}
+
+
+def collect_runs(artifacts_dir: Path) -> List[CanaryRun]:
+    if not artifacts_dir.exists():
+        return []
+
+    runs: List[CanaryRun] = []
+
+    for artifact_path in sorted([item for item in artifacts_dir.iterdir() if item.is_dir()]):
+        metadata = load_metadata(artifact_path / "xdist-canary-metadata.json")
+        workers = str(metadata.get("workers", "unknown"))
+        dist = str(metadata.get("dist", "unknown"))
+        exit_code = int(metadata.get("exit_code", 0))
+        duration_seconds = int(metadata.get("duration_seconds", 0))
+
+        junit_events = parse_junit(artifact_path / "xdist-canary-junit.xml")
+        log_failed_tests, log_signatures = parse_log(artifact_path / "xdist-canary-pytest.log")
+
+        merged_events: Dict[str, FailureEvent] = {event.test_id: event for event in junit_events}
+        for test_id in sorted(log_failed_tests):
+            merged_events.setdefault(
+                test_id,
+                FailureEvent(
+                    test_id=test_id,
+                    signature="failed-from-log-without-junit-entry",
+                    source="log",
+                ),
+            )
+
+        runtime_signatures: Set[str] = set(log_signatures)
+        for event in merged_events.values():
+            runtime_signatures.add(event.signature)
+
+        if exit_code != 0 and not runtime_signatures:
+            runtime_signatures.add("non-zero-exit-without-signature")
+
+        runs.append(
+            CanaryRun(
+                artifact_name=artifact_path.name,
+                workers=workers,
+                dist=dist,
+                exit_code=exit_code,
+                duration_seconds=duration_seconds,
+                failure_events=sorted(merged_events.values(), key=lambda item: item.test_id),
+                runtime_signatures=sorted(runtime_signatures),
+            )
+        )
+
+    return runs
+
+
+def build_payload(runs: List[CanaryRun]) -> dict:
+    test_counter: Counter[str] = Counter()
+    signature_counter: Counter[str] = Counter()
+    tests_to_artifacts: Dict[str, List[str]] = defaultdict(list)
+    signatures_to_artifacts: Dict[str, List[str]] = defaultdict(list)
+
+    matrix_rows: List[dict] = []
+    failed_runs = 0
+
+    for run in runs:
+        run_tests = sorted({event.test_id for event in run.failure_events})
+        run_signatures = sorted(set(run.runtime_signatures))
+        has_failure = run.exit_code != 0 or bool(run_tests)
+
+        if has_failure:
+            failed_runs += 1
+
+        for test_id in run_tests:
+            test_counter[test_id] += 1
+            tests_to_artifacts[test_id].append(run.artifact_name)
+
+        for signature in run_signatures:
+            signature_counter[signature] += 1
+            signatures_to_artifacts[signature].append(run.artifact_name)
+
+        matrix_rows.append(
+            {
+                "artifact_name": run.artifact_name,
+                "workers": run.workers,
+                "dist": run.dist,
+                "exit_code": run.exit_code,
+                "duration_seconds": run.duration_seconds,
+                "status": "failed" if has_failure else "passed",
+                "failed_tests_count": len(run_tests),
+                "failure_signatures_count": len(run_signatures),
+                "failed_tests": run_tests,
+                "failure_signatures": run_signatures,
+            }
+        )
+
+    recurrent_tests = [
+        {
+            "test_id": test_id,
+            "count": count,
+            "artifacts": sorted(tests_to_artifacts[test_id]),
+        }
+        for test_id, count in test_counter.most_common()
+    ]
+
+    recurrent_signatures = [
+        {
+            "signature": signature,
+            "count": count,
+            "artifacts": sorted(signatures_to_artifacts[signature]),
+        }
+        for signature, count in signature_counter.most_common()
+    ]
+
+    return {
+        "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+        "runs_total": len(runs),
+        "runs_with_failures": failed_runs,
+        "runs_without_failures": max(0, len(runs) - failed_runs),
+        "matrix_results": matrix_rows,
+        "recurrent_failed_tests": recurrent_tests,
+        "recurrent_failure_signatures": recurrent_signatures,
+    }
+
+
+def write_json(path: Path, payload: dict) -> None:
+    if path.parent:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_markdown(path: Path, payload: dict) -> None:
+    if path.parent:
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+    lines: List[str] = []
+    lines.append("# Backend xdist Canary Report")
+    lines.append("")
+    lines.append("Non-blocking canary: this workflow is informational and never a required PR gate.")
+    lines.append("")
+    lines.append(f"- Generated at (UTC): `{payload['generated_at_utc']}`")
+    lines.append(f"- Matrix runs: `{payload['runs_total']}`")
+    lines.append(f"- Runs with failures: `{payload['runs_with_failures']}`")
+    lines.append(f"- Runs without failures: `{payload['runs_without_failures']}`")
+    lines.append("")
+
+    lines.append("## Matrix results")
+    lines.append("")
+    lines.append("| Artifact | Workers | Dist | Exit | Status | Failed tests | Signatures | Duration (s) |")
+    lines.append("|---|---:|---|---:|---|---:|---:|---:|")
+
+    for row in payload["matrix_results"]:
+        lines.append(
+            f"| {row['artifact_name']} | {row['workers']} | {row['dist']} | {row['exit_code']} | "
+            f"{row['status']} | {row['failed_tests_count']} | {row['failure_signatures_count']} | "
+            f"{row['duration_seconds']} |"
+        )
+
+    recurrent_tests = payload["recurrent_failed_tests"]
+    lines.append("")
+    lines.append("## Recurrent failed tests")
+    lines.append("")
+    if recurrent_tests:
+        for item in recurrent_tests[:20]:
+            lines.append(
+                f"- `{item['test_id']}`: {item['count']} run(s) "
+                f"({', '.join(item['artifacts'])})"
+            )
+    else:
+        lines.append("- No failed tests detected.")
+
+    recurrent_signatures = payload["recurrent_failure_signatures"]
+    lines.append("")
+    lines.append("## Failure signatures")
+    lines.append("")
+    if recurrent_signatures:
+        for item in recurrent_signatures[:20]:
+            lines.append(
+                f"- `{item['signature']}`: {item['count']} run(s) "
+                f"({', '.join(item['artifacts'])})"
+            )
+    else:
+        lines.append("- No failure signatures detected.")
+
+    lines.append("")
+    lines.append("## Triage rule")
+    lines.append("")
+    lines.append("- Any test/signature recurring in 2+ runs should have a linked stabilization issue.")
+
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    args = parse_args()
+    artifacts_dir = Path(args.artifacts_dir)
+    output_json = Path(args.output_json)
+    output_md = Path(args.output_md)
+
+    runs = collect_runs(artifacts_dir)
+    payload = build_payload(runs)
+
+    write_json(output_json, payload)
+    write_markdown(output_md, payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Objetivo
Implementar a Fase 3 da otimização de runtime backend com trilha **non-blocking canary** para xdist, sem alterar gates obrigatórios de PR.

Refs #677

## O que foi implementado
- Novo workflow canary: `.github/workflows/backend-xdist-canary.yml`
  - Trigger: `schedule` + `workflow_dispatch` + `push` em `main` para arquivos da própria trilha.
  - Matriz controlada de xdist:
    - workers: `2`, `auto`
    - dist: `loadscope`, `loadfile`
  - Execução explicitamente informativa (`[info]`) e trilha operacional (`[ops]`), fora de checks required de PR.
- Novo agregador de evidências: `v2/scripts/xdist_canary_report.py`
  - Consolida artifacts da matriz.
  - Publica:
    - testes que falharam
    - assinaturas de erro
    - frequência de reincidência por teste/assinatura
- Documentação operacional da trilha:
  - `docs/operations/ci-backend-xdist-canary.md`
  - Critério formal de promoção de xdist para caminho obrigatório.
- Política de checks atualizada:
  - `docs/operations/ci-check-policy.md`
  - Classificação explícita de checks `[info]`/`[ops]` da trilha canary.

## Backlog de estabilização aberto (sub-issues)
- #681 CI xdist stabilization: isolar `test_config_validation` para execução paralela segura
- #682 CI xdist stabilization: eliminar conflitos de unique constraint em execução paralela

## Validação local
- `yaml.safe_load` no workflow novo (`yaml-ok`).
- `python -m py_compile v2/scripts/xdist_canary_report.py` (`pycompile-ok`).
- Execução do script de relatório com diretório vazio (sem artifacts) concluída com sucesso.

## Risco e segurança
- Nenhuma alteração em `.github/workflows/ci.yaml` (gates obrigatórios permanecem intactos).
- A trilha canary não roda em `pull_request` e não bloqueia merges.
