### PR TITLE
test(ci): reduzir conflitos de unique em suíte xdist

### DIFF
--- a/v2/backend/apps/core/tests/test_dat_module.py
+++ b/v2/backend/apps/core/tests/test_dat_module.py
@@ -21,7 +21,7 @@ from decimal import Decimal
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
-from django.db import IntegrityError
+from django.core.exceptions import ValidationError
 from django.test import TestCase
 from django.urls import reverse
 from rest_framework import status
@@ -62,8 +62,9 @@ class DATAreaModelTests(TestCase):
     def test_unique_nome(self):
         """DATArea nome should be unique."""
         DATArea.objects.create(nome="DAT")
-        with self.assertRaises(IntegrityError):
-            DATArea.objects.create(nome="DAT")
+        duplicate = DATArea(nome="DAT")
+        with self.assertRaises(ValidationError):
+            duplicate.full_clean()
 
 
 class DATCoordenadorModelTests(TestCase):
@@ -172,8 +173,9 @@ class DATAcaoModelTests(TestCase):
     def test_unique_municipio_projeto(self):
         """DATAcao should be unique per municipio+projeto."""
         DATAcao.objects.create(municipio=self.municipio, projeto=self.projeto, created_by=self.user)
-        with self.assertRaises(IntegrityError):
-            DATAcao.objects.create(municipio=self.municipio, projeto=self.projeto, created_by=self.user)
+        duplicate = DATAcao(municipio=self.municipio, projeto=self.projeto, created_by=self.user)
+        with self.assertRaises(ValidationError):
+            duplicate.full_clean()
 
 
 class DATCompraModelTests(TestCase):
@@ -322,10 +324,11 @@ class DATCadastroModelTests(TestCase):
         DATCadastro.objects.create(
             municipio=self.municipio, projeto_geral=self.projeto_geral, plataforma="FORMAR", created_by=self.user
         )
-        with self.assertRaises(IntegrityError):
-            DATCadastro.objects.create(
-                municipio=self.municipio, projeto_geral=self.projeto_geral, plataforma="FORMAR", created_by=self.user
-            )
+        duplicate = DATCadastro(
+            municipio=self.municipio, projeto_geral=self.projeto_geral, plataforma="FORMAR", created_by=self.user
+        )
+        with self.assertRaises(ValidationError):
+            duplicate.full_clean()
 
 
 class DATFormacaoModelTests(TestCase):

--- a/v2/backend/apps/core/tests/test_dat_registros.py
+++ b/v2/backend/apps/core/tests/test_dat_registros.py
@@ -13,6 +13,7 @@ from decimal import Decimal
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
+from django.core.exceptions import ValidationError
 from django.test import TestCase
 from django.urls import reverse
 from rest_framework import status
@@ -232,18 +233,16 @@ class DATRegistroModelTests(TestCase):
             professor_qtde=10,
             created_by=self.user,
         )
-        # Try to create duplicate
-        from django.db import IntegrityError
-
-        with self.assertRaises(IntegrityError):
-            DATRegistro.objects.create(
-                municipio=self.municipio,
-                projeto_geral=self.projeto_geral_professor,
-                projeto=self.projeto,
-                aluno_qtde=200,
-                professor_qtde=20,
-                created_by=self.user,
-            )
+        duplicate = DATRegistro(
+            municipio=self.municipio,
+            projeto_geral=self.projeto_geral_professor,
+            projeto=self.projeto,
+            aluno_qtde=200,
+            professor_qtde=20,
+            created_by=self.user,
+        )
+        with self.assertRaises(ValidationError):
+            duplicate.full_clean()
 
 
 class DATRegistroAPITests(APITestCase):

--- a/v2/backend/apps/core/tests/test_participation_uniqueness.py
+++ b/v2/backend/apps/core/tests/test_participation_uniqueness.py
@@ -11,7 +11,7 @@ Valida:
 from __future__ import annotations
 
 from django.contrib.auth import get_user_model
-from django.db import IntegrityError
+from django.core.exceptions import ValidationError
 from django.utils import timezone
 
 import pytest
@@ -78,13 +78,13 @@ def test_participation_unique_constraint(factory_solicitacao):
         role=Participation.Role.COORDENADOR,
     )
 
-    # Tentar criar duplicata deve falhar
-    with pytest.raises(IntegrityError):
-        Participation.objects.create(
-            solicitacao=solicitacao,
-            usuario=user,
-            role=Participation.Role.COORDENADOR,
-        )
+    duplicate = Participation(
+        solicitacao=solicitacao,
+        usuario=user,
+        role=Participation.Role.COORDENADOR,
+    )
+    with pytest.raises(ValidationError):
+        duplicate.full_clean()
 
 
 def test_participation_allows_different_roles_same_user(factory_solicitacao):

--- a/v2/backend/apps/core/tests/test_plano_formacoes.py
+++ b/v2/backend/apps/core/tests/test_plano_formacoes.py
@@ -17,6 +17,7 @@ from datetime import date
 from decimal import Decimal
 
 from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
 
 import pytest
 
@@ -92,12 +93,13 @@ class TestPlanoFormacoesModel:
 
     def test_unique_constraint(self, plano, municipio, projeto, user):
         """Test unique constraint on municipio + projeto."""
-        with pytest.raises(Exception):
-            PlanoFormacoes.objects.create(
-                municipio=municipio,
-                projeto=projeto,
-                created_by=user,
-            )
+        duplicate = PlanoFormacoes(
+            municipio=municipio,
+            projeto=projeto,
+            created_by=user,
+        )
+        with pytest.raises(ValidationError):
+            duplicate.full_clean()
 
     def test_recalcular_ch(self, plano):
         """Test recalcular_ch method."""
@@ -164,8 +166,9 @@ class TestFormacaoModel:
     def test_unique_constraint(self, plano):
         """Test unique constraint on plano + numero_formacao."""
         Formacao.objects.create(plano=plano, numero_formacao=1)
-        with pytest.raises(Exception):
-            Formacao.objects.create(plano=plano, numero_formacao=1)
+        duplicate = Formacao(plano=plano, numero_formacao=1)
+        with pytest.raises(ValidationError):
+            duplicate.full_clean()
 
     def test_numero_range_constraint(self, plano):
         """Test numero_formacao range constraint (1-15)."""
@@ -219,8 +222,9 @@ class TestAcompanhamentoModel:
     def test_unique_constraint(self, plano):
         """Test unique constraint on plano + tipo."""
         Acompanhamento.objects.create(plano=plano, tipo="primeiro")
-        with pytest.raises(Exception):
-            Acompanhamento.objects.create(plano=plano, tipo="primeiro")
+        duplicate = Acompanhamento(plano=plano, tipo="primeiro")
+        with pytest.raises(ValidationError):
+            duplicate.full_clean()
 
     def test_tipo_choices(self, plano):
         """Test tipo must be valid choice."""
@@ -297,8 +301,9 @@ class TestProvaModel:
     def test_unique_constraint(self, plano):
         """Test unique constraint on plano + numero_prova."""
         Prova.objects.create(plano=plano, numero_prova=1)
-        with pytest.raises(Exception):
-            Prova.objects.create(plano=plano, numero_prova=1)
+        duplicate = Prova(plano=plano, numero_prova=1)
+        with pytest.raises(ValidationError):
+            duplicate.full_clean()
 
     def test_numero_prova_validators(self, plano):
         """Test numero_prova validators (1-3 range)."""


### PR DESCRIPTION
## Objetivo
Reduzir conflitos de unicidade observados no contexto xdist, removendo inserções duplicadas intencionais no banco em testes de constraint.

Closes #682
Refs #677

## O que foi ajustado
Arquivos alterados:
- `v2/backend/apps/core/tests/test_dat_module.py`
- `v2/backend/apps/core/tests/test_dat_registros.py`
- `v2/backend/apps/core/tests/test_participation_uniqueness.py`
- `v2/backend/apps/core/tests/test_plano_formacoes.py`

Mudança técnica:
- Nos testes de unicidade, troquei o padrão “criar duplicata e esperar `IntegrityError` no DB” por validação explícita com `full_clean()` e `ValidationError`.
- Isso mantém a cobertura de regra de unicidade, mas evita escrita duplicada no banco durante execução paralela.

## Por que isso melhora xdist
No experimento original, apareceram múltiplas linhas de `duplicate key value violates unique constraint` nos logs do Postgres durante execução paralela. Parte desse ruído vinha de testes que forçavam duplicatas de propósito.

Com este ajuste:
- os cenários continuam testando unicidade;
- a verificação ocorre antes do `INSERT` duplicado;
- reduzimos ruído e contenção de escrita concorrente em xdist.

## Validação em Docker
Executado com `v2/infra/docker-compose.yml`:

1. Alvo específico (9 testes de unicidade alterados):
- serial: `9 passed`
- xdist `-n 2 --dist loadscope`: `9 passed`

2. Arquivos completos alterados (111 testes):
- serial:
  - `pytest -q apps/core/tests/test_dat_module.py apps/core/tests/test_dat_registros.py apps/core/tests/test_plano_formacoes.py apps/core/tests/test_participation_uniqueness.py`
  - resultado: `111 passed`
- xdist:
  - `pytest -q -n 2 --dist loadscope ...`
  - resultado: `111 passed`

3. Inspeção de logs do Postgres (janela 5 min após execução):
- sem ocorrências de `duplicate key`/`unique constraint` para esses testes alterados.
- apenas `check constraint` intencional do teste `prova_numero_range` (já existente, fora do escopo desta issue).
