### PR TITLE
ci(xdist): rastrear evidências do canary e backlog de estabilização

### DIFF
--- a/.github/workflows/backend-xdist-canary.yml
+++ b/.github/workflows/backend-xdist-canary.yml
@@ -15,10 +15,12 @@ on:
       - ".github/workflows/backend-xdist-canary.yml"
       - "v2/scripts/xdist_canary_report.py"
       - "docs/operations/ci-backend-xdist-canary.md"
+      - "docs/operations/ci-backend-xdist-stabilization-backlog.md"
       - "docs/operations/ci-check-policy.md"
 
 permissions:
   contents: read
+  issues: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -219,3 +221,59 @@ jobs:
           else
             echo "xdist-canary-report.md not found." >> "$GITHUB_STEP_SUMMARY"
           fi
+
+      - name: Publish evidence snapshot to issue #677
+        if: always()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ ! -f xdist-canary-report.json ]; then
+            echo "xdist-canary-report.json not found; skipping issue comment."
+            exit 0
+          fi
+
+          python - <<'PY' > /tmp/xdist_issue_677_comment.md
+          import json
+          import os
+          from datetime import datetime, timezone
+
+          run_id = os.environ.get("GITHUB_RUN_ID", "")
+          repo = os.environ.get("GITHUB_REPOSITORY", "")
+          run_url = f"https://github.com/{repo}/actions/runs/{run_id}" if repo and run_id else ""
+          now_utc = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+
+          with open("xdist-canary-report.json", "r", encoding="utf-8") as f:
+              report = json.load(f)
+
+          def _top(items, key, limit=5):
+              result = []
+              for item in items[:limit]:
+                  label = item.get(key, "unknown")
+                  count = item.get("count", 0)
+                  result.append(f"- `{label}`: {count} run(s)")
+              if not result:
+                  result.append("- none")
+              return result
+
+          lines = []
+          lines.append("### xdist canary evidence snapshot")
+          lines.append("")
+          lines.append(f"- Timestamp: `{now_utc}`")
+          if run_url:
+              lines.append(f"- Workflow run: {run_url}")
+          lines.append(f"- Matrix runs: `{report.get('runs_total', 0)}`")
+          lines.append(f"- Runs with failures: `{report.get('runs_with_failures', 0)}`")
+          lines.append(f"- Runs without failures: `{report.get('runs_without_failures', 0)}`")
+          lines.append("- Backlog tracking: `docs/operations/ci-backend-xdist-stabilization-backlog.md`")
+          lines.append("")
+          lines.append("Top recurrent failed tests:")
+          lines.extend(_top(report.get("recurrent_failed_tests", []), "test_id"))
+          lines.append("")
+          lines.append("Top failure signatures:")
+          lines.extend(_top(report.get("recurrent_failure_signatures", []), "signature"))
+
+          print("\n".join(lines))
+          PY
+
+          gh issue comment 677 --repo "${GITHUB_REPOSITORY}" --body-file /tmp/xdist_issue_677_comment.md

--- a/docs/operations/ci-backend-xdist-canary.md
+++ b/docs/operations/ci-backend-xdist-canary.md
@@ -41,6 +41,15 @@ O relatorio consolidado inclui:
 
 Regra de triagem:
 - teste/assinatura com reincidencia em `2+` execucoes precisa ter issue de estabilizacao vinculada ao epic da fase (`#677`).
+- backlog com owner/status: [CI Backend xdist Stabilization Backlog](ci-backend-xdist-stabilization-backlog.md)
+
+## Trilha de evidencia (14 dias)
+
+- O job `[ops] backend xdist canary summary` publica:
+  - artifact consolidado (`xdist-canary-report`)
+  - resumo no `GITHUB_STEP_SUMMARY`
+  - snapshot em comentario na issue `#677`
+- Esses snapshots formam a trilha objetiva para o criterio de 14 dias antes de qualquer promocao para gate obrigatorio.
 
 ## Criterio formal para promocao ao caminho obrigatorio
 

--- a/docs/operations/ci-backend-xdist-stabilization-backlog.md
+++ b/docs/operations/ci-backend-xdist-stabilization-backlog.md
@@ -1,0 +1,26 @@
+# CI Backend xdist Stabilization Backlog
+
+Lista rastreavel de testes/assinaturas nao paralelizaveis identificados na trilha canary.
+
+Ultima atualizacao: 2026-02-25
+
+## Politica de backlog
+
+- Qualquer teste ou assinatura recorrente (`>=2` ocorrencias no canary) precisa de issue vinculada ao epic `#677`.
+- Cada item precisa ter owner e status explicitos.
+- Item so pode ser marcado como `resolved` com evidencia de execucao (runner ou canary) apos a correcao.
+
+## Itens de estabilizacao
+
+| Issue | Escopo | Owner | Status | Evidencia | Observacoes |
+|---|---|---|---|---|---|
+| #681 | `test_config_validation` com `SessionInterrupted` em xdist | @matheusnorjosa | resolved | PR #685 (mergeado) | Troca para `APIClient` + `force_authenticate` no modulo de config API |
+| #682 | Ruido de `duplicate key / unique constraint` intencional em testes de unicidade | @matheusnorjosa | resolved | PR #686 (mergeado) | Testes migrados para validacao por `full_clean()`/`ValidationError` |
+
+## Proximo gatilho de acao
+
+- Se o canary apontar nova recorrencia (`>=2`), abrir issue filha de `#677` com:
+  - teste/assinatura
+  - owner
+  - plano de mitigacao
+  - criterio de aceite

--- a/docs/operations/ci-check-policy.md
+++ b/docs/operations/ci-check-policy.md
@@ -40,6 +40,7 @@ Executados por `schedule` ou `workflow_dispatch`:
 ## Trilha Canary Backend xdist
 
 - Documento operacional: [CI Backend xdist Canary](ci-backend-xdist-canary.md)
+- Backlog de estabilizacao: [CI Backend xdist Stabilization Backlog](ci-backend-xdist-stabilization-backlog.md)
 - Finalidade: experimentação de paralelismo (`pytest-xdist`) sem alterar o gate obrigatório.
 - Regra: findings recorrentes da trilha canary viram issues de estabilização antes de qualquer promoção para o caminho obrigatório.
 


### PR DESCRIPTION
## Objetivo
Fortalecer a trilha de evidências da canary xdist da issue #677 sem tornar o job bloqueante.

## O que foi feito
- publica snapshot automático da canary em comentário da issue #677
- adiciona backlog operacional de estabilização xdist em `docs/operations/ci-backend-xdist-stabilization-backlog.md`
- atualiza docs de canary/política com links e processo de evidência

## Validação
- parse YAML do workflow validado localmente
- geração de markdown do snapshot validada com artefato JSON real

Refs #677