### PR TITLE
ci(monitoring): harden telemetry against transient GitHub API failures

### DIFF
--- a/v2/scripts/ci_runtime_telemetry.py
+++ b/v2/scripts/ci_runtime_telemetry.py
@@ -7,16 +7,22 @@ import argparse
 import json
 import math
 import os
+import random
 import statistics
 import sys
+import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Dict, Iterable, List, Tuple
+from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
 
 API_BASE = "https://api.github.com"
+RETRYABLE_HTTP_CODES = {429, 500, 502, 503, 504}
+DEFAULT_MAX_RETRIES = 5
+MAX_BACKOFF_SECONDS = 30.0
 
 
 @dataclass(frozen=True)
@@ -62,14 +68,69 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
+def _parse_retry_after(value: str | None) -> float | None:
+    if not value:
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _compute_retry_delay(attempt: int, retry_after_header: str | None = None) -> float:
+    retry_after = _parse_retry_after(retry_after_header)
+    if retry_after is not None:
+        return min(retry_after, MAX_BACKOFF_SECONDS)
+    base = min(float(2**attempt), MAX_BACKOFF_SECONDS)
+    # Small jitter to avoid synchronized retries across runners.
+    return base + random.uniform(0.0, 0.5)
+
+
 def github_get(path: str, token: str, params: Dict[str, str] | None = None) -> dict:
     query = f"?{urlencode(params)}" if params else ""
     req = Request(f"{API_BASE}{path}{query}")
     req.add_header("Accept", "application/vnd.github+json")
     req.add_header("Authorization", f"Bearer {token}")
     req.add_header("X-GitHub-Api-Version", "2022-11-28")
-    with urlopen(req, timeout=30) as resp:
-        return json.loads(resp.read().decode("utf-8"))
+    max_retries_raw = os.getenv("GITHUB_API_MAX_RETRIES", str(DEFAULT_MAX_RETRIES))
+    try:
+        max_retries = max(1, int(max_retries_raw))
+    except ValueError:
+        max_retries = DEFAULT_MAX_RETRIES
+
+    for attempt in range(max_retries):
+        try:
+            with urlopen(req, timeout=30) as resp:
+                return json.loads(resp.read().decode("utf-8"))
+        except HTTPError as exc:
+            should_retry = exc.code in RETRYABLE_HTTP_CODES and attempt < (max_retries - 1)
+            if not should_retry:
+                raise
+            delay = _compute_retry_delay(attempt, exc.headers.get("Retry-After"))
+            print(
+                (
+                    f"[warn] github_get retryable HTTP {exc.code} "
+                    f"for {path}{query} (attempt {attempt + 1}/{max_retries - 1}, "
+                    f"sleep={delay:.2f}s)"
+                ),
+                file=sys.stderr,
+            )
+            time.sleep(delay)
+        except URLError as exc:
+            if attempt >= (max_retries - 1):
+                raise
+            delay = _compute_retry_delay(attempt)
+            print(
+                (
+                    f"[warn] github_get network error for {path}{query}: {exc.reason} "
+                    f"(attempt {attempt + 1}/{max_retries - 1}, sleep={delay:.2f}s)"
+                ),
+                file=sys.stderr,
+            )
+            time.sleep(delay)
+
+    raise RuntimeError("github_get exhausted retries unexpectedly")
 
 
 def parse_ts(value: str) -> datetime:


### PR DESCRIPTION
## Summary

- adiciona retry com backoff limitado para chamadas da API GitHub no script de telemetria
- mantém a regra de regressão (p95) e formato de relatório inalterados

## Scope

- Incluido:
  - tratamento de erros transitórios (`429`, `500`, `502`, `503`, `504`) e falhas de rede em `v2/scripts/ci_runtime_telemetry.py`
  - delay com jitter e limite de tentativas via `GITHUB_API_MAX_RETRIES` (default `5`)
- Fora de escopo:
  - mudança de baseline/threshold
  - mudança de checks obrigatórios

## Test Plan

- [x] `python3 -m py_compile v2/scripts/ci_runtime_telemetry.py` (ok)
- [x] `GITHUB_TOKEN=$(gh auth token) python3 v2/scripts/ci_runtime_telemetry.py --repo "matheusnorjosa/aprender_sistema" --workflows "CI – Continuous Integration" --runs-per-workflow 1 --required-only --output-json /tmp/ci-runtime-report-smoke.json --output-md /tmp/ci-runtime-report-smoke.md` (ok; `Metrics keys: 6`, `Regressions: 0`)
- [x] rerun do run que falhou: `22436996575` (ok após rerun)

## Risks

- Risco 1: em indisponibilidade persistente da API, o job pode demorar mais para falhar.
- Mitigacao: tentativas limitadas e backoff com teto.

## Links

- Closes #688
- Run com falha original: https://github.com/matheusnorjosa/aprender_sistema/actions/runs/22436996575
