### PR TITLE
fix(security): add upload validation to import-compras endpoint

### DIFF
--- a/v2/backend/apps/core/tests/test_upload_validation.py
+++ b/v2/backend/apps/core/tests/test_upload_validation.py
@@ -128,6 +128,38 @@ def test_controle_upload_valid_xlsx(authenticated_controle_client):
 
 
 # ============================================================================
+# Testes para ImportComprasView (/api/controle/import-compras/)
+# ============================================================================
+
+
+def test_controle_import_compras_upload_file_too_large(authenticated_controle_client):
+    """Issue #569: Arquivo >10MB deve ser rejeitado com 413 no import-compras."""
+    large_file_size = 10 * 1024 * 1024 + 1
+    large_file = SimpleUploadedFile("compras.csv", b"x" * large_file_size, content_type="text/csv")
+
+    response = authenticated_controle_client.post(
+        "/api/controle/import-compras/?dry_run=true", {"file": large_file}, format="multipart"
+    )
+
+    assert response.status_code == status.HTTP_413_REQUEST_ENTITY_TOO_LARGE
+    assert "muito grande" in response.data["detail"].lower()
+
+
+def test_controle_import_compras_upload_invalid_mime_type(authenticated_controle_client):
+    """Issue #569: MIME inválido deve ser rejeitado com 400 no import-compras."""
+    malicious_file = SimpleUploadedFile(
+        "malicious.exe", b"MZ\x90\x00", content_type="application/x-msdownload"  # PE header (Windows executable)
+    )
+
+    response = authenticated_controle_client.post(
+        "/api/controle/import-compras/?dry_run=true", {"file": malicious_file}, format="multipart"
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert "tipo de arquivo não permitido" in response.data["detail"].lower()
+
+
+# ============================================================================
 # Testes para DATImportCadastrosView (/api/dat/import-cadastros/)
 # ============================================================================
 

--- a/v2/backend/apps/core/views_controle_imports.py
+++ b/v2/backend/apps/core/views_controle_imports.py
@@ -24,6 +24,14 @@ from rest_framework.views import APIView
 from apps.core.permissions import IsControleOrSuper
 from apps.core.services.controle_imports import import_compras_from_file
 
+# Issue #569: Upload validation hardening (DoS/malicious file prevention)
+MAX_UPLOAD_SIZE = 10 * 1024 * 1024  # 10MB
+ALLOWED_CONTENT_TYPES = {
+    "text/csv",
+    "application/vnd.ms-excel",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+}
+
 
 class ImportComprasView(APIView):
     """
@@ -64,6 +72,18 @@ class ImportComprasView(APIView):
             upload = request.FILES["file"]
         except (KeyError, MultiValueDictKeyError):
             return Response({"detail": "Campo 'file' é obrigatório."}, status=status.HTTP_400_BAD_REQUEST)
+
+        if upload.size > MAX_UPLOAD_SIZE:
+            return Response(
+                {"detail": f"Arquivo muito grande. Máximo: {MAX_UPLOAD_SIZE / 1024 / 1024:.0f}MB"},
+                status=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            )
+
+        if upload.content_type not in ALLOWED_CONTENT_TYPES:
+            return Response(
+                {"detail": f"Tipo de arquivo não permitido. Aceitos: CSV, XLS, XLSX. Recebido: {upload.content_type}"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
         # Salvar upload em /tmp via tempfile
         temp_file = None


### PR DESCRIPTION
## Summary

- aplica validação de upload no endpoint `POST /api/controle/import-compras/`
- rejeita arquivo acima de 10MB (`413`) e MIME não permitido (`400`)
- adiciona testes dedicados para esse endpoint no suite de upload validation

## Scope

- Incluido:
  - `v2/backend/apps/core/views_controle_imports.py`
  - `v2/backend/apps/core/tests/test_upload_validation.py`
- Fora de escopo:
  - mudança de parser do import de compras
  - mudança de regra de negócio do import

## Test Plan

- [x] `docker compose -p aprender_v2 -f v2/infra/docker-compose.yml exec -T web bash -lc 'cd /app && pytest -q apps/core/tests/test_upload_validation.py apps/core/tests/test_import_compras.py --tb=short'`
  - Resultado: `21 passed`
- [x] `docker compose -p aprender_v2 -f v2/infra/docker-compose.yml exec -T web bash -lc 'cd /app && black --check apps/core/views_controle_imports.py apps/core/tests/test_upload_validation.py'`
  - Resultado: `All done! 2 files would be left unchanged.`

## Risks

- Risco: rejeição de uploads com `content_type` incomum enviado por algum cliente legado.
- Mitigacao: lista de MIME segue o mesmo padrão já aplicado nos outros endpoints de importação.

## Links

- Closes #569
