### PR TITLE
fix(makefile): corrige alvos seed/e2e quebrados

### DIFF
--- a/v2/Makefile
+++ b/v2/Makefile
@@ -36,7 +36,7 @@ seed:
 	$(WEB) python manage.py seed_rbac --verbose
 
 seed-demo:
-	$(WEB) python manage.py seed_demo_users --verbose
+	$(WEB) python manage.py seed_e2e_users
 
 seed-rbac:
 	$(WEB) python manage.py seed_rbac
@@ -242,15 +242,15 @@ seed-e2e:
 
 test-e2e:
 	@echo "🎭 Executando testes E2E (Playwright headless)..."
-	@cd ../tests/playwright && npm run test
+	@cd tests/playwright && npm run test
 
 test-e2e-ui:
 	@echo "🎭 Executando testes E2E com UI interativa (Playwright)..."
-	@cd ../tests/playwright && npm run test:ui
+	@cd tests/playwright && npm run test:ui
 
 test-e2e-headed:
 	@echo "🎭 Executando testes E2E (headed mode - ver browser)..."
-	@cd ../tests/playwright && npm run test:headed
+	@cd tests/playwright && npm run test:headed
 
 # ════════════════════════════════════════════════════════════════════════════
 # Help
@@ -309,7 +309,7 @@ help:
 	@echo "  make test-e2e              Run E2E tests (headless)"
 	@echo "  make test-e2e-ui           Run E2E tests with interactive UI"
 	@echo "  make test-e2e-headed       Run E2E tests (headed mode - visible browser)"
-	@echo "  Nota: Requer npm install em ../tests/playwright/"
+	@echo "  Nota: Requer npm install em tests/playwright/"
 	@echo ""
 	@echo "Health Checks:"
 	@echo "  make readyz                Check /api/readyz/ (db + redis)"


### PR DESCRIPTION
## Resumo
Corrige drift operacional do `v2/Makefile` da issue #617:
- `seed-demo` deixa de chamar comando inexistente (`seed_demo_users`) e passa a usar `seed_e2e_users`.
- Alvos Playwright agora usam caminho real `tests/playwright` (antes `../tests/playwright`).
- Mensagem de ajuda atualizada para o novo caminho.

## Validação
Executado:
- `COMPOSE_PROJECT_NAME=aprender_v2 docker compose -f v2/infra/docker-compose.yml exec -T web python manage.py help seed_e2e_users`
- `cd v2/tests/playwright && npm run test -- --list`

Observação técnica:
- A execução completa de `seed_e2e_users` no banco atual encontrou `IntegrityError` de município duplicado (`Salvador/BA`), alinhado ao problema já rastreado na #618 (idempotência), e não a comando/caminho inválido desta issue.

Closes #617