### PR TITLE
fix(dat-module): align cadastro etapa update with POST (#702)

### DIFF
--- a/v2/frontend/src/api/__tests__/datModule.test.ts
+++ b/v2/frontend/src/api/__tests__/datModule.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const { postMock, patchMock } = vi.hoisted(() => ({
+  postMock: vi.fn(),
+  patchMock: vi.fn(),
+}));
+
+vi.mock('../../api', () => ({
+  default: {
+    get: vi.fn(),
+    post: postMock,
+    patch: patchMock,
+    delete: vi.fn(),
+  },
+}));
+
+import { updateCadastroEtapa } from '../datModule';
+
+describe('datModule API', () => {
+  beforeEach(() => {
+    postMock.mockReset();
+    patchMock.mockReset();
+  });
+
+  test('updateCadastroEtapa uses POST on /dat/cadastros/{id}/etapa/', async () => {
+    const payload = { id: 7, etapa: 'chaves', status: 'concluido' };
+    postMock.mockResolvedValue({ data: payload });
+
+    const response = await updateCadastroEtapa(7, 'chaves', 'concluido');
+
+    expect(postMock).toHaveBeenCalledWith('/dat/cadastros/7/etapa/', {
+      etapa: 'chaves',
+      status: 'concluido',
+    });
+    expect(patchMock).not.toHaveBeenCalled();
+    expect(response).toEqual(payload);
+  });
+});

--- a/v2/frontend/src/api/datModule.ts
+++ b/v2/frontend/src/api/datModule.ts
@@ -369,7 +369,7 @@ export async function deleteCadastro(id: ID): Promise<void> {
 }
 
 export async function updateCadastroEtapa(id: ID, etapa: string, status: string): Promise<GenericRecord> {
-  return apiRequest(() => api.patch(`/dat/cadastros/${id}/etapa/`, { etapa, status }));
+  return apiRequest(() => api.post(`/dat/cadastros/${id}/etapa/`, { etapa, status }));
 }
 
 export async function getCadastrosStats(params: FilterParams = {}): Promise<GenericStats> {


### PR DESCRIPTION
## Summary

- Corrigido o método HTTP de `updateCadastroEtapa` em `v2/frontend/src/api/datModule.ts` de `PATCH` para `POST`.
- Adicionado teste de regressão em `v2/frontend/src/api/__tests__/datModule.test.ts` para garantir que o fluxo de etapa use `POST` em `/dat/cadastros/{id}/etapa/`.

## Scope

- Incluido:
  - ajuste de método HTTP no wrapper da API do módulo DAT.
  - teste unitário de contrato do cliente para prevenir regressão para `PATCH`.
- Fora de escopo:
  - refatoração ampla do módulo DAT.
  - alterações de regra de negócio de etapas.

## Test Plan

- [x] `docker compose -f v2/infra/docker-compose.yml exec -T web pytest -q apps/core/tests/test_dat_module.py -k etapa` -> `3 passed`.
- [x] `cd v2/frontend && npm run lint` -> passou.
- [x] `cd v2/frontend && npm run build` -> passou.
- [ ] `cd v2/frontend && npm run test -- src/api/__tests__/datModule.test.ts --run` -> bloqueado localmente por timeout de pool do Vitest (`[vitest-pool]: Timeout starting threads/forks runner` no ambiente atual). O teste foi adicionado para validação no CI.

## Risks

- Risco: baixo. Mudança isolada em um endpoint/action específica.
- Mitigação: teste de regressão dedicado e validação backend/compilação frontend.

## Links

- Closes #702
