### PR TITLE
fix(etl): count updated records before upsert in core pipeline (#695)

### DIFF
--- a/v2/backend/apps/dat_ingest/management/commands/etl_upsert_core.py
+++ b/v2/backend/apps/dat_ingest/management/commands/etl_upsert_core.py
@@ -105,28 +105,26 @@ class Command(BaseCommand):
 
             # Generate username from email if needed
             username = email.split("@")[0]
+            upsert_defaults = {
+                "username": username,
+                "email": email,
+                **defaults,
+            }
+            existing_obj = Usuario.objects.filter(email__iexact=email).first()
+            changed = existing_obj is not None and any(
+                getattr(existing_obj, field) != value for field, value in upsert_defaults.items()
+            )
 
             try:
-                obj, created = Usuario.objects.update_or_create(
+                _, created = Usuario.objects.update_or_create(
                     email__iexact=email,
-                    defaults={
-                        "username": username,
-                        "email": email,
-                        **defaults,
-                    },
+                    defaults=upsert_defaults,
                 )
 
                 if created:
                     created_count += 1
                     self.stdout.write(f"  ✓ Created: {stg.nome} ({email})")
                 else:
-                    # Check if any field changed
-                    changed = False
-                    for field, value in defaults.items():
-                        if getattr(obj, field) != value:
-                            changed = True
-                            break
-
                     if changed:
                         updated_count += 1
                         self.stdout.write(f"  ↻ Updated: {stg.nome} ({email})")
@@ -168,15 +166,19 @@ class Command(BaseCommand):
             defaults = {
                 "ativo": stg.ativo,
             }
+            existing_obj = Municipio.objects.filter(nome=nome, uf=uf).first()
+            changed = existing_obj is not None and any(
+                getattr(existing_obj, field) != value for field, value in defaults.items()
+            )
 
             try:
-                obj, created = Municipio.objects.update_or_create(nome=nome, uf=uf, defaults=defaults)
+                _, created = Municipio.objects.update_or_create(nome=nome, uf=uf, defaults=defaults)
 
                 if created:
                     created_count += 1
                     self.stdout.write(f"  ✓ Created: {nome}-{uf}")
                 else:
-                    if obj.ativo != stg.ativo:
+                    if changed:
                         updated_count += 1
                         self.stdout.write(f"  ↻ Updated: {nome}-{uf}")
                     else:
@@ -219,15 +221,18 @@ class Command(BaseCommand):
                 "descricao": stg.descricao or "",
                 "ativo": stg.ativo,
             }
+            existing_obj = Projeto.objects.filter(nome=nome).first()
+            changed = existing_obj is not None and any(
+                getattr(existing_obj, field) != value for field, value in defaults.items()
+            )
 
             try:
-                obj, created = Projeto.objects.update_or_create(nome=nome, defaults=defaults)
+                _, created = Projeto.objects.update_or_create(nome=nome, defaults=defaults)
 
                 if created:
                     created_count += 1
                     self.stdout.write(f"  ✓ Created: {nome}")
                 else:
-                    changed = obj.descricao != stg.descricao or obj.ativo != stg.ativo
                     if changed:
                         updated_count += 1
                         self.stdout.write(f"  ↻ Updated: {nome}")
@@ -269,15 +274,18 @@ class Command(BaseCommand):
                 "descricao": stg.descricao or "",
                 "cor": stg.cor or "",
             }
+            existing_obj = TipoEvento.objects.filter(nome=nome).first()
+            changed = existing_obj is not None and any(
+                getattr(existing_obj, field) != value for field, value in defaults.items()
+            )
 
             try:
-                obj, created = TipoEvento.objects.update_or_create(nome=nome, defaults=defaults)
+                _, created = TipoEvento.objects.update_or_create(nome=nome, defaults=defaults)
 
                 if created:
                     created_count += 1
                     self.stdout.write(f"  ✓ Created: {nome}")
                 else:
-                    changed = obj.descricao != stg.descricao or obj.cor != stg.cor
                     if changed:
                         updated_count += 1
                         self.stdout.write(f"  ↻ Updated: {nome}")

--- a/v2/backend/apps/dat_ingest/tests/test_etl_idempotency.py
+++ b/v2/backend/apps/dat_ingest/tests/test_etl_idempotency.py
@@ -7,6 +7,8 @@ Garante que executar o ETL 2x com os mesmos dados produz 0 inserts/updates na 2�
 
 from __future__ import annotations
 
+from io import StringIO
+
 from django.core.management import call_command
 
 import pytest
@@ -334,3 +336,75 @@ class TestETLIdempotency:
         assert usuario.first_name == "João", "First name deve ter sido atualizado"
         assert usuario.last_name == "Pedro Silva", "Last name deve ter sido atualizado"
         assert Usuario.objects.count() == initial_count + 2, "Não deve ter criado novos usuários"
+
+    def test_upsert_core_counts_updated_for_changed_usuarios(self, temp_xlsx_usuarios):
+        """Test: summary contabiliza updated quando staging de usuário muda."""
+        directory = temp_xlsx_usuarios.parent
+
+        call_command("etl_load_xlsx", dir=str(directory), only="usuarios")
+        call_command("etl_upsert_core", only="usuarios")
+
+        stg = StgUsuario.objects.get(email="joao@example.com")
+        stg.nome = "João Pedro Silva"
+        stg.save()
+
+        out = StringIO()
+        call_command("etl_upsert_core", only="usuarios", stdout=out)
+
+        usuario = Usuario.objects.get(email="joao@example.com")
+        assert usuario.last_name == "Pedro Silva"
+        assert "Created: 0, Updated: 1, Unchanged: 1" in out.getvalue()
+
+    def test_upsert_core_counts_updated_for_changed_municipios(self, temp_xlsx_municipios):
+        """Test: summary contabiliza updated quando staging de município muda."""
+        directory = temp_xlsx_municipios.parent
+
+        call_command("etl_load_xlsx", dir=str(directory), only="municipios")
+        call_command("etl_upsert_core", only="municipios")
+
+        stg = StgMunicipio.objects.get(nome="Fortaleza", uf="CE")
+        stg.ativo = False
+        stg.save()
+
+        out = StringIO()
+        call_command("etl_upsert_core", only="municipios", stdout=out)
+
+        municipio = Municipio.objects.get(nome="Fortaleza", uf="CE")
+        assert municipio.ativo is False
+        assert "Created: 0, Updated: 1, Unchanged: 1" in out.getvalue()
+
+    def test_upsert_core_counts_updated_for_changed_projetos(self, temp_xlsx_projetos):
+        """Test: summary contabiliza updated quando staging de projeto muda."""
+        directory = temp_xlsx_projetos.parent
+
+        call_command("etl_load_xlsx", dir=str(directory), only="projetos")
+        call_command("etl_upsert_core", only="projetos")
+
+        stg = StgProjeto.objects.get(nome="Alfabetização")
+        stg.descricao = "Projeto atualizado"
+        stg.save()
+
+        out = StringIO()
+        call_command("etl_upsert_core", only="projetos", stdout=out)
+
+        projeto = Projeto.objects.get(nome="Alfabetização")
+        assert projeto.descricao == "Projeto atualizado"
+        assert "Created: 0, Updated: 1, Unchanged: 1" in out.getvalue()
+
+    def test_upsert_core_counts_updated_for_changed_tipos_evento(self, temp_xlsx_tipos):
+        """Test: summary contabiliza updated quando staging de tipo de evento muda."""
+        directory = temp_xlsx_tipos.parent
+
+        call_command("etl_load_xlsx", dir=str(directory), only="tipos")
+        call_command("etl_upsert_core", only="tipos")
+
+        stg = StgTipoEvento.objects.get(nome="Formação")
+        stg.cor = "#111111"
+        stg.save()
+
+        out = StringIO()
+        call_command("etl_upsert_core", only="tipos", stdout=out)
+
+        tipo = TipoEvento.objects.get(nome="Formação")
+        assert tipo.cor == "#111111"
+        assert "Created: 0, Updated: 1, Unchanged: 1" in out.getvalue()


### PR DESCRIPTION
## Summary

- Corrige a contagem `updated/unchanged` no `etl_upsert_core` para calcular mudança **antes** do `update_or_create`.
- Aplica a correção nas quatro entidades do comando: `usuarios`, `municipios`, `projetos`, `tipos`.
- Adiciona testes de regressão para validar simultaneamente:
  - persistência no banco após mudança real;
  - resumo final com `Created: 0, Updated: 1, Unchanged: 1`.

## Scope

- Incluido:
  - `v2/backend/apps/dat_ingest/management/commands/etl_upsert_core.py`
  - `v2/backend/apps/dat_ingest/tests/test_etl_idempotency.py`
- Fora de escopo:
  - redesenho do pipeline ETL completo.
  - mudanças de regra de negócio dos dados importados.

## Test Plan

- [x] `docker compose -f v2/infra/docker-compose.yml run --rm --build web pytest -q apps/dat_ingest/tests/test_etl_idempotency.py` -> `12 passed`.
- [x] `docker compose -f v2/infra/docker-compose.yml run --rm web pytest -q apps/dat_ingest/tests/test_etl_idempotency.py -k upsert_core` -> `8 passed`.
- [x] `docker compose -f v2/infra/docker-compose.yml run --rm web black apps/dat_ingest/management/commands/etl_upsert_core.py apps/dat_ingest/tests/test_etl_idempotency.py` -> sem alterações pendentes.

## Risks

- Risco: regressão na idempotência dos upserts.
- Mitigação: suíte de idempotência executada em Docker com casos de unchanged e de update real por entidade.

## Links

- Closes #695
