### PR TITLE
fix(etl): count deslocamento updates before upsert (#696)

### DIFF
--- a/v2/backend/apps/dat_ingest/management/commands/etl_upsert_deslocamento.py
+++ b/v2/backend/apps/dat_ingest/management/commands/etl_upsert_deslocamento.py
@@ -383,37 +383,32 @@ class Command(BaseCommand):
 
         # Observação
         observacao = row.get("obs", "").strip()
+        observacao_value = observacao if observacao else None
 
         # Gerar external_hash
         external_hash = self.compute_external_hash(usuario.id, origem, destino, start_date, end_date)
 
         # Upsert Deslocamento
         if not self.dry_run:
-            deslocamento, created = Deslocamento.objects.update_or_create(
-                external_hash=external_hash,
-                defaults={
-                    "usuario": usuario,
-                    "origem": origem,
-                    "destino": destino,
-                    "start_date": start_date,
-                    "end_date": end_date,
-                    "observacao": observacao if observacao else None,
-                },
+            defaults = {
+                "usuario": usuario,
+                "origem": origem,
+                "destino": destino,
+                "start_date": start_date,
+                "end_date": end_date,
+                "observacao": observacao_value,
+            }
+            existing_deslocamento = Deslocamento.objects.filter(external_hash=external_hash).first()
+            changed = existing_deslocamento is not None and any(
+                getattr(existing_deslocamento, field) != value for field, value in defaults.items()
             )
+
+            _, created = Deslocamento.objects.update_or_create(external_hash=external_hash, defaults=defaults)
 
             if created:
                 self.stats["created"] += 1
                 self.stdout.write(f"   ✅ Linha {linha_num}: Deslocamento criado ({external_hash[:8]}...)")
             else:
-                # Verificar se houve mudança
-                changed = False
-                if deslocamento.origem != origem or deslocamento.destino != destino:
-                    changed = True
-                if deslocamento.start_date != start_date or deslocamento.end_date != end_date:
-                    changed = True
-                if deslocamento.observacao != (observacao if observacao else None):
-                    changed = True
-
                 if changed:
                     self.stats["updated"] += 1
                     self.stdout.write(f"   🔄 Linha {linha_num}: Deslocamento atualizado ({external_hash[:8]}...)")

--- a/v2/backend/apps/dat_ingest/tests/test_etl_commands_coverage.py
+++ b/v2/backend/apps/dat_ingest/tests/test_etl_commands_coverage.py
@@ -19,6 +19,7 @@ Test patterns:
 
 from __future__ import annotations
 
+import json
 from io import StringIO
 from unittest.mock import patch
 
@@ -680,6 +681,58 @@ class TestEtlUpsertDeslocamento:
         second_count = Deslocamento.objects.count()
 
         assert first_count == second_count, "Should not duplicate records"
+
+    def test_counts_updated_and_report_when_data_changes(self, tmp_path, usuario_formador):
+        """Test: Changed payload increments updated and report json reflects counters."""
+        from apps.core.models import Deslocamento
+
+        initial_csv = tmp_path / "deslocamento_initial.csv"
+        initial_csv.write_text(
+            f"""email,start,end,origem,destino,obs
+{usuario_formador.email},2025-01-10,2025-01-12,Fortaleza,Caucaia,Obs 1
+""",
+            encoding="utf-8",
+        )
+        updated_csv = tmp_path / "deslocamento_updated.csv"
+        updated_csv.write_text(
+            f"""email,start,end,origem,destino,obs
+{usuario_formador.email},2025-01-10,2025-01-12,Fortaleza,Caucaia,Obs 2
+""",
+            encoding="utf-8",
+        )
+
+        with patch("apps.dat_ingest.management.commands.etl_upsert_deslocamento.settings.BASE_DIR", tmp_path):
+            call_command("etl_upsert_deslocamento", f"--file={initial_csv}")
+
+            out = StringIO()
+            call_command("etl_upsert_deslocamento", f"--file={updated_csv}", stdout=out)
+
+            report_path = tmp_path / "out_etl" / "etl_deslocamento_report.json"
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+
+        deslocamentos = Deslocamento.objects.filter(usuario=usuario_formador)
+        assert deslocamentos.count() == 1
+        assert deslocamentos.first().observacao == "Obs 2"
+        assert "Updated: 1" in out.getvalue()
+        assert "Unchanged: 0" in out.getvalue()
+        assert report["stats"]["updated"] == 1
+        assert report["stats"]["unchanged"] == 0
+
+    def test_counts_unchanged_and_report_when_data_is_identical(self, temp_csv_deslocamento, tmp_path):
+        """Test: Same payload increments unchanged and report json reflects counters."""
+        with patch("apps.dat_ingest.management.commands.etl_upsert_deslocamento.settings.BASE_DIR", tmp_path):
+            call_command("etl_upsert_deslocamento", f"--file={temp_csv_deslocamento}")
+
+            out = StringIO()
+            call_command("etl_upsert_deslocamento", f"--file={temp_csv_deslocamento}", stdout=out)
+
+            report_path = tmp_path / "out_etl" / "etl_deslocamento_report.json"
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+
+        assert "Updated: 0" in out.getvalue()
+        assert "Unchanged: 1" in out.getvalue()
+        assert report["stats"]["updated"] == 0
+        assert report["stats"]["unchanged"] == 1
 
     def test_skips_invalid_usuario(self, tmp_path):
         """Test: Skips rows with invalid/unknown usuario."""


### PR DESCRIPTION
## Summary

- Corrigida a lógica de contagem em `etl_upsert_deslocamento` para detectar mudanças com snapshot pré-upsert (antes do `update_or_create`).
- Agora `updated` e `unchanged` refletem corretamente alteração real vs reexecução idêntica.
- Adicionados testes de regressão cobrindo:
  - update real (mesma chave, `observacao` alterada) com `updated=1`;
  - reexecução idêntica com `unchanged=1`;
  - consistência do `etl_deslocamento_report.json`.

## Scope

- Incluido:
  - `v2/backend/apps/dat_ingest/management/commands/etl_upsert_deslocamento.py`
  - `v2/backend/apps/dat_ingest/tests/test_etl_commands_coverage.py`
- Fora de escopo:
  - mudança de regra de `external_hash`.
  - mudanças de parsing além do necessário para o bug de contadores.

## Test Plan

- [x] `docker compose -f v2/infra/docker-compose.yml run --rm --build web black apps/dat_ingest/management/commands/etl_upsert_deslocamento.py apps/dat_ingest/tests/test_etl_commands_coverage.py` -> sem mudanças pendentes.
- [x] `docker compose -f v2/infra/docker-compose.yml run --rm web pytest -q apps/dat_ingest/tests/test_etl_commands_coverage.py -k TestEtlUpsertDeslocamento` -> `9 passed`.

## Risks

- Risco: afetar comportamento idempotente do hash externo.
- Mitigação: classe alvo de testes cobre criação, idempotência, update real e unchanged, além de relatório JSON.

## Links

- Closes #696
