### PR TITLE
chore(gcal): align frontend API with implemented backend endpoints (#591)

### DIFF
--- a/v2/frontend/src/api/__tests__/gcal.test.ts
+++ b/v2/frontend/src/api/__tests__/gcal.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const { fetchAPIMock, buildUrlMock } = vi.hoisted(() => ({
+  fetchAPIMock: vi.fn(),
+  buildUrlMock: vi.fn(),
+}));
+
+vi.mock('../config', () => ({
+  fetchAPI: fetchAPIMock,
+  buildUrl: buildUrlMock,
+}));
+
+import {
+  getStatusSummary,
+  listApprovedWithGCalStatus,
+  publishBatch,
+  reapplyBatch,
+  resyncBatch,
+} from '../gcal';
+
+describe('gcal API endpoints', () => {
+  beforeEach(() => {
+    fetchAPIMock.mockReset();
+    buildUrlMock.mockReset();
+    buildUrlMock.mockImplementation((path: string) => path);
+  });
+
+  test('getStatusSummary uses /gcal/status-summary/', async () => {
+    fetchAPIMock.mockResolvedValue({ counts: {}, total: 0 });
+
+    await getStatusSummary({ status: 'approved' });
+
+    expect(buildUrlMock).toHaveBeenCalledWith('/gcal/status-summary/', { status: 'approved' });
+    expect(fetchAPIMock).toHaveBeenCalledWith('/gcal/status-summary/');
+  });
+
+  test('listApprovedWithGCalStatus uses /gcal/list/ (implemented backend endpoint)', async () => {
+    fetchAPIMock.mockResolvedValue({ count: 0, next: null, previous: null, results: [] });
+
+    await listApprovedWithGCalStatus({ q: 'teste' });
+
+    expect(buildUrlMock).toHaveBeenCalledWith('/gcal/list/', { q: 'teste' });
+    expect(fetchAPIMock).toHaveBeenCalledWith('/gcal/list/');
+  });
+
+  test('publishBatch posts to /gcal/publish-batch/', async () => {
+    fetchAPIMock.mockResolvedValue({ queued: 1, errors: [] });
+
+    await publishBatch({ solicitacao_ids: [1], dry_run: true, apply_blocked: true });
+
+    expect(fetchAPIMock).toHaveBeenCalledWith('/gcal/publish-batch/', {
+      method: 'POST',
+      body: JSON.stringify({ solicitacao_ids: [1], dry_run: true, apply_blocked: true }),
+    });
+  });
+
+  test('reapplyBatch posts to /gcal/dashboard/batch/reapply/', async () => {
+    fetchAPIMock.mockResolvedValue({ queued: 1, errors: [] });
+
+    await reapplyBatch({ ids: [10], dry_run: false, apply_blocked: true });
+
+    expect(fetchAPIMock).toHaveBeenCalledWith('/gcal/dashboard/batch/reapply/', {
+      method: 'POST',
+      body: JSON.stringify({ ids: [10], dry_run: false, apply_blocked: true }),
+    });
+  });
+
+  test('resyncBatch posts to /gcal/dashboard/batch/resync/', async () => {
+    fetchAPIMock.mockResolvedValue({ queued: 1, errors: [] });
+
+    await resyncBatch({ ids: [20], dry_run: true, apply_blocked: false });
+
+    expect(fetchAPIMock).toHaveBeenCalledWith('/gcal/dashboard/batch/resync/', {
+      method: 'POST',
+      body: JSON.stringify({ ids: [20], dry_run: true, apply_blocked: false }),
+    });
+  });
+});

--- a/v2/frontend/src/api/gcal.ts
+++ b/v2/frontend/src/api/gcal.ts
@@ -1,7 +1,7 @@
 /**
  * API Client - Google Calendar Dashboard
  *
- * Endpoints para painel de publicação GCal.
+ * Endpoints consumidos pelo frontend e implementados no backend.
  */
 
 import { fetchAPI, buildUrl, type QueryParams } from './config';
@@ -51,8 +51,10 @@ export interface BatchPublishRequest {
  */
 export interface BatchOperationResponse {
   queued: number;
-  skipped: number;
-  errors: Array<{ id: ID; error: string }>;
+  errors: Array<{ id: ID; detail?: string; error?: string }>;
+  skipped?: number;
+  dry_run?: boolean;
+  apply_blocked?: boolean;
   task_ids?: string[];
 }
 
@@ -60,7 +62,9 @@ export interface BatchOperationResponse {
  * Batch IDs request
  */
 export interface BatchIdsRequest {
-  solicitacao_ids: ID[];
+  ids: ID[];
+  dry_run?: boolean;
+  apply_blocked?: boolean;
 }
 
 /**
@@ -79,7 +83,7 @@ export async function getStatusSummary(filters: GCalFilters = {}): Promise<GCalS
  * @param filters - Filtros (date_from, date_to, sector, gcal_status, q)
  */
 export async function listApprovedWithGCalStatus(filters: GCalFilters = {}): Promise<PaginatedResponse<GCalDashboardEvent>> {
-  const url = buildUrl('/gcal/approved/', filters as QueryParams);
+  const url = buildUrl('/gcal/list/', filters as QueryParams);
   return await fetchAPI(url);
 }
 
@@ -96,24 +100,24 @@ export async function publishBatch(body: BatchPublishRequest): Promise<BatchOper
 }
 
 /**
- * Remove múltiplas solicitações do Google Calendar (unpublish).
+ * Reaplica eventos já publicados sem resetar hash.
  *
- * @param body - { solicitacao_ids: [...] }
+ * @param body - { ids: [...], dry_run?: bool, apply_blocked?: bool }
  */
-export async function unpublishBatch(body: BatchIdsRequest): Promise<BatchOperationResponse> {
-  return await fetchAPI('/gcal/unpublish-batch/', {
+export async function reapplyBatch(body: BatchIdsRequest): Promise<BatchOperationResponse> {
+  return await fetchAPI('/gcal/dashboard/batch/reapply/', {
     method: 'POST',
     body: JSON.stringify(body),
   });
 }
 
 /**
- * Sincroniza solicitações bloqueadas (marca como PENDING no GCal).
+ * Força resync (reseta hash + marca pending + republica em lote).
  *
- * @param body - { solicitacao_ids: [...] }
+ * @param body - { ids: [...], dry_run?: bool, apply_blocked?: bool }
  */
-export async function syncBlocked(body: BatchIdsRequest): Promise<BatchOperationResponse> {
-  return await fetchAPI('/gcal/sync-blocked/', {
+export async function resyncBatch(body: BatchIdsRequest): Promise<BatchOperationResponse> {
+  return await fetchAPI('/gcal/dashboard/batch/resync/', {
     method: 'POST',
     body: JSON.stringify(body),
   });


### PR DESCRIPTION
## Summary

- Alinha `v2/frontend/src/api/gcal.ts` com endpoints reais do backend:
  - `listApprovedWithGCalStatus` agora usa `/gcal/list/` (em vez de `/gcal/approved/`, inexistente).
  - remove chamadas para endpoints inexistentes (`/gcal/unpublish-batch/`, `/gcal/sync-blocked/`).
  - adiciona wrappers para endpoints existentes de batch:
    - `/gcal/dashboard/batch/reapply/`
    - `/gcal/dashboard/batch/resync/`
- Ajusta tipos de resposta batch para refletir payload real do backend (`detail`, `dry_run`, `apply_blocked`, `skipped?`).
- Adiciona teste unitário em `v2/frontend/src/api/__tests__/gcal.test.ts` cobrindo os paths usados pelas funções.

## Scope

- Incluido:
  - `v2/frontend/src/api/gcal.ts`
  - `v2/frontend/src/api/__tests__/gcal.test.ts`
- Fora de escopo:
  - migração das páginas para usar integralmente wrappers (tema da #704).
  - criação de novos endpoints backend.

## Test Plan

- [x] `cd v2/frontend && npm run lint` -> passou.
- [x] `cd v2/frontend && npm run build` -> passou.
- [ ] `cd v2/frontend && npm run test -- src/api/__tests__/gcal.test.ts --run` -> bloqueado localmente por timeout conhecido do pool do Vitest (`[vitest-pool]: Timeout starting threads runner`). Teste incluído para validação no CI.

## Risks

- Risco: baixo. Mudança restrita à camada de client API GCal.
- Mitigação: teste de contrato de endpoints + checks de CI obrigatórios.

## Links

- Closes #591
