### PR TITLE
chore(dat-module): align produto CRUD endpoints with backend route (#593)

### DIFF
--- a/v2/frontend/src/api/__tests__/datModule.test.ts
+++ b/v2/frontend/src/api/__tests__/datModule.test.ts
@@ -1,25 +1,36 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
-const { postMock, patchMock } = vi.hoisted(() => ({
+const { getMock, postMock, patchMock, deleteMock } = vi.hoisted(() => ({
+  getMock: vi.fn(),
   postMock: vi.fn(),
   patchMock: vi.fn(),
+  deleteMock: vi.fn(),
 }));
 
 vi.mock('../../api', () => ({
   default: {
-    get: vi.fn(),
+    get: getMock,
     post: postMock,
     patch: patchMock,
-    delete: vi.fn(),
+    delete: deleteMock,
   },
 }));
 
-import { updateCadastroEtapa } from '../datModule';
+import {
+  createProdutoDAT,
+  deleteProdutoDAT,
+  getProdutoDAT,
+  listProdutosDAT,
+  updateCadastroEtapa,
+  updateProdutoDAT,
+} from '../datModule';
 
 describe('datModule API', () => {
   beforeEach(() => {
+    getMock.mockReset();
     postMock.mockReset();
     patchMock.mockReset();
+    deleteMock.mockReset();
   });
 
   test('updateCadastroEtapa uses POST on /dat/cadastros/{id}/etapa/', async () => {
@@ -34,5 +45,25 @@ describe('datModule API', () => {
     });
     expect(patchMock).not.toHaveBeenCalled();
     expect(response).toEqual(payload);
+  });
+
+  test('produto endpoints use /produtos/ base path', async () => {
+    getMock.mockResolvedValueOnce({ data: { count: 0, results: [] } });
+    getMock.mockResolvedValueOnce({ data: { id: 5, nome: 'Produto X' } });
+    postMock.mockResolvedValueOnce({ data: { id: 6, nome: 'Produto Novo' } });
+    patchMock.mockResolvedValueOnce({ data: { id: 5, nome: 'Produto Atualizado' } });
+    deleteMock.mockResolvedValueOnce({ data: undefined });
+
+    await listProdutosDAT({ search: 'abc' });
+    await getProdutoDAT(5);
+    await createProdutoDAT({ nome: 'Produto Novo' });
+    await updateProdutoDAT(5, { nome: 'Produto Atualizado' });
+    await deleteProdutoDAT(5);
+
+    expect(getMock).toHaveBeenNthCalledWith(1, '/produtos/', { params: { search: 'abc' } });
+    expect(getMock).toHaveBeenNthCalledWith(2, '/produtos/5/');
+    expect(postMock).toHaveBeenCalledWith('/produtos/', { nome: 'Produto Novo' });
+    expect(patchMock).toHaveBeenCalledWith('/produtos/5/', { nome: 'Produto Atualizado' });
+    expect(deleteMock).toHaveBeenCalledWith('/produtos/5/');
   });
 });

--- a/v2/frontend/src/api/datModule.ts
+++ b/v2/frontend/src/api/datModule.ts
@@ -441,23 +441,23 @@ export async function getCoordenadorAlocacoes(id: ID): Promise<GenericRecord[]> 
 // ========== PRODUTOS ==========
 
 export async function listProdutosDAT(params: FilterParams = {}): Promise<PaginatedResponse<GenericRecord>> {
-  return apiRequest(() => api.get('/dat/produtos/', { params }));
+  return apiRequest(() => api.get('/produtos/', { params }));
 }
 
 export async function getProdutoDAT(id: ID): Promise<GenericRecord> {
-  return apiRequest(() => api.get(`/dat/produtos/${id}/`));
+  return apiRequest(() => api.get(`/produtos/${id}/`));
 }
 
 export async function createProdutoDAT(data: Record<string, unknown>): Promise<GenericRecord> {
-  return apiRequest(() => api.post('/dat/produtos/', data));
+  return apiRequest(() => api.post('/produtos/', data));
 }
 
 export async function updateProdutoDAT(id: ID, data: Record<string, unknown>): Promise<GenericRecord> {
-  return apiRequest(() => api.patch(`/dat/produtos/${id}/`, data));
+  return apiRequest(() => api.patch(`/produtos/${id}/`, data));
 }
 
 export async function deleteProdutoDAT(id: ID): Promise<void> {
-  return apiRequest(() => api.delete(`/dat/produtos/${id}/`));
+  return apiRequest(() => api.delete(`/produtos/${id}/`));
 }
 
 // ========== ÁREAS ==========


### PR DESCRIPTION
## Summary

- Corrige o endpoint de CRUD de produtos no client `datModule` para usar rota existente no backend:
  - de `/api/dat/produtos/*` para `/api/produtos/*`.
- Mantém as funções `list/get/create/update/deleteProdutoDAT`, apenas alinhando o path.
- Expande teste de contrato em `datModule.test.ts` para validar os paths de produtos.

## Scope

- Incluido:
  - `v2/frontend/src/api/datModule.ts`
  - `v2/frontend/src/api/__tests__/datModule.test.ts`
- Fora de escopo:
  - migração das telas para usar essas funções (não há uso atual no código).
  - criação de novos endpoints backend.

## Test Plan

- [x] `cd v2/frontend && npm run lint` -> passou.
- [x] `cd v2/frontend && npm run build` -> passou.
- [ ] `cd v2/frontend && npm run test -- src/api/__tests__/datModule.test.ts --run` -> bloqueado localmente por timeout conhecido de pool do Vitest (`[vitest-pool]: Timeout starting threads runner`). Teste incluído para validação no CI.

## Risks

- Risco: baixo, alteração pontual de path na camada API.
- Mitigação: teste dedicado de endpoint path e checks obrigatórios no PR.

## Links

- Closes #593
