### PR TITLE
fix(frontend): aplicar filtro dependente de municípios no wizard (#722)

### DIFF
--- a/v2/frontend/src/api/__tests__/lookup.test.ts
+++ b/v2/frontend/src/api/__tests__/lookup.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const { fetchAPIMock, buildUrlMock } = vi.hoisted(() => ({
+  fetchAPIMock: vi.fn(),
+  buildUrlMock: vi.fn(),
+}));
+
+vi.mock('../config', () => ({
+  fetchAPI: fetchAPIMock,
+  buildUrl: buildUrlMock,
+}));
+
+import {
+  lookupMunicipios,
+  lookupMunicipiosWithFilters,
+  lookupProjetos,
+  lookupProjetosWithFilters,
+} from '../lookup';
+
+describe('lookup API filters', () => {
+  beforeEach(() => {
+    fetchAPIMock.mockReset();
+    buildUrlMock.mockReset();
+    buildUrlMock.mockImplementation((path: string) => path);
+    fetchAPIMock.mockResolvedValue([]);
+  });
+
+  test('lookupMunicipios mantém contrato atual (q simples)', async () => {
+    await lookupMunicipios('Fort');
+
+    expect(buildUrlMock).toHaveBeenCalledWith('/lookup/municipios/', { q: 'Fort' });
+    expect(fetchAPIMock).toHaveBeenCalledWith('/lookup/municipios/');
+  });
+
+  test('lookupMunicipiosWithFilters envia com_compra + projeto_id', async () => {
+    await lookupMunicipiosWithFilters({ q: '', com_compra: true, projeto_id: 123 });
+
+    expect(buildUrlMock).toHaveBeenCalledWith('/lookup/municipios/', {
+      q: '',
+      com_compra: true,
+      projeto_id: 123,
+    });
+    expect(fetchAPIMock).toHaveBeenCalledWith('/lookup/municipios/');
+  });
+
+  test('lookupProjetos mantém contrato atual (q simples)', async () => {
+    await lookupProjetos('Ace');
+
+    expect(buildUrlMock).toHaveBeenCalledWith('/lookup/projetos/', { q: 'Ace' });
+    expect(fetchAPIMock).toHaveBeenCalledWith('/lookup/projetos/');
+  });
+
+  test('lookupProjetosWithFilters envia municipio_id + com_compra', async () => {
+    await lookupProjetosWithFilters({ q: 'A', com_compra: true, municipio_id: 77 });
+
+    expect(buildUrlMock).toHaveBeenCalledWith('/lookup/projetos/', {
+      q: 'A',
+      com_compra: true,
+      municipio_id: 77,
+    });
+    expect(fetchAPIMock).toHaveBeenCalledWith('/lookup/projetos/');
+  });
+});

--- a/v2/frontend/src/api/lookup.ts
+++ b/v2/frontend/src/api/lookup.ts
@@ -5,7 +5,7 @@
  * e validação de solicitações.
  */
 
-import { fetchAPI, buildUrl } from './config';
+import { fetchAPI, buildUrl, type QueryParams } from './config';
 import type { ID } from '../types';
 
 /**
@@ -15,6 +15,7 @@ export interface LookupItem {
   id: ID;
   label: string;
   kind: string;
+  [key: string]: unknown;
 }
 
 /**
@@ -51,6 +52,24 @@ export interface ValidateSolicResult {
 }
 
 /**
+ * Filtros opcionais para lookup de municípios.
+ */
+export type LookupMunicipiosParams = QueryParams & {
+  q?: string;
+  com_compra?: boolean;
+  projeto_id?: ID;
+};
+
+/**
+ * Filtros opcionais para lookup de projetos.
+ */
+export type LookupProjetosParams = QueryParams & {
+  q?: string;
+  com_compra?: boolean;
+  municipio_id?: ID;
+};
+
+/**
  * Buscar municípios (autocomplete)
  *
  * @param q - Query string
@@ -61,12 +80,32 @@ export async function lookupMunicipios(q: string = ''): Promise<LookupItem[]> {
 }
 
 /**
+ * Buscar municípios (autocomplete) com filtros de elegibilidade.
+ *
+ * @param params - Filtros do lookup
+ */
+export async function lookupMunicipiosWithFilters(params: LookupMunicipiosParams = {}): Promise<LookupItem[]> {
+  const url = buildUrl('/lookup/municipios/', params);
+  return await fetchAPI(url);
+}
+
+/**
  * Buscar projetos (autocomplete)
  *
  * @param q - Query string
  */
 export async function lookupProjetos(q: string = ''): Promise<LookupItem[]> {
   const url = buildUrl('/lookup/projetos/', { q });
+  return await fetchAPI(url);
+}
+
+/**
+ * Buscar projetos (autocomplete) com filtros de elegibilidade.
+ *
+ * @param params - Filtros do lookup
+ */
+export async function lookupProjetosWithFilters(params: LookupProjetosParams = {}): Promise<LookupItem[]> {
+  const url = buildUrl('/lookup/projetos/', params);
   return await fetchAPI(url);
 }
 

--- a/v2/frontend/src/components/ComboBox.tsx
+++ b/v2/frontend/src/components/ComboBox.tsx
@@ -5,7 +5,7 @@
  * Trabalha com objetos {id, label} e fornece busca via lookup API
  */
 
-import { useState, useEffect } from 'react';
+import { ReactNode, useState, useEffect } from 'react';
 import { AutoComplete, Spin } from 'antd';
 import logger from '../utils/logger';
 import type { ID } from '../types';
@@ -37,6 +37,7 @@ export interface ComboBoxProps {
   lookupFunction: (query: string) => Promise<LookupItem[]>;
   placeholder?: string;
   disabled?: boolean;
+  notFoundContent?: ReactNode;
 }
 
 export default function ComboBox({
@@ -45,6 +46,7 @@ export default function ComboBox({
   lookupFunction,
   placeholder = 'Digite para buscar...',
   disabled = false,
+  notFoundContent = 'Nenhum resultado encontrado',
 }: ComboBoxProps): JSX.Element {
   const [options, setOptions] = useState<AutoCompleteOption[]>([]);
   const [loading, setLoading] = useState(false);
@@ -140,7 +142,7 @@ export default function ComboBox({
       placeholder={placeholder}
       disabled={disabled}
       style={{ width: '100%' }}
-      notFoundContent={loading ? <Spin size="small" /> : 'Nenhum resultado encontrado'}
+      notFoundContent={loading ? <Spin size="small" /> : notFoundContent}
       allowClear
     />
   );

--- a/v2/frontend/src/pages/Solicitacoes/NewSolicitacaoWizard.tsx
+++ b/v2/frontend/src/pages/Solicitacoes/NewSolicitacaoWizard.tsx
@@ -10,7 +10,7 @@
  * 4. Revisão e Confirmação
  */
 
-import { useState, useMemo, useCallback, ChangeEvent, JSX, ReactNode } from 'react';
+import { useState, useMemo, useCallback, useEffect, ChangeEvent, JSX, ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
 // antd - direct imports for tree-shaking (Issue #424)
 import Steps from 'antd/es/steps';
@@ -37,10 +37,11 @@ import timezone from 'dayjs/plugin/timezone';
 
 import { createSolicitacao } from '../../api/solicitacoes';
 import {
-  lookupMunicipios,
+  lookupMunicipiosWithFilters,
   lookupProjetos,
   lookupTiposEvento,
 } from '../../api/lookup';
+import { getMe } from '../../api/availability';
 import DateTimeRange from '../../components/DateTimeRange';
 import ComboBox from '../../components/ComboBox';
 import FormadoresPicker from '../../components/FormadoresPicker';
@@ -114,6 +115,8 @@ export default function NewSolicitacaoWizard(): JSX.Element {
 
   const [currentStep, setCurrentStep] = useState<number>(0);
   const [loading, setLoading] = useState<boolean>(false);
+  const [isSuperuser, setIsSuperuser] = useState<boolean>(false);
+  const [municipioLookupHasResults, setMunicipioLookupHasResults] = useState<boolean | null>(null);
 
   // Estado do formulário
   const [formData, setFormData] = useState<FormDataType>({
@@ -135,6 +138,28 @@ export default function NewSolicitacaoWizard(): JSX.Element {
     // PR19: Modalidade online/presencial
     is_online: false,
   });
+
+  useEffect(() => {
+    let mounted = true;
+    const loadUserRole = async (): Promise<void> => {
+      try {
+        const me = await getMe();
+        if (mounted) {
+          setIsSuperuser(Boolean(me?.is_superuser));
+        }
+      } catch (error) {
+        logger.warn('Falha ao carregar perfil do usuário no wizard:', error);
+        if (mounted) {
+          setIsSuperuser(false);
+        }
+      }
+    };
+
+    void loadUserRole();
+    return () => {
+      mounted = false;
+    };
+  }, []);
 
   // Handler para DateTimeRange: converte {date, start, end} para ISO UTC (Issue #428)
   const handleRangeChange = useCallback((range: RangeValueType | null): void => {
@@ -172,6 +197,42 @@ export default function NewSolicitacaoWizard(): JSX.Element {
       end: dayjs(formData.fim).tz(RANGE_TIMEZONE).format('HH:mm'),
     };
   }, [formData.inicio, formData.fim]);
+
+  const handleProjetoChange = useCallback((value: ComboBoxValue | null): void => {
+    const projetoChanged = formData.projeto?.id !== value?.id;
+    setFormData(prev => ({
+      ...prev,
+      projeto: value,
+      municipio: projetoChanged ? null : prev.municipio,
+    }));
+
+    if (projetoChanged) {
+      form.setFieldsValue({ municipio: null });
+      setMunicipioLookupHasResults(null);
+    }
+  }, [form, formData.projeto?.id]);
+
+  const lookupMunicipiosElegiveis = useCallback(async (q: string): Promise<Array<{ id: ID; label: string; [key: string]: unknown }>> => {
+    const projetoId = formData.projeto?.id;
+
+    // Para usuário comum, exige projeto para aplicar filtro município+projeto.
+    if (!isSuperuser && !projetoId) {
+      setMunicipioLookupHasResults(false);
+      return [];
+    }
+
+    const results = await lookupMunicipiosWithFilters({
+      q,
+      com_compra: isSuperuser ? undefined : true,
+      projeto_id: !isSuperuser ? projetoId : undefined,
+    });
+
+    if (!q.trim()) {
+      setMunicipioLookupHasResults(results.length > 0);
+    }
+
+    return results;
+  }, [formData.projeto?.id, isSuperuser]);
 
   // Navegação entre passos
   const next = (): void => {
@@ -274,7 +335,7 @@ export default function NewSolicitacaoWizard(): JSX.Element {
           >
             <ComboBox
               lookupFunction={lookupProjetos as unknown as (query: string) => Promise<Array<{ id: ID; label: string; [key: string]: unknown }>>}
-              onChange={(value: ComboBoxValue | null) => setFormData({ ...formData, projeto: value })}
+              onChange={handleProjetoChange}
               value={formData.projeto as unknown as { id: ID; label: string; [key: string]: unknown } | null}
               placeholder="Busque ou selecione um projeto"
             />
@@ -313,12 +374,32 @@ export default function NewSolicitacaoWizard(): JSX.Element {
             rules={[{ required: true, message: 'Por favor selecione um município' }]}
           >
             <ComboBox
-              lookupFunction={lookupMunicipios as unknown as (query: string) => Promise<Array<{ id: ID; label: string; [key: string]: unknown }>>}
+              lookupFunction={lookupMunicipiosElegiveis}
               onChange={(value: ComboBoxValue | null) => setFormData({ ...formData, municipio: value })}
               value={formData.municipio as unknown as { id: ID; label: string; [key: string]: unknown } | null}
-              placeholder="Busque ou selecione um município"
+              placeholder={
+                !isSuperuser && !formData.projeto
+                  ? 'Selecione um projeto para carregar municípios elegíveis'
+                  : 'Busque ou selecione um município'
+              }
+              disabled={!isSuperuser && !formData.projeto}
+              notFoundContent={
+                !isSuperuser && formData.projeto
+                  ? 'Nenhum município elegível para o projeto selecionado'
+                  : 'Nenhum resultado encontrado'
+              }
             />
           </Form.Item>
+
+          {!isSuperuser && formData.projeto && municipioLookupHasResults === false && (
+            <Alert
+              message="Sem municípios elegíveis"
+              description="Não há municípios com compra registrada para o projeto selecionado."
+              type="warning"
+              showIcon
+              style={{ marginBottom: 16 }}
+            />
+          )}
 
           <DateTimeRange
             value={rangeValue}
@@ -539,7 +620,7 @@ export default function NewSolicitacaoWizard(): JSX.Element {
         </>
       ),
     },
-  ], [formData, rangeValue, handleRangeChange]);
+  ], [formData, rangeValue, handleRangeChange, handleProjetoChange, lookupMunicipiosElegiveis, isSuperuser, municipioLookupHasResults]);
 
   return (
     <section className="p-6 max-w-4xl mx-auto" aria-labelledby="nova-solicitacao-title">

--- a/v2/frontend/src/pages/Solicitacoes/__tests__/NewSolicitacaoWizard.test.tsx
+++ b/v2/frontend/src/pages/Solicitacoes/__tests__/NewSolicitacaoWizard.test.tsx
@@ -1,0 +1,182 @@
+import { useEffect } from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+
+const {
+  createSolicitacaoMock,
+  getMeMock,
+  lookupMunicipiosWithFiltersMock,
+  lookupProjetosMock,
+  lookupTiposEventoMock,
+  navigateMock,
+} = vi.hoisted(() => ({
+  createSolicitacaoMock: vi.fn(),
+  getMeMock: vi.fn(),
+  lookupMunicipiosWithFiltersMock: vi.fn(),
+  lookupProjetosMock: vi.fn(),
+  lookupTiposEventoMock: vi.fn(),
+  navigateMock: vi.fn(),
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
+
+vi.mock('../../../api/solicitacoes', () => ({
+  createSolicitacao: createSolicitacaoMock,
+}));
+
+vi.mock('../../../api/availability', () => ({
+  getMe: getMeMock,
+}));
+
+vi.mock('../../../api/lookup', () => ({
+  lookupMunicipiosWithFilters: lookupMunicipiosWithFiltersMock,
+  lookupProjetos: lookupProjetosMock,
+  lookupTiposEvento: lookupTiposEventoMock,
+}));
+
+vi.mock('../../../components/DateTimeRange', () => ({
+  default: () => <div data-testid="datetime-range">DateTimeRange</div>,
+}));
+
+vi.mock('../../../components/FormadoresPicker', () => ({
+  default: () => <div data-testid="formadores-picker">FormadoresPicker</div>,
+}));
+
+vi.mock('../../../components/CoordenadoresPicker', () => ({
+  default: () => <div data-testid="coordenadores-picker">CoordenadoresPicker</div>,
+}));
+
+vi.mock('../../../components/ComboBox', () => ({
+  default: ({
+    placeholder = '',
+    lookupFunction,
+    onChange,
+    disabled = false,
+  }: {
+    placeholder?: string;
+    lookupFunction: (query: string) => Promise<unknown[]>;
+    onChange?: (item: unknown) => void;
+    disabled?: boolean;
+  }) => {
+    useEffect(() => {
+      void lookupFunction('');
+    }, [lookupFunction]);
+
+    return (
+      <button
+        type="button"
+        data-testid={placeholder}
+        disabled={disabled}
+        onClick={() => {
+          if (placeholder.includes('projeto')) {
+            onChange?.({ id: 123, label: 'Projeto X', fluxo: 'SUPER' });
+            return;
+          }
+          onChange?.({ id: 456, label: 'Fortaleza - CE' });
+        }}
+      >
+        {placeholder}
+      </button>
+    );
+  },
+}));
+
+import NewSolicitacaoWizard from '../NewSolicitacaoWizard';
+
+describe('NewSolicitacaoWizard - filtros dependentes municipio/projeto', () => {
+  beforeEach(() => {
+    if (!window.matchMedia) {
+      Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: vi.fn().mockImplementation((query: string) => ({
+          matches: false,
+          media: query,
+          onchange: null,
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          dispatchEvent: vi.fn(),
+        })),
+      });
+    }
+
+    vi.clearAllMocks();
+    lookupProjetosMock.mockResolvedValue([]);
+    lookupTiposEventoMock.mockResolvedValue([]);
+    lookupMunicipiosWithFiltersMock.mockResolvedValue([]);
+    getMeMock.mockResolvedValue({ is_superuser: false });
+  });
+
+  test('usuário comum consulta municípios elegíveis por projeto e mostra estado vazio', async () => {
+    render(
+      <MemoryRouter>
+        <NewSolicitacaoWizard />
+      </MemoryRouter>
+    );
+
+    const municipioDisabledButton = await screen.findByRole('button', {
+      name: 'Selecione um projeto para carregar municípios elegíveis',
+    });
+    expect(municipioDisabledButton).toBeDisabled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Busque ou selecione um projeto' }));
+
+    await waitFor(() => {
+      expect(lookupMunicipiosWithFiltersMock).toHaveBeenCalledWith({
+        q: '',
+        com_compra: true,
+        projeto_id: 123,
+      });
+    });
+
+    expect(await screen.findByText('Sem municípios elegíveis')).toBeInTheDocument();
+    expect(
+      screen.getByText('Não há municípios com compra registrada para o projeto selecionado.')
+    ).toBeInTheDocument();
+  });
+
+  test('superuser mantém lookup de municípios sem filtro de compra/projeto', async () => {
+    getMeMock.mockResolvedValue({ is_superuser: true });
+    lookupMunicipiosWithFiltersMock.mockResolvedValue([{ id: 1, label: 'Fortaleza - CE' }]);
+
+    render(
+      <MemoryRouter>
+        <NewSolicitacaoWizard />
+      </MemoryRouter>
+    );
+
+    const municipioButton = await screen.findByRole('button', {
+      name: 'Busque ou selecione um município',
+    });
+    expect(municipioButton).not.toBeDisabled();
+
+    await waitFor(() => {
+      expect(lookupMunicipiosWithFiltersMock).toHaveBeenCalled();
+    });
+
+    const firstCallArg = lookupMunicipiosWithFiltersMock.mock.calls[0][0];
+    expect(firstCallArg.q).toBe('');
+    expect(firstCallArg.com_compra).toBeUndefined();
+    expect(firstCallArg.projeto_id).toBeUndefined();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Busque ou selecione um projeto' }));
+
+    await waitFor(() => {
+      const lastCallArg =
+        lookupMunicipiosWithFiltersMock.mock.calls[lookupMunicipiosWithFiltersMock.mock.calls.length - 1][0];
+      expect(lastCallArg.q).toBe('');
+      expect(lastCallArg.com_compra).toBeUndefined();
+      expect(lastCallArg.projeto_id).toBeUndefined();
+    });
+
+    expect(screen.queryByText('Sem municípios elegíveis')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Contexto
Implementa a issue #722 para alinhar o wizard de nova solicitação com a regra de elegibilidade por compra (município + projeto) já aplicada no backend (#721).

## O que foi alterado
- `v2/frontend/src/pages/Solicitacoes/NewSolicitacaoWizard.tsx`
  - carrega perfil do usuário (`is_superuser`) no mount;
  - usuário comum: município só é consultado após seleção de projeto;
  - lookup de município passa a usar `lookupMunicipiosWithFilters` com `com_compra=true` + `projeto_id`;
  - troca de projeto limpa município selecionado e força recarga dos elegíveis;
  - adiciona estado vazio explícito quando projeto não possui municípios elegíveis.
- `v2/frontend/src/api/lookup.ts`
  - adiciona `lookupMunicipiosWithFilters` e `lookupProjetosWithFilters`;
  - mantém `lookupMunicipios` e `lookupProjetos` para compatibilidade;
  - inclui tipos de params dos filtros.
- `v2/frontend/src/components/ComboBox.tsx`
  - adiciona prop opcional `notFoundContent` para mensagem customizada de vazio.

## Testes adicionados
- `v2/frontend/src/api/__tests__/lookup.test.ts`
- `v2/frontend/src/pages/Solicitacoes/__tests__/NewSolicitacaoWizard.test.tsx`
  - cenário usuário comum (filtro por projeto + estado vazio)
  - cenário superuser (sem filtro de compra/projeto)

## Evidências (Docker)
- `npm run test -- --run src/api/__tests__/lookup.test.ts src/pages/Solicitacoes/__tests__/NewSolicitacaoWizard.test.tsx`
  - resultado: `6 passed`
- `npm run lint`
  - resultado: `pass`
- `npm run build`
  - resultado: `pass`

Closes #722
