### PR TITLE
fix(compras): eliminar ambiguidade entre core_compra e dat_compra (#724)

### DIFF
--- a/docs/architecture/backend.md
+++ b/docs/architecture/backend.md
@@ -52,6 +52,33 @@ class Usuario(AbstractUser):
     # Função: Formador, Coordenador, Gerente
 ```
 
+## Fronteira de Domínio de Compras
+
+O sistema possui dois domínios distintos de compras e eles não devem ser confundidos:
+
+- `core_compra` (`core_compra` table, endpoint `/api/controle/compras/`)
+- `core_dat_compra` (`core_dat_compra` table, endpoint `/api/dat/compras-materiais/`)
+
+### Política oficial (fonte de verdade)
+
+- Elegibilidade de solicitação (município + projeto) usa **somente** `core_compra`.
+- Operação DAT de materiais/estoque usa **somente** `core_dat_compra`.
+- Dashboard de compras DAT usa `core_dat_compra`.
+- Importação de compras de controle (planilha de compras que libera solicitação) alimenta `core_compra`.
+
+### Leitura e escrita por caso de uso
+
+- `core_compra`
+  - leitura: Controle e Superintendência
+  - escrita: pipelines/importações de controle e rotinas ETL
+- `core_dat_compra`
+  - leitura/escrita: DAT e Superintendência (CRUD operacional DAT)
+
+### Contratos mínimos
+
+- `/api/controle/compras/` retorna `quantidade` (não `valor`).
+- `/api/dat/compras-materiais/` retorna contrato DAT (`quantidade`, `quantidade_utilizada`, `valor_unitario`, etc.).
+
 ## Services
 
 A lógica de negócio está isolada em services:

--- a/docs/architecture/frontend.md
+++ b/docs/architecture/frontend.md
@@ -32,6 +32,8 @@ src/
 | `/aprovacoes` | Aprovação (Superintendência) |
 | `/pre-agenda` | Publicação no GCal (Controle) |
 | `/dashboards` | Dashboards e métricas |
+| `/controle/compras` | Compras do domínio Controle (`core_compra`) |
+| `/dat/compras-materiais` | Compras de materiais DAT (`core_dat_compra`) |
 
 ## Autenticação
 

--- a/docs/operations/go-live.md
+++ b/docs/operations/go-live.md
@@ -66,6 +66,13 @@ make ban-v1
 - [ ] Publicar no Calendar funciona
 - [ ] Meet link é gerado
 
+### Compras (fronteira de domínio)
+
+- [ ] `/controle/compras` mostra dados de `core_compra` (com campo `quantidade`).
+- [ ] `/dat/compras-materiais` mostra dados de `core_dat_compra` (materiais/estoque DAT).
+- [ ] Criar solicitação aceita apenas município+projeto elegível em `core_compra`.
+- [ ] Alterações em `core_dat_compra` não mudam elegibilidade de solicitação.
+
 ### Técnicas
 
 - [ ] Logs sem erros críticos

--- a/v2/backend/apps/core/tests/test_compras_domain_boundary.py
+++ b/v2/backend/apps/core/tests/test_compras_domain_boundary.py
@@ -1,0 +1,134 @@
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportOptionalMemberAccess=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportMissingTypeArgument=false, reportCallIssue=false, reportIndexIssue=false, reportOperatorIssue=false, reportOptionalSubscript=false, reportUnknownLambdaType=false
+"""
+Regression tests for explicit boundary between core_compra and dat_compra domains.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+from django.contrib.auth.models import Group
+from rest_framework.test import APIClient
+
+import pytest
+
+from apps.core.models import Compra, DATCompra, Municipio, Projeto, Usuario
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def api_client() -> APIClient:
+    return APIClient()
+
+
+@pytest.fixture
+def controle_user() -> Usuario:
+    user = Usuario.objects.create_user(username="controle_boundary", password="test123", cpf="20000000001")
+    group, _ = Group.objects.get_or_create(name="Controle")
+    user.groups.add(group)
+    return user
+
+
+@pytest.fixture
+def dat_user() -> Usuario:
+    user = Usuario.objects.create_user(username="dat_boundary", password="test123", cpf="20000000002")
+    group, _ = Group.objects.get_or_create(name="DAT")
+    user.groups.add(group)
+    return user
+
+
+@pytest.fixture
+def municipio() -> Municipio:
+    return Municipio.objects.create(nome="Fortaleza", uf="CE")
+
+
+@pytest.fixture
+def projeto() -> Projeto:
+    return Projeto.objects.create(nome="Projeto Fronteira")
+
+
+@pytest.fixture
+def compra_core(municipio: Municipio, projeto: Projeto) -> Compra:
+    return Compra.objects.create(
+        codigo="CORE-001",
+        projeto=projeto,
+        municipio=municipio,
+        quantidade=7,
+        data=date(2026, 3, 1),
+        uso="Libera solicitacao",
+        external_hash="c" * 64,
+    )
+
+
+@pytest.fixture
+def compra_dat(municipio: Municipio, projeto: Projeto, dat_user: Usuario) -> DATCompra:
+    return DATCompra.objects.create(
+        municipio=municipio,
+        projeto=projeto,
+        quantidade=20,
+        quantidade_utilizada=5,
+        valor_unitario=Decimal("12.34"),
+        ano_uso=2026,
+        created_by=dat_user,
+    )
+
+
+def _records(data):
+    if isinstance(data, dict) and "results" in data:
+        return data["results"]
+    return data
+
+
+def test_controle_endpoint_exposes_core_compra_contract(
+    api_client: APIClient,
+    controle_user: Usuario,
+    compra_core: Compra,
+    compra_dat: DATCompra,
+) -> None:
+    api_client.force_authenticate(user=controle_user)
+    response = api_client.get("/api/controle/compras/", secure=True)
+
+    assert response.status_code == 200
+    records = _records(response.data)
+    core_record = next(item for item in records if item["codigo"] == compra_core.codigo)
+
+    assert core_record["quantidade"] == 7
+    assert "valor" not in core_record
+    assert core_record["municipio"] == compra_core.municipio.nome
+
+
+def test_dat_endpoint_exposes_dat_compra_contract(
+    api_client: APIClient,
+    dat_user: Usuario,
+    compra_dat: DATCompra,
+) -> None:
+    api_client.force_authenticate(user=dat_user)
+    response = api_client.get("/api/dat/compras-materiais/", secure=True)
+
+    assert response.status_code == 200
+    records = _records(response.data)
+    dat_record = next(item for item in records if item["id"] == compra_dat.id)
+
+    assert dat_record["quantidade"] == 20
+    assert "valor_unitario" in dat_record
+    assert dat_record["municipio_nome"] == compra_dat.municipio.nome
+
+
+def test_controle_user_cannot_access_dat_compra_domain(
+    api_client: APIClient,
+    controle_user: Usuario,
+) -> None:
+    api_client.force_authenticate(user=controle_user)
+    response = api_client.get("/api/dat/compras-materiais/", secure=True)
+    assert response.status_code == 403
+
+
+def test_dat_user_cannot_access_controle_compra_domain(
+    api_client: APIClient,
+    dat_user: Usuario,
+) -> None:
+    api_client.force_authenticate(user=dat_user)
+    response = api_client.get("/api/controle/compras/", secure=True)
+    assert response.status_code == 403

--- a/v2/backend/apps/core/urls.py
+++ b/v2/backend/apps/core/urls.py
@@ -191,16 +191,6 @@ urlpatterns = [
         name="controle-compras-list",
     ),
     path(
-        "controle/import-acoes/",
-        ControleImportAcoesView.as_view(),
-        name="controle-import-acoes",
-    ),
-    path(
-        "controle/compras/",
-        ControleComprasListView.as_view(),
-        name="controle-compras-list",
-    ),
-    path(
         "controle/acoes/",
         ControleAcoesListView.as_view(),
         name="controle-acoes-list",

--- a/v2/frontend/src/App.tsx
+++ b/v2/frontend/src/App.tsx
@@ -67,7 +67,7 @@ const DeslocamentosPage = lazy(() => import('./pages/Deslocamentos/Deslocamentos
 const DATRegistrosPage = lazy(() => import('./pages/DATModule/DATRegistrosPage'));
 // DAT Module - Novas páginas de gestão
 const AcoesPage = lazy(() => import('./pages/DATModule/AcoesPage'));
-const ComprasPage = lazy(() => import('./pages/DATModule/ComprasPage'));
+const DATComprasPage = lazy(() => import('./pages/DATModule/ComprasPage'));
 const CadastrosPage = lazy(() => import('./pages/DATModule/CadastrosPage'));
 const FormacoesPage = lazy(() => import('./pages/DATModule/FormacoesPage'));
 const PlanoFormacoesPage = lazy(() => import('./pages/DATModule/PlanoFormacoesPage'));
@@ -142,6 +142,7 @@ const ROUTE_TO_MENU_KEY: Record<string, string> = {
   '/dat/admin/colecoes': 'dat-admin-colecoes',
   '/dat/admin/equipe-gerencia': 'dat-admin-equipe-gerencia',
   '/dat/cadastros': 'dat-cadastros',
+  '/dat/compras-materiais': 'dat-compras-materiais',
   '/dat/coordenadores': 'dat-coordenadores',
   '/dat/importacao': 'dat-importacao',
   '/dat/registros': 'dat-registros',
@@ -171,6 +172,7 @@ const MENU_KEY_TO_PARENT: Record<string, string> = {
   'dat-admin-colecoes': 'dat-submenu',
   'dat-admin-equipe-gerencia': 'dat-submenu',
   'dat-cadastros': 'dat-submenu',
+  'dat-compras-materiais': 'dat-submenu',
   'dat-coordenadores': 'dat-submenu',
   'dat-etl-reports': 'dat-submenu',
   'dat-importacao': 'dat-submenu',
@@ -669,6 +671,9 @@ function AppContent(): JSX.Element {
                   <Menu.Item key="dat-cadastros">
                     <Link to="/dat/cadastros">Cadastros</Link>
                   </Menu.Item>
+                  <Menu.Item key="dat-compras-materiais">
+                    <Link to="/dat/compras-materiais">Compras Materiais</Link>
+                  </Menu.Item>
                   <Menu.Item key="dat-coordenadores">
                     <Link to="/dat/coordenadores">Coordenadores</Link>
                   </Menu.Item>
@@ -838,7 +843,7 @@ function AppContent(): JSX.Element {
                   />
                   <Route
                     path="/controle/compras"
-                    element={canControle ? <ComprasPage /> : <Forbidden />}
+                    element={canControle ? <ControlePage /> : <Forbidden />}
                   />
                   {/* Deslocamentos (item único no menu) */}
                   <Route
@@ -902,6 +907,10 @@ function AppContent(): JSX.Element {
                   <Route
                     path="/dat/cadastros"
                     element={canDAT ? <CadastrosPage /> : <Forbidden />}
+                  />
+                  <Route
+                    path="/dat/compras-materiais"
+                    element={canDAT ? <DATComprasPage /> : <Forbidden />}
                   />
                   <Route
                     path="/dat/coordenadores"

--- a/v2/frontend/src/api/ops.ts
+++ b/v2/frontend/src/api/ops.ts
@@ -34,7 +34,7 @@ export interface Compra {
   data: string;
   codigo: string;
   uso: string;
-  valor: number;
+  quantidade: number;
 }
 
 /**

--- a/v2/frontend/src/pages/Controle/ControlePage.tsx
+++ b/v2/frontend/src/pages/Controle/ControlePage.tsx
@@ -229,7 +229,7 @@ export default function ControlePage(): JSX.Element {
                   <th className="px-4 py-3 text-left font-medium text-gray-700">UF</th>
                   <th className="px-4 py-3 text-left font-medium text-gray-700">Projeto</th>
                   <th className="px-4 py-3 text-left font-medium text-gray-700">Código</th>
-                  <th className="px-4 py-3 text-left font-medium text-gray-700">Valor</th>
+                  <th className="px-4 py-3 text-left font-medium text-gray-700">Quantidade</th>
                   <th className="px-4 py-3 text-left font-medium text-gray-700">Uso</th>
                 </tr>
               </thead>
@@ -241,7 +241,7 @@ export default function ControlePage(): JSX.Element {
                     <td className="px-4 py-3">{r.uf}</td>
                     <td className="px-4 py-3">{r.projeto}</td>
                     <td className="px-4 py-3">{r.codigo}</td>
-                    <td className="px-4 py-3">{r.valor}</td>
+                    <td className="px-4 py-3">{r.quantidade}</td>
                     <td className="px-4 py-3">{r.uso}</td>
                   </tr>
                 ))}


### PR DESCRIPTION
## Contexto
Implementa a `#724` para remover ambiguidade entre os domínios de compras e formalizar a fronteira de uso entre `core_compra` e `core_dat_compra`.

## O que foi alterado
- Frontend: `/controle/compras` agora usa o fluxo de Controle (`core_compra`) em `ControlePage`.
- Frontend: adicionada rota explícita `/dat/compras-materiais` para operação DAT (`DATComprasPage`) e item de menu no submenu DAT.
- Frontend: contrato `Compra` alinhado com payload real do backend (`quantidade` em vez de `valor`) e tabela atualizada para exibir `Quantidade`.
- Backend: removidas entradas duplicadas em `core/urls.py` para `controle/import-acoes` e `controle/compras`.
- Backend: adicionado teste de regressão `test_compras_domain_boundary.py` cobrindo:
  - contrato de `/api/controle/compras/`
  - contrato de `/api/dat/compras-materiais/`
  - isolamento de permissão entre Controle e DAT
- Documentação: fronteira oficial e checklist operacional atualizados em:
  - `docs/architecture/backend.md`
  - `docs/architecture/frontend.md`
  - `docs/operations/go-live.md`

## Validação executada (Docker)
- `pytest -q apps/core/tests/test_compras_domain_boundary.py`
- `black --check apps/core/tests/test_compras_domain_boundary.py apps/core/urls.py`
- `isort --check-only apps/core/tests/test_compras_domain_boundary.py apps/core/urls.py`
- `flake8 apps/core/tests/test_compras_domain_boundary.py apps/core/urls.py`
- `npm run lint`
- `npm run build`

Todos passaram localmente.

## Risco e rollback
- Risco principal: usuário DAT acostumado com `/controle/compras` pode precisar usar a nova rota DAT dedicada.
- Rollback simples: reverter este PR restaura o mapeamento anterior.


Closes #724