### PR TITLE
feat(dashboard): relatório de municípios com compra sem evento agendado (#717)

### DIFF
--- a/v2/backend/apps/core/tests/test_dat_module.py
+++ b/v2/backend/apps/core/tests/test_dat_module.py
@@ -24,10 +24,12 @@ from django.contrib.auth.models import Group
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 from django.urls import reverse
+from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APITestCase
 
 from apps.core.models import (
+    Compra,
     DATAcao,
     DATArea,
     DATCadastro,
@@ -38,6 +40,8 @@ from apps.core.models import (
     Produto,
     Projeto,
     ProjetoGeral,
+    Solicitacao,
+    TipoEvento,
 )
 
 User = get_user_model()
@@ -608,6 +612,61 @@ class DATCompraAPITests(DATModuleAPITestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn("total", response.data)
+
+    def test_pendencias_action_returns_only_pairs_without_active_event(self):
+        """Pendencias should list only core_compra pairs without pending/approved solicitacao."""
+        self.client.force_authenticate(user=self.dat_user)
+
+        tipo_evento = TipoEvento.objects.create(nome="Seminário DAT")
+
+        Compra.objects.create(
+            codigo="CORE-A",
+            projeto=self.projeto,
+            municipio=self.municipio,
+            quantidade=10,
+            data=date(2026, 3, 1),
+            uso="Fluxo A",
+            external_hash="a" * 64,
+        )
+        Compra.objects.create(
+            codigo="CORE-B",
+            projeto=self.projeto,
+            municipio=self.municipio2,
+            quantidade=20,
+            data=date(2026, 3, 2),
+            uso="Fluxo B",
+            external_hash="b" * 64,
+        )
+
+        inicio = timezone.now() + timedelta(days=2)
+        fim = inicio + timedelta(hours=2)
+        Solicitacao.objects.create(
+            usuario=self.dat_user,
+            municipio=self.municipio,
+            projeto=self.projeto,
+            tipo_evento=tipo_evento,
+            inicio=inicio,
+            fim=fim,
+            status="pendente",
+        )
+
+        url = reverse("core:dat-compra-material-pendencias")
+        response = self.client.get(url, secure=True)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["total_com_compra"], 2)
+        self.assertEqual(response.data["total_com_evento"], 1)
+        self.assertEqual(response.data["total_pendentes"], 1)
+        self.assertEqual(len(response.data["pendentes"]), 1)
+        self.assertEqual(response.data["pendentes"][0]["municipio"], self.municipio2.nome)
+        self.assertEqual(response.data["pendentes"][0]["projeto"], self.projeto.nome)
+
+    def test_pendencias_action_forbidden_for_regular_user(self):
+        """Regular users should not access pendencias action."""
+        self.client.force_authenticate(user=self.regular_user)
+        url = reverse("core:dat-compra-material-pendencias")
+        response = self.client.get(url, secure=True)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
 
 class DATCadastroAPITests(DATModuleAPITestCase):

--- a/v2/backend/apps/core/views/dat_module.py
+++ b/v2/backend/apps/core/views/dat_module.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from django.db.models import Count, F, Q, Sum, Value
+from django.db.models import Count, Exists, F, Max, OuterRef, Q, Sum, Value
 from django.db.models.functions import Coalesce
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
@@ -32,6 +32,7 @@ from django_filters import rest_framework as filters
 from django_filters.rest_framework import DjangoFilterBackend
 
 from apps.core.models import (
+    Compra,
     DATAcao,
     DATArea,
     DATCadastro,
@@ -39,6 +40,7 @@ from apps.core.models import (
     DATCoordenador,
     DATFormacao,
     MunicipioReferencia,
+    Solicitacao,
 )
 from apps.core.permissions import IsDATOrSuper, IsSuperintendenciaOnly
 from apps.core.serializers import (
@@ -549,6 +551,82 @@ class DATCompraViewSet(viewsets.ModelViewSet):
                 "top_frequencia": top_frequencia,
                 "por_ano": por_ano,
                 "por_tipo_compra": por_tipo_compra,
+            }
+        )
+
+    @action(detail=False, methods=["get"], permission_classes=[IsDATOrSuper])
+    def pendencias(self, request: Request) -> Response:
+        """
+        Municípios com compra no domínio core_compra e sem solicitação ativa.
+
+        A pendência é calculada por par (município + projeto) para refletir
+        a regra de negócio da operação.
+
+        GET /api/dat/compras-materiais/pendencias/
+        Query params opcionais:
+            - uf: filtra por UF
+            - projeto_id: filtra por projeto
+        """
+        compras_qs = Compra.objects.select_related("municipio", "projeto")
+
+        uf = request.query_params.get("uf")
+        projeto_id = request.query_params.get("projeto_id")
+
+        if uf:
+            compras_qs = compras_qs.filter(municipio__uf__iexact=uf)
+        if projeto_id:
+            compras_qs = compras_qs.filter(projeto_id=projeto_id)
+
+        solicitacoes_ativas = Solicitacao.objects.filter(
+            municipio_id=OuterRef("municipio_id"),
+            projeto_id=OuterRef("projeto_id"),
+            status__in=["pendente", "aprovado"],
+        )
+
+        base_pairs = (
+            compras_qs.values(
+                "municipio_id",
+                "municipio__nome",
+                "municipio__uf",
+                "projeto_id",
+                "projeto__nome",
+            )
+            .annotate(
+                total_itens=Sum("quantidade"),
+                total_compras=Count("id"),
+                ultima_compra=Max("data"),
+                possui_evento=Exists(solicitacoes_ativas),
+            )
+            .order_by("municipio__nome", "projeto__nome")
+        )
+
+        total_com_compra = base_pairs.count()
+        total_com_evento = base_pairs.filter(possui_evento=True).count()
+        pendentes_pairs = base_pairs.filter(possui_evento=False)
+        total_pendentes = pendentes_pairs.count()
+        percentual_pendentes = round((total_pendentes / total_com_compra) * 100, 1) if total_com_compra > 0 else 0
+
+        pendentes = [
+            {
+                "municipio_id": item["municipio_id"],
+                "municipio": item["municipio__nome"],
+                "uf": item["municipio__uf"],
+                "projeto_id": item["projeto_id"],
+                "projeto": item["projeto__nome"],
+                "total_itens": item["total_itens"] or 0,
+                "total_compras": item["total_compras"],
+                "ultima_compra": item["ultima_compra"],
+            }
+            for item in pendentes_pairs
+        ]
+
+        return Response(
+            {
+                "total_com_compra": total_com_compra,
+                "total_com_evento": total_com_evento,
+                "total_pendentes": total_pendentes,
+                "percentual_pendentes": percentual_pendentes,
+                "pendentes": pendentes,
             }
         )
 

--- a/v2/frontend/src/api/datModule.ts
+++ b/v2/frontend/src/api/datModule.ts
@@ -343,6 +343,29 @@ export async function getComprasDashboard(params: FilterParams = {}): Promise<Co
   return apiRequest(() => api.get('/dat/compras-materiais/dashboard/', { params }));
 }
 
+export interface CompraPendenteItem {
+  municipio_id: number;
+  municipio: string;
+  uf: string;
+  projeto_id: number;
+  projeto: string;
+  total_itens: number;
+  total_compras: number;
+  ultima_compra: string | null;
+}
+
+export interface ComprasPendenciasResponse {
+  total_com_compra: number;
+  total_com_evento: number;
+  total_pendentes: number;
+  percentual_pendentes: number;
+  pendentes: CompraPendenteItem[];
+}
+
+export async function getComprasPendencias(params: FilterParams = {}): Promise<ComprasPendenciasResponse> {
+  return apiRequest(() => api.get('/dat/compras-materiais/pendencias/', { params }));
+}
+
 // ========== CADASTROS (Workflow FORMAR/AVALIAR) ==========
 
 /**

--- a/v2/frontend/src/pages/Dashboards/ComprasDashboardPage.tsx
+++ b/v2/frontend/src/pages/Dashboards/ComprasDashboardPage.tsx
@@ -25,6 +25,7 @@ import {
   AppstoreOutlined,
   BookOutlined,
   CheckCircleOutlined,
+  DownloadOutlined,
   DollarOutlined,
   EnvironmentOutlined,
   InboxOutlined,
@@ -33,9 +34,12 @@ import {
 } from '@ant-design/icons';
 import {
   getComprasDashboard,
+  getComprasPendencias,
   getProdutosOptions,
   getProjetosOptions,
+  type CompraPendenteItem,
   type ComprasDashboardData,
+  type ComprasPendenciasResponse,
 } from '../../api/datModule';
 import { UF_OPTIONS } from '../../constants';
 import './ComprasDashboardPage.css';
@@ -69,6 +73,11 @@ const formatNumber = (value: unknown): string =>
 
 const formatCurrency = (value: unknown): string =>
   `R$ ${toNumber(value).toLocaleString('pt-BR', { minimumFractionDigits: 2 })}`;
+
+const formatDate = (value: string | null): string => {
+  if (!value) return '-';
+  return new Date(`${value}T00:00:00`).toLocaleDateString('pt-BR');
+};
 
 function BarList({
   data,
@@ -175,6 +184,7 @@ export default function ComprasDashboardPage(): JSX.Element {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [data, setData] = useState<ComprasDashboardData | null>(null);
+  const [pendencias, setPendencias] = useState<ComprasPendenciasResponse | null>(null);
 
   const [projetos, setProjetos] = useState<OptionItem[]>([]);
   const [produtos, setProdutos] = useState<OptionItem[]>([]);
@@ -192,17 +202,26 @@ export default function ComprasDashboardPage(): JSX.Element {
     setError(null);
 
     try {
-      const params: Record<string, string | number> = {};
-      if (filters.uf) params.uf = filters.uf;
-      if (filters.ano_uso) params.ano_uso = filters.ano_uso;
-      if (filters.projeto) params.projeto_id = filters.projeto;
-      if (filters.produto) params.produto_id = filters.produto;
-      if (filters.tipo_compra) params.tipo_compra = filters.tipo_compra;
+      const dashboardParams: Record<string, string | number> = {};
+      if (filters.uf) dashboardParams.uf = filters.uf;
+      if (filters.ano_uso) dashboardParams.ano_uso = filters.ano_uso;
+      if (filters.projeto) dashboardParams.projeto_id = filters.projeto;
+      if (filters.produto) dashboardParams.produto_id = filters.produto;
+      if (filters.tipo_compra) dashboardParams.tipo_compra = filters.tipo_compra;
 
-      const response = await getComprasDashboard(params);
-      setData(response);
+      const pendenciasParams: Record<string, string | number> = {};
+      if (filters.uf) pendenciasParams.uf = filters.uf;
+      if (filters.projeto) pendenciasParams.projeto_id = filters.projeto;
+
+      const [dashboardResponse, pendenciasResponse] = await Promise.all([
+        getComprasDashboard(dashboardParams),
+        getComprasPendencias(pendenciasParams),
+      ]);
+      setData(dashboardResponse);
+      setPendencias(pendenciasResponse);
     } catch (err) {
       setError((err as Error).message || 'Erro ao carregar dashboard');
+      setPendencias(null);
     } finally {
       setLoading(false);
     }
@@ -297,6 +316,95 @@ export default function ComprasDashboardPage(): JSX.Element {
       },
     },
   ];
+
+  const pendenciasColumns: ColumnsType<CompraPendenteItem> = [
+    {
+      title: 'Município',
+      dataIndex: 'municipio',
+      key: 'municipio',
+      render: (value: string, record) => (
+        <Space>
+          <Tag color="gold">{record.uf}</Tag>
+          <Text strong>{value}</Text>
+        </Space>
+      ),
+    },
+    {
+      title: 'Projeto',
+      dataIndex: 'projeto',
+      key: 'projeto',
+    },
+    {
+      title: 'Itens',
+      dataIndex: 'total_itens',
+      key: 'total_itens',
+      align: 'right',
+      render: (value: number) => formatNumber(value),
+    },
+    {
+      title: 'Compras',
+      dataIndex: 'total_compras',
+      key: 'total_compras',
+      align: 'right',
+      render: (value: number) => formatNumber(value),
+    },
+    {
+      title: 'Última compra',
+      dataIndex: 'ultima_compra',
+      key: 'ultima_compra',
+      align: 'right',
+      render: (value: string | null) => formatDate(value),
+    },
+  ];
+
+  const handleExportPendenciasCsv = () => {
+    if (!pendencias || pendencias.pendentes.length === 0) return;
+
+    const escapeCsv = (value: string | number | null) => {
+      const text = value === null ? '' : String(value);
+      return `"${text.replace(/"/g, '""')}"`;
+    };
+
+    const header = [
+      'municipio_id',
+      'municipio',
+      'uf',
+      'projeto_id',
+      'projeto',
+      'total_itens',
+      'total_compras',
+      'ultima_compra',
+    ];
+
+    const lines = pendencias.pendentes.map((item) =>
+      [
+        item.municipio_id,
+        item.municipio,
+        item.uf,
+        item.projeto_id,
+        item.projeto,
+        item.total_itens,
+        item.total_compras,
+        item.ultima_compra ?? '',
+      ]
+        .map(escapeCsv)
+        .join(';')
+    );
+
+    const csv = `${header.join(';')}\n${lines.join('\n')}`;
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const url = window.URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.setAttribute(
+      'download',
+      `municipios-pendentes-agendamento-${new Date().toISOString().slice(0, 10)}.csv`
+    );
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    window.URL.revokeObjectURL(url);
+  };
 
   if (loading) {
     return (
@@ -483,6 +591,45 @@ export default function ComprasDashboardPage(): JSX.Element {
           </Card>
         </Col>
       </Row>
+
+      <Card
+        className="chart-card mb-6"
+        bordered={false}
+        title={(
+          <Space>
+            <EnvironmentOutlined />
+            <span className="chart-title">Municípios pendentes de agendamento</span>
+          </Space>
+        )}
+        extra={(
+          <Button
+            icon={<DownloadOutlined />}
+            onClick={handleExportPendenciasCsv}
+            disabled={!pendencias || pendencias.pendentes.length === 0}
+          >
+            Exportar CSV
+          </Button>
+        )}
+      >
+        {pendencias ? (
+          <Space direction="vertical" size={12} style={{ width: '100%' }}>
+            <Text type="secondary">
+              {formatNumber(pendencias.total_com_compra)} com compra · {formatNumber(pendencias.total_com_evento)} com
+              evento · <Text strong>{formatNumber(pendencias.total_pendentes)} pendentes</Text>
+              {' '}({pendencias.percentual_pendentes}%)
+            </Text>
+            <Table
+              dataSource={pendencias.pendentes}
+              columns={pendenciasColumns}
+              rowKey={(record) => `${record.municipio_id}-${record.projeto_id}`}
+              pagination={{ pageSize: 10, showSizeChanger: false }}
+              locale={{ emptyText: 'Sem pendências para os filtros selecionados' }}
+            />
+          </Space>
+        ) : (
+          <Empty description="Sem dados de pendências" />
+        )}
+      </Card>
 
       <Row gutter={[16, 16]} className="mb-6">
         <Col xs={24} lg={12}>


### PR DESCRIPTION
## Contexto
Implementa a `#717` com relatório de pendências de agendamento no Dashboard de Compras, usando `core_compra` como fonte de verdade e regra por par `município + projeto`.

## O que foi feito
- Backend: adicionado endpoint `GET /api/dat/compras-materiais/pendencias/` em `DATCompraViewSet`.
  - Fonte de dados: `core_compra`.
  - Regra de pendência: par município+projeto sem solicitação ativa (`pendente` ou `aprovado`).
  - Filtros opcionais: `uf` e `projeto_id`.
  - Retorno: totais (`total_com_compra`, `total_com_evento`, `total_pendentes`, `percentual_pendentes`) + lista `pendentes`.
- Backend tests: novos testes em `test_dat_module.py`:
  - retorno correto de pendências por par município+projeto
  - permissão (usuário regular recebe 403)
- Frontend API: adicionadas tipagens e client `getComprasPendencias` em `v2/frontend/src/api/datModule.ts`.
- Frontend Dashboard: nova seção **Municípios pendentes de agendamento** em `ComprasDashboardPage.tsx`:
  - resumo com contadores
  - tabela de pendências
  - exportação CSV da tabela
  - respeita filtros aplicáveis (`UF` e `Projeto`)

## Validação executada (Docker)
- `black --check apps/core/views/dat_module.py apps/core/tests/test_dat_module.py`
- `isort --check-only apps/core/views/dat_module.py apps/core/tests/test_dat_module.py`
- `flake8 apps/core/views/dat_module.py apps/core/tests/test_dat_module.py`
- `pytest -q apps/core/tests/test_dat_module.py -k 'DATCompraAPITests and pendencias'`
- `npm run lint`
- `npm run build`

Todos passaram localmente.

## Risco e rollback
- Risco principal: interpretação de “evento ativo” (considerado como `pendente`/`aprovado`).
- Rollback: reverter este PR para remover endpoint/visualização de pendências.

Closes #717
