### PR TITLE
ci(api-contract): harden OpenAPI for critical frontend endpoints

### DIFF
--- a/docs/architecture/openapi-contract-gate.md
+++ b/docs/architecture/openapi-contract-gate.md
@@ -1,22 +1,47 @@
-# OpenAPI Contract Gate (Dashboard/GCal)
+# OpenAPI Contract Gate (Frontend Critical Endpoints)
 
 Esta política define o conjunto mínimo de endpoints críticos cujo contrato OpenAPI é bloqueante no CI.
 
 ## Objetivo
 
-Evitar regressão silenciosa de schema (`No response body` ou respostas genéricas) nos endpoints usados pelo frontend em páginas de dashboard e GCal.
+Evitar regressão silenciosa de schema (`No response body` ou respostas genéricas) nos endpoints críticos usados pelo frontend.
 
 ## Endpoints no gate mínimo
 
-- `GET /api/dashboard/overview/`
-- `GET /api/gcal/status-summary/`
-- `GET /api/gcal/dashboard/metrics/`
-- `GET /api/gcal/dashboard/events/`
-- `GET /api/gcal/dashboard/insights/success-rate/`
-- `GET /api/gcal/dashboard/insights/top/`
-- `GET /api/gcal/dashboard/events/{id}/detail/`
-- `POST /api/gcal/dashboard/batch/reapply/`
-- `POST /api/gcal/dashboard/batch/resync/`
+- Dashboard/GCal:
+  - `GET /api/dashboard/overview/`
+  - `GET /api/gcal/status-summary/`
+  - `GET /api/gcal/dashboard/metrics/`
+  - `GET /api/gcal/dashboard/events/`
+  - `GET /api/gcal/dashboard/insights/success-rate/`
+  - `GET /api/gcal/dashboard/insights/top/`
+  - `GET /api/gcal/dashboard/events/{id}/detail/`
+  - `POST /api/gcal/dashboard/batch/reapply/`
+  - `POST /api/gcal/dashboard/batch/resync/`
+- Home/Disponibilidade:
+  - `GET /api/stats/home/`
+  - `GET /api/availability/monthly/`
+- Options (`/api/options/*`):
+  - `GET /api/options/municipios/`
+  - `GET /api/options/projetos/`
+  - `GET /api/options/tipos-evento/`
+  - `GET /api/options/usuarios/`
+  - `GET /api/options/produtos/`
+  - `GET /api/options/coordenadores/`
+  - `GET /api/options/areas/`
+  - `GET /api/options/formadores-do-setor/`
+- Import operations (frontend):
+  - `POST /api/controle/import-compras/`
+  - `POST /api/controle/import-acoes/`
+  - `POST /api/dat/import-cadastros/`
+  - `POST /api/disponibilidade/import-bloqueios/`
+  - `POST /api/deslocamentos/import/`
+  - `POST /api/solicitacoes/import/`
+  - `POST /api/usuarios/import/`
+  - `POST /api/municipios/import/`
+  - `POST /api/colecoes/import/`
+  - `POST /api/equipe-gerencia/import/`
+  - `POST /api/produtos/import/`
 
 ## Como o gate é aplicado
 

--- a/v2/backend/apps/core/serializers/openapi_critical_contract.py
+++ b/v2/backend/apps/core/serializers/openapi_critical_contract.py
@@ -1,0 +1,58 @@
+"""
+OpenAPI contract serializers for critical frontend endpoints (#703).
+
+These serializers exist only to provide explicit, stable API contracts in
+drf-spectacular for CI gate assertions.
+"""
+
+# pyright: reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportMissingParameterType=false, reportAttributeAccessIssue=false, reportReturnType=false, reportArgumentType=false, reportUntypedBaseClass=false, reportMissingTypeArgument=false, reportOptionalMemberAccess=false, reportCallIssue=false, reportUntypedFunctionDecorator=false, reportMissingTypeStubs=false
+
+from __future__ import annotations
+
+from rest_framework import serializers
+
+
+class HomeStatsResponseSerializer(serializers.Serializer):
+    pending_approvals = serializers.IntegerField(allow_null=True)
+    upcoming_events = serializers.IntegerField()
+    my_requests = serializers.IntegerField(allow_null=True)
+
+
+class MonthlyAvailabilityPersonSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    name = serializers.CharField()
+    email = serializers.EmailField(allow_blank=True)
+    ch_month = serializers.FloatField()
+    ch_year = serializers.FloatField()
+    position_month = serializers.IntegerField()
+
+
+class MonthlyAvailabilityResponseSerializer(serializers.Serializer):
+    days = serializers.ListField(child=serializers.IntegerField())
+    legend = serializers.DictField(child=serializers.CharField())
+    people = MonthlyAvailabilityPersonSerializer(many=True)
+    cells = serializers.ListField(child=serializers.ListField(child=serializers.CharField(allow_blank=True)))
+    details_index = serializers.DictField(child=serializers.ListField(child=serializers.JSONField()))
+
+
+class MonthlyAvailabilityErrorResponseSerializer(serializers.Serializer):
+    error = serializers.CharField()
+
+
+class ImportFileUploadRequestSerializer(serializers.Serializer):
+    file = serializers.FileField()
+
+
+class ImportOperationResponseSerializer(serializers.Serializer):
+    stats = serializers.DictField(child=serializers.JSONField(), required=False)
+    pendencias = serializers.DictField(child=serializers.JSONField(), required=False)
+    dry_run = serializers.BooleanField(required=False)
+    file = serializers.CharField(required=False)
+    path = serializers.CharField(required=False)
+    created_ids = serializers.ListField(child=serializers.IntegerField(), required=False)
+    ts = serializers.CharField(required=False)
+    detail = serializers.CharField(required=False)
+
+
+class ImportOperationErrorResponseSerializer(serializers.Serializer):
+    detail = serializers.CharField()

--- a/v2/backend/apps/core/tests/test_openapi.py
+++ b/v2/backend/apps/core/tests/test_openapi.py
@@ -109,6 +109,21 @@ class TestOpenAPISchema(TestCase):
             if isinstance(first_ref, dict):
                 return self._resolve_schema_properties(schema, first_ref)
 
+        if "oneOf" in schema_ref and schema_ref["oneOf"]:
+            first_ref = schema_ref["oneOf"][0]
+            if isinstance(first_ref, dict):
+                return self._resolve_schema_properties(schema, first_ref)
+
+        if "anyOf" in schema_ref and schema_ref["anyOf"]:
+            first_ref = schema_ref["anyOf"][0]
+            if isinstance(first_ref, dict):
+                return self._resolve_schema_properties(schema, first_ref)
+
+        if schema_ref.get("type") == "array":
+            items_ref = schema_ref.get("items", {})
+            if isinstance(items_ref, dict):
+                return self._resolve_schema_properties(schema, items_ref)
+
         if "$ref" not in schema_ref:
             return schema_ref.get("properties", {})
 
@@ -195,6 +210,112 @@ class TestOpenAPISchema(TestCase):
                 properties,
                 f"Missing field '{field}' in /api/dashboard/overview/ OpenAPI response schema",
             )
+
+    def test_schema_has_typed_response_for_home_stats(self) -> None:
+        """Schema must define explicit response fields for /api/stats/home/."""
+        response = self.client.get("/api/schema/?format=json")
+        self.assertEqual(response.status_code, 200)
+        schema = response.json()
+
+        response_schema = self._get_response_schema(schema, "/api/stats/home/", "get", "200")
+        self.assertTrue(response_schema, "Expected typed 200 response schema for /api/stats/home/")
+
+        properties = self._resolve_schema_properties(schema, response_schema)
+        for field in ["pending_approvals", "upcoming_events", "my_requests"]:
+            self.assertIn(field, properties, f"Missing field '{field}' in /api/stats/home/ OpenAPI response schema")
+
+    def test_schema_has_typed_response_for_monthly_availability(self) -> None:
+        """Schema must define explicit response fields and query parameters for /api/availability/monthly/."""
+        response = self.client.get("/api/schema/?format=json")
+        self.assertEqual(response.status_code, 200)
+        schema = response.json()
+
+        response_schema = self._get_response_schema(schema, "/api/availability/monthly/", "get", "200")
+        self.assertTrue(response_schema, "Expected typed 200 response schema for /api/availability/monthly/")
+
+        properties = self._resolve_schema_properties(schema, response_schema)
+        for field in ["days", "legend", "people", "cells", "details_index"]:
+            self.assertIn(
+                field,
+                properties,
+                f"Missing field '{field}' in /api/availability/monthly/ OpenAPI response schema",
+            )
+
+        parameters = schema.get("paths", {}).get("/api/availability/monthly/", {}).get("get", {}).get("parameters", [])
+        parameter_names = {param.get("name") for param in parameters}
+        for param_name in ["year", "month", "role", "gerencia_id", "sector", "q"]:
+            self.assertIn(
+                param_name, parameter_names, f"Missing query parameter '{param_name}' in monthly availability"
+            )
+
+    def test_schema_has_typed_responses_for_options_endpoints(self) -> None:
+        """Schema must define explicit list item fields for /api/options/* endpoints used by frontend."""
+        response = self.client.get("/api/schema/?format=json")
+        self.assertEqual(response.status_code, 200)
+        schema = response.json()
+
+        endpoints = [
+            ("/api/options/municipios/", ["id", "nome", "uf"]),
+            ("/api/options/projetos/", ["id", "nome", "codigo"]),
+            ("/api/options/tipos-evento/", ["id", "nome"]),
+            ("/api/options/usuarios/", ["id", "first_name", "last_name", "email"]),
+            ("/api/options/produtos/", ["id", "nome", "codigo"]),
+            ("/api/options/coordenadores/", ["id", "nome", "area", "ativo"]),
+            ("/api/options/areas/", ["id", "nome", "cor"]),
+            ("/api/options/formadores-do-setor/", ["id", "first_name", "last_name", "email"]),
+        ]
+
+        for path, expected_fields in endpoints:
+            response_schema = self._get_response_schema(schema, path, "get", "200")
+            self.assertTrue(response_schema, f"Expected typed 200 response schema for {path} GET")
+            properties = self._resolve_schema_properties(schema, response_schema)
+            for field in expected_fields:
+                self.assertIn(
+                    field,
+                    properties,
+                    f"Missing field '{field}' in {path} GET OpenAPI response schema",
+                )
+
+    def test_schema_has_typed_responses_for_import_operations_used_by_frontend(self) -> None:
+        """Schema must define explicit request/response contracts for critical import operations."""
+        response = self.client.get("/api/schema/?format=json")
+        self.assertEqual(response.status_code, 200)
+        schema = response.json()
+
+        import_paths = [
+            "/api/controle/import-compras/",
+            "/api/controle/import-acoes/",
+            "/api/dat/import-cadastros/",
+            "/api/disponibilidade/import-bloqueios/",
+            "/api/deslocamentos/import/",
+            "/api/solicitacoes/import/",
+            "/api/usuarios/import/",
+            "/api/municipios/import/",
+            "/api/colecoes/import/",
+            "/api/equipe-gerencia/import/",
+            "/api/produtos/import/",
+        ]
+
+        for path in import_paths:
+            response_schema = self._get_response_schema(schema, path, "post", "200")
+            self.assertTrue(response_schema, f"Expected typed 200 response schema for {path} POST")
+            properties = self._resolve_schema_properties(schema, response_schema)
+
+            for field in ["stats", "pendencias", "dry_run", "file", "path", "detail"]:
+                self.assertIn(field, properties, f"Missing field '{field}' in {path} POST OpenAPI response schema")
+
+            request_schema = (
+                schema.get("paths", {})
+                .get(path, {})
+                .get("post", {})
+                .get("requestBody", {})
+                .get("content", {})
+                .get("multipart/form-data", {})
+                .get("schema", {})
+            )
+            self.assertTrue(request_schema, f"Expected multipart request schema for {path} POST")
+            request_properties = self._resolve_schema_properties(schema, request_schema)
+            self.assertIn("file", request_properties, f"Missing field 'file' in {path} POST request schema")
 
     def test_schema_has_typed_responses_for_gcal_dashboard_reads(self) -> None:
         """Schema must define explicit response fields for critical GCal dashboard read endpoints."""

--- a/v2/backend/apps/core/views/stats.py
+++ b/v2/backend/apps/core/views/stats.py
@@ -19,7 +19,10 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from drf_spectacular.utils import extend_schema
+
 from apps.core.models import EquipeGerencia, Solicitacao
+from apps.core.serializers.openapi_critical_contract import HomeStatsResponseSerializer
 
 
 class HomeStatsView(APIView):
@@ -38,6 +41,11 @@ class HomeStatsView(APIView):
 
     permission_classes = [IsAuthenticated]
 
+    @extend_schema(
+        responses={200: HomeStatsResponseSerializer},
+        tags=["stats"],
+        summary="Estatísticas da home por perfil",
+    )
     def get(self, request: Request) -> Response:
         user = request.user
         now = timezone.now()

--- a/v2/backend/apps/core/views_availability_monthly.py
+++ b/v2/backend/apps/core/views_availability_monthly.py
@@ -33,7 +33,13 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from drf_spectacular.utils import OpenApiParameter, extend_schema
+
 from apps.core.permissions import HasSectorAccess
+from apps.core.serializers.openapi_critical_contract import (
+    MonthlyAvailabilityErrorResponseSerializer,
+    MonthlyAvailabilityResponseSerializer,
+)
 from apps.core.services.monthly_grid_service import build_monthly_grid
 
 
@@ -61,6 +67,54 @@ class MonthlyAvailabilityView(APIView):
 
     permission_classes = [IsAuthenticated, HasSectorAccess]
 
+    @extend_schema(
+        summary="Grade mensal de disponibilidade",
+        parameters=[
+            OpenApiParameter(
+                name="year",
+                location=OpenApiParameter.QUERY,
+                required=True,
+                type=int,
+            ),
+            OpenApiParameter(
+                name="month",
+                location=OpenApiParameter.QUERY,
+                required=True,
+                type=int,
+            ),
+            OpenApiParameter(
+                name="role",
+                location=OpenApiParameter.QUERY,
+                required=True,
+                type=str,
+                enum=["FORMADOR", "COORDENADOR"],
+            ),
+            OpenApiParameter(
+                name="gerencia_id",
+                location=OpenApiParameter.QUERY,
+                required=False,
+                type=int,
+            ),
+            OpenApiParameter(
+                name="sector",
+                location=OpenApiParameter.QUERY,
+                required=False,
+                type=str,
+            ),
+            OpenApiParameter(
+                name="q",
+                location=OpenApiParameter.QUERY,
+                required=False,
+                type=str,
+            ),
+        ],
+        responses={
+            200: MonthlyAvailabilityResponseSerializer,
+            400: MonthlyAvailabilityErrorResponseSerializer,
+            500: MonthlyAvailabilityErrorResponseSerializer,
+        },
+        tags=["availability"],
+    )
     def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         # Validação de parâmetros básicos
         try:

--- a/v2/backend/apps/core/views_controle_imports.py
+++ b/v2/backend/apps/core/views_controle_imports.py
@@ -21,7 +21,15 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from drf_spectacular.utils import OpenApiParameter, extend_schema
+
+from apps.core.api_schemas import COMMON_ERROR_RESPONSES
 from apps.core.permissions import IsControleOrSuper
+from apps.core.serializers.openapi_critical_contract import (
+    ImportFileUploadRequestSerializer,
+    ImportOperationErrorResponseSerializer,
+    ImportOperationResponseSerializer,
+)
 from apps.core.services.controle_imports import import_compras_from_file
 
 # Issue #569: Upload validation hardening (DoS/malicious file prevention)
@@ -62,6 +70,28 @@ class ImportComprasView(APIView):
 
     permission_classes = [IsControleOrSuper]
 
+    @extend_schema(
+        summary="Importar compras",
+        parameters=[
+            OpenApiParameter(
+                name="dry_run",
+                location=OpenApiParameter.QUERY,
+                required=False,
+                type=bool,
+                description="Quando true, executa validação sem persistir dados.",
+            ),
+        ],
+        request=ImportFileUploadRequestSerializer,
+        responses={
+            200: ImportOperationResponseSerializer,
+            400: ImportOperationErrorResponseSerializer,
+            401: COMMON_ERROR_RESPONSES[401],
+            403: COMMON_ERROR_RESPONSES[403],
+            413: ImportOperationErrorResponseSerializer,
+            500: ImportOperationErrorResponseSerializer,
+        },
+        tags=["imports"],
+    )
     def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         # Parse dry_run query param
         dry_run_param = str(request.query_params.get("dry_run", "true")).lower()

--- a/v2/backend/apps/core/views_import_bloqueios.py
+++ b/v2/backend/apps/core/views_import_bloqueios.py
@@ -23,7 +23,15 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from drf_spectacular.utils import OpenApiParameter, extend_schema
+
+from apps.core.api_schemas import COMMON_ERROR_RESPONSES
 from apps.core.permissions import IsControleOrSuper
+from apps.core.serializers.openapi_critical_contract import (
+    ImportFileUploadRequestSerializer,
+    ImportOperationErrorResponseSerializer,
+    ImportOperationResponseSerializer,
+)
 from apps.core.services.bloqueios_import import import_bloqueios_from_file
 
 # Issue #132: Upload validation (SEC-P0)
@@ -62,6 +70,28 @@ class ImportBloqueiosView(APIView):
 
     permission_classes = [IsAuthenticated, IsControleOrSuper]
 
+    @extend_schema(
+        summary="Importar bloqueios de disponibilidade",
+        parameters=[
+            OpenApiParameter(
+                name="dry_run",
+                location=OpenApiParameter.QUERY,
+                required=False,
+                type=bool,
+                description="Quando true, executa validação sem persistir dados.",
+            ),
+        ],
+        request=ImportFileUploadRequestSerializer,
+        responses={
+            200: ImportOperationResponseSerializer,
+            400: ImportOperationErrorResponseSerializer,
+            401: COMMON_ERROR_RESPONSES[401],
+            403: COMMON_ERROR_RESPONSES[403],
+            413: ImportOperationErrorResponseSerializer,
+            500: ImportOperationErrorResponseSerializer,
+        },
+        tags=["imports"],
+    )
     def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         # Parse dry_run query param
         dry_run_param = str(request.query_params.get("dry_run", "true")).lower()

--- a/v2/backend/apps/core/views_import_colecoes.py
+++ b/v2/backend/apps/core/views_import_colecoes.py
@@ -23,7 +23,15 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from drf_spectacular.utils import OpenApiParameter, extend_schema
+
+from apps.core.api_schemas import COMMON_ERROR_RESPONSES
 from apps.core.permissions import IsDATOrSuper
+from apps.core.serializers.openapi_critical_contract import (
+    ImportFileUploadRequestSerializer,
+    ImportOperationErrorResponseSerializer,
+    ImportOperationResponseSerializer,
+)
 from apps.core.services.colecoes_import import import_colecoes_from_file
 
 # Issue #132: Upload validation (SEC-P0)
@@ -50,6 +58,28 @@ class ImportColecoesView(APIView):
 
     permission_classes = [IsAuthenticated, IsDATOrSuper]
 
+    @extend_schema(
+        summary="Importar coleções",
+        parameters=[
+            OpenApiParameter(
+                name="dry_run",
+                location=OpenApiParameter.QUERY,
+                required=False,
+                type=bool,
+                description="Quando true, executa validação sem persistir dados.",
+            ),
+        ],
+        request=ImportFileUploadRequestSerializer,
+        responses={
+            200: ImportOperationResponseSerializer,
+            400: ImportOperationErrorResponseSerializer,
+            401: COMMON_ERROR_RESPONSES[401],
+            403: COMMON_ERROR_RESPONSES[403],
+            413: ImportOperationErrorResponseSerializer,
+            500: ImportOperationErrorResponseSerializer,
+        },
+        tags=["imports"],
+    )
     def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         # Parse dry_run query param
         dry_run_param = str(request.query_params.get("dry_run", "true")).lower()

--- a/v2/backend/apps/core/views_import_deslocamentos.py
+++ b/v2/backend/apps/core/views_import_deslocamentos.py
@@ -23,7 +23,15 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from drf_spectacular.utils import OpenApiParameter, extend_schema
+
+from apps.core.api_schemas import COMMON_ERROR_RESPONSES
 from apps.core.permissions import IsControleOrSuper
+from apps.core.serializers.openapi_critical_contract import (
+    ImportFileUploadRequestSerializer,
+    ImportOperationErrorResponseSerializer,
+    ImportOperationResponseSerializer,
+)
 from apps.core.services.deslocamentos_import import import_deslocamentos_from_file
 
 # Issue #132: Upload validation (SEC-P0)
@@ -62,6 +70,28 @@ class ImportDeslocamentosView(APIView):
 
     permission_classes = [IsAuthenticated, IsControleOrSuper]
 
+    @extend_schema(
+        summary="Importar deslocamentos",
+        parameters=[
+            OpenApiParameter(
+                name="dry_run",
+                location=OpenApiParameter.QUERY,
+                required=False,
+                type=bool,
+                description="Quando true, executa validação sem persistir dados.",
+            ),
+        ],
+        request=ImportFileUploadRequestSerializer,
+        responses={
+            200: ImportOperationResponseSerializer,
+            400: ImportOperationErrorResponseSerializer,
+            401: COMMON_ERROR_RESPONSES[401],
+            403: COMMON_ERROR_RESPONSES[403],
+            413: ImportOperationErrorResponseSerializer,
+            500: ImportOperationErrorResponseSerializer,
+        },
+        tags=["imports"],
+    )
     def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         # Parse dry_run query param
         dry_run_param = str(request.query_params.get("dry_run", "true")).lower()

--- a/v2/backend/apps/core/views_import_equipe_gerencia.py
+++ b/v2/backend/apps/core/views_import_equipe_gerencia.py
@@ -23,7 +23,15 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from drf_spectacular.utils import OpenApiParameter, extend_schema
+
+from apps.core.api_schemas import COMMON_ERROR_RESPONSES
 from apps.core.permissions import IsDATOrSuper
+from apps.core.serializers.openapi_critical_contract import (
+    ImportFileUploadRequestSerializer,
+    ImportOperationErrorResponseSerializer,
+    ImportOperationResponseSerializer,
+)
 from apps.core.services.equipe_gerencia_import import import_equipe_gerencia_from_file
 
 # Issue #132: Upload validation (SEC-P0)
@@ -50,6 +58,28 @@ class ImportEquipeGerenciaView(APIView):
 
     permission_classes = [IsAuthenticated, IsDATOrSuper]
 
+    @extend_schema(
+        summary="Importar vínculos de equipe-gerência",
+        parameters=[
+            OpenApiParameter(
+                name="dry_run",
+                location=OpenApiParameter.QUERY,
+                required=False,
+                type=bool,
+                description="Quando true, executa validação sem persistir dados.",
+            ),
+        ],
+        request=ImportFileUploadRequestSerializer,
+        responses={
+            200: ImportOperationResponseSerializer,
+            400: ImportOperationErrorResponseSerializer,
+            401: COMMON_ERROR_RESPONSES[401],
+            403: COMMON_ERROR_RESPONSES[403],
+            413: ImportOperationErrorResponseSerializer,
+            500: ImportOperationErrorResponseSerializer,
+        },
+        tags=["imports"],
+    )
     def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         # Parse dry_run query param
         dry_run_param = str(request.query_params.get("dry_run", "true")).lower()

--- a/v2/backend/apps/core/views_import_eventos.py
+++ b/v2/backend/apps/core/views_import_eventos.py
@@ -24,7 +24,15 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from drf_spectacular.utils import OpenApiParameter, extend_schema
+
+from apps.core.api_schemas import COMMON_ERROR_RESPONSES
 from apps.core.permissions import IsControleOrSuper
+from apps.core.serializers.openapi_critical_contract import (
+    ImportFileUploadRequestSerializer,
+    ImportOperationErrorResponseSerializer,
+    ImportOperationResponseSerializer,
+)
 from apps.core.services.eventos_import import import_eventos_from_file
 
 # Issue #132: Upload validation (SEC-P0)
@@ -70,6 +78,28 @@ class ImportEventosView(APIView):
 
     permission_classes = [IsAuthenticated, IsControleOrSuper]
 
+    @extend_schema(
+        summary="Importar solicitações/eventos",
+        parameters=[
+            OpenApiParameter(
+                name="dry_run",
+                location=OpenApiParameter.QUERY,
+                required=False,
+                type=bool,
+                description="Quando true, executa validação sem persistir dados.",
+            ),
+        ],
+        request=ImportFileUploadRequestSerializer,
+        responses={
+            200: ImportOperationResponseSerializer,
+            400: ImportOperationErrorResponseSerializer,
+            401: COMMON_ERROR_RESPONSES[401],
+            403: COMMON_ERROR_RESPONSES[403],
+            413: ImportOperationErrorResponseSerializer,
+            500: ImportOperationErrorResponseSerializer,
+        },
+        tags=["imports"],
+    )
     def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         # Parse dry_run query param
         dry_run_param = str(request.query_params.get("dry_run", "true")).lower()

--- a/v2/backend/apps/core/views_import_municipios.py
+++ b/v2/backend/apps/core/views_import_municipios.py
@@ -23,7 +23,15 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from drf_spectacular.utils import OpenApiParameter, extend_schema
+
+from apps.core.api_schemas import COMMON_ERROR_RESPONSES
 from apps.core.permissions import IsDATOrSuper
+from apps.core.serializers.openapi_critical_contract import (
+    ImportFileUploadRequestSerializer,
+    ImportOperationErrorResponseSerializer,
+    ImportOperationResponseSerializer,
+)
 from apps.core.services.municipios_import import import_municipios_from_file
 
 # Issue #132: Upload validation (SEC-P0)
@@ -50,6 +58,28 @@ class ImportMunicipiosView(APIView):
 
     permission_classes = [IsAuthenticated, IsDATOrSuper]
 
+    @extend_schema(
+        summary="Importar municípios",
+        parameters=[
+            OpenApiParameter(
+                name="dry_run",
+                location=OpenApiParameter.QUERY,
+                required=False,
+                type=bool,
+                description="Quando true, executa validação sem persistir dados.",
+            ),
+        ],
+        request=ImportFileUploadRequestSerializer,
+        responses={
+            200: ImportOperationResponseSerializer,
+            400: ImportOperationErrorResponseSerializer,
+            401: COMMON_ERROR_RESPONSES[401],
+            403: COMMON_ERROR_RESPONSES[403],
+            413: ImportOperationErrorResponseSerializer,
+            500: ImportOperationErrorResponseSerializer,
+        },
+        tags=["imports"],
+    )
     def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         # Parse dry_run query param
         dry_run_param = str(request.query_params.get("dry_run", "true")).lower()

--- a/v2/backend/apps/core/views_import_produtos.py
+++ b/v2/backend/apps/core/views_import_produtos.py
@@ -23,7 +23,15 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from drf_spectacular.utils import OpenApiParameter, extend_schema
+
+from apps.core.api_schemas import COMMON_ERROR_RESPONSES
 from apps.core.permissions import IsControleOrSuper
+from apps.core.serializers.openapi_critical_contract import (
+    ImportFileUploadRequestSerializer,
+    ImportOperationErrorResponseSerializer,
+    ImportOperationResponseSerializer,
+)
 from apps.core.services.produtos_import import import_produtos_from_file
 
 # Issue #132: Upload validation (SEC-P0)
@@ -63,6 +71,28 @@ class ImportProdutosView(APIView):
 
     permission_classes = [IsAuthenticated, IsControleOrSuper]
 
+    @extend_schema(
+        summary="Importar produtos",
+        parameters=[
+            OpenApiParameter(
+                name="dry_run",
+                location=OpenApiParameter.QUERY,
+                required=False,
+                type=bool,
+                description="Quando true, executa validação sem persistir dados.",
+            ),
+        ],
+        request=ImportFileUploadRequestSerializer,
+        responses={
+            200: ImportOperationResponseSerializer,
+            400: ImportOperationErrorResponseSerializer,
+            401: COMMON_ERROR_RESPONSES[401],
+            403: COMMON_ERROR_RESPONSES[403],
+            413: ImportOperationErrorResponseSerializer,
+            500: ImportOperationErrorResponseSerializer,
+        },
+        tags=["imports"],
+    )
     def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         # Parse dry_run query param
         dry_run_param = str(request.query_params.get("dry_run", "true")).lower()

--- a/v2/backend/apps/core/views_import_usuarios.py
+++ b/v2/backend/apps/core/views_import_usuarios.py
@@ -23,7 +23,15 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from drf_spectacular.utils import OpenApiParameter, extend_schema
+
+from apps.core.api_schemas import COMMON_ERROR_RESPONSES
 from apps.core.permissions import IsDATOrSuper
+from apps.core.serializers.openapi_critical_contract import (
+    ImportFileUploadRequestSerializer,
+    ImportOperationErrorResponseSerializer,
+    ImportOperationResponseSerializer,
+)
 from apps.core.services.usuarios_import import import_usuarios_from_file
 
 # Issue #132: Upload validation (SEC-P0)
@@ -62,6 +70,28 @@ class ImportUsuariosView(APIView):
 
     permission_classes = [IsAuthenticated, IsDATOrSuper]
 
+    @extend_schema(
+        summary="Importar usuários",
+        parameters=[
+            OpenApiParameter(
+                name="dry_run",
+                location=OpenApiParameter.QUERY,
+                required=False,
+                type=bool,
+                description="Quando true, executa validação sem persistir dados.",
+            ),
+        ],
+        request=ImportFileUploadRequestSerializer,
+        responses={
+            200: ImportOperationResponseSerializer,
+            400: ImportOperationErrorResponseSerializer,
+            401: COMMON_ERROR_RESPONSES[401],
+            403: COMMON_ERROR_RESPONSES[403],
+            413: ImportOperationErrorResponseSerializer,
+            500: ImportOperationErrorResponseSerializer,
+        },
+        tags=["imports"],
+    )
     def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         # Parse dry_run query param
         dry_run_param = str(request.query_params.get("dry_run", "true")).lower()

--- a/v2/backend/apps/core/views_imports.py
+++ b/v2/backend/apps/core/views_imports.py
@@ -30,7 +30,15 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from drf_spectacular.utils import OpenApiParameter, extend_schema
+
+from apps.core.api_schemas import COMMON_ERROR_RESPONSES
 from apps.core.permissions import IsControleOrSuper, IsDATOrSuper
+from apps.core.serializers.openapi_critical_contract import (
+    ImportFileUploadRequestSerializer,
+    ImportOperationErrorResponseSerializer,
+    ImportOperationResponseSerializer,
+)
 from apps.core.services.controle_acoes_import import import_acoes_controle
 from apps.core.services.dat_cadastros_import import import_dat_cadastros
 
@@ -70,6 +78,28 @@ class ControleImportAcoesView(APIView):
 
     permission_classes = [IsAuthenticated, IsControleOrSuper]
 
+    @extend_schema(
+        summary="Importar ações de controle",
+        parameters=[
+            OpenApiParameter(
+                name="dry_run",
+                location=OpenApiParameter.QUERY,
+                required=False,
+                type=bool,
+                description="Quando true, executa validação sem persistir dados.",
+            ),
+        ],
+        request=ImportFileUploadRequestSerializer,
+        responses={
+            200: ImportOperationResponseSerializer,
+            400: ImportOperationErrorResponseSerializer,
+            401: COMMON_ERROR_RESPONSES[401],
+            403: COMMON_ERROR_RESPONSES[403],
+            413: ImportOperationErrorResponseSerializer,
+            500: ImportOperationErrorResponseSerializer,
+        },
+        tags=["imports"],
+    )
     def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         # Parse dry_run query param
         dry_run_param = str(request.query_params.get("dry_run", "true")).lower()
@@ -151,6 +181,28 @@ class DATImportCadastrosView(APIView):
 
     permission_classes = [IsAuthenticated, IsDATOrSuper]
 
+    @extend_schema(
+        summary="Importar cadastros DAT",
+        parameters=[
+            OpenApiParameter(
+                name="dry_run",
+                location=OpenApiParameter.QUERY,
+                required=False,
+                type=bool,
+                description="Quando true, executa validação sem persistir dados.",
+            ),
+        ],
+        request=ImportFileUploadRequestSerializer,
+        responses={
+            200: ImportOperationResponseSerializer,
+            400: ImportOperationErrorResponseSerializer,
+            401: COMMON_ERROR_RESPONSES[401],
+            403: COMMON_ERROR_RESPONSES[403],
+            413: ImportOperationErrorResponseSerializer,
+            500: ImportOperationErrorResponseSerializer,
+        },
+        tags=["imports"],
+    )
     def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         # Parse dry_run query param
         dry_run_param = str(request.query_params.get("dry_run", "true")).lower()

--- a/v2/backend/apps/core/views_options.py
+++ b/v2/backend/apps/core/views_options.py
@@ -17,6 +17,8 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from drf_spectacular.utils import OpenApiParameter, extend_schema
+
 from .models import DATArea, DATCoordenador, Municipio, Produto, Projeto, TipoEvento, Usuario
 from .serializers import (
     MunicipioOptionSerializer,
@@ -28,6 +30,12 @@ from .serializers import (
 from .serializers.dat_module import DATAreaOptionSerializer, DATCoordenadorOptionSerializer
 
 
+@extend_schema(
+    methods=["GET"],
+    summary="Listar municípios para opções",
+    responses=MunicipioOptionSerializer(many=True),
+    tags=["options"],
+)
 @api_view(["GET"])
 @permission_classes([IsAuthenticated])
 def municipios_options(request: Request) -> Response:
@@ -63,6 +71,21 @@ def municipios_options(request: Request) -> Response:
     return Response(data)
 
 
+@extend_schema(
+    methods=["GET"],
+    summary="Listar projetos para opções",
+    parameters=[
+        OpenApiParameter(
+            name="include_test",
+            location=OpenApiParameter.QUERY,
+            required=False,
+            type=bool,
+            description="Quando true, inclui projetos de teste.",
+        ),
+    ],
+    responses=ProjetoOptionSerializer(many=True),
+    tags=["options"],
+)
 @api_view(["GET"])
 @permission_classes([IsAuthenticated])
 def projetos_options(request: Request) -> Response:
@@ -110,6 +133,12 @@ def projetos_options(request: Request) -> Response:
     return Response(data)
 
 
+@extend_schema(
+    methods=["GET"],
+    summary="Listar tipos de evento para opções",
+    responses=TipoEventoOptionSerializer(many=True),
+    tags=["options"],
+)
 @api_view(["GET"])
 @permission_classes([IsAuthenticated])
 def tipos_evento_options(request: Request) -> Response:
@@ -145,6 +174,12 @@ def tipos_evento_options(request: Request) -> Response:
     return Response(data)
 
 
+@extend_schema(
+    methods=["GET"],
+    summary="Listar usuários para opções",
+    responses=UsuarioOptionSerializer(many=True),
+    tags=["options"],
+)
 @api_view(["GET"])
 @permission_classes([IsAuthenticated])
 def usuarios_options(request: Request) -> Response:
@@ -179,6 +214,12 @@ def usuarios_options(request: Request) -> Response:
     return Response(data)
 
 
+@extend_schema(
+    methods=["GET"],
+    summary="Listar produtos para opções",
+    responses=ProdutoOptionSerializer(many=True),
+    tags=["options"],
+)
 @api_view(["GET"])
 @permission_classes([IsAuthenticated])
 def produtos_options(request: Request) -> Response:
@@ -209,6 +250,12 @@ def produtos_options(request: Request) -> Response:
     return Response(data)
 
 
+@extend_schema(
+    methods=["GET"],
+    summary="Listar coordenadores para opções",
+    responses=DATCoordenadorOptionSerializer(many=True),
+    tags=["options"],
+)
 @api_view(["GET"])
 @permission_classes([IsAuthenticated])
 def coordenadores_options(request: Request) -> Response:
@@ -239,6 +286,12 @@ def coordenadores_options(request: Request) -> Response:
     return Response(data)
 
 
+@extend_schema(
+    methods=["GET"],
+    summary="Listar áreas DAT para opções",
+    responses=DATAreaOptionSerializer(many=True),
+    tags=["options"],
+)
 @api_view(["GET"])
 @permission_classes([IsAuthenticated])
 def areas_options(request: Request) -> Response:
@@ -269,6 +322,12 @@ def areas_options(request: Request) -> Response:
     return Response(data)
 
 
+@extend_schema(
+    methods=["GET"],
+    summary="Listar formadores do setor para opções",
+    responses=UsuarioOptionSerializer(many=True),
+    tags=["options"],
+)
 @api_view(["GET"])
 @permission_classes([IsAuthenticated])
 def formadores_do_setor_options(request: Request) -> Response:


### PR DESCRIPTION
## Summary\n- expand OpenAPI hardening to critical frontend endpoints from issue #703\n- add explicit response/request contracts for home stats, monthly availability, options endpoints, and frontend import operations\n- extend OpenAPI contract gate tests and policy documentation with the new endpoint set\n\n## Changes\n- added openapi_critical_contract.py with serializers for stats/monthly/import contracts\n- applied @extend_schema to:\n  - GET /api/stats/home/\n  - GET /api/availability/monthly/\n  - GET /api/options/* endpoints used by frontend\n  - import operation POST endpoints used by frontend\n- expanded pps/core/tests/test_openapi.py to assert typed contracts for those endpoints\n- updated docs/architecture/openapi-contract-gate.md endpoint coverage\n\n## Validation\n- docker compose -p aprender_v2 -f v2/infra/docker-compose.yml run --rm web black --check ...\n- docker compose -p aprender_v2 -f v2/infra/docker-compose.yml run --rm web isort --check-only ...\n- docker compose -p aprender_v2 -f v2/infra/docker-compose.yml run --rm web flake8 ...\n- docker compose -p aprender_v2 -f v2/infra/docker-compose.yml run --rm web pytest -q apps/core/tests/test_openapi.py (18 passed)\n- docker compose -p aprender_v2 -f v2/infra/docker-compose.yml run --rm web python manage.py spectacular --format openapi-json --file /tmp/schema-703.json\n\nCloses #703