### PR TITLE
bug(frontend-contract): align CurrentUser with /api/me contract

### DIFF
--- a/v2/frontend/src/App.tsx
+++ b/v2/frontend/src/App.tsx
@@ -308,7 +308,7 @@ function AppContent(): JSX.Element {
     try {
       const userData = await getMe();
       if (isMountedRef.current) {
-        setUser(userData as unknown as CurrentUser);
+        setUser(userData);
         // Issue #418: Preload search data after successful login
         preloadSearchData().catch((err) => logger.warn('Search preload failed:', err));
       }

--- a/v2/frontend/src/api/__tests__/availability.test.ts
+++ b/v2/frontend/src/api/__tests__/availability.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const { fetchAPIMock, buildUrlMock } = vi.hoisted(() => ({
+  fetchAPIMock: vi.fn(),
+  buildUrlMock: vi.fn(),
+}))
+
+vi.mock('../config', () => ({
+  fetchAPI: fetchAPIMock,
+  buildUrl: buildUrlMock,
+}))
+
+import { getMe } from '../availability'
+
+const validCurrentUserPayload = {
+  id: 1,
+  username: 'admin',
+  email: 'admin@test.com',
+  first_name: 'Admin',
+  last_name: 'User',
+  name: 'Admin User',
+  groups: ['DAT'],
+  setores: ['DAT'],
+  funcoes: ['Coordenador'],
+  is_superuser: true,
+  is_superintendencia: false,
+  can_approve_super: true,
+}
+
+describe('availability API - current user contract', () => {
+  beforeEach(() => {
+    fetchAPIMock.mockReset()
+    buildUrlMock.mockReset()
+    buildUrlMock.mockImplementation((path: string) => path)
+  })
+
+  test('getMe returns data when /api/me payload matches contract', async () => {
+    fetchAPIMock.mockResolvedValue(validCurrentUserPayload)
+
+    const user = await getMe()
+
+    expect(fetchAPIMock).toHaveBeenCalledWith('/me/')
+    expect(user).toEqual(validCurrentUserPayload)
+  })
+
+  test('getMe throws when /api/me payload drifts from expected shape', async () => {
+    fetchAPIMock.mockResolvedValue({
+      id: 1,
+      username: 'admin',
+      // missing mandatory contract fields
+    })
+
+    await expect(getMe()).rejects.toThrow('Invalid /api/me payload shape')
+  })
+})

--- a/v2/frontend/src/api/auth.ts
+++ b/v2/frontend/src/api/auth.ts
@@ -8,7 +8,8 @@
  */
 
 import { fetchAPI, clearCsrfCache } from './config';
-import type { CurrentUser, LoginResponse, AuthCheckResponse } from '../types';
+import type { LoginResponse, AuthCheckResponse } from '../types';
+import { assertCurrentUserPayload } from '../types';
 
 /**
  * Realiza login com username e senha
@@ -43,7 +44,8 @@ export async function logout(): Promise<{ detail: string }> {
  */
 export async function checkAuth(): Promise<AuthCheckResponse> {
   try {
-    const user = await fetchAPI<CurrentUser>('/me/');
+    const payload = await fetchAPI<unknown>('/me/');
+    const user = assertCurrentUserPayload(payload);
     return { authenticated: true, user };
   } catch {
     return { authenticated: false, user: null };

--- a/v2/frontend/src/api/availability.ts
+++ b/v2/frontend/src/api/availability.ts
@@ -14,6 +14,7 @@ import type {
   MonthlyGridResponse,
   Gerencia,
 } from '../types';
+import { assertCurrentUserPayload } from '../types';
 
 /**
  * Block filter parameters
@@ -59,7 +60,8 @@ export interface FeatureFlags {
  * Busca informações do usuário atual.
  */
 export async function getMe(): Promise<CurrentUser> {
-  return await fetchAPI('/me/');
+  const payload = await fetchAPI<unknown>('/me/');
+  return assertCurrentUserPayload(payload);
 }
 
 /**

--- a/v2/frontend/src/pages/Aprovacoes/ApprovalsPage.tsx
+++ b/v2/frontend/src/pages/Aprovacoes/ApprovalsPage.tsx
@@ -53,7 +53,7 @@ import {
 } from '../../api/solicitacoes';
 import { getMe } from '../../api/availability';
 import logger from '../../utils/logger';
-import type { ID, Solicitacao, SolicitacaoStatus, CurrentUser, PaginatedResponse, Participation, BatchOperationResult } from '../../types';
+import type { ID, Solicitacao, SolicitacaoStatus, PaginatedResponse, Participation, BatchOperationResult } from '../../types';
 
 const { Title, Paragraph, Text } = Typography;
 
@@ -131,7 +131,7 @@ export default function ApprovalsPage(): JSX.Element {
   useEffect(() => {
     const loadUser = async (): Promise<void> => {
       try {
-        const userData = await getMe() as CurrentUser & { can_approve_super?: boolean };
+        const userData = await getMe();
 
         // Usar can_approve_super da API (Superintendência/DAT ou superuser)
         // A API já calcula: is_superuser || Superintendência || DAT

--- a/v2/frontend/src/pages/Deslocamentos/DeslocamentosPage.tsx
+++ b/v2/frontend/src/pages/Deslocamentos/DeslocamentosPage.tsx
@@ -52,7 +52,7 @@ import { getMe } from '../../api/availability';
 import { importDeslocamentos } from '../../api/ops';
 import ImportUploader, { ValidationResult, ApplyResult } from '../../components/ImportUploader';
 import logger from '../../utils/logger';
-import type { ID, CurrentUser } from '../../types';
+import type { ID } from '../../types';
 
 const { Title, Text } = Typography;
 const { RangePicker } = DatePicker;
@@ -262,13 +262,13 @@ export default function DeslocamentosPage(): JSX.Element {
   useEffect(() => {
     async function loadUser(): Promise<void> {
       try {
-        const userData = await getMe() as CurrentUser;
+        const userData = await getMe();
 
         // Check RBAC: Controle, Coordenador, or DAT
         const canControle = userData.groups?.includes('Controle');
         const canCoordenador = userData.groups?.includes('Coordenador');
         const canDAT = userData.groups?.includes('DAT');
-        const canSuper = userData.is_superuser || (userData as CurrentUser & { is_superintendencia?: boolean }).is_superintendencia;
+        const canSuper = userData.is_superuser || userData.is_superintendencia;
 
         setCanAccess(!!(canControle || canCoordenador || canDAT || canSuper));
       } catch (error) {

--- a/v2/frontend/src/pages/Disponibilidade/FiltersBar.tsx
+++ b/v2/frontend/src/pages/Disponibilidade/FiltersBar.tsx
@@ -43,7 +43,7 @@ const GROUP_TO_NOME_SETOR: Record<string, string> = {
 
 export default function FiltersBar({ year, month, gerenciaId, sector, q, onChange }: FiltersBarProps): JSX.Element {
   const [allGerencias, setAllGerencias] = useState<Gerencia[]>([]);
-  const [userInfo, setUserInfo] = useState<(CurrentUser & { is_superintendencia?: boolean }) | null>(null);
+  const [userInfo, setUserInfo] = useState<CurrentUser | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
 
   // Carrega lista de gerências e info do usuário ao montar
@@ -52,7 +52,7 @@ export default function FiltersBar({ year, month, gerenciaId, sector, q, onChang
       try {
         const [gerenciasData, meData] = await Promise.all([
           getGerencias() as Promise<Gerencia[]>,
-          getMe() as Promise<CurrentUser & { is_superintendencia?: boolean }>,
+          getMe(),
         ]);
         setAllGerencias(gerenciasData);
         setUserInfo(meData);

--- a/v2/frontend/src/pages/Home/HomePage.tsx
+++ b/v2/frontend/src/pages/Home/HomePage.tsx
@@ -89,7 +89,7 @@ function AccessCard({ icon, title, description, link, badge, disabled = false }:
 }
 
 export default function HomePage(): JSX.Element {
-  const [user, setUser] = useState<(CurrentUser & { can_approve_super?: boolean }) | null>(null);
+  const [user, setUser] = useState<CurrentUser | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
   const [stats, setStats] = useState<StatsType>({
     pendingApprovals: 0,
@@ -102,7 +102,7 @@ export default function HomePage(): JSX.Element {
       try {
         // Carregar dados do usuário e estatísticas em paralelo
         const [userData, statsData] = await Promise.all([
-          getMe() as Promise<CurrentUser & { can_approve_super?: boolean }>,
+          getMe(),
           getHomeStats() as Promise<HomeStatsResponse>,
         ]);
 

--- a/v2/frontend/src/pages/PreAgenda/PreAgendaPage.tsx
+++ b/v2/frontend/src/pages/PreAgenda/PreAgendaPage.tsx
@@ -111,11 +111,6 @@ interface BatchResponseType {
   errors?: Array<{ detail: string }>;
 }
 
-/** Extended current user */
-interface ExtendedCurrentUser extends CurrentUser {
-  is_superintendencia?: boolean;
-}
-
 export default function PreAgendaPage(): JSX.Element {
   const [loading, setLoading] = useState<boolean>(false);
   const [rows, setRows] = useState<Solicitacao[]>([]);
@@ -135,7 +130,7 @@ export default function PreAgendaPage(): JSX.Element {
   const [batchLoading, setBatchLoading] = useState<boolean>(false);
 
   // OAuth Phase 5: Estado do usuário e integração Google
-  const [user, setUser] = useState<ExtendedCurrentUser | null>(null);
+  const [user, setUser] = useState<CurrentUser | null>(null);
   const { status: googleStatus, disconnect: googleDisconnect } = useGoogleIntegration();
 
   // Section 4 Epic #459: Consolidated Google OAuth guard
@@ -148,7 +143,7 @@ export default function PreAgendaPage(): JSX.Element {
   useEffect(() => {
     const loadUser = async (): Promise<void> => {
       try {
-        const userData = await getMe() as ExtendedCurrentUser;
+        const userData = await getMe();
         setUser(userData);
       } catch (error) {
         logger.error('Erro ao carregar usuário:', error);

--- a/v2/frontend/src/pages/Solicitacoes.tsx
+++ b/v2/frontend/src/pages/Solicitacoes.tsx
@@ -41,7 +41,7 @@ import {
 import { getMe } from '../api/availability';
 import { MeetLink } from '../components/MeetLink';
 import logger from '../utils/logger';
-import type { ID, Solicitacao, SolicitacaoStatus, CurrentUser, PaginatedResponse } from '../types';
+import type { ID, Solicitacao, SolicitacaoStatus, PaginatedResponse } from '../types';
 
 const { TextArea } = Input;
 
@@ -99,7 +99,7 @@ function Solicitacoes(): JSX.Element {
   useEffect(() => {
     async function fetchCurrentUser(): Promise<void> {
       try {
-        const user = await getMe() as CurrentUser & { is_superintendencia?: boolean };
+        const user = await getMe();
 
         // PA-06: Verificar se usuário pertence ao grupo "Superintendência" ou é superuser
         const isSuper =

--- a/v2/frontend/src/types/index.ts
+++ b/v2/frontend/src/types/index.ts
@@ -30,6 +30,8 @@ export type {
   Group,
 } from './usuario';
 
+export { assertCurrentUserPayload, isCurrentUserPayload } from './usuario';
+
 // Solicitacao types
 export type {
   SolicitacaoStatus,

--- a/v2/frontend/src/types/usuario.ts
+++ b/v2/frontend/src/types/usuario.ts
@@ -7,7 +7,7 @@
  * - UsuarioAdminSerializer
  */
 
-import type { ID, ISODateTime } from './common';
+import type { ID } from './common';
 
 /**
  * Slim user representation (UserSlimSerializer)
@@ -41,19 +41,53 @@ export interface CurrentUser {
   email: string;
   first_name: string;
   last_name: string;
-  is_active: boolean;
-  is_staff: boolean;
-  is_superuser: boolean;
-  date_joined: ISODateTime;
-  last_login: ISODateTime | null;
+  name: string;
   groups: string[];
   setores: string[];
   funcoes: string[];
-  permissions: string[];
-  // Optional computed properties from backend
-  name?: string;
-  can_approve_super?: boolean;
-  is_superintendencia?: boolean;
+  is_superuser: boolean;
+  is_superintendencia: boolean;
+  can_approve_super: boolean;
+}
+
+/**
+ * Runtime guard for /api/me/ payload.
+ * Keeps frontend authentication bootstrap aligned with backend contract.
+ */
+export function isCurrentUserPayload(value: unknown): value is CurrentUser {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const payload = value as Record<string, unknown>;
+  const isStringArray = (field: unknown): field is string[] =>
+    Array.isArray(field) && field.every((item) => typeof item === 'string');
+
+  return (
+    typeof payload.id === 'number'
+    && typeof payload.username === 'string'
+    && typeof payload.email === 'string'
+    && typeof payload.first_name === 'string'
+    && typeof payload.last_name === 'string'
+    && typeof payload.name === 'string'
+    && isStringArray(payload.groups)
+    && isStringArray(payload.setores)
+    && isStringArray(payload.funcoes)
+    && typeof payload.is_superuser === 'boolean'
+    && typeof payload.is_superintendencia === 'boolean'
+    && typeof payload.can_approve_super === 'boolean'
+  );
+}
+
+/**
+ * Asserts that payload matches /api/me/ minimal contract.
+ */
+export function assertCurrentUserPayload(value: unknown): CurrentUser {
+  if (!isCurrentUserPayload(value)) {
+    throw new Error('Invalid /api/me payload shape');
+  }
+
+  return value;
 }
 
 /**


### PR DESCRIPTION
## Summary\n- align CurrentUser type with actual /api/me/ backend payload\n- remove unsafe casts in critical auth/bootstrap and pages consuming getMe()\n- add minimal runtime contract validation for /api/me/ payload and frontend regression tests\n\n## Changes\n- updated 2/frontend/src/types/usuario.ts:\n  - removed fictitious/legacy required fields (is_active, is_staff, date_joined, last_login, permissions)\n  - kept only fields returned by backend (id, username, email, irst_name, last_name, 
ame, groups, setores, uncoes, is_superuser, is_superintendencia, can_approve_super)\n  - added isCurrentUserPayload and ssertCurrentUserPayload runtime guard/assert\n- updated getMe() and checkAuth() to validate payload shape before returning typed user\n- removed unsafe casts (s unknown as CurrentUser / CurrentUser & {...}) in:\n  - src/App.tsx\n  - src/pages/Solicitacoes.tsx\n  - src/pages/Aprovacoes/ApprovalsPage.tsx\n  - src/pages/Home/HomePage.tsx\n  - src/pages/Disponibilidade/FiltersBar.tsx\n  - src/pages/PreAgenda/PreAgendaPage.tsx\n  - src/pages/Deslocamentos/DeslocamentosPage.tsx\n- added src/api/__tests__/availability.test.ts with contract regression coverage for /api/me/\n\n## Validation\n- cd v2/frontend && npm run lint\n- cd v2/frontend && npm run build\n- cd v2/frontend && npm run test -- --run\n\nCloses #699