### PR TITLE
chore(frontend-api): padronizar consumo HTTP crítico em wrappers tipados

### DIFF
--- a/v2/frontend/src/App.tsx
+++ b/v2/frontend/src/App.tsx
@@ -28,6 +28,7 @@ import { ThemeProvider, useTheme, useBrandColors } from './contexts/ThemeContext
 import ptBR from 'antd/locale/pt_BR';
 import { getMe } from './api/availability';
 import { logout as apiLogout } from './api/auth';
+import { getAlertsSummary } from './api/gcal';
 import { LAYOUT, TIMING } from './constants';
 import { preloadSearchData } from './services/preloadSearchData';
 import OfflineBanner from './components/OfflineBanner';
@@ -351,19 +352,7 @@ function AppContent(): JSX.Element {
 
     const fetchAlerts = async () => {
       try {
-        const response = await fetch('/api/gcal/dashboard/alerts/summary/', {
-          credentials: 'include'
-        });
-
-        if (!response.ok) {
-          if (response.status === 401 || response.status === 403) {
-            logger.warn('[Alerts] Sem permissão para acessar alerts');
-            return;
-          }
-          throw new Error(`HTTP ${response.status}`);
-        }
-
-        const data = await response.json();
+        const data = await getAlertsSummary();
         setAlerts(data);
 
         // Toast quando errors aumentar (com cooldown)
@@ -382,6 +371,13 @@ function AppContent(): JSX.Element {
           localStorage.setItem('gcalAlertsLastErrors', data.errors.toString());
         }
       } catch (error) {
+        const status =
+          (error as { status?: number }).status
+          ?? (error as { response?: { status?: number } }).response?.status;
+        if (status === 401 || status === 403) {
+          logger.warn('[Alerts] Sem permissão para acessar alerts');
+          return;
+        }
         logger.error('[Alerts] Erro ao buscar alertas:', error);
       }
     };

--- a/v2/frontend/src/api/__tests__/dashboard.test.ts
+++ b/v2/frontend/src/api/__tests__/dashboard.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const { fetchAPIMock } = vi.hoisted(() => ({
+  fetchAPIMock: vi.fn(),
+}))
+
+vi.mock('../config', () => ({
+  fetchAPI: fetchAPIMock,
+}))
+
+import { getDashboardOverview } from '../dashboard'
+
+describe('dashboard API wrappers', () => {
+  beforeEach(() => {
+    fetchAPIMock.mockReset()
+  })
+
+  test('getDashboardOverview uses /dashboard/overview/', async () => {
+    const response = {
+      kpis: {
+        eventos_futuros: 1,
+        eventos_aprovados: 2,
+        total_formadores: 3,
+        aprovacoes_pendentes: 4,
+      },
+      por_fluxo: [],
+      por_gerencia: [],
+      top_coordenadores: [],
+    }
+    fetchAPIMock.mockResolvedValue(response)
+
+    const result = await getDashboardOverview()
+
+    expect(fetchAPIMock).toHaveBeenCalledWith('/dashboard/overview/')
+    expect(result).toEqual(response)
+  })
+})

--- a/v2/frontend/src/api/__tests__/gcal.test.ts
+++ b/v2/frontend/src/api/__tests__/gcal.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+﻿import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 const { fetchAPIMock, buildUrlMock } = vi.hoisted(() => ({
   fetchAPIMock: vi.fn(),
@@ -8,11 +8,19 @@ const { fetchAPIMock, buildUrlMock } = vi.hoisted(() => ({
 vi.mock('../config', () => ({
   fetchAPI: fetchAPIMock,
   buildUrl: buildUrlMock,
+  API_BASE: '/api',
 }));
 
 import {
+  buildDashboardEventsExportUrl,
+  getAlertsSummary,
+  getDashboardEventDetail,
+  getDashboardMetrics,
+  getDashboardSuccessRate,
+  getDashboardTopInsights,
   getStatusSummary,
   listApprovedWithGCalStatus,
+  listDashboardEvents,
   publishBatch,
   reapplyBatch,
   resyncBatch,
@@ -74,5 +82,90 @@ describe('gcal API endpoints', () => {
       method: 'POST',
       body: JSON.stringify({ ids: [20], dry_run: true, apply_blocked: false }),
     });
+  });
+
+  test('getDashboardMetrics uses /gcal/dashboard/metrics/', async () => {
+    fetchAPIMock.mockResolvedValue({ counts: {}, recent_errors: [] });
+
+    await getDashboardMetrics({ start: '2026-01-01', end: '2026-01-31' });
+
+    expect(buildUrlMock).toHaveBeenCalledWith('/gcal/dashboard/metrics/', {
+      start: '2026-01-01',
+      end: '2026-01-31',
+    });
+    expect(fetchAPIMock).toHaveBeenCalledWith('/gcal/dashboard/metrics/');
+  });
+
+  test('listDashboardEvents uses /gcal/dashboard/events/', async () => {
+    fetchAPIMock.mockResolvedValue({ count: 0, next: null, previous: null, results: [] });
+
+    await listDashboardEvents({ page: 2, page_size: 50, status: 'ERROR' });
+
+    expect(buildUrlMock).toHaveBeenCalledWith('/gcal/dashboard/events/', {
+      page: 2,
+      page_size: 50,
+      status: 'ERROR',
+    });
+    expect(fetchAPIMock).toHaveBeenCalledWith('/gcal/dashboard/events/');
+  });
+
+  test('getDashboardSuccessRate uses /gcal/dashboard/insights/success-rate/', async () => {
+    fetchAPIMock.mockResolvedValue({ rate: 0, published: 0, error: 0, pending: 0, none: 0 });
+
+    await getDashboardSuccessRate({ start: '2026-02-01', end: '2026-02-28' });
+
+    expect(buildUrlMock).toHaveBeenCalledWith('/gcal/dashboard/insights/success-rate/', {
+      start: '2026-02-01',
+      end: '2026-02-28',
+    });
+    expect(fetchAPIMock).toHaveBeenCalledWith('/gcal/dashboard/insights/success-rate/');
+  });
+
+  test('getDashboardTopInsights uses /gcal/dashboard/insights/top/', async () => {
+    fetchAPIMock.mockResolvedValue({ items: [], metric: 'municipios', limit: 5 });
+
+    await getDashboardTopInsights({ metric: 'municipios', limit: 5, start: '2026-02-01' });
+
+    expect(buildUrlMock).toHaveBeenCalledWith('/gcal/dashboard/insights/top/', {
+      metric: 'municipios',
+      limit: 5,
+      start: '2026-02-01',
+    });
+    expect(fetchAPIMock).toHaveBeenCalledWith('/gcal/dashboard/insights/top/');
+  });
+
+  test('getDashboardEventDetail uses event detail endpoint', async () => {
+    fetchAPIMock.mockResolvedValue({ id: 123 });
+
+    await getDashboardEventDetail(123);
+
+    expect(fetchAPIMock).toHaveBeenCalledWith('/gcal/dashboard/events/123/detail/');
+  });
+
+  test('getAlertsSummary uses alerts summary endpoint', async () => {
+    fetchAPIMock.mockResolvedValue({ errors: 0, pending: 0, published: 0, none: 0 });
+
+    await getAlertsSummary();
+
+    expect(fetchAPIMock).toHaveBeenCalledWith('/gcal/dashboard/alerts/summary/');
+  });
+
+  test('buildDashboardEventsExportUrl builds API_BASE absolute url', () => {
+    buildUrlMock.mockReturnValue('/gcal/dashboard/events/export/?export_format=csv');
+
+    const url = buildDashboardEventsExportUrl({
+      export_format: 'csv',
+      start: '2026-03-01',
+      end: '2026-03-02',
+      status: 'ERROR',
+    });
+
+    expect(buildUrlMock).toHaveBeenCalledWith('/gcal/dashboard/events/export/', {
+      export_format: 'csv',
+      start: '2026-03-01',
+      end: '2026-03-02',
+      status: 'ERROR',
+    });
+    expect(url).toBe('/api/gcal/dashboard/events/export/?export_format=csv');
   });
 });

--- a/v2/frontend/src/api/__tests__/systemConfig.test.ts
+++ b/v2/frontend/src/api/__tests__/systemConfig.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const { fetchAPIMock } = vi.hoisted(() => ({
+  fetchAPIMock: vi.fn(),
+}))
+
+vi.mock('../config', () => ({
+  fetchAPI: fetchAPIMock,
+}))
+
+import { getSystemConfig, updateSystemConfig } from '../systemConfig'
+
+describe('systemConfig API wrappers', () => {
+  beforeEach(() => {
+    fetchAPIMock.mockReset()
+  })
+
+  test('getSystemConfig calls /config/', async () => {
+    fetchAPIMock.mockResolvedValue({ TRAVEL_BUFFER_MINUTES: 120 })
+
+    const result = await getSystemConfig()
+
+    expect(fetchAPIMock).toHaveBeenCalledWith('/config/')
+    expect(result).toEqual({ TRAVEL_BUFFER_MINUTES: 120 })
+  })
+
+  test('updateSystemConfig sends PUT /config/ with JSON body', async () => {
+    const payload = { TRAVEL_BUFFER_MINUTES: 90 }
+    fetchAPIMock.mockResolvedValue(payload)
+
+    const result = await updateSystemConfig(payload)
+
+    expect(fetchAPIMock).toHaveBeenCalledWith('/config/', {
+      method: 'PUT',
+      body: JSON.stringify(payload),
+    })
+    expect(result).toEqual(payload)
+  })
+})

--- a/v2/frontend/src/api/__tests__/teamMetrics.test.ts
+++ b/v2/frontend/src/api/__tests__/teamMetrics.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+const { fetchAPIMock, buildUrlMock } = vi.hoisted(() => ({
+  fetchAPIMock: vi.fn(),
+  buildUrlMock: vi.fn(),
+}))
+
+vi.mock('../config', () => ({
+  fetchAPI: fetchAPIMock,
+  buildUrl: buildUrlMock,
+}))
+
+import { getTeamProductivity, getTeamFormadores, getTeamQuality } from '../teamMetrics'
+
+describe('teamMetrics API wrappers', () => {
+  beforeEach(() => {
+    fetchAPIMock.mockReset()
+    buildUrlMock.mockReset()
+    buildUrlMock.mockImplementation((path: string) => path)
+  })
+
+  test('getTeamProductivity builds URL and fetches data', async () => {
+    fetchAPIMock.mockResolvedValue({ period: '7d', events_created: 10 })
+
+    await getTeamProductivity(7)
+
+    expect(buildUrlMock).toHaveBeenCalledWith('/metrics/team/productivity/', { days: 7 })
+    expect(fetchAPIMock).toHaveBeenCalledWith('/metrics/team/productivity/')
+  })
+
+  test('getTeamFormadores builds URL and fetches data', async () => {
+    fetchAPIMock.mockResolvedValue({ period: '7d', formadores: [] })
+
+    await getTeamFormadores(7)
+
+    expect(buildUrlMock).toHaveBeenCalledWith('/metrics/team/formadores/', { days: 7 })
+    expect(fetchAPIMock).toHaveBeenCalledWith('/metrics/team/formadores/')
+  })
+
+  test('getTeamQuality builds URL and fetches data', async () => {
+    fetchAPIMock.mockResolvedValue({ period: '7d', rejection_rate: 0 })
+
+    await getTeamQuality(7)
+
+    expect(buildUrlMock).toHaveBeenCalledWith('/metrics/team/quality/', { days: 7 })
+    expect(fetchAPIMock).toHaveBeenCalledWith('/metrics/team/quality/')
+  })
+})

--- a/v2/frontend/src/api/config.ts
+++ b/v2/frontend/src/api/config.ts
@@ -209,8 +209,18 @@ export async function fetchAPI<T = unknown>(url: string, options: FetchOptions =
       error = { detail: `HTTP ${response.status}: ${response.statusText}` };
     }
 
-    const err = new Error(error.detail || error.message || `Erro ${response.status}`) as Error & { status?: number };
+    const err = new Error(error.detail || error.message || `Erro ${response.status}`) as Error & {
+      status?: number;
+      response?: {
+        status: number;
+        data: unknown;
+      };
+    };
     err.status = response.status;
+    err.response = {
+      status: response.status,
+      data: error,
+    };
     throw err;
   }
 

--- a/v2/frontend/src/api/dashboard.ts
+++ b/v2/frontend/src/api/dashboard.ts
@@ -1,0 +1,57 @@
+/**
+ * API Client - Dashboard Overview
+ */
+
+import { fetchAPI } from './config'
+
+/**
+ * KPI payload for /api/dashboard/overview/.
+ */
+export interface DashboardKpis {
+  eventos_futuros: number
+  eventos_aprovados: number
+  total_formadores: number
+  aprovacoes_pendentes: number
+}
+
+/**
+ * Flux summary item.
+ */
+export interface DashboardFluxoItem {
+  fluxo: string
+  quantidade: number
+}
+
+/**
+ * Gerencia summary item.
+ */
+export interface DashboardGerenciaItem {
+  gerencia: string
+  quantidade?: number
+  porcentagem: number
+}
+
+/**
+ * Coordenador ranking item.
+ */
+export interface DashboardCoordenadorItem {
+  nome: string
+  eventos: number
+}
+
+/**
+ * Response for /api/dashboard/overview/.
+ */
+export interface DashboardOverviewResponse {
+  kpis: DashboardKpis
+  por_fluxo: DashboardFluxoItem[]
+  por_gerencia: DashboardGerenciaItem[]
+  top_coordenadores: DashboardCoordenadorItem[]
+}
+
+/**
+ * Load dashboard overview data.
+ */
+export async function getDashboardOverview(): Promise<DashboardOverviewResponse> {
+  return fetchAPI('/dashboard/overview/')
+}

--- a/v2/frontend/src/api/gcal.ts
+++ b/v2/frontend/src/api/gcal.ts
@@ -5,6 +5,7 @@
  */
 
 import { fetchAPI, buildUrl, type QueryParams } from './config';
+import { API_BASE } from './config';
 import type { ID, PaginatedResponse, GCalDashboardEvent } from '../types';
 
 /**
@@ -68,6 +69,151 @@ export interface BatchIdsRequest {
 }
 
 /**
+ * GCal dashboard window filter params.
+ */
+export interface GCalDashboardWindowFilters {
+  start?: string;
+  end?: string;
+}
+
+/**
+ * GCal dashboard metrics response.
+ */
+export interface GCalDashboardMetricsResponse {
+  counts: GCalStatusCounts;
+  recent_errors: Array<{
+    id: number;
+    summary: string;
+    gcal_last_error: string;
+    updated_at: string | null;
+  }>;
+  window?: {
+    start?: string | null;
+    end?: string | null;
+  };
+}
+
+/**
+ * Event row in /api/gcal/dashboard/events/.
+ */
+export interface GCalDashboardEventRecord {
+  id: number;
+  summary: string;
+  gcal_status: 'NONE' | 'PENDING' | 'PUBLISHED' | 'ERROR';
+  gcal_last_sync_at: string | null;
+  gcal_last_error: string | null;
+}
+
+/**
+ * Params for dashboard events listing.
+ */
+export interface GCalDashboardEventsParams extends GCalDashboardWindowFilters {
+  page?: number;
+  page_size?: number;
+  status?: string;
+}
+
+/**
+ * Success rate response.
+ */
+export interface GCalSuccessRateResponse {
+  published: number;
+  error: number;
+  pending: number;
+  none: number;
+  rate: number;
+  window?: {
+    start?: string | null;
+    end?: string | null;
+  };
+}
+
+/**
+ * Top insights item.
+ */
+export interface GCalTopInsightItem {
+  name: string;
+  count: number;
+  published: number;
+  error: number;
+  rate: number;
+}
+
+/**
+ * Top insights response.
+ */
+export interface GCalTopInsightsResponse {
+  items: GCalTopInsightItem[];
+  window?: {
+    start?: string | null;
+    end?: string | null;
+  };
+  metric: 'municipios' | 'projetos' | string;
+  limit: number;
+}
+
+/**
+ * Params for top insights endpoint.
+ */
+export interface GCalTopInsightsParams extends GCalDashboardWindowFilters {
+  metric: 'municipios' | 'projetos' | string;
+  limit?: number;
+}
+
+/**
+ * Timeline item for event detail.
+ */
+export interface GCalEventTimelineItem {
+  action: string;
+  usuario_nome: string;
+  created_at: string;
+  details?: Record<string, unknown>;
+}
+
+/**
+ * Event detail response.
+ */
+export interface GCalDashboardEventDetail {
+  id: number;
+  municipio_nome: string | null;
+  projeto_nome: string | null;
+  tipo_evento_nome: string | null;
+  inicio: string | null;
+  fim: string | null;
+  usuario_username: string | null;
+  coordenador_username: string | null;
+  fluxo: string;
+  gcal_status: 'NONE' | 'PENDING' | 'PUBLISHED' | 'ERROR';
+  external_event_id: string | null;
+  gcal_last_sync_at: string | null;
+  meet_link: string | null;
+  gcal_payload_hash: string | null;
+  gcal_last_error: string | null;
+  updated_at: string | null;
+  participations: Array<{
+    email: string;
+    role: string;
+    ch_horas?: number;
+    observacao?: string;
+  }>;
+  timeline: GCalEventTimelineItem[];
+}
+
+/**
+ * Alerts summary response.
+ */
+export interface GCalAlertsSummaryResponse {
+  errors: number;
+  pending: number;
+  published: number;
+  none: number;
+  window?: {
+    start?: string | null;
+    end?: string | null;
+  };
+}
+
+/**
  * Busca resumo de status do GCal (contadores).
  *
  * @param filters - Filtros opcionais (date_from, date_to, sector, q, status)
@@ -121,4 +267,72 @@ export async function resyncBatch(body: BatchIdsRequest): Promise<BatchOperation
     method: 'POST',
     body: JSON.stringify(body),
   });
+}
+
+/**
+ * Loads dashboard metrics cards and recent errors.
+ */
+export async function getDashboardMetrics(
+  params: GCalDashboardWindowFilters = {}
+): Promise<GCalDashboardMetricsResponse> {
+  const url = buildUrl('/gcal/dashboard/metrics/', params as QueryParams);
+  return await fetchAPI(url);
+}
+
+/**
+ * Loads dashboard events table.
+ */
+export async function listDashboardEvents(
+  params: GCalDashboardEventsParams = {}
+): Promise<PaginatedResponse<GCalDashboardEventRecord>> {
+  const url = buildUrl('/gcal/dashboard/events/', params as QueryParams);
+  return await fetchAPI(url);
+}
+
+/**
+ * Loads success-rate insight card.
+ */
+export async function getDashboardSuccessRate(
+  params: GCalDashboardWindowFilters = {}
+): Promise<GCalSuccessRateResponse> {
+  const url = buildUrl('/gcal/dashboard/insights/success-rate/', params as QueryParams);
+  return await fetchAPI(url);
+}
+
+/**
+ * Loads top insights table.
+ */
+export async function getDashboardTopInsights(
+  params: GCalTopInsightsParams
+): Promise<GCalTopInsightsResponse> {
+  const queryParams: QueryParams = { ...params };
+  const url = buildUrl('/gcal/dashboard/insights/top/', queryParams);
+  return await fetchAPI(url);
+}
+
+/**
+ * Loads full event detail drawer payload.
+ */
+export async function getDashboardEventDetail(eventId: number): Promise<GCalDashboardEventDetail> {
+  return await fetchAPI(`/gcal/dashboard/events/${eventId}/detail/`);
+}
+
+/**
+ * Loads alerts summary used for menu badge/toast.
+ */
+export async function getAlertsSummary(): Promise<GCalAlertsSummaryResponse> {
+  return await fetchAPI('/gcal/dashboard/alerts/summary/');
+}
+
+/**
+ * Builds export URL for dashboard events with active filters.
+ */
+export function buildDashboardEventsExportUrl(params: {
+  export_format: 'csv' | 'json';
+  start?: string;
+  end?: string;
+  status?: string;
+}): string {
+  const relativePath = buildUrl('/gcal/dashboard/events/export/', params as QueryParams);
+  return `${API_BASE}${relativePath}`;
 }

--- a/v2/frontend/src/api/systemConfig.ts
+++ b/v2/frontend/src/api/systemConfig.ts
@@ -1,0 +1,39 @@
+/**
+ * API Client - System Config
+ *
+ * Centralized wrappers for /api/config/ endpoints.
+ */
+
+import { fetchAPI } from './config'
+
+/**
+ * System configuration object.
+ */
+export interface SystemConfig {
+  buffer_deslocamento_minutos?: number
+  session_cookie_age?: number
+  batch_size?: number
+  [key: string]: unknown
+}
+
+/**
+ * Validation errors returned by backend.
+ */
+export type ConfigValidationErrors = Record<string, string | string[]>
+
+/**
+ * Load current system config.
+ */
+export async function getSystemConfig(): Promise<SystemConfig> {
+  return fetchAPI('/config/')
+}
+
+/**
+ * Persist config changes.
+ */
+export async function updateSystemConfig(values: SystemConfig): Promise<SystemConfig> {
+  return fetchAPI('/config/', {
+    method: 'PUT',
+    body: JSON.stringify(values),
+  })
+}

--- a/v2/frontend/src/api/teamMetrics.ts
+++ b/v2/frontend/src/api/teamMetrics.ts
@@ -1,0 +1,70 @@
+/**
+ * API Client - Team Metrics Dashboard
+ */
+
+import { buildUrl, fetchAPI, type QueryParams } from './config'
+
+/**
+ * Productivity response.
+ */
+export interface TeamProductivityData {
+  period: string
+  events_created: number
+  approval_rate: number
+  avg_approval_time_hours: number
+  gcal_error_rate: number
+}
+
+/**
+ * Formador row.
+ */
+export interface TeamFormadorRecord {
+  id: number
+  nome: string
+  eventos: number
+  horas_trabalhadas: number
+  municipios_atendidos: number
+}
+
+/**
+ * Formadores response.
+ */
+export interface TeamFormadoresData {
+  period: string
+  formadores: TeamFormadorRecord[]
+}
+
+/**
+ * Quality response.
+ */
+export interface TeamQualityData {
+  period: string
+  rejection_rate: number
+  conflict_rate: number
+  rework_rate: number
+  avg_publish_time_minutes: number
+}
+
+/**
+ * Load productivity metrics.
+ */
+export async function getTeamProductivity(days: number): Promise<TeamProductivityData> {
+  const url = buildUrl('/metrics/team/productivity/', { days } as QueryParams)
+  return fetchAPI(url)
+}
+
+/**
+ * Load formadores metrics.
+ */
+export async function getTeamFormadores(days: number): Promise<TeamFormadoresData> {
+  const url = buildUrl('/metrics/team/formadores/', { days } as QueryParams)
+  return fetchAPI(url)
+}
+
+/**
+ * Load quality metrics.
+ */
+export async function getTeamQuality(days: number): Promise<TeamQualityData> {
+  const url = buildUrl('/metrics/team/quality/', { days } as QueryParams)
+  return fetchAPI(url)
+}

--- a/v2/frontend/src/hooks/__tests__/useConfig.test.js
+++ b/v2/frontend/src/hooks/__tests__/useConfig.test.js
@@ -13,9 +13,15 @@ import { renderHook, waitFor, act } from '@testing-library/react'
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
 import { useConfig } from '../useConfig'
 
-// Mock fetch
-const mockFetch = vi.fn()
-globalThis.fetch = mockFetch
+const { getSystemConfigMock, updateSystemConfigMock } = vi.hoisted(() => ({
+  getSystemConfigMock: vi.fn(),
+  updateSystemConfigMock: vi.fn(),
+}))
+
+vi.mock('../../api/systemConfig', () => ({
+  getSystemConfig: getSystemConfigMock,
+  updateSystemConfig: updateSystemConfigMock,
+}))
 
 // Mock antd message
 vi.mock('antd', () => ({
@@ -45,10 +51,7 @@ describe('useConfig', () => {
   // ============================================================================
 
   test('deve iniciar com loading=true', () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => mockConfigData,
-    })
+    getSystemConfigMock.mockResolvedValueOnce(mockConfigData)
 
     const { result } = renderHook(() => useConfig())
 
@@ -56,10 +59,7 @@ describe('useConfig', () => {
   })
 
   test('deve carregar config com sucesso', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => mockConfigData,
-    })
+    getSystemConfigMock.mockResolvedValueOnce(mockConfigData)
 
     const { result } = renderHook(() => useConfig())
 
@@ -68,17 +68,11 @@ describe('useConfig', () => {
     })
 
     expect(result.current.config).toEqual(mockConfigData)
-    expect(mockFetch).toHaveBeenCalledWith('/api/config/', {
-      credentials: 'include',
-    })
+    expect(getSystemConfigMock).toHaveBeenCalledTimes(1)
   })
 
   test('deve lidar com erro de carregamento', async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: false,
-      status: 500,
-      statusText: 'Internal Server Error',
-    })
+    getSystemConfigMock.mockRejectedValueOnce(new Error('HTTP 500: Internal Server Error'))
 
     const { result } = renderHook(() => useConfig())
 
@@ -90,7 +84,7 @@ describe('useConfig', () => {
   })
 
   test('deve lidar com erro de rede', async () => {
-    mockFetch.mockRejectedValueOnce(new Error('Network error'))
+    getSystemConfigMock.mockRejectedValueOnce(new Error('Network error'))
 
     const { result } = renderHook(() => useConfig())
 
@@ -107,10 +101,7 @@ describe('useConfig', () => {
 
   test('saveConfig deve retornar true em sucesso', async () => {
     // Mock para load inicial
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => mockConfigData,
-    })
+    getSystemConfigMock.mockResolvedValueOnce(mockConfigData)
 
     const { result } = renderHook(() => useConfig())
 
@@ -120,10 +111,7 @@ describe('useConfig', () => {
 
     // Mock para saveConfig
     const updatedConfig = { ...mockConfigData, buffer_deslocamento_minutos: 90 }
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => updatedConfig,
-    })
+    updateSystemConfigMock.mockResolvedValueOnce(updatedConfig)
 
     let saveResult
     await act(async () => {
@@ -132,14 +120,12 @@ describe('useConfig', () => {
 
     expect(saveResult).toBe(true)
     expect(result.current.config).toEqual(updatedConfig)
+    expect(updateSystemConfigMock).toHaveBeenCalledWith(updatedConfig)
   })
 
   test('saveConfig deve retornar false em erro', async () => {
     // Mock para load inicial
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => mockConfigData,
-    })
+    getSystemConfigMock.mockResolvedValueOnce(mockConfigData)
 
     const { result } = renderHook(() => useConfig())
 
@@ -148,9 +134,10 @@ describe('useConfig', () => {
     })
 
     // Mock para saveConfig com erro
-    mockFetch.mockResolvedValueOnce({
-      ok: false,
-      json: async () => ({ buffer_deslocamento_minutos: ['Valor inválido'] }),
+    updateSystemConfigMock.mockRejectedValueOnce({
+      response: {
+        data: { buffer_deslocamento_minutos: ['Valor inválido'] },
+      },
     })
 
     let saveResult
@@ -167,10 +154,7 @@ describe('useConfig', () => {
 
   test('reload deve recarregar config do servidor', async () => {
     // Mock para load inicial
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => mockConfigData,
-    })
+    getSystemConfigMock.mockResolvedValueOnce(mockConfigData)
 
     const { result } = renderHook(() => useConfig())
 
@@ -180,16 +164,13 @@ describe('useConfig', () => {
 
     // Mock para reload
     const updatedConfig = { ...mockConfigData, buffer_deslocamento_minutos: 120 }
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => updatedConfig,
-    })
+    getSystemConfigMock.mockResolvedValueOnce(updatedConfig)
 
     await act(async () => {
       await result.current.reload()
     })
 
     expect(result.current.config).toEqual(updatedConfig)
-    expect(mockFetch).toHaveBeenCalledTimes(2)
+    expect(getSystemConfigMock).toHaveBeenCalledTimes(2)
   })
 })

--- a/v2/frontend/src/hooks/useConfig.ts
+++ b/v2/frontend/src/hooks/useConfig.ts
@@ -25,21 +25,12 @@
 import { useState, useEffect } from 'react';
 import { message } from 'antd';
 import logger from '../utils/logger';
-
-/**
- * System configuration object
- */
-export interface SystemConfig {
-  buffer_deslocamento_minutos?: number;
-  session_cookie_age?: number;
-  batch_size?: number;
-  [key: string]: unknown;
-}
-
-/**
- * Validation errors from backend
- */
-type ValidationErrors = Record<string, string | string[]>;
+import {
+  getSystemConfig,
+  updateSystemConfig,
+  type ConfigValidationErrors,
+  type SystemConfig,
+} from '../api/systemConfig';
 
 /**
  * Return type for useConfig hook
@@ -58,21 +49,20 @@ export function useConfig(): UseConfigReturn {
   const [config, setConfig] = useState<SystemConfig | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
 
+  type ApiClientError = Error & {
+    response?: {
+      status?: number;
+      data?: unknown;
+    };
+  };
+
   /**
    * Load config from server
    */
   const loadConfig = async (): Promise<void> => {
     setLoading(true);
     try {
-      const res = await fetch('/api/config/', {
-        credentials: 'include'
-      });
-
-      if (!res.ok) {
-        throw new Error(`HTTP ${res.status}: ${res.statusText}`);
-      }
-
-      const data: SystemConfig = await res.json();
+      const data = await getSystemConfig();
       setConfig(data);
     } catch (error) {
       message.error('Erro ao carregar configurações');
@@ -90,39 +80,25 @@ export function useConfig(): UseConfigReturn {
    */
   const saveConfig = async (values: SystemConfig): Promise<boolean> => {
     try {
-      const res = await fetch('/api/config/', {
-        method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        credentials: 'include',
-        body: JSON.stringify(values)
-      });
-
-      if (!res.ok) {
-        const errors: ValidationErrors = await res.json();
-        logger.error('useConfig saveConfig validation errors:', errors);
-
-        // Display validation errors
-        if (typeof errors === 'object' && !Array.isArray(errors)) {
-          const errorMessages = Object.entries(errors)
-            .map(([field, msgs]) => `${field}: ${Array.isArray(msgs) ? msgs.join(', ') : msgs}`)
-            .join('\n');
-          message.error(`Erro de validação:\n${errorMessages}`, 5);
-        } else {
-          message.error('Erro ao salvar configurações');
-        }
-
-        return false;
-      }
-
-      const data: SystemConfig = await res.json();
+      const data = await updateSystemConfig(values);
       setConfig(data);
       message.success('Configurações salvas com sucesso!');
       return true;
     } catch (error) {
-      message.error('Erro ao salvar configurações');
+      const apiError = error as ApiClientError;
+      const validationData = apiError.response?.data;
       logger.error('useConfig saveConfig error:', error);
+
+      // Display backend validation errors when available.
+      if (validationData && typeof validationData === 'object' && !Array.isArray(validationData)) {
+        const errors = validationData as ConfigValidationErrors;
+        const errorMessages = Object.entries(errors)
+            .map(([field, msgs]) => `${field}: ${Array.isArray(msgs) ? msgs.join(', ') : msgs}`)
+            .join('\n');
+        message.error(`Erro de validação:\n${errorMessages}`, 5);
+      } else {
+        message.error('Erro ao salvar configurações');
+      }
       return false;
     }
   };

--- a/v2/frontend/src/pages/Dashboards/DashboardsPage.tsx
+++ b/v2/frontend/src/pages/Dashboards/DashboardsPage.tsx
@@ -29,6 +29,11 @@ import {
 import type { ColumnsType } from 'antd/es/table';
 import logger from '../../utils/logger';
 import {
+  getDashboardOverview,
+  type DashboardOverviewResponse,
+  type DashboardCoordenadorItem,
+} from '../../api/dashboard';
+import {
   CalendarOutlined,
   CheckCircleOutlined,
   TeamOutlined,
@@ -42,50 +47,6 @@ import {
 
 const { Title, Text } = Typography;
 
-/**
- * KPIs data interface
- */
-interface KPIs {
-  eventos_futuros: number;
-  eventos_aprovados: number;
-  total_formadores: number;
-  aprovacoes_pendentes: number;
-}
-
-/**
- * Fluxo item interface
- */
-interface FluxoItem {
-  fluxo: string;
-  quantidade: number;
-}
-
-/**
- * Gerencia item interface
- */
-interface GerenciaItem {
-  gerencia: string;
-  porcentagem: number;
-}
-
-/**
- * Coordenador item interface
- */
-interface CoordenadorItem {
-  nome: string;
-  eventos: number;
-}
-
-/**
- * Dashboard data interface
- */
-interface DashboardData {
-  kpis: KPIs;
-  por_fluxo: FluxoItem[];
-  por_gerencia: GerenciaItem[];
-  top_coordenadores: CoordenadorItem[];
-}
-
 // Cores para os graficos
 const FLUXO_COLORS: Record<string, string> = {
   SUPER: '#1890ff',
@@ -95,7 +56,7 @@ const FLUXO_COLORS: Record<string, string> = {
 const GERENCIA_COLORS = ['#1890ff', '#52c41a', '#faad14', '#f5222d', '#722ed1'];
 
 export default function DashboardsPage(): JSX.Element {
-  const [data, setData] = useState<DashboardData | null>(null);
+  const [data, setData] = useState<DashboardOverviewResponse | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -104,15 +65,7 @@ export default function DashboardsPage(): JSX.Element {
     setError(null);
 
     try {
-      const response = await fetch('/api/dashboard/overview/', {
-        credentials: 'include',
-      });
-
-      if (!response.ok) {
-        throw new Error(`Erro ${response.status}: ${response.statusText}`);
-      }
-
-      const result = await response.json();
+      const result = await getDashboardOverview();
       setData(result);
     } catch (err) {
       logger.error('Erro ao carregar dashboard:', err);
@@ -175,7 +128,7 @@ export default function DashboardsPage(): JSX.Element {
   const maxCoord = top_coordenadores.length > 0 ? top_coordenadores[0].eventos : 1;
 
   // Columns for top coordenadores table
-  const columns: ColumnsType<CoordenadorItem> = [
+  const columns: ColumnsType<DashboardCoordenadorItem> = [
     {
       title: 'Posicao',
       key: 'posicao',

--- a/v2/frontend/src/pages/Dashboards/EquipeDashboardPage.tsx
+++ b/v2/frontend/src/pages/Dashboards/EquipeDashboardPage.tsx
@@ -40,83 +40,37 @@ import {
   SafetyOutlined,
 } from '@ant-design/icons';
 import logger from '../../utils/logger';
+import {
+  getTeamProductivity,
+  getTeamFormadores,
+  getTeamQuality,
+  type TeamProductivityData,
+  type TeamFormadoresData,
+  type TeamQualityData,
+  type TeamFormadorRecord,
+} from '../../api/teamMetrics';
 
 const { Title, Text } = Typography;
 const { Option } = Select;
-
-/**
- * Productivity data interface
- */
-interface ProductivityData {
-  period: string;
-  events_created: number;
-  approval_rate: number;
-  avg_approval_time_hours: number;
-  gcal_error_rate: number;
-}
-
-/**
- * Formador record interface
- */
-interface FormadorRecord {
-  id: number;
-  nome: string;
-  eventos: number;
-  horas_trabalhadas: number;
-  municipios_atendidos: number;
-}
-
-/**
- * Formadores data interface
- */
-interface FormadoresData {
-  period: string;
-  formadores: FormadorRecord[];
-}
-
-/**
- * Quality data interface
- */
-interface QualityData {
-  period: string;
-  rejection_rate: number;
-  conflict_rate: number;
-  rework_rate: number;
-  avg_publish_time_minutes: number;
-}
 
 export default function EquipeDashboardPage(): JSX.Element {
   const [days, setDays] = useState<number>(7);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
 
-  const [productivityData, setProductivityData] = useState<ProductivityData | null>(null);
-  const [formadoresData, setFormadoresData] = useState<FormadoresData | null>(null);
-  const [qualityData, setQualityData] = useState<QualityData | null>(null);
+  const [productivityData, setProductivityData] = useState<TeamProductivityData | null>(null);
+  const [formadoresData, setFormadoresData] = useState<TeamFormadoresData | null>(null);
+  const [qualityData, setQualityData] = useState<TeamQualityData | null>(null);
 
   const loadAllMetrics = useCallback(async () => {
     setLoading(true);
     setError(null);
 
     try {
-      // Fetch em paralelo para performance
-      const [prodRes, formRes, qualRes] = await Promise.all([
-        fetch(`/api/metrics/team/productivity/?days=${days}`, { credentials: 'include' }),
-        fetch(`/api/metrics/team/formadores/?days=${days}`, { credentials: 'include' }),
-        fetch(`/api/metrics/team/quality/?days=${days}`, { credentials: 'include' }),
-      ]);
-
-      // Validar respostas
-      if (!prodRes.ok || !formRes.ok || !qualRes.ok) {
-        const errorStatus = !prodRes.ok ? prodRes.status : !formRes.ok ? formRes.status : qualRes.status;
-        throw new Error(`Erro HTTP ${errorStatus}`);
-      }
-
-      // Parse JSON
       const [prod, form, qual] = await Promise.all([
-        prodRes.json(),
-        formRes.json(),
-        qualRes.json(),
+        getTeamProductivity(days),
+        getTeamFormadores(days),
+        getTeamQuality(days),
       ]);
 
       setProductivityData(prod);
@@ -177,7 +131,7 @@ export default function EquipeDashboardPage(): JSX.Element {
   };
 
   // Columns for formadores table
-  const formadoresColumns: ColumnsType<FormadorRecord> = [
+  const formadoresColumns: ColumnsType<TeamFormadorRecord> = [
     {
       title: '#',
       key: 'rank',

--- a/v2/frontend/src/pages/Dashboards/GCalDashboardPage.tsx
+++ b/v2/frontend/src/pages/Dashboards/GCalDashboardPage.tsx
@@ -53,7 +53,22 @@ import {
 import dayjs from 'dayjs';
 import logger from '../../utils/logger';
 import { TIMING } from '../../constants';
-import { ensureCsrfToken } from '../../api/config';
+import {
+  getDashboardMetrics,
+  listDashboardEvents,
+  getDashboardSuccessRate,
+  getDashboardTopInsights,
+  getDashboardEventDetail,
+  reapplyBatch,
+  resyncBatch,
+  buildDashboardEventsExportUrl,
+  type GCalDashboardMetricsResponse,
+  type GCalDashboardEventRecord,
+  type GCalDashboardEventDetail,
+  type GCalSuccessRateResponse,
+  type GCalTopInsightsResponse,
+  type GCalTopInsightItem,
+} from '../../api/gcal';
 
 const { Title, Text } = Typography;
 const { RangePicker } = DatePicker;
@@ -63,115 +78,12 @@ const { RangePicker } = DatePicker;
  */
 type GCalStatus = 'NONE' | 'PENDING' | 'PUBLISHED' | 'ERROR';
 
-/**
- * Status counts interface
- */
-interface StatusCounts {
-  NONE: number;
-  PENDING: number;
-  PUBLISHED: number;
-  ERROR: number;
-}
-
-/**
- * Recent error interface
- */
-interface RecentError {
-  id: number;
-  summary: string;
-  gcal_last_error: string;
-  updated_at: string;
-}
-
-/**
- * Metrics data interface
- */
-interface MetricsData {
-  counts: StatusCounts;
-  recent_errors: RecentError[];
-}
-
-/**
- * Event record interface
- */
-interface EventRecord {
-  id: number;
-  summary: string;
-  gcal_status: GCalStatus;
-  gcal_last_sync_at: string | null;
-  gcal_last_error: string | null;
-}
-
-/**
- * Event detail participation interface
- */
-interface Participation {
-  email: string;
-  role: string;
-  ch_horas?: number;
-  observacao?: string;
-}
-
-/**
- * Timeline log interface
- */
-interface TimelineLog {
-  action: string;
-  usuario_nome: string;
-  created_at: string;
-  details?: Record<string, unknown>;
-}
-
-/**
- * Event detail interface
- */
-interface EventDetail {
-  id: number;
-  municipio_nome: string | null;
-  projeto_nome: string | null;
-  tipo_evento_nome: string | null;
-  inicio: string | null;
-  fim: string | null;
-  usuario_username: string | null;
-  coordenador_username: string | null;
-  fluxo: string;
-  gcal_status: GCalStatus;
-  external_event_id: string | null;
-  gcal_last_sync_at: string | null;
-  meet_link: string | null;
-  gcal_payload_hash: string | null;
-  gcal_last_error: string | null;
-  updated_at: string | null;
-  participations: Participation[];
-  timeline: TimelineLog[];
-}
-
-/**
- * Success rate data interface
- */
-interface SuccessRateData {
-  rate: number;
-  published: number;
-  error: number;
-}
-
-/**
- * Top insight item interface
- */
-interface TopInsightItem {
-  name: string;
-  count: number;
-  published: number;
-  error: number;
-  rate: number;
-}
-
-/**
- * Top insights data interface
- */
-interface TopInsightsData {
-  items: TopInsightItem[];
-}
+type MetricsData = GCalDashboardMetricsResponse;
+type EventRecord = GCalDashboardEventRecord;
+type EventDetail = GCalDashboardEventDetail;
+type SuccessRateData = GCalSuccessRateResponse;
+type TopInsightItem = GCalTopInsightItem;
+type TopInsightsData = GCalTopInsightsResponse;
 
 /**
  * Pagination state interface
@@ -265,21 +177,10 @@ export default function GCalDashboardPage(): JSX.Element {
   const loadMetrics = async () => {
     setLoading(true);
     try {
-      const params = new URLSearchParams();
-      if (dateRange && dateRange[0] && dateRange[1]) {
-        params.append('start', dateRange[0].format('YYYY-MM-DD'));
-        params.append('end', dateRange[1].format('YYYY-MM-DD'));
-      }
-
-      const response = await fetch(`/api/gcal/dashboard/metrics/?${params}`, {
-        credentials: 'include',
+      const data = await getDashboardMetrics({
+        start: dateRange[0].format('YYYY-MM-DD'),
+        end: dateRange[1].format('YYYY-MM-DD'),
       });
-
-      if (!response.ok) {
-        throw new Error('Erro ao carregar métricas');
-      }
-
-      const data = await response.json();
       setMetrics(data);
     } catch (error) {
       logger.error('Erro ao carregar métricas:', error);
@@ -292,28 +193,13 @@ export default function GCalDashboardPage(): JSX.Element {
   const loadEvents = async (page = 1, pageSize = 20) => {
     setTableLoading(true);
     try {
-      const params = new URLSearchParams();
-      params.append('page', String(page));
-      params.append('page_size', String(pageSize));
-
-      if (dateRange && dateRange[0] && dateRange[1]) {
-        params.append('start', dateRange[0].format('YYYY-MM-DD'));
-        params.append('end', dateRange[1].format('YYYY-MM-DD'));
-      }
-
-      if (statusFilter) {
-        params.append('status', statusFilter);
-      }
-
-      const response = await fetch(`/api/gcal/dashboard/events/?${params}`, {
-        credentials: 'include',
+      const data = await listDashboardEvents({
+        page,
+        page_size: pageSize,
+        start: dateRange[0].format('YYYY-MM-DD'),
+        end: dateRange[1].format('YYYY-MM-DD'),
+        status: statusFilter || undefined,
       });
-
-      if (!response.ok) {
-        throw new Error('Erro ao carregar eventos');
-      }
-
-      const data = await response.json();
       setEvents(data.results || []);
       setPagination({
         current: page,
@@ -340,21 +226,10 @@ export default function GCalDashboardPage(): JSX.Element {
   const loadSuccessRate = async () => {
     setInsightsLoading(true);
     try {
-      const params = new URLSearchParams();
-      if (dateRange && dateRange[0] && dateRange[1]) {
-        params.append('start', dateRange[0].format('YYYY-MM-DD'));
-        params.append('end', dateRange[1].format('YYYY-MM-DD'));
-      }
-
-      const response = await fetch(`/api/gcal/dashboard/insights/success-rate/?${params}`, {
-        credentials: 'include',
+      const data = await getDashboardSuccessRate({
+        start: dateRange[0].format('YYYY-MM-DD'),
+        end: dateRange[1].format('YYYY-MM-DD'),
       });
-
-      if (!response.ok) {
-        throw new Error('Erro ao carregar success rate');
-      }
-
-      const data = await response.json();
       setSuccessRate(data);
     } catch (error) {
       logger.error('Erro ao carregar success rate:', error);
@@ -367,24 +242,12 @@ export default function GCalDashboardPage(): JSX.Element {
   const loadTopInsights = async () => {
     setInsightsLoading(true);
     try {
-      const params = new URLSearchParams();
-      params.append('metric', topMetric);
-      params.append('limit', '5');
-
-      if (dateRange && dateRange[0] && dateRange[1]) {
-        params.append('start', dateRange[0].format('YYYY-MM-DD'));
-        params.append('end', dateRange[1].format('YYYY-MM-DD'));
-      }
-
-      const response = await fetch(`/api/gcal/dashboard/insights/top/?${params}`, {
-        credentials: 'include',
+      const data = await getDashboardTopInsights({
+        metric: topMetric,
+        limit: 5,
+        start: dateRange[0].format('YYYY-MM-DD'),
+        end: dateRange[1].format('YYYY-MM-DD'),
       });
-
-      if (!response.ok) {
-        throw new Error('Erro ao carregar top insights');
-      }
-
-      const data = await response.json();
       setTopInsights(data);
     } catch (error) {
       logger.error('Erro ao carregar top insights:', error);
@@ -401,21 +264,12 @@ export default function GCalDashboardPage(): JSX.Element {
   };
 
   const handleExport = (format: string) => {
-    // Construir URL de export com os mesmos filtros ativos
-    const params = new URLSearchParams();
-    params.append('export_format', format);
-
-    if (dateRange && dateRange[0] && dateRange[1]) {
-      params.append('start', dateRange[0].format('YYYY-MM-DD'));
-      params.append('end', dateRange[1].format('YYYY-MM-DD'));
-    }
-
-    if (statusFilter) {
-      params.append('status', statusFilter);
-    }
-
-    // Abrir URL em nova aba (download automático via Content-Disposition)
-    const exportUrl = `/api/gcal/dashboard/events/export/?${params}`;
+    const exportUrl = buildDashboardEventsExportUrl({
+      export_format: format === 'json' ? 'json' : 'csv',
+      start: dateRange[0].format('YYYY-MM-DD'),
+      end: dateRange[1].format('YYYY-MM-DD'),
+      status: statusFilter || undefined,
+    });
     window.open(exportUrl, '_blank');
     message.success(`Exportação ${format.toUpperCase()} iniciada!`);
   };
@@ -431,15 +285,7 @@ export default function GCalDashboardPage(): JSX.Element {
   const loadEventDetail = async (eventId: number) => {
     setDetailLoading(true);
     try {
-      const response = await fetch(`/api/gcal/dashboard/events/${eventId}/detail/`, {
-        credentials: 'include',
-      });
-
-      if (!response.ok) {
-        throw new Error('Erro ao carregar detalhes do evento');
-      }
-
-      const data = await response.json();
+      const data = await getDashboardEventDetail(eventId);
       setEventDetail(data);
     } catch (error) {
       logger.error('Erro ao carregar detalhes:', error);
@@ -461,27 +307,11 @@ export default function GCalDashboardPage(): JSX.Element {
     if (!selectedEventId) return;
 
     try {
-      const csrfToken = await ensureCsrfToken();
-      const response = await fetch('/api/gcal/dashboard/batch/reapply/', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-CSRFToken': csrfToken || '',
-        },
-        credentials: 'include',
-        body: JSON.stringify({
-          ids: [selectedEventId],
-          dry_run: false,
-          apply_blocked: false,
-        }),
+      const data = await reapplyBatch({
+        ids: [selectedEventId],
+        dry_run: false,
+        apply_blocked: false,
       });
-
-      if (!response.ok) {
-        const errorData = await response.json();
-        throw new Error(errorData.detail || 'Erro ao reapliar evento');
-      }
-
-      const data = await response.json();
 
       if (data.queued > 0) {
         message.success(`Evento reenfileirado para publicação (Reapply)`);
@@ -501,27 +331,11 @@ export default function GCalDashboardPage(): JSX.Element {
     if (!selectedEventId) return;
 
     try {
-      const csrfToken = await ensureCsrfToken();
-      const response = await fetch('/api/gcal/dashboard/batch/resync/', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-CSRFToken': csrfToken || '',
-        },
-        credentials: 'include',
-        body: JSON.stringify({
-          ids: [selectedEventId],
-          dry_run: false,
-          apply_blocked: false,
-        }),
+      const data = await resyncBatch({
+        ids: [selectedEventId],
+        dry_run: false,
+        apply_blocked: false,
       });
-
-      if (!response.ok) {
-        const errorData = await response.json();
-        throw new Error(errorData.detail || 'Erro ao ressincronizar evento');
-      }
-
-      const data = await response.json();
 
       if (data.queued > 0) {
         message.success(`Evento reenfileirado para ressincronização (Resync)`);

--- a/v2/frontend/src/pages/PreAgenda/PreAgendaPage.tsx
+++ b/v2/frontend/src/pages/PreAgenda/PreAgendaPage.tsx
@@ -60,14 +60,13 @@ import {
   resyncSolicitacao,
   cancelSolicitacao,
 } from '../../api/solicitacoes';
-import { getStatusSummary } from '../../api/gcal';
+import { getStatusSummary, reapplyBatch, resyncBatch, type GCalStatusSummary } from '../../api/gcal';
 import { MeetLink } from '../../components/MeetLink';
 import { getMe } from '../../api/availability';
 import useGoogleIntegration from '../../hooks/useGoogleIntegration';
 import useGoogleGuard from '../../hooks/useGoogleGuard';
 import GoogleIntegrationCard from '../../components/google/GoogleIntegrationCard';
 import logger from '../../utils/logger';
-import { ensureCsrfToken } from '../../api/config';
 import type { ID, Solicitacao, GCalStatus, CurrentUser, PaginatedResponse } from '../../types';
 
 const { Title, Text } = Typography;
@@ -80,12 +79,6 @@ const GCAL_STATUS_COLORS: Record<string, string> = {
   PUBLISHED: 'success',
   ERROR: 'error',
 };
-
-/** Summary type */
-interface SummaryType {
-  counts: Record<string, number>;
-  total: number;
-}
 
 /** Preview data type */
 interface PreviewDataType {
@@ -105,18 +98,15 @@ interface PreviewDataType {
   };
 }
 
-/** Batch response type */
-interface BatchResponseType {
-  queued: number;
-  errors?: Array<{ detail: string }>;
-}
-
 export default function PreAgendaPage(): JSX.Element {
   const [loading, setLoading] = useState<boolean>(false);
   const [rows, setRows] = useState<Solicitacao[]>([]);
   const [total, setTotal] = useState<number>(0);
 
-  const [summary, setSummary] = useState<SummaryType>({ counts: {}, total: 0 });
+  const [summary, setSummary] = useState<GCalStatusSummary>({
+    counts: { NONE: 0, PENDING: 0, PUBLISHED: 0, ERROR: 0 },
+    total: 0,
+  });
 
   const [searchTerm, setSearchTerm] = useState<string>('');
   const [sectorFilter, setSectorFilter] = useState<string>('');
@@ -166,7 +156,7 @@ export default function PreAgendaPage(): JSX.Element {
       const [superData, naoSuperData, summaryData] = await Promise.all([
         listSolicitacoes({ ...filters, flow: 'SUPER' }) as Promise<PaginatedResponse<Solicitacao> | Solicitacao[]>,
         listSolicitacoes({ ...filters, flow: 'NAO_SUPER' }) as Promise<PaginatedResponse<Solicitacao> | Solicitacao[]>,
-        getStatusSummary(filters) as unknown as Promise<SummaryType>,
+        getStatusSummary(filters),
       ]);
 
       const superRows = 'results' in superData ? superData.results : superData;
@@ -309,40 +299,22 @@ export default function PreAgendaPage(): JSX.Element {
       onOk: async () => {
         try {
           setBatchLoading(true);
-          const csrfToken = await ensureCsrfToken();
-          const response = await fetch('/api/gcal/dashboard/batch/reapply/', {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              'X-CSRFToken': csrfToken || '',
-            },
-            credentials: 'include',
-            body: JSON.stringify({
-              ids: selectedRowKeys,
-              dry_run: false,
-              apply_blocked: true,
-            }),
+          const data = await reapplyBatch({
+            ids: selectedRowKeys as ID[],
+            dry_run: false,
+            apply_blocked: true,
           });
-
-          const data = await response.json() as BatchResponseType & { code?: string };
-
-          // Section 4 Epic #459: Handle Google not connected error
-          if (response.status === 403 && data.code === 'google_not_connected') {
-            handleGoogleError({ response: { status: 403, data } } as unknown as Error);
-            return;
-          }
-
-          if (!response.ok) {
-            throw new Error((data as { detail?: string }).detail || 'Erro ao reenviar eventos');
-          }
 
           message.success(`${data.queued} eventos enfileirados para reapply!`);
           if (data.errors && data.errors.length > 0) {
-            message.warning(`${data.errors.length} erros: ${data.errors.map(e => e.detail).join(', ')}`);
+            message.warning(
+              `${data.errors.length} erros: ${data.errors.map((e) => e.detail || e.error || 'erro').join(', ')}`
+            );
           }
           setSelectedRowKeys([]);
           loadData();
         } catch (error) {
+          if (handleGoogleError(error)) return;
           message.error('Erro ao reenviar em massa: ' + (error as Error).message);
         } finally {
           setBatchLoading(false);
@@ -378,40 +350,22 @@ export default function PreAgendaPage(): JSX.Element {
       onOk: async () => {
         try {
           setBatchLoading(true);
-          const csrfToken = await ensureCsrfToken();
-          const response = await fetch('/api/gcal/dashboard/batch/resync/', {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              'X-CSRFToken': csrfToken || '',
-            },
-            credentials: 'include',
-            body: JSON.stringify({
-              ids: selectedRowKeys,
-              dry_run: false,
-              apply_blocked: true,
-            }),
+          const data = await resyncBatch({
+            ids: selectedRowKeys as ID[],
+            dry_run: false,
+            apply_blocked: true,
           });
-
-          const data = await response.json() as BatchResponseType & { code?: string };
-
-          // Section 4 Epic #459: Handle Google not connected error
-          if (response.status === 403 && data.code === 'google_not_connected') {
-            handleGoogleError({ response: { status: 403, data } } as unknown as Error);
-            return;
-          }
-
-          if (!response.ok) {
-            throw new Error((data as { detail?: string }).detail || 'Erro ao fazer resync de eventos');
-          }
 
           message.success(`${data.queued} eventos enfileirados para resync!`);
           if (data.errors && data.errors.length > 0) {
-            message.warning(`${data.errors.length} erros: ${data.errors.map(e => e.detail).join(', ')}`);
+            message.warning(
+              `${data.errors.length} erros: ${data.errors.map((e) => e.detail || e.error || 'erro').join(', ')}`
+            );
           }
           setSelectedRowKeys([]);
           loadData();
         } catch (error) {
+          if (handleGoogleError(error)) return;
           message.error('Erro ao resync em massa: ' + (error as Error).message);
         } finally {
           setBatchLoading(false);


### PR DESCRIPTION
﻿## Summary

- Migra consumo HTTP cr?tico do frontend para wrappers tipados em `src/api/*` (config, dashboard overview, m?tricas de equipe e dashboard GCal).
- Remove `fetch('/api/...')` direto dos fluxos cr?ticos mapeados, centralizando autentica??o/CSRF e tratamento de erro no `fetchAPI`.
- Alinha tipagem dos payloads consumidos nas telas cr?ticas e adiciona/atualiza testes de API client e hook.

## Scope

- Incluido:
  - `useConfig` -> `api/systemConfig`
  - `DashboardsPage` -> `api/dashboard`
  - `EquipeDashboardPage` -> `api/teamMetrics`
  - `GCalDashboardPage`, `PreAgendaPage` e polling em `App.tsx` -> wrappers de `api/gcal`
  - Novos testes: `systemConfig`, `dashboard`, `teamMetrics` e extens?o de `gcal`
  - Atualiza??o de `fetchAPI` para expor `error.response.status/data` de forma consistente
- Fora de escopo:
  - Refatora??o massiva de todos os consumidores HTTP do frontend em uma ?nica PR
  - Mudan?a de comportamento funcional das telas

## Test Plan

- [x] `cd v2/frontend && npm run lint` (passou)
- [x] `cd v2/frontend && npm run build` (passou)
- [x] `cd v2/frontend && npm run test -- --run` (149 passed)
- [x] `docker compose -p aprender_v2 -f v2/infra/docker-compose.yml exec -T web pytest -q apps/core/tests/test_config_api.py` (6 passed)

## Risks

- Risco 1: regress?o por mudan?a de integra??o em telas de alto uso (dashboard/pre-agenda).
- Mitigacao: wrappers tipados + cobertura de testes de API client e su?te frontend completa local.

## Links

- Closes #704
