### PR TITLE
ci(telemetry): estabilizar baseline com filtro main/push

### DIFF
--- a/.github/workflows/ci-runtime-telemetry.yml
+++ b/.github/workflows/ci-runtime-telemetry.yml
@@ -37,6 +37,9 @@ jobs:
             --workflows "CI – Continuous Integration" "frontend-ci" "Security Scan" \
             --runs-per-workflow 30 \
             --required-only \
+            --branch "main" \
+            --events "push" \
+            --successful-runs-only \
             --baseline-json "v2/docs/analysis/ci-runtime-baseline.json" \
             --regression-threshold-pct 35 \
             --regression-min-absolute-seconds 20 \

--- a/v2/docs/analysis/ci-runtime-baseline.json
+++ b/v2/docs/analysis/ci-runtime-baseline.json
@@ -1,100 +1,107 @@
 {
-  "generated_at_utc": "2026-02-27T17:30:00.000000+00:00",
+  "branch": "main",
+  "events": [
+    "push"
+  ],
+  "generated_at_utc": "2026-03-04T11:03:08.803465+00:00",
   "metrics": {
     "CI \u2013 Continuous Integration::[required] backend impact": {
       "max_seconds": 109.0,
       "median_seconds": 8.0,
       "min_seconds": 6.0,
-      "p95_seconds": 10.0,
+      "p95_seconds": 12.0,
       "samples": 30
     },
     "CI \u2013 Continuous Integration::[required] backend tests (runner)": {
       "max_seconds": 177.0,
-      "median_seconds": 67.0,
-      "min_seconds": 0.0,
+      "median_seconds": 70.0,
+      "min_seconds": 60.0,
       "p95_seconds": 82.0,
-      "samples": 27
+      "samples": 30
     },
     "CI \u2013 Continuous Integration::[required] backend typecheck (pyright)": {
-      "max_seconds": 78.0,
-      "median_seconds": 72.0,
-      "min_seconds": 0.0,
-      "p95_seconds": 78.0,
-      "samples": 27
+      "max_seconds": 90.0,
+      "median_seconds": 72.5,
+      "min_seconds": 63.0,
+      "p95_seconds": 79.0,
+      "samples": 30
     },
     "CI \u2013 Continuous Integration::[required] docker parity (backend)": {
-      "max_seconds": 139.0,
-      "median_seconds": 126.0,
-      "min_seconds": 0.0,
-      "p95_seconds": 136.0,
-      "samples": 27
+      "max_seconds": 150.0,
+      "median_seconds": 130.0,
+      "min_seconds": 114.0,
+      "p95_seconds": 140.0,
+      "samples": 30
     },
     "CI \u2013 Continuous Integration::[required] lint": {
-      "max_seconds": 139.0,
-      "median_seconds": 24.0,
+      "max_seconds": 29.0,
+      "median_seconds": 25.0,
       "min_seconds": 21.0,
-      "p95_seconds": 31.0,
+      "p95_seconds": 29.0,
       "samples": 30
     },
     "CI \u2013 Continuous Integration::[required] tests": {
-      "max_seconds": 32.0,
+      "max_seconds": 4.0,
       "median_seconds": 3.0,
       "min_seconds": 2.0,
       "p95_seconds": 4.0,
       "samples": 30
     },
     "Security Scan::[required] Container Scan": {
-      "max_seconds": 157.0,
-      "median_seconds": 130.0,
-      "min_seconds": 114.0,
-      "p95_seconds": 152.0,
+      "max_seconds": 148.0,
+      "median_seconds": 127.5,
+      "min_seconds": 117.0,
+      "p95_seconds": 144.0,
       "samples": 30
     },
     "Security Scan::[required] Frontend Dependencies": {
-      "max_seconds": 31.0,
-      "median_seconds": 21.0,
+      "max_seconds": 28.0,
+      "median_seconds": 20.0,
       "min_seconds": 17.0,
-      "p95_seconds": 28.0,
+      "p95_seconds": 24.0,
       "samples": 30
     },
     "Security Scan::[required] Python Dependencies": {
-      "max_seconds": 181.0,
-      "median_seconds": 45.0,
-      "min_seconds": 40.0,
-      "p95_seconds": 54.0,
+      "max_seconds": 53.0,
+      "median_seconds": 44.0,
+      "min_seconds": 37.0,
+      "p95_seconds": 52.0,
       "samples": 30
     },
     "Security Scan::[required] Secret Detection": {
-      "max_seconds": 47.0,
-      "median_seconds": 16.0,
+      "max_seconds": 23.0,
+      "median_seconds": 15.0,
       "min_seconds": 12.0,
-      "p95_seconds": 23.0,
+      "p95_seconds": 22.0,
       "samples": 30
     },
     "frontend-ci::[required] build/lint do frontend": {
-      "max_seconds": 316.0,
-      "median_seconds": 55.0,
-      "min_seconds": 49.0,
-      "p95_seconds": 188.0,
-      "samples": 30
+      "max_seconds": 188.0,
+      "median_seconds": 57.0,
+      "min_seconds": 47.0,
+      "p95_seconds": 67.0,
+      "samples": 21
     },
     "frontend-ci::[required] checklist tests (meta, a11y, security)": {
-      "max_seconds": 686.0,
-      "median_seconds": 76.0,
+      "max_seconds": 197.0,
+      "median_seconds": 88.0,
       "min_seconds": 70.0,
-      "p95_seconds": 97.0,
-      "samples": 30
+      "p95_seconds": 187.0,
+      "samples": 21
     },
     "frontend-ci::[required] react doctor quality gate": {
       "max_seconds": 102.0,
       "median_seconds": 31.0,
-      "min_seconds": 17.0,
-      "p95_seconds": 40.0,
-      "samples": 30
+      "min_seconds": 24.0,
+      "p95_seconds": 38.0,
+      "samples": 21
     }
   },
+  "regression_min_absolute_seconds": 20.0,
+  "regression_threshold_pct": 35.0,
   "repo": "matheusnorjosa/aprender_sistema",
   "runs_per_workflow": 30,
+  "successful_runs_only": true,
   "workflows": [
     "CI \u2013 Continuous Integration",
     "frontend-ci",

--- a/v2/scripts/ci_runtime_telemetry.py
+++ b/v2/scripts/ci_runtime_telemetry.py
@@ -53,6 +53,22 @@ def parse_args() -> argparse.Namespace:
         help="Only include jobs with name starting with [required]",
     )
     parser.add_argument(
+        "--branch",
+        default="",
+        help="Optional branch filter for workflow runs (e.g. main)",
+    )
+    parser.add_argument(
+        "--events",
+        nargs="+",
+        default=[],
+        help="Optional run event filters (e.g. push pull_request)",
+    )
+    parser.add_argument(
+        "--successful-runs-only",
+        action="store_true",
+        help="Only include workflow runs with conclusion=success",
+    )
+    parser.add_argument(
         "--baseline-json",
         default="",
         help="Optional baseline json for regression detection",
@@ -173,24 +189,69 @@ def fetch_workflow_id(repo: str, workflow_name: str, token: str) -> int:
 
 
 def fetch_completed_runs(repo: str, workflow_id: int, token: str, limit: int) -> List[dict]:
-    runs: List[dict] = []
-    page = 1
-    while len(runs) < limit:
-        payload = github_get(
-            f"/repos/{repo}/actions/workflows/{workflow_id}/runs",
-            token,
-            params={
+    return fetch_completed_runs_with_filters(
+        repo=repo,
+        workflow_id=workflow_id,
+        token=token,
+        limit=limit,
+        branch="",
+        events=[],
+        successful_runs_only=False,
+    )
+
+
+def fetch_completed_runs_with_filters(
+    repo: str,
+    workflow_id: int,
+    token: str,
+    limit: int,
+    branch: str,
+    events: List[str],
+    successful_runs_only: bool,
+) -> List[dict]:
+    runs_by_id: Dict[int, dict] = {}
+    event_filters = events if events else [""]
+
+    for event_filter in event_filters:
+        page = 1
+        while True:
+            params = {
                 "status": "completed",
                 "per_page": "100",
                 "page": str(page),
-            },
-        )
-        page_runs = payload.get("workflow_runs", [])
-        if not page_runs:
-            break
-        runs.extend(page_runs)
-        page += 1
-    return runs[:limit]
+            }
+            if branch:
+                params["branch"] = branch
+            if event_filter:
+                params["event"] = event_filter
+
+            payload = github_get(
+                f"/repos/{repo}/actions/workflows/{workflow_id}/runs",
+                token,
+                params=params,
+            )
+            page_runs = payload.get("workflow_runs", [])
+            if not page_runs:
+                break
+
+            for run in page_runs:
+                run_id = int(run.get("id", 0))
+                if run_id <= 0:
+                    continue
+                if successful_runs_only and run.get("conclusion") != "success":
+                    continue
+                runs_by_id[run_id] = run
+
+            if len(page_runs) < 100:
+                break
+            page += 1
+
+    runs_sorted = sorted(
+        runs_by_id.values(),
+        key=lambda item: parse_ts(item.get("created_at", "1970-01-01T00:00:00Z")),
+        reverse=True,
+    )
+    return runs_sorted[:limit]
 
 
 def fetch_run_jobs(repo: str, run_id: int, token: str) -> List[dict]:
@@ -218,11 +279,22 @@ def collect_samples(
     token: str,
     runs_per_workflow: int,
     required_only: bool,
+    branch: str,
+    events: List[str],
+    successful_runs_only: bool,
 ) -> List[JobSample]:
     samples: List[JobSample] = []
     for workflow_name in workflows:
         workflow_id = fetch_workflow_id(repo, workflow_name, token)
-        runs = fetch_completed_runs(repo, workflow_id, token, runs_per_workflow)
+        runs = fetch_completed_runs_with_filters(
+            repo=repo,
+            workflow_id=workflow_id,
+            token=token,
+            limit=runs_per_workflow,
+            branch=branch,
+            events=events,
+            successful_runs_only=successful_runs_only,
+        )
         for run in runs:
             run_id = int(run["id"])
             jobs = fetch_run_jobs(repo, run_id, token)
@@ -318,6 +390,12 @@ def write_markdown(path: str, payload: dict, regressions: List[Tuple[str, float,
     lines.append(f"- Repo: `{payload['repo']}`")
     lines.append(f"- Workflows: `{', '.join(payload['workflows'])}`")
     lines.append(f"- Runs per workflow: `{payload['runs_per_workflow']}`")
+    if payload.get("branch"):
+        lines.append(f"- Branch filter: `{payload['branch']}`")
+    events = payload.get("events", [])
+    if events:
+        lines.append(f"- Event filters: `{', '.join(events)}`")
+    lines.append(f"- Successful runs only: `{payload.get('successful_runs_only', False)}`")
     lines.append(f"- Regression threshold (p95): `+{payload['regression_threshold_pct']}%`")
     lines.append(
         f"- Regression minimum absolute delta: `+{payload['regression_min_absolute_seconds']}s`"
@@ -367,6 +445,9 @@ def main() -> int:
         token=token,
         runs_per_workflow=args.runs_per_workflow,
         required_only=args.required_only,
+        branch=args.branch,
+        events=args.events,
+        successful_runs_only=args.successful_runs_only,
     )
     metrics = build_metrics(samples)
 
@@ -375,6 +456,9 @@ def main() -> int:
         "repo": args.repo,
         "workflows": args.workflows,
         "runs_per_workflow": args.runs_per_workflow,
+        "branch": args.branch,
+        "events": args.events,
+        "successful_runs_only": args.successful_runs_only,
         "regression_threshold_pct": args.regression_threshold_pct,
         "regression_min_absolute_seconds": args.regression_min_absolute_seconds,
         "metrics": metrics,


### PR DESCRIPTION
﻿## Summary

- Corrige falso positivo no workflow `CI Runtime Telemetry` que estava misturando amostras de `pull_request` com `push` da `main`.
- Adiciona filtros no script de telemetry para branch, evento e conclus?o de run.
- Atualiza o workflow para coletar baseline apenas de `main + push + success`.
- Recalibra `v2/docs/analysis/ci-runtime-baseline.json` com o novo recorte compar?vel.

## Scope

- Incluido:
  - `.github/workflows/ci-runtime-telemetry.yml`
  - `v2/scripts/ci_runtime_telemetry.py`
  - `v2/docs/analysis/ci-runtime-baseline.json`
- Fora de escopo:
  - Alterar thresholds de regress?o (`35%`, `20s`)
  - Alterar outros workflows de CI

## Test Plan

- [x] Reproduzido failure do run `22663999787` (regress?es em checklist/secret detection por dataset misto).
- [x] Execu??o local do script com novo recorte:
  - `python v2/scripts/ci_runtime_telemetry.py --repo matheusnorjosa/aprender_sistema --workflows "CI ? Continuous Integration" "frontend-ci" "Security Scan" --runs-per-workflow 30 --required-only --branch main --events push --successful-runs-only --baseline-json v2/docs/analysis/ci-runtime-baseline.json --regression-threshold-pct 35 --regression-min-absolute-seconds 20 --output-json .codex/tmp/ci-runtime-local-report-after-baseline.json --output-md .codex/tmp/ci-runtime-local-report-after-baseline.md`
  - Resultado: `Regressions: 0`.

## Risks

- Risco: menor sensibilidade a degrada??es que ocorram apenas em `pull_request`.
- Mitiga??o: o objetivo deste monitor ? baseline est?vel da `main`; PRs continuam cobertos pelos checks obrigat?rios dos pr?prios workflows.

## Links

- Corrige o failing run: https://github.com/matheusnorjosa/aprender_sistema/actions/runs/22663999787
