### PR TITLE
fix(e2e): padronizar ambiente canônico Playwright em Docker

### DIFF
--- a/v2/frontend/README.md
+++ b/v2/frontend/README.md
@@ -63,6 +63,36 @@ Output em: `dist/`
 npm run preview
 ```
 
+## 🧪 Execução E2E Canônica (Playwright + Docker)
+
+Para evitar drift de runtime (libs de browser no host e browser ausente no container frontend),
+o caminho canônico de E2E é o runner Docker `frontend-e2e` (imagem oficial Playwright).
+
+No diretório `v2/frontend`:
+
+```bash
+npm run test:e2e:docker -- e2e/z-auth.spec.ts --project=chromium --reporter=line
+```
+
+Esse comando:
+- sobe `db/redis/web` via Docker Compose;
+- aplica migrations;
+- executa `seed_e2e_users`;
+- roda Playwright no runner canônico com web server Vite interno + proxy para `http://web:8000`.
+
+Para rodar a suíte chromium padrão:
+
+```bash
+npm run test:e2e:docker
+```
+
+Após finalizar, se quiser limpar o ambiente:
+
+```bash
+cd ../infra
+docker compose -p aprender_v2 -f docker-compose.yml down
+```
+
 ## 🔐 Autenticação
 
 O frontend utiliza **sessão/cookie do Django** para autenticação. Para testar localmente:

--- a/v2/frontend/package.json
+++ b/v2/frontend/package.json
@@ -14,6 +14,7 @@
     "test:ui": "vitest --ui",
     "test:coverage": "vitest --coverage",
     "test:e2e": "playwright test",
+    "test:e2e:docker": "node scripts/run-e2e-docker.mjs",
     "test:e2e:ui": "playwright test --ui",
     "test:checklist": "playwright test --project=checklist",
     "smoke:agent-browser": "node scripts/agent-browser-smoke.mjs",

--- a/v2/frontend/scripts/run-e2e-docker.mjs
+++ b/v2/frontend/scripts/run-e2e-docker.mjs
@@ -1,0 +1,84 @@
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = resolve(__dirname, '..', '..');
+const composeFile = resolve(repoRoot, 'infra', 'docker-compose.yml');
+const composePrefix = ['compose', '-p', 'aprender_v2', '-f', composeFile];
+
+const testArgs = process.argv.slice(2);
+const finalTestArgs = testArgs.length > 0 ? testArgs : ['--project=chromium', '--reporter=line'];
+
+function sleep(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function shellEscape(value) {
+  return `'${String(value).replace(/'/g, `'\"'\"'`)}'`;
+}
+
+function runCommand(command, args, { allowFailure = false, quiet = false } = {}) {
+  const result = spawnSync(command, args, {
+    stdio: quiet ? 'pipe' : 'inherit',
+    encoding: 'utf-8',
+    env: process.env,
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (result.status !== 0 && !allowFailure) {
+    throw new Error(`${command} ${args.join(' ')} failed with exit code ${result.status}`);
+  }
+
+  return result;
+}
+
+function runCompose(args, options) {
+  return runCommand('docker', [...composePrefix, ...args], options);
+}
+
+function waitForDbReady(maxAttempts = 40, delayMs = 2000) {
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const probe = runCompose(
+      ['exec', '-T', 'db', 'sh', '-lc', 'pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"'],
+      { allowFailure: true, quiet: true }
+    );
+    if (probe.status === 0) {
+      return;
+    }
+    sleep(delayMs);
+  }
+  throw new Error('PostgreSQL did not become ready in time.');
+}
+
+try {
+  console.log('[e2e-docker] starting required services (db, redis, web)...');
+  runCompose(['up', '-d', 'db', 'redis', 'web']);
+
+  console.log('[e2e-docker] waiting for database readiness...');
+  waitForDbReady();
+
+  console.log('[e2e-docker] applying migrations...');
+  runCompose(['exec', '-T', 'web', 'python', 'manage.py', 'migrate', '--noinput']);
+
+  console.log('[e2e-docker] seeding E2E users...');
+  runCompose(['exec', '-T', 'web', 'python', 'manage.py', 'seed_e2e_users']);
+
+  const playwrightArgString = finalTestArgs.map(shellEscape).join(' ');
+  const runnerCmd = [
+    'npm ci',
+    `npm run test:e2e -- ${playwrightArgString}`,
+  ].join(' && ');
+
+  console.log('[e2e-docker] running Playwright in canonical runner (frontend-e2e)...');
+  runCompose(['run', '--rm', 'frontend-e2e', 'bash', '-lc', runnerCmd]);
+
+  console.log('[e2e-docker] success.');
+} catch (error) {
+  console.error(`[e2e-docker] failed: ${error.message}`);
+  process.exit(1);
+}

--- a/v2/infra/docker-compose.yml
+++ b/v2/infra/docker-compose.yml
@@ -192,6 +192,22 @@ services:
       retries: 3
       start_period: 30s
 
+  # Runner canônico para E2E (Issue #615):
+  # usa imagem oficial do Playwright com browsers + deps pré-instalados.
+  frontend-e2e:
+    image: mcr.microsoft.com/playwright:v1.57.0-noble
+    working_dir: /work
+    environment:
+      CI: "1"
+      E2E_DOCKER: "1"
+      PROXY_TARGET: "http://web:8000"
+      VITE_API_URL: "/api"
+      PLAYWRIGHT_BROWSERS_PATH: "/ms-playwright"
+    volumes:
+      - ../frontend:/work
+    depends_on:
+      - web
+
   # ================================================================
   # Observability Stack (Prometheus + Grafana + Exporters)
   # ================================================================


### PR DESCRIPTION
﻿## Summary

- Define caminho canônico de execução E2E via Docker usando runner dedicado `frontend-e2e` com imagem oficial Playwright (`mcr.microsoft.com/playwright:v1.57.0-noble`).
- Adiciona script `npm run test:e2e:docker` para orquestrar ambiente reproduzível (up db/redis/web, migrate, seed_e2e_users e execução Playwright).
- Documenta passo a passo mínimo no README do frontend.

## Scope

- Incluido:
  - serviço `frontend-e2e` em `v2/infra/docker-compose.yml`
  - script `v2/frontend/scripts/run-e2e-docker.mjs`
  - comando npm `test:e2e:docker`
  - documentação de execução canônica no `v2/frontend/README.md`
- Fora de escopo:
  - reescrita da suíte E2E
  - alterações de comportamento de produção

## Test Plan

- [x] `npm run test:e2e:docker -- e2e/z-auth.spec.ts --project=chromium --reporter=line`
  - Resultado: `5 passed` (incluindo `auth.setup.ts` sem falha de launch/runtime)
- [x] `docker compose -p aprender_v2 -f v2/infra/docker-compose.yml run --rm frontend-e2e bash -lc "npm ci && npm run lint"`
  - Resultado: lint frontend sem erros

## Risks

- Risco: primeiro run mais lento por `npm ci` no runner.
- Mitigação: caminho canônico prioriza reprodutibilidade e elimina dependência de libs/browser no host.

## Links

- Closes #615
