### PR TITLE
fix(security): resposta de login uniforme contra account enumeration (#745)

### DIFF
--- a/v2/backend/apps/core/tests/test_views_auth.py
+++ b/v2/backend/apps/core/tests/test_views_auth.py
@@ -15,10 +15,12 @@ Valida:
 
 from __future__ import annotations
 
+from unittest.mock import patch
 from uuid import uuid4
 
 from django.contrib.auth.models import Group
 from django.core.cache import cache
+from django.test import override_settings
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -199,6 +201,9 @@ def test_login_invalid_credentials_rejected(api_client, usuario_ativo):
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert response.data["error"] == "Credenciais inválidas."
+    assert "remaining_attempts" not in response.data
+    assert "locked" not in response.data
+    assert "lockout_minutes" not in response.data
 
     # Usuário inexistente
     response = api_client.post(
@@ -206,6 +211,82 @@ def test_login_invalid_credentials_rejected(api_client, usuario_ativo):
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     assert response.data["error"] == "Credenciais inválidas."
+    assert "remaining_attempts" not in response.data
+    assert "locked" not in response.data
+    assert "lockout_minutes" not in response.data
+
+
+@override_settings(ACCOUNT_LOCKOUT_THRESHOLD=1, ACCOUNT_LOCKOUT_DURATION=900)
+def test_login_locked_account_returns_generic_error_response(api_client, usuario_ativo):
+    """
+    Conta bloqueada deve retornar a mesma resposta genérica de credencial inválida.
+
+    Valida:
+    - Status 400 (não 403) mesmo em lockout
+    - Sem campos sensíveis (locked/remaining_attempts/lockout_minutes)
+    - Detalhes de lockout mantidos apenas em AuditLog
+    """
+    # 1ª tentativa inválida: incrementa contador para atingir lockout (threshold=1)
+    first = api_client.post(
+        "/api/auth/login/", {"username": usuario_ativo.username, "password": "wrongpass"}, format="json"
+    )
+    assert first.status_code == status.HTTP_400_BAD_REQUEST
+    assert first.data == {"error": "Credenciais inválidas."}
+
+    # 2ª tentativa: conta já bloqueada internamente, resposta pública continua genérica
+    locked = api_client.post(
+        "/api/auth/login/", {"username": usuario_ativo.username, "password": "wrongpass"}, format="json"
+    )
+    assert locked.status_code == status.HTTP_400_BAD_REQUEST
+    assert locked.data == {"error": "Credenciais inválidas."}
+    assert "locked" not in locked.data
+    assert "remaining_attempts" not in locked.data
+    assert "lockout_minutes" not in locked.data
+
+    blocked_log = AuditLog.objects.filter(action="LOGIN_BLOCKED").latest("created_at")
+    assert blocked_log.details["username"] == usuario_ativo.username
+    assert blocked_log.details["reason"] == "account_locked"
+
+
+@override_settings(ACCOUNT_LOCKOUT_THRESHOLD=1, ACCOUNT_LOCKOUT_DURATION=900)
+def test_login_failure_response_is_uniform_across_invalid_nonexistent_and_locked(api_client, usuario_ativo):
+    """
+    Cenários de falha de autenticação devem ter payload idêntico (anti-enumeração).
+
+    Valida:
+    - Senha inválida (usuário existente)
+    - Usuário inexistente
+    - Conta bloqueada por lockout
+    """
+    expected = {"error": "Credenciais inválidas."}
+
+    invalid_existing = api_client.post(
+        "/api/auth/login/", {"username": usuario_ativo.username, "password": "wrongpass"}, format="json"
+    )
+    nonexistent = api_client.post("/api/auth/login/", {"username": "ghost_user_123", "password": "wrongpass"})
+    locked = api_client.post("/api/auth/login/", {"username": usuario_ativo.username, "password": "wrongpass"})
+
+    assert invalid_existing.status_code == status.HTTP_400_BAD_REQUEST
+    assert nonexistent.status_code == status.HTTP_400_BAD_REQUEST
+    assert locked.status_code == status.HTTP_400_BAD_REQUEST
+
+    assert invalid_existing.data == expected
+    assert nonexistent.data == expected
+    assert locked.data == expected
+
+
+@patch("apps.core.views_auth.make_password")
+def test_login_uses_dummy_hash_for_failed_authentication(mock_make_password, api_client):
+    """
+    Em falha de autenticação, deve executar hash dummy para reduzir timing leak.
+    """
+    response = api_client.post(
+        "/api/auth/login/",
+        {"username": "nonexistent_timing_user", "password": "testpass123"},
+        format="json",
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    mock_make_password.assert_called_once_with("testpass123")
 
 
 def test_login_returns_groups(api_client, usuario_superintendencia):

--- a/v2/backend/apps/core/views_auth.py
+++ b/v2/backend/apps/core/views_auth.py
@@ -20,6 +20,7 @@ from django.conf import settings
 from django.contrib.auth import authenticate
 from django.contrib.auth import login as django_login
 from django.contrib.auth import logout as django_logout
+from django.contrib.auth.hashers import make_password
 from django.core.cache import cache
 from django.middleware.csrf import get_token
 from django.views.decorators.csrf import ensure_csrf_cookie
@@ -94,6 +95,16 @@ def _get_lockout_remaining_time(username: str) -> int | None:
     return None
 
 
+def _invalid_credentials_response() -> Response:
+    """
+    Generic authentication failure response to prevent account enumeration.
+
+    OWASP recommendation: never disclose whether username exists, password is wrong,
+    or account is locked.
+    """
+    return Response({"error": "Credenciais inválidas."}, status=status.HTTP_400_BAD_REQUEST)
+
+
 # Issue #135: CSRF token endpoint (SEC-P2)
 @ensure_csrf_cookie
 @api_view(["GET"])
@@ -149,8 +160,7 @@ def login(request: Request) -> Response:
 
     Returns:
         200: Login bem-sucedido com dados do usuário
-        400: Credenciais inválidas
-        403: Conta bloqueada por excesso de tentativas
+        400: Falha de autenticação (resposta genérica)
         429: Too Many Requests (rate limit excedido)
     """
     username = request.data.get("username")
@@ -159,13 +169,22 @@ def login(request: Request) -> Response:
     if not username or not password:
         return Response({"error": "Username e password são obrigatórios."}, status=status.HTTP_400_BAD_REQUEST)
 
-    # Security Audit 2025-01: Account Lockout
-    # Verifica se a conta está bloqueada ANTES de tentar autenticar
-    if _is_account_locked(username):
-        lockout_duration = getattr(settings, "ACCOUNT_LOCKOUT_DURATION", 900)
-        minutes = lockout_duration // 60
+    # Security hardening #745:
+    # - Keep a generic client response for all auth failures
+    # - Preserve detailed reason only in AuditLog
+    is_locked = _is_account_locked(username)
 
-        # Log tentativa de login em conta bloqueada
+    user = authenticate(request, username=username, password=password)
+    if user is None:
+        # Dummy hash to reduce timing differences between existing/non-existing users.
+        make_password(password)
+
+    if is_locked:
+        threshold = getattr(settings, "ACCOUNT_LOCKOUT_THRESHOLD", 10)
+        attempts = _get_failed_attempts(username)
+        lockout_remaining_seconds = _get_lockout_remaining_time(username)
+
+        # Log tentativa de login em conta bloqueada (detalhes só internamente)
         AuditLog.objects.create(
             usuario=None,
             action="LOGIN_BLOCKED",
@@ -175,25 +194,18 @@ def login(request: Request) -> Response:
                 "ip_address": request.META.get("REMOTE_ADDR", ""),
                 "user_agent": request.META.get("HTTP_USER_AGENT", "")[:200],
                 "reason": "account_locked",
+                "attempts": attempts,
+                "threshold": threshold,
+                "lockout_remaining_seconds": lockout_remaining_seconds,
             },
         )
 
-        return Response(
-            {
-                "error": f"Conta bloqueada por excesso de tentativas. Tente novamente em {minutes} minutos.",
-                "locked": True,
-                "lockout_minutes": minutes,
-            },
-            status=status.HTTP_403_FORBIDDEN,
-        )
-
-    user = authenticate(request, username=username, password=password)
+        return _invalid_credentials_response()
 
     if user is None:
-        # Incrementa contador de tentativas falhas
+        # Incrementa contador de tentativas falhas (estado interno)
         attempts = _increment_failed_attempts(username)
         threshold = getattr(settings, "ACCOUNT_LOCKOUT_THRESHOLD", 10)
-        remaining = threshold - attempts
 
         # Log tentativa falha
         AuditLog.objects.create(
@@ -204,33 +216,32 @@ def login(request: Request) -> Response:
                 "username": username,
                 "ip_address": request.META.get("REMOTE_ADDR", ""),
                 "user_agent": request.META.get("HTTP_USER_AGENT", "")[:200],
+                "reason": "invalid_credentials",
                 "attempts": attempts,
                 "threshold": threshold,
             },
         )
 
-        if remaining <= 0:
-            lockout_duration = getattr(settings, "ACCOUNT_LOCKOUT_DURATION", 900)
-            minutes = lockout_duration // 60
-            return Response(
-                {
-                    "error": f"Conta bloqueada por excesso de tentativas. Tente novamente em {minutes} minutos.",
-                    "locked": True,
-                    "lockout_minutes": minutes,
-                },
-                status=status.HTTP_403_FORBIDDEN,
-            )
-
-        return Response(
-            {
-                "error": "Credenciais inválidas.",
-                "remaining_attempts": remaining if remaining > 0 else 0,
-            },
-            status=status.HTTP_400_BAD_REQUEST,
-        )
+        return _invalid_credentials_response()
 
     if not user.is_active:
-        return Response({"error": "Usuário inativo."}, status=status.HTTP_400_BAD_REQUEST)
+        # Defensive fallback for alternate backends that might return inactive users.
+        attempts = _increment_failed_attempts(username)
+        threshold = getattr(settings, "ACCOUNT_LOCKOUT_THRESHOLD", 10)
+        AuditLog.objects.create(
+            usuario=None,
+            action="LOGIN_FAILED",
+            model_name="Usuario",
+            details={
+                "username": username,
+                "ip_address": request.META.get("REMOTE_ADDR", ""),
+                "user_agent": request.META.get("HTTP_USER_AGENT", "")[:200],
+                "reason": "inactive_user",
+                "attempts": attempts,
+                "threshold": threshold,
+            },
+        )
+        return _invalid_credentials_response()
 
     # Login bem-sucedido: limpa contador de tentativas
     _clear_failed_attempts(username)


### PR DESCRIPTION
﻿## Contexto
Corrige a issue #745 (epic #743): account enumeration no endpoint de login.

Este PR substitui o #749 com histórico de commits limpo para evitar falso positivo de secret scan.

## O que foi alterado
### Backend
- `apps/core/views_auth.py`
  - Adicionada resposta genérica `_invalid_credentials_response()`.
  - Falhas de autenticação retornam sempre **HTTP 400 + `{"error": "Credenciais inválidas."}`**.
  - Campos sensíveis removidos da resposta pública (`locked`, `remaining_attempts`, `lockout_minutes`).
  - Detalhes preservados apenas em `AuditLog` (`LOGIN_FAILED` / `LOGIN_BLOCKED`, com `reason`, `attempts`, etc.).
  - `make_password(password)` em falha de autenticação para reduzir timing leak.

### Testes
- `apps/core/tests/test_views_auth.py`
  - Reforço de asserts para ausência de campos sensíveis na resposta.
  - Novo teste: conta bloqueada retorna resposta genérica.
  - Novo teste: uniformidade de resposta entre senha errada, usuário inexistente e conta bloqueada.
  - Novo teste: valida hash dummy (`make_password`) em falha de auth.

## Frontend
- Sem alteração necessária: fluxo atual de login não depende desses campos sensíveis.

## Evidências (Docker)
```bash
docker compose -p aprender_v2 -f v2/infra/docker-compose.yml run --rm --build web pytest apps/core/tests/test_views_auth.py -q
# 13 passed

docker compose -p aprender_v2 -f v2/infra/docker-compose.yml run --rm web pytest apps/core/tests/test_csrf_httponly.py -q
# 8 passed, 1 skipped

docker compose -p aprender_v2 -f v2/infra/docker-compose.yml run --rm web pytest apps/core/tests/test_login_throttle_simple.py -q
# 3 passed
```
