### PR TITLE
ci(images): add weekly Docker Hub rebuild workflow with security gate (#757)

### DIFF
--- a/.github/workflows/dockerhub-rebuild.yml
+++ b/.github/workflows/dockerhub-rebuild.yml
@@ -28,7 +28,6 @@ jobs:
   rebuild-and-publish:
     name: "[ops] rebuild Docker Hub images (weekly)"
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
 
     steps:
       - name: Checkout code
@@ -49,22 +48,39 @@ jobs:
         id: publish-mode
         env:
           EVENT_NAME: ${{ github.event_name }}
+          GITHUB_REF_NAME: ${{ github.ref }}
           DISPATCH_PUBLISH_IMAGES: ${{ inputs.publish_images }}
         run: |
           set -euo pipefail
           publish_images="false"
+          publish_reason="manual-skip"
 
-          if [ "$EVENT_NAME" = "schedule" ]; then
+          if [ "$GITHUB_REF_NAME" != "refs/heads/main" ]; then
+            publish_images="false"
+            publish_reason="non-main-ref"
+          elif [ "$EVENT_NAME" = "schedule" ]; then
             publish_images="true"
+            publish_reason="scheduled-main"
           elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             case "$DISPATCH_PUBLISH_IMAGES" in
-              true|false) publish_images="$DISPATCH_PUBLISH_IMAGES" ;;
-              *) publish_images="true" ;;
+              true)
+                publish_images="true"
+                publish_reason="dispatch-enabled"
+                ;;
+              false)
+                publish_images="false"
+                publish_reason="dispatch-disabled"
+                ;;
+              *)
+                publish_images="true"
+                publish_reason="dispatch-default"
+                ;;
             esac
           fi
 
           echo "publish_images=$publish_images" >> "$GITHUB_OUTPUT"
-          echo "Publish images: $publish_images"
+          echo "publish_reason=$publish_reason" >> "$GITHUB_OUTPUT"
+          echo "Publish images: $publish_images ($publish_reason)"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
@@ -89,6 +105,7 @@ jobs:
             echo "short_sha=${{ steps.version.outputs.short_sha }}"
             echo "maintenance_tag=${{ steps.version.outputs.maintenance_tag }}"
             echo "publish_images=${{ steps.publish-mode.outputs.publish_images }}"
+            echo "publish_reason=${{ steps.publish-mode.outputs.publish_reason }}"
             echo "started_at_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           } > supply-chain/rebuild/rebuild-metrics.txt
 

--- a/v2/docs/RUNBOOK.md
+++ b/v2/docs/RUNBOOK.md
@@ -120,6 +120,9 @@ gh workflow run dockerhub-rebuild.yml -f publish_images=true
 gh workflow run dockerhub-rebuild.yml -f publish_images=false
 ```
 
+Observação:
+- fora da `main`, o workflow força `publish_images=false` para evitar push acidental.
+
 ## 🏷️ Deploy por Tag (Staging/Produção)
 
 Staging e produção devem operar somente com imagem publicada.


### PR DESCRIPTION
## Contexto
Implementa a issue #757 com um workflow periódico para rebuild/push no Docker Hub, condicionado por gate de segurança antes da publicação.

## O que foi implementado
- Novo workflow: `.github/workflows/dockerhub-rebuild.yml`
  - `schedule` semanal (domingo 03:00 UTC)
  - `workflow_dispatch` com input `publish_images` (`true/false`)
- Estratégia de tags no push:
  - `latest`
  - `maint-YYYY.MM.DD-<sha>-r<run_id>` (imutável/rastreável)
- Gate de segurança obrigatório antes de publicar:
  - build local de backend/frontend para scan
  - Trivy JSON para backend/frontend
  - bloqueio em CVE `HIGH`/`CRITICAL`
- Push condicionado:
  - login/push só ocorre quando gate aprova e `publish_images=true`
  - fora da `main`, o workflow força `publish_images=false` (evita push acidental em branch)
- Evidências e métricas por execução:
  - `supply-chain/security/*`
  - `supply-chain/rebuild/rebuild-metrics.txt`
  - artifact `dockerhub-rebuild-<run_id>` (sempre enviado)
- Documentação atualizada:
  - `v2/docs/RUNBOOK.md` (seção de rebuild periódico e execução manual)

## Critérios de aceite (issue #757)
- [x] Workflow com `schedule` criado
- [x] `workflow_dispatch` implementado
- [x] Push condicionado a scan aprovado
- [x] Tag de manutenção com rastreabilidade

## Validação realizada
- `actionlint` no workflow novo:
  - `docker run --rm -v ${PWD}:/repo -w /repo rhysd/actionlint:1.7.4 .github/workflows/dockerhub-rebuild.yml`
- `git diff --check` sem erros de whitespace/merge.

## Limitação conhecida nesta fase de PR
- Não foi possível disparar `workflow_dispatch` deste workflow antes do merge porque o GitHub só permite disparo de workflow que já exista na branch padrão (`main`).
- Após merge, o teste manual pode ser executado com:
  - `gh workflow run dockerhub-rebuild.yml -f publish_images=false`
  - `gh workflow run dockerhub-rebuild.yml -f publish_images=true`

Closes #757