### PR TITLE
feat(infra): Watchtower auto-deploy, /api/version/ endpoint e alinhamento 3-VMs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,10 @@ on:
         options:
           - production
           - staging
+      promotion_tag:
+        description: "Required for production: existing tag validated in staging (example: v2026.03.05-abc1234)"
+        required: false
+        type: string
 
 env:
   DOCKER_USERNAME: norjosamatheus
@@ -40,11 +44,27 @@ jobs:
 
       - name: Generate version
         id: version
+        env:
+          TARGET_ENV: ${{ github.event.inputs.environment }}
+          PROMOTION_TAG: ${{ github.event.inputs.promotion_tag }}
         run: |
-          SHORT_SHA=$(git rev-parse --short HEAD)
-          VERSION="v$(date -u +%Y.%m.%d)-${SHORT_SHA}"
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          if [ "$TARGET_ENV" = "production" ]; then
+            if [ -z "${PROMOTION_TAG:-}" ]; then
+              echo "For production promotion, input 'promotion_tag' is required." >&2
+              exit 1
+            fi
+            VERSION="$PROMOTION_TAG"
+            MODE="production-promotion"
+          else
+            SHORT_SHA=$(git rev-parse --short HEAD)
+            VERSION="v$(date -u +%Y.%m.%d)-${SHORT_SHA}"
+            MODE="staging-release"
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "mode=$MODE" >> "$GITHUB_OUTPUT"
           echo "Generated version: $VERSION"
+          echo "Release mode: $MODE"
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -67,11 +87,22 @@ jobs:
           python manage.py check --deploy
 
       - name: Create tag
+        if: github.event.inputs.environment != 'production'
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git tag -a "${{ steps.version.outputs.version }}" -m "Release ${{ steps.version.outputs.version }}"
           git push origin "${{ steps.version.outputs.version }}"
+
+      - name: Validate promotion tag exists
+        if: github.event.inputs.environment == 'production'
+        run: |
+          set -euo pipefail
+          git fetch --tags --force
+          if ! git rev-parse -q --verify "refs/tags/${{ steps.version.outputs.version }}" >/dev/null; then
+            echo "Promotion tag '${{ steps.version.outputs.version }}' was not found in the repository tags." >&2
+            exit 1
+          fi
 
       # =========================================================================
       # Docker Hub Authentication & Build
@@ -83,9 +114,11 @@ jobs:
       # Pre-publish Security Gate (blocks HIGH/CRITICAL before push)
       # =========================================================================
       - name: Prepare release security artifact directory
+        if: github.event.inputs.environment != 'production'
         run: mkdir -p supply-chain/security
 
       - name: Build Backend image for pre-release scan
+        if: github.event.inputs.environment != 'production'
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: ./v2
@@ -95,8 +128,13 @@ jobs:
           tags: aprender-backend:scan-${{ github.run_id }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            APP_VERSION=${{ steps.version.outputs.version }}
+            GIT_SHA=${{ github.sha }}
+            BUILD_DATE=${{ github.event.repository.updated_at }}
 
       - name: Build Frontend image for pre-release scan
+        if: github.event.inputs.environment != 'production'
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: ./v2/frontend
@@ -108,6 +146,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Generate Trivy report (backend pre-release)
+        if: github.event.inputs.environment != 'production'
         uses: aquasecurity/trivy-action@e368e328979b113139d6f9068e03accaed98a518 # 0.34.1
         with:
           image-ref: aprender-backend:scan-${{ github.run_id }}
@@ -118,6 +157,7 @@ jobs:
           ignore-unfixed: true
 
       - name: Generate Trivy report (frontend pre-release)
+        if: github.event.inputs.environment != 'production'
         uses: aquasecurity/trivy-action@e368e328979b113139d6f9068e03accaed98a518 # 0.34.1
         with:
           image-ref: aprender-frontend:scan-${{ github.run_id }}
@@ -128,6 +168,7 @@ jobs:
           ignore-unfixed: true
 
       - name: Enforce security gate (block HIGH/CRITICAL on release publish)
+        if: github.event.inputs.environment != 'production'
         run: |
           set -euo pipefail
           python - <<'PY'
@@ -166,7 +207,7 @@ jobs:
           PY
 
       - name: Upload release security scan artifacts
-        if: always()
+        if: always() && github.event.inputs.environment != 'production'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: release-security-scan-${{ steps.version.outputs.version }}
@@ -182,6 +223,7 @@ jobs:
 
       - name: Build and push Backend image
         id: build-backend
+        if: github.event.inputs.environment != 'production'
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: ./v2
@@ -192,6 +234,10 @@ jobs:
             ${{ env.BACKEND_IMAGE }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            APP_VERSION=${{ steps.version.outputs.version }}
+            GIT_SHA=${{ github.sha }}
+            BUILD_DATE=${{ github.event.repository.updated_at }}
           labels: |
             org.opencontainers.image.title=Aprender Sistema Backend
             org.opencontainers.image.description=Django backend for Aprender Sistema
@@ -201,6 +247,7 @@ jobs:
 
       - name: Build and push Frontend image
         id: build-frontend
+        if: github.event.inputs.environment != 'production'
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: ./v2/frontend
@@ -218,6 +265,40 @@ jobs:
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
 
+      - name: Resolve image digests for deployment and evidence
+        id: image-digests
+        env:
+          TARGET_ENV: ${{ github.event.inputs.environment }}
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+          BACKEND_DIGEST_FROM_BUILD: ${{ steps.build-backend.outputs.digest }}
+          FRONTEND_DIGEST_FROM_BUILD: ${{ steps.build-frontend.outputs.digest }}
+        run: |
+          set -euo pipefail
+
+          backend_digest=""
+          frontend_digest=""
+
+          if [ "$TARGET_ENV" = "production" ]; then
+            docker pull "${{ env.BACKEND_IMAGE }}:${RELEASE_VERSION}"
+            docker pull "${{ env.FRONTEND_IMAGE }}:${RELEASE_VERSION}"
+
+            backend_digest="$(docker image inspect "${{ env.BACKEND_IMAGE }}:${RELEASE_VERSION}" --format '{{index .RepoDigests 0}}' | sed 's|.*@||')"
+            frontend_digest="$(docker image inspect "${{ env.FRONTEND_IMAGE }}:${RELEASE_VERSION}" --format '{{index .RepoDigests 0}}' | sed 's|.*@||')"
+          else
+            backend_digest="$BACKEND_DIGEST_FROM_BUILD"
+            frontend_digest="$FRONTEND_DIGEST_FROM_BUILD"
+          fi
+
+          if [ -z "$backend_digest" ] || [ -z "$frontend_digest" ]; then
+            echo "Could not resolve backend/frontend digest for release version '${RELEASE_VERSION}'." >&2
+            exit 1
+          fi
+
+          echo "backend_digest=$backend_digest" >> "$GITHUB_OUTPUT"
+          echo "frontend_digest=$frontend_digest" >> "$GITHUB_OUTPUT"
+          echo "Resolved backend digest: $backend_digest"
+          echo "Resolved frontend digest: $frontend_digest"
+
       # =========================================================================
       # Supply Chain Hardening (SBOM + Provenance Attestation)
       # =========================================================================
@@ -227,7 +308,7 @@ jobs:
       - name: Generate Backend SBOM (SPDX JSON)
         uses: anchore/sbom-action@f8bdd1d8ac5e901a77a92f111440fdb1b593736b # v0.20.6
         with:
-          image: ${{ env.BACKEND_IMAGE }}@${{ steps.build-backend.outputs.digest }}
+          image: ${{ env.BACKEND_IMAGE }}@${{ steps.image-digests.outputs.backend_digest }}
           format: spdx-json
           output-file: supply-chain/backend-sbom.spdx.json
           upload-artifact: false
@@ -236,7 +317,7 @@ jobs:
       - name: Generate Frontend SBOM (SPDX JSON)
         uses: anchore/sbom-action@f8bdd1d8ac5e901a77a92f111440fdb1b593736b # v0.20.6
         with:
-          image: ${{ env.FRONTEND_IMAGE }}@${{ steps.build-frontend.outputs.digest }}
+          image: ${{ env.FRONTEND_IMAGE }}@${{ steps.image-digests.outputs.frontend_digest }}
           format: spdx-json
           output-file: supply-chain/frontend-sbom.spdx.json
           upload-artifact: false
@@ -247,14 +328,14 @@ jobs:
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
         with:
           subject-name: ${{ env.BACKEND_IMAGE }}
-          subject-digest: ${{ steps.build-backend.outputs.digest }}
+          subject-digest: ${{ steps.image-digests.outputs.backend_digest }}
 
       - name: Attest Frontend image provenance
         id: attest-frontend-image
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
         with:
           subject-name: ${{ env.FRONTEND_IMAGE }}
-          subject-digest: ${{ steps.build-frontend.outputs.digest }}
+          subject-digest: ${{ steps.image-digests.outputs.frontend_digest }}
 
       - name: Attest SBOM files provenance
         id: attest-sbom-files
@@ -302,14 +383,19 @@ jobs:
           echo "# Release ${{ steps.version.outputs.version }}" > release_notes.md
           echo "" >> release_notes.md
           echo "**Environment:** ${{ github.event.inputs.environment }}" >> release_notes.md
+          echo "**Mode:** ${{ steps.version.outputs.mode }}" >> release_notes.md
           echo "**Date:** $(date -u +%Y-%m-%d)" >> release_notes.md
+          if [ "${{ github.event.inputs.environment }}" = "production" ]; then
+            echo "**Promotion Source:** staging tag \`${{ steps.version.outputs.version }}\`" >> release_notes.md
+            echo "**Latest Alias:** refreshed to \`${{ steps.version.outputs.version }}\` before deploy trigger" >> release_notes.md
+          fi
           echo "" >> release_notes.md
           echo "## Docker Images" >> release_notes.md
           echo "" >> release_notes.md
           echo "- Backend: \`${{ env.BACKEND_IMAGE }}:${{ steps.version.outputs.version }}\`" >> release_notes.md
-          echo "  - Digest: \`${{ steps.build-backend.outputs.digest }}\`" >> release_notes.md
+          echo "  - Digest: \`${{ steps.image-digests.outputs.backend_digest }}\`" >> release_notes.md
           echo "- Frontend: \`${{ env.FRONTEND_IMAGE }}:${{ steps.version.outputs.version }}\`" >> release_notes.md
-          echo "  - Digest: \`${{ steps.build-frontend.outputs.digest }}\`" >> release_notes.md
+          echo "  - Digest: \`${{ steps.image-digests.outputs.frontend_digest }}\`" >> release_notes.md
           echo "" >> release_notes.md
           echo "## Supply Chain Artifacts" >> release_notes.md
           echo "" >> release_notes.md
@@ -331,11 +417,14 @@ jobs:
       # Deployment
       # =========================================================================
       - name: Release summary
+        env:
+          RELEASE_MODE: ${{ steps.version.outputs.mode }}
         run: |
           echo "========================================"
-          echo "Docker images published to Docker Hub!"
+          echo "Release pipeline summary"
           echo "========================================"
           echo ""
+          echo "Mode: $RELEASE_MODE"
           echo "Backend:  ${{ env.BACKEND_IMAGE }}:${{ steps.version.outputs.version }}"
           echo "Frontend: ${{ env.FRONTEND_IMAGE }}:${{ steps.version.outputs.version }}"
           echo ""
@@ -388,6 +477,71 @@ jobs:
             echo "$DEPLOY_COMMAND"
             echo "$delimiter"
           } >> "$GITHUB_ENV"
+
+      - name: Verify staging is running promoted release
+        if: github.event.inputs.environment == 'production'
+        env:
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+          STAGING_VERSIONCHECK_URL_SECRET: ${{ secrets.STAGING_VERSIONCHECK_URL || '' }}
+          STAGING_VERSIONCHECK_URL_VAR: ${{ vars.STAGING_VERSIONCHECK_URL || '' }}
+        run: |
+          set -euo pipefail
+
+          STAGING_VERSION_URL="$STAGING_VERSIONCHECK_URL_SECRET"
+          if [ -z "$STAGING_VERSION_URL" ]; then
+            STAGING_VERSION_URL="$STAGING_VERSIONCHECK_URL_VAR"
+          fi
+
+          if [ -z "$STAGING_VERSION_URL" ]; then
+            echo "STAGING_VERSIONCHECK_URL is required to verify production promotion." >&2
+            exit 1
+          fi
+
+          echo "::add-mask::$STAGING_VERSION_URL"
+          response_file="supply-chain/verification/pre-prod-staging-version-response.txt"
+          attempts=8
+          sleep_seconds=8
+
+          for attempt in $(seq 1 "$attempts"); do
+            http_code="$(curl --silent --show-error --location --max-time 20 -o "$response_file" -w '%{http_code}' "$STAGING_VERSION_URL" || true)"
+            if [ "$http_code" = "200" ]; then
+              break
+            fi
+            if [ "$attempt" -eq "$attempts" ]; then
+              echo "Could not read staging version endpoint (HTTP=${http_code:-curl_error})." >&2
+              exit 1
+            fi
+            echo "Staging version check attempt ${attempt}/${attempts} failed (HTTP=${http_code:-curl_error}). Retrying in ${sleep_seconds}s..."
+            sleep "$sleep_seconds"
+          done
+
+          if ! grep -Fq "$RELEASE_VERSION" "$response_file"; then
+            echo "Staging version endpoint does not contain promoted release '$RELEASE_VERSION'." >&2
+            cat "$response_file" >&2
+            exit 1
+          fi
+
+          echo "Staging is serving release '$RELEASE_VERSION'. Proceeding with production promotion."
+
+      - name: Promote selected release tag to latest (production)
+        if: github.event.inputs.environment == 'production'
+        env:
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          echo "Promoting release tag '${RELEASE_VERSION}' to :latest for production rollout."
+
+          docker pull "${{ env.BACKEND_IMAGE }}:${RELEASE_VERSION}"
+          docker pull "${{ env.FRONTEND_IMAGE }}:${RELEASE_VERSION}"
+
+          docker tag "${{ env.BACKEND_IMAGE }}:${RELEASE_VERSION}" "${{ env.BACKEND_IMAGE }}:latest"
+          docker tag "${{ env.FRONTEND_IMAGE }}:${RELEASE_VERSION}" "${{ env.FRONTEND_IMAGE }}:latest"
+
+          docker push "${{ env.BACKEND_IMAGE }}:latest"
+          docker push "${{ env.FRONTEND_IMAGE }}:latest"
+
+          echo "Promotion to :latest completed."
 
       - name: Execute deploy command
         id: deploy-command
@@ -544,8 +698,8 @@ jobs:
           HEALTHCHECK_URL: ${{ steps.resolve-post-deploy-verification.outputs.healthcheck_url }}
           VERSIONCHECK_URL: ${{ steps.resolve-post-deploy-verification.outputs.versioncheck_url }}
           COMMAND_HASH: ${{ steps.resolve-deploy-command.outputs.command_hash }}
-          BACKEND_DIGEST: ${{ steps.build-backend.outputs.digest }}
-          FRONTEND_DIGEST: ${{ steps.build-frontend.outputs.digest }}
+          BACKEND_DIGEST: ${{ steps.image-digests.outputs.backend_digest }}
+          FRONTEND_DIGEST: ${{ steps.image-digests.outputs.frontend_digest }}
         run: |
           set -euo pipefail
           {
@@ -576,6 +730,7 @@ jobs:
           retention-days: 30
 
       - name: Create GitHub Release
+        if: github.event.inputs.environment != 'production'
         uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -586,18 +741,32 @@ jobs:
           draft: false
           prerelease: false
 
+      - name: Ensure GitHub Release exists for promotion tag
+        if: github.event.inputs.environment == 'production'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh release view "${{ steps.version.outputs.version }}" >/dev/null
+
       - name: Upload release assets (SBOM + provenance + evidence)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          gh release upload "${{ steps.version.outputs.version }}" \
-            supply-chain/backend-sbom.spdx.json \
-            supply-chain/frontend-sbom.spdx.json \
-            supply-chain/attestations/backend-image-provenance.bundle.jsonl \
-            supply-chain/attestations/frontend-image-provenance.bundle.jsonl \
-            supply-chain/attestations/sbom-files-provenance.bundle.jsonl \
-            supply-chain/verification/post-deploy-health-response.txt \
-            supply-chain/verification/post-deploy-version-response.txt \
-            deploy-evidence.txt \
-            --clobber
+          files=(
+            "supply-chain/backend-sbom.spdx.json"
+            "supply-chain/frontend-sbom.spdx.json"
+            "supply-chain/attestations/backend-image-provenance.bundle.jsonl"
+            "supply-chain/attestations/frontend-image-provenance.bundle.jsonl"
+            "supply-chain/attestations/sbom-files-provenance.bundle.jsonl"
+            "supply-chain/verification/post-deploy-health-response.txt"
+            "supply-chain/verification/post-deploy-version-response.txt"
+            "deploy-evidence.txt"
+          )
+
+          if [ -f "supply-chain/verification/pre-prod-staging-version-response.txt" ]; then
+            files+=("supply-chain/verification/pre-prod-staging-version-response.txt")
+          fi
+
+          gh release upload "${{ steps.version.outputs.version }}" "${files[@]}" --clobber

--- a/v2/backend/apps/core/urls.py
+++ b/v2/backend/apps/core/urls.py
@@ -60,7 +60,7 @@ from .views_gcal import (  # Core GCal; Dashboard views
     gcal_calendars,
     gcal_health,
 )
-from .views_health import features, readyz
+from .views_health import features, readyz, versionz
 from .views_import_bloqueios import ImportBloqueiosView
 from .views_import_colecoes import ImportColecoesView
 from .views_import_deslocamentos import ImportDeslocamentosView
@@ -138,6 +138,7 @@ router.register(r"dat/plano-formacoes", PlanoFormacoesViewSet, basename="plano-f
 urlpatterns = [
     path("", api_root, name="api-root"),
     path("readyz/", readyz, name="readyz"),
+    path("version/", versionz, name="version"),
     path("features/", features, name="features"),
     path("me/", CurrentUserView.as_view(), name="current-user"),
     path("stats/home/", HomeStatsView.as_view(), name="stats-home"),

--- a/v2/backend/apps/core/views_health.py
+++ b/v2/backend/apps/core/views_health.py
@@ -6,7 +6,9 @@ Health Check and Features Views
 
 from __future__ import annotations
 
+import json
 import os
+from pathlib import Path
 from typing import Any
 
 from django.core.cache import cache
@@ -69,6 +71,38 @@ def readyz(request: Request) -> Response:
     status = "healthy" if db_ok else "unhealthy"
 
     return JsonResponse({"status": status, "checks": checks}, status=status_code)
+
+
+def versionz(request: Request) -> JsonResponse:
+    """
+    Returns the deployed version of the application.
+
+    Reads from BUILD_INFO.json baked into the image at build time.
+    Used by CI/CD (release.yaml) to verify the correct version is running.
+
+    GET /api/version/
+
+    Response format:
+    {
+        "version": "v2026.03.05-abc1234",
+        "git_sha": "abc1234",
+        "build_date": "2026-03-05"
+    }
+    """
+    build_info_path = Path("/app/BUILD_INFO.json")
+    try:
+        with build_info_path.open(encoding="utf-8") as f:
+            data: dict[str, str] = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        data = {"version": "unknown", "git_sha": "unknown", "build_date": "unknown"}
+
+    return JsonResponse(
+        {
+            "version": data.get("version", "unknown"),
+            "git_sha": data.get("git_sha", "unknown"),
+            "build_date": data.get("build_date", "unknown"),
+        }
+    )
 
 
 @api_view(["GET"])

--- a/v2/docs/DEPLOY_CHECKLIST.md
+++ b/v2/docs/DEPLOY_CHECKLIST.md
@@ -57,6 +57,15 @@ Checklist de variáveis de ambiente para deploy em produção.
 | `REDIS_PORT` | `6379` | Porta do Redis |
 | `CELERY_BROKER_URL` | `redis://<host>:6379/0` | URL do broker Celery |
 
+### Stack de Produção (Watchtower)
+
+| Variável | Valor Prod | Descrição |
+|----------|------------|-----------|
+| `IMAGE_TAG` | `latest` | Stack produtiva fixa em latest (promovido pelo workflow) |
+| `DOCKER_HUB_TOKEN` | `<token>` | Token para pull autenticado no Watchtower |
+| `WATCHTOWER_TOKEN` | `<token-forte>` | Token do endpoint `POST /v1/update` |
+| `FRONTEND_PORT` | `81` | Porta host do frontend na VM01 |
+
 ### GitHub Release Workflow (Deploy + Verificação)
 
 Use **secrets** ou **variables** com os mesmos nomes (secrets têm prioridade):
@@ -108,6 +117,12 @@ DB_PASSWORD=<senha-forte>
 REDIS_HOST=redis.exemplo.com
 REDIS_PORT=6379
 CELERY_BROKER_URL=redis://redis.exemplo.com:6379/0
+
+# Watchtower / imagem
+IMAGE_TAG=latest
+DOCKER_HUB_TOKEN=<docker-hub-token>
+WATCHTOWER_TOKEN=<watchtower-token-forte>
+FRONTEND_PORT=81
 ```
 
 ---
@@ -128,23 +143,56 @@ O sistema valida automaticamente em produção (`ENVIRONMENT=production`):
 ## Comandos de Deploy
 
 ```bash
-# Definir tag explicita da release (obrigatorio)
-export IMAGE_TAG=vYYYY.MM.DD-<sha>
+# Produção usa promoção por tag homologada em staging
+gh workflow run release.yaml -f environment=production -f promotion_tag=vYYYY.MM.DD-<sha>
 
-# Atualizar template de ambiente com IMAGE_TAG e segredos reais (fora do Git)
-# Exemplo: /etc/aprender/.env.production
+# O workflow promove a tag para latest e dispara o deploy via Watchtower
+# (equivalente ao PRODUCTION_DEPLOY_COMMAND):
+curl -H "Authorization: Bearer $WATCHTOWER_TOKEN" \
+  -X POST http://45.174.67.141:8080/v1/update
 
-# Pull das imagens publicadas (build once, deploy many)
-docker compose --env-file /etc/aprender/.env.production -f infra/docker-compose.prod.yml pull
+# Validar health
+curl http://45.174.67.141:8000/api/readyz/
+```
 
-# Subir sem build local
-docker compose --env-file /etc/aprender/.env.production -f infra/docker-compose.prod.yml up -d --no-build
+---
 
-# Verificar logs
-docker compose --env-file /etc/aprender/.env.production -f infra/docker-compose.prod.yml logs -f web
+## Promocao Staging -> Producao (Mesmo Artefato)
 
-# Verificar health
-curl https://aprender.com.br/healthz/
+No workflow `Release`:
+
+1. Executar em `staging` (gera tag `vYYYY.MM.DD-<sha>` e valida health/version).
+2. Executar em `production` com `promotion_tag` igual a tag homologada em staging.
+3. O workflow valida o endpoint de versao de staging antes do deploy em producao.
+4. Producao usa a mesma tag/digest homologada (sem rebuild na etapa de producao).
+5. Antes do deploy, o workflow repointa `latest` para a `promotion_tag`.
+6. Watchtower aplica update dos containers monitorados.
+
+Topologia alvo em producao:
+- VM01_App: containers `web`, `worker`, `beat`, `frontend`, `watchtower`
+- VM02_Banco: PostgreSQL externo (`DB_HOST`)
+- VM03_Redis: Redis externo (`REDIS_HOST`)
+
+Exemplo (GitHub CLI):
+
+```bash
+# 1) staging (gera tag nova)
+gh workflow run release.yaml -f environment=staging
+
+# 2) producao (promove tag homologada)
+gh workflow run release.yaml -f environment=production -f promotion_tag=vYYYY.MM.DD-<sha>
+```
+
+---
+
+## Rollback por Tag Anterior
+
+```bash
+# Exemplo: rollback para tag anterior homologada
+gh workflow run release.yaml -f environment=production -f promotion_tag=vYYYY.MM.DD-<sha-anterior>
+
+# Confirmar versao ativa apos rollback
+curl https://aprender.com.br/version
 ```
 
 ---

--- a/v2/docs/RUNBOOK.md
+++ b/v2/docs/RUNBOOK.md
@@ -30,24 +30,36 @@ Configure como **secret** ou **variable** (secret tem prioridade):
 - `STAGING_HEALTHCHECK_URL` / `PRODUCTION_HEALTHCHECK_URL`
 - `STAGING_VERSIONCHECK_URL` / `PRODUCTION_VERSIONCHECK_URL`
 
+Exemplo de `PRODUCTION_DEPLOY_COMMAND` (Watchtower HTTP API):
+
+```bash
+curl -H "Authorization: Bearer $WATCHTOWER_TOKEN" -X POST http://45.174.67.141:8080/v1/update
+```
+
 ### **2. Fluxo operacional**
 
 ```bash
 # A execução é manual (workflow_dispatch):
 # GitHub -> Actions -> Release -> Run workflow
 # Environment: staging ou production
+#
+# Para production:
+# - informar promotion_tag com a mesma tag homologada em staging
+#   (ex.: vYYYY.MM.DD-<sha>)
 ```
 
 Ordem crítica no pipeline:
 
-1. Build e push de imagens backend/frontend.
-2. Geração de SBOM (`backend-sbom.spdx.json`, `frontend-sbom.spdx.json`).
-3. Geração de provenance attestation (imagens + SBOM).
-4. Deploy via comando configurado.
-5. Verificação pós-deploy:
+1. `staging`: build/push de imagens backend/frontend + gate de segurança.
+2. `production`: promoção por `promotion_tag` (sem rebuild) com repoint de `:latest`.
+3. Resolução de digest e geração de SBOM (`backend-sbom.spdx.json`, `frontend-sbom.spdx.json`).
+4. Geração de provenance attestation (imagens + SBOM).
+5. `production`: verificação prévia de staging para garantir que a mesma tag está homologada.
+6. Deploy via comando configurado.
+7. Verificação pós-deploy:
    - health endpoint deve retornar HTTP 200
    - version endpoint deve conter a release (`vYYYY.MM.DD-<sha>`)
-6. Criação da GitHub Release + upload dos assets de evidência.
+8. Criação/atualização da GitHub Release + upload dos assets de evidência.
 
 ### **3. Evidências geradas**
 
@@ -66,6 +78,16 @@ O workflow falha quando qualquer item crítico falha:
 - geração de SBOM/attestation
 
 Isso evita sinal verde operacional sem confirmação real de deploy íntegro.
+
+### Promoção staging -> produção (mesmo artefato)
+
+1. Executar release em `staging` (gera tag `vYYYY.MM.DD-<sha>`).
+2. Validar staging (health/version) no próprio workflow.
+3. Executar release em `production` com `promotion_tag` igual à tag homologada.
+4. Workflow valida staging com essa mesma tag antes do deploy em produção.
+5. Workflow promove a tag homologada para `latest` no Docker Hub.
+6. `PRODUCTION_DEPLOY_COMMAND` dispara `POST /v1/update` no Watchtower da VM01.
+7. Watchtower executa pull/restart dos containers monitorados (web/worker/beat/frontend).
 
 ## Gate de Segurança no Release (Publicação de Imagem)
 
@@ -123,12 +145,13 @@ gh workflow run dockerhub-rebuild.yml -f publish_images=false
 Observação:
 - fora da `main`, o workflow força `publish_images=false` para evitar push acidental.
 
-## 🏷️ Deploy por Tag (Staging/Produção)
+## 🏷️ Deploy por Imagem Publicada (Staging/Produção)
 
-Staging e produção devem operar somente com imagem publicada.
+Staging e produção operam somente com imagem publicada.
 
 Regras operacionais:
-- `IMAGE_TAG` é obrigatória (sem fallback para `latest`).
+- `staging`: `IMAGE_TAG` explícita da release.
+- `produção`: stack fixa em `IMAGE_TAG=latest` + promoção controlada por `promotion_tag`.
 - Fazer `pull` antes do `up`.
 - Usar `up --no-build` (proibido build local em VM).
 - Não aplicar `docker-compose.override.yml` em staging/produção.
@@ -152,17 +175,25 @@ docker compose --env-file .env.staging -f docker-compose.yml up -d --no-build
 ### Produção
 
 ```bash
-cd v2/infra
+# 1) stack em producao permanece com IMAGE_TAG=latest
+# 2) release em production com promotion_tag valida staging e repointa latest
+# 3) deploy trigger via Watchtower HTTP API
+curl -H "Authorization: Bearer $WATCHTOWER_TOKEN" \
+  -X POST http://45.174.67.141:8080/v1/update
+```
 
-# 1) Definir tag explícita
-export IMAGE_TAG=vYYYY.MM.DD-<sha>
+Observacao de seguranca:
+- manter `WATCHTOWER_TOKEN` longo e rotacionado;
+- restringir firewall da porta `8080` sempre que possivel.
 
-# 2) Validar compose (falha se IMAGE_TAG estiver vazia)
-docker compose --env-file .env.production -f docker-compose.prod.yml config
+### Rollback por tag anterior (staging/producao)
 
-# 3) Pull + up sem build
-docker compose --env-file .env.production -f docker-compose.prod.yml pull
-docker compose --env-file .env.production -f docker-compose.prod.yml up -d --no-build
+```bash
+# Produção: rollback = reexecutar release em production com promotion_tag anterior
+gh workflow run release.yaml -f environment=production -f promotion_tag=vYYYY.MM.DD-<sha-anterior>
+
+# Confirmar versao ativa
+curl -fsS https://SEU_HOST/version
 ```
 
 ## 🔄 Recarregar Variáveis de Ambiente (.env)

--- a/v2/infra/.env.production
+++ b/v2/infra/.env.production
@@ -2,7 +2,7 @@
 # Ambiente de producao (PRODUCAO)
 # -----------------------------------------------------------------------------
 # Uso recomendado:
-#   IMAGE_TAG=vYYYY.MM.DD-<sha> docker compose --env-file .env.production \
+#   IMAGE_TAG=latest docker compose --env-file .env.production \
 #     -f docker-compose.prod.yml up -d
 #
 # IMPORTANTE:
@@ -10,31 +10,33 @@
 # - Nao versionar segredos reais de producao.
 
 COMPOSE_PROJECT_NAME=aprender_prod
+# Para validacao local controlada usa este proprio arquivo;
+# em Portainer, deixe APP_ENV_FILE vazio para usar stack.env (default no compose).
 APP_ENV_FILE=.env.production
-# Obrigatorio em producao (nao usar latest implicito)
-IMAGE_TAG=
+# Obrigatorio em producao com Watchtower
+IMAGE_TAG=latest
+FRONTEND_PORT=81
+DOCKER_HUB_TOKEN=CHANGE_ME_DOCKER_HUB_TOKEN
+WATCHTOWER_TOKEN=CHANGE_ME_WATCHTOWER_TOKEN
 
 ENVIRONMENT=production
 DEBUG=0
 SECRET_KEY=CHANGE_ME_PRODUCTION_SECRET_KEY
 REQUIRE_DOCKER=1
 
-ALLOWED_HOSTS=aprender.exemplo.com,web
-CORS_ALLOWED_ORIGINS=https://aprender.exemplo.com
-CSRF_TRUSTED_ORIGINS=https://aprender.exemplo.com
+ALLOWED_HOSTS=as-aprendersistema.aprendereditora.com.br,45.174.67.141,localhost
+CORS_ALLOWED_ORIGINS=https://as-aprendersistema.aprendereditora.com.br,https://45.174.67.141
+CSRF_TRUSTED_ORIGINS=https://as-aprendersistema.aprendereditora.com.br,https://45.174.67.141
 
-# Banco de dados
+# Banco de dados (VM02_Banco)
 DB_NAME=aprender_db
-DB_USER=aprender_user
+DB_USER=matheus_aprender
 DB_PASSWORD=CHANGE_ME_PRODUCTION_DB_PASSWORD
-DB_HOST=db
+DB_HOST=172.17.0.3
 DB_PORT=5432
-POSTGRES_DB=aprender_db
-POSTGRES_USER=aprender_user
-POSTGRES_PASSWORD=CHANGE_ME_PRODUCTION_DB_PASSWORD
 
-# Redis
-REDIS_HOST=redis
+# Redis (VM03_Redis)
+REDIS_HOST=172.17.0.4
 REDIS_PORT=6379
 
 # Google Calendar (exemplo)

--- a/v2/infra/Dockerfile.prod
+++ b/v2/infra/Dockerfile.prod
@@ -32,6 +32,7 @@ RUN chmod +x /app/infra/scripts/*.sh
 
 ARG GIT_SHA=unknown
 ARG BUILD_DATE=unknown
+ARG APP_VERSION=dev
 RUN python - <<'PY2'
 import json
 import os
@@ -39,6 +40,7 @@ import os
 with open("/app/BUILD_INFO.json", "w", encoding="utf-8") as f:
     json.dump(
         {
+            "version": os.environ.get("APP_VERSION", "dev"),
             "git_sha": os.environ.get("GIT_SHA", "unknown"),
             "build_date": os.environ.get("BUILD_DATE", "unknown"),
             "profile": "prod",

--- a/v2/infra/ENVIRONMENTS.md
+++ b/v2/infra/ENVIRONMENTS.md
@@ -61,8 +61,9 @@ make build-prod-image
 4. Para deploy real em VM, registrar `IMAGE_TAG` usada como evidencia.
 5. Arquivos `.env.*` deste diretorio sao templates e nao devem conter segredos reais.
 6. `staging/producao` devem usar imagem publicada gerada com `Dockerfile.prod`.
-7. `staging/producao` exigem `IMAGE_TAG` explicita (sem fallback implicito para `latest`).
+7. `staging` exige `IMAGE_TAG` explicita da release; em `producao` a stack opera com `IMAGE_TAG=latest` e promocao controlada por `promotion_tag` no workflow.
 8. Em `staging/producao`, `docker-compose.override.yml` nao e aplicado.
+9. Em producao Golden Cloud (3-VMs), `docker-compose.prod.yml` usa DB/Redis externos (VM02/VM03); a stack da VM01 sobe `web/worker/beat/frontend/watchtower`.
 
 ## 5) Evidencias Minimas por Mudanca
 

--- a/v2/infra/Makefile
+++ b/v2/infra/Makefile
@@ -162,8 +162,8 @@ check-env-prod: ## Validar configuração do ambiente PRODUÇÃO
 		-f $(COMPOSE_PROD_FILE) config > /dev/null
 	@echo "✅ [PROD] configuração válida"
 
-pull-prod: ## Pull das imagens do ambiente PRODUÇÃO (tag obrigatoria)
-	@echo "📥 [PROD] puxando imagens por tag..."
+pull-prod: ## Pull das imagens do ambiente PRODUÇÃO (latest promovida)
+	@echo "📥 [PROD] puxando imagens publicadas..."
 	docker compose --env-file $(ENV_FILE_PROD) \
 		-f $(COMPOSE_PROD_FILE) pull
 	@echo "✅ [PROD] pull concluido"
@@ -174,7 +174,7 @@ up-prod: ## Subir ambiente PRODUÇÃO (sem build local)
 		-f $(COMPOSE_PROD_FILE) up -d --no-build
 	@echo "✅ [PROD] ambiente iniciado"
 	@echo "🌐 [PROD] backend: http://localhost:8000"
-	@echo "🌐 [PROD] frontend: http://localhost"
+	@echo "🌐 [PROD] frontend: http://localhost:$${FRONTEND_PORT:-81}"
 
 health-prod: ## Verificar health do ambiente PRODUÇÃO
 	@echo "❤️  [PROD] verificando /api/readyz..."

--- a/v2/infra/README.md
+++ b/v2/infra/README.md
@@ -110,7 +110,7 @@ Default env templates are versioned as:
 
 Important:
 - keep placeholders only in these files (real secrets outside Git).
-- `staging/prod` require explicit `IMAGE_TAG` (no implicit `latest`).
+- `staging` uses explicit `IMAGE_TAG`; `prod` stays on `IMAGE_TAG=latest` with controlled promotion by workflow.
 - `staging/prod` do not use local build; use published images (`pull + up --no-build`).
 
 ## Backend Dockerfiles
@@ -132,21 +132,26 @@ Create `/etc/aprender/env` with:
 ```bash
 DJANGO_SETTINGS_MODULE=config.settings
 SECRET_KEY=your-secret-key
-DB_HOST=10.0.0.2
+DB_HOST=172.17.0.3
 DB_PORT=5432
 DB_NAME=aprender_db
-DB_USER=aprender_user
+DB_USER=matheus_aprender
 DB_PASSWORD=your-db-password
-REDIS_PASSWORD=your-redis-password
+REDIS_HOST=172.17.0.4
+REDIS_PORT=6379
+IMAGE_TAG=latest
+FRONTEND_PORT=81
+DOCKER_HUB_TOKEN=your-docker-hub-token
+WATCHTOWER_TOKEN=your-watchtower-token
 ```
 
 ## VM Architecture
 
-| VM | Role | IP | Ports |
+| VM | Role | IP interno | Ports |
 |----|------|-----|-------|
-| VM01_App | App + Workers | 10.0.0.1 | 80, 443 |
-| VM02_Banco | PostgreSQL | 10.0.0.2 | 5432 |
-| VM03_Redis | Redis | 10.0.0.3 | 6379 |
+| VM01_App | App + Workers (Docker) | 172.17.0.2 | 8000 (web), 81 (frontend), 80/443 (via NPM) |
+| VM02_Banco | PostgreSQL 15 (servico nativo) | 172.17.0.3 | 5432 |
+| VM03_Redis | Redis 7 (servico nativo) | 172.17.0.4 | 6379 |
 
 ## Related Documentation
 

--- a/v2/infra/docker-compose.prod.yml
+++ b/v2/infra/docker-compose.prod.yml
@@ -1,65 +1,43 @@
 # =============================================================================
-# Docker Compose - Production Configuration
+# Docker Compose - Production Configuration (Golden Cloud — topologia 3-VMs)
 # =============================================================================
-# Usage:
-#   docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+# Topologia:
+#   VM01_App  — esta stack (web, worker, beat, frontend, watchtower)
+#   VM02_Banco — PostgreSQL externo (DB_HOST apontando para IP da VM02)
+#   VM03_Redis — Redis externo (REDIS_HOST apontando para IP da VM03)
 #
-# Or pull from Docker Hub:
-#   IMAGE_TAG=v1.0.0 docker compose -f docker-compose.prod.yml up -d
+# Uso:
+#   IMAGE_TAG=latest docker compose -f docker-compose.prod.yml up -d
+#
+# IMPORTANTE: IMAGE_TAG deve ser "latest" para o Watchtower detectar atualizacoes.
+# O GitHub Actions publica :latest a cada release, o Watchtower detecta e atualiza.
+# Apenas servicos com label com.centurylinklabs.watchtower.enable=true sao atualizados.
+#
+# Variaveis obrigatorias no .env (ou stack.env no Portainer):
+#   IMAGE_TAG=latest
+#   DB_HOST, DB_NAME, DB_USER, DB_PASSWORD
+#   REDIS_HOST, REDIS_PORT, SECRET_KEY
+#   WATCHTOWER_TOKEN  (token para acionar o deploy via HTTP API)
+#   DOCKER_HUB_TOKEN  (access token do Docker Hub para evitar rate limit)
 # =============================================================================
 
-name: ${COMPOSE_PROJECT_NAME:-aprender_v2_prod}
+name: ${COMPOSE_PROJECT_NAME:-aprender_prod}
 
 services:
-  db:
-    image: postgres:15-alpine
-    environment:
-      POSTGRES_DB: ${POSTGRES_DB}
-      POSTGRES_USER: ${POSTGRES_USER}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-    volumes:
-      - db_data:/var/lib/postgresql/data
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-      start_period: 10s
-    restart: unless-stopped
-
-  redis:
-    image: redis:7-alpine
-    command: redis-server --save 60 1 --loglevel warning
-    volumes:
-      - redis_data:/data
-    healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
-      interval: 10s
-      timeout: 5s
-      retries: 3
-      start_period: 5s
-    restart: unless-stopped
-
   web:
     image: norjosamatheus/aprender-backend:${IMAGE_TAG:?IMAGE_TAG is required}
     command: gunicorn config.wsgi:application --config /app/infra/gunicorn.conf.py
     env_file:
-      - ${APP_ENV_FILE:-.env}
+      - ${APP_ENV_FILE:-stack.env}
     environment:
       ENVIRONMENT: production
       DEBUG: "False"
-      REQUIRE_DOCKER: 1
+      REQUIRE_DOCKER: "1"
       SERVICE_NAME: web
-    depends_on:
-      db:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
     ports:
       - "8000:8000"
-    volumes:
-      - backup_data:/backups
-      - ./scripts:/app/infra/scripts:ro # MP5: Backup scripts
+    labels:
+      com.centurylinklabs.watchtower.enable: "true"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/api/readyz/"]
       interval: 30s
@@ -72,20 +50,14 @@ services:
     image: norjosamatheus/aprender-backend:${IMAGE_TAG:?IMAGE_TAG is required}
     command: celery -A config worker -l info
     env_file:
-      - ${APP_ENV_FILE:-.env}
+      - ${APP_ENV_FILE:-stack.env}
     environment:
       ENVIRONMENT: production
       DEBUG: "False"
-      REQUIRE_DOCKER: 1
+      REQUIRE_DOCKER: "1"
       SERVICE_NAME: worker
-    depends_on:
-      db:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
-    volumes:
-      - backup_data:/backups # MP5: Database backups storage (C-05)
-      - ./scripts:/app/infra/scripts:ro # MP5: Backup scripts (C-05)
+    labels:
+      com.centurylinklabs.watchtower.enable: "true"
     healthcheck:
       test: ["CMD-SHELL", "celery -A config inspect ping -d celery@$$HOSTNAME || exit 1"]
       interval: 30s
@@ -98,20 +70,14 @@ services:
     image: norjosamatheus/aprender-backend:${IMAGE_TAG:?IMAGE_TAG is required}
     command: celery -A config beat -l info
     env_file:
-      - ${APP_ENV_FILE:-.env}
+      - ${APP_ENV_FILE:-stack.env}
     environment:
       ENVIRONMENT: production
       DEBUG: "False"
-      REQUIRE_DOCKER: 1
+      REQUIRE_DOCKER: "1"
       SERVICE_NAME: beat
-    depends_on:
-      db:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
-    volumes:
-      - backup_data:/backups # MP5: Database backups storage (C-05)
-      - ./scripts:/app/infra/scripts:ro # MP5: Backup scripts (C-05)
+    labels:
+      com.centurylinklabs.watchtower.enable: "true"
     healthcheck:
       test: ["CMD-SHELL", "python -c 'import celery; print(celery.__version__)' || exit 1"]
       interval: 60s
@@ -123,9 +89,11 @@ services:
   frontend:
     image: norjosamatheus/aprender-frontend:${IMAGE_TAG:?IMAGE_TAG is required}
     ports:
-      - "80:80"
+      - "${FRONTEND_PORT:-81}:80"
     depends_on:
       - web
+    labels:
+      com.centurylinklabs.watchtower.enable: "true"
     healthcheck:
       test: ["CMD-SHELL", "wget --quiet --tries=1 --spider http://localhost:80/health || exit 1"]
       interval: 30s
@@ -134,7 +102,18 @@ services:
       start_period: 10s
     restart: unless-stopped
 
-volumes:
-  db_data:
-  redis_data:
-  backup_data:
+  watchtower:
+    image: containrrr/watchtower
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      # Autenticacao no Docker Hub (evita rate limit de pulls)
+      REPO_USER: norjosamatheus
+      REPO_PASS: ${DOCKER_HUB_TOKEN:?DOCKER_HUB_TOKEN is required}
+      # HTTP API — permite acionar update imediato via POST /v1/update
+      WATCHTOWER_HTTP_API_UPDATE: "true"
+      WATCHTOWER_HTTP_API_TOKEN: ${WATCHTOWER_TOKEN:?WATCHTOWER_TOKEN is required}
+    command: --label-enable --rolling-restart --cleanup --interval 300
+    ports:
+      - "8080:8080"
+    restart: unless-stopped


### PR DESCRIPTION
## Resumo

Implementa deploy automático de produção via Watchtower e adiciona endpoint de versão para verificação pós-deploy no pipeline de release.

### O que foi feito

**Watchtower (deploy automático)**
- Adiciona serviço `watchtower` no `docker-compose.prod.yml` com `--label-enable`, `--rolling-restart` e HTTP API (`POST /v1/update`) para trigger imediato pelo GitHub Actions
- Apenas containers com `com.centurylinklabs.watchtower.enable: "true"` são atualizados (web, worker, beat, frontend)
- Autenticação no Docker Hub via `REPO_USER`/`REPO_PASS` para evitar rate limit

**Endpoint `/api/version/`**
- Novo endpoint público `GET /api/version/` que retorna versão, git_sha e build_date
- Versão é baked na imagem em `BUILD_INFO.json` via `ARG APP_VERSION` no `Dockerfile.prod`
- Usado pelo `release.yaml` como `PRODUCTION_VERSIONCHECK_URL` para confirmar que a versão correta foi deployada

**Pipeline de release (`release.yaml`)**
- Passa `build-args: APP_VERSION/GIT_SHA/BUILD_DATE` nos steps de build do backend (scan + push)
- Promoção para produção: retag da imagem staging para `:latest` antes do trigger do Watchtower

**Alinhamento topologia 3-VMs (Codex)**
- `docker-compose.prod.yml` adaptado para VM01_App sem db/redis embutidos (`IMAGE_TAG=latest`)
- `RUNBOOK.md`, `DEPLOY_CHECKLIST.md`, `ENVIRONMENTS.md`, `README.md` e `Makefile` atualizados para refletir fluxo real Golden Cloud

## Secrets necessários no GitHub (já configurados)

| Secret | Valor |
|--------|-------|
| `PRODUCTION_DEPLOY_COMMAND` | `curl -H "Authorization: Bearer <WATCHTOWER_TOKEN>" -X POST http://45.174.67.141:8080/v1/update` |
| `PRODUCTION_HEALTHCHECK_URL` | `http://45.174.67.141:8000/api/readyz/` |
| `PRODUCTION_VERSIONCHECK_URL` | `http://45.174.67.141:8000/api/version/` |

## Checklist

- [x] `docker-compose.prod.yml` validado com `docker compose config`
- [x] `actionlint` passou no `release.yaml`
- [x] Stack atualizada no Portainer com IMAGE_TAG=latest, DOCKER_HUB_TOKEN, WATCHTOWER_TOKEN
- [x] Watchtower rodando na VM01 (container `aprender_prod-watchtower-1`)
- [x] Secrets de produção configurados no GitHub