### PR TITLE
fix(frontend): atualizar runtime alpine para destravar gate de release

### DIFF
--- a/v2/frontend/Dockerfile.prod
+++ b/v2/frontend/Dockerfile.prod
@@ -32,6 +32,9 @@ LABEL org.opencontainers.image.description="React frontend for Aprender Sistema"
 LABEL org.opencontainers.image.vendor="norjosamatheus"
 LABEL org.opencontainers.image.source="https://github.com/matheusnorjosa/aprender-sistema"
 
+# Atualiza pacotes base para reduzir CVEs conhecidos da imagem runtime.
+RUN apk upgrade --no-cache
+
 # Remover configuracao default do nginx
 RUN rm /etc/nginx/conf.d/default.conf
 


### PR DESCRIPTION
## Contexto
A release manual foi bloqueada no gate de segurança do workflow Release por 1 vulnerabilidade HIGH no frontend runtime image:
- CVE-2026-25646 em libpng (alpine), detectada em 	rivy-frontend-pre-release.json.

## Mudança
- Adiciona pk upgrade --no-cache no stage production do 2/frontend/Dockerfile.prod para atualizar pacotes base e reduzir CVEs conhecidas da imagem final.

## Objetivo
- Permitir publicar release de hoje para teste em produção sem relaxar gate de segurança.
