### PR TITLE
fix(infra): alinhar scheduler do Celery Beat com agenda em código (#571)

### DIFF
--- a/v2/docs/RUNBOOK.md
+++ b/v2/docs/RUNBOOK.md
@@ -346,6 +346,10 @@ docker compose -p aprender_v2 -f infra/docker-compose.yml ps worker beat
    - "beat: Starting..."
 ```
 
+Notas operacionais:
+- Em produção/systemd, usar scheduler padrão do Celery para respeitar `app.conf.beat_schedule` definido em `config/celery.py`.
+- Só usar `django_celery_beat.schedulers:DatabaseScheduler` se as `PeriodicTask` estiverem cadastradas no banco.
+
 ---
 
 ## 🏥 Health Checks e Validações

--- a/v2/infra/systemd/aprender-celerybeat.service
+++ b/v2/infra/systemd/aprender-celerybeat.service
@@ -18,11 +18,13 @@ WorkingDirectory=/var/www/aprender/backend
 Environment="PATH=/var/www/aprender/venv/bin"
 Environment="DJANGO_SETTINGS_MODULE=config.settings"
 
+# Use Celery default scheduler (PersistentScheduler) so app.conf.beat_schedule
+# from config/celery.py is applied. If DatabaseScheduler is required, create
+# periodic entries in django_celery_beat first.
 ExecStart=/var/www/aprender/venv/bin/celery -A config beat \
     --pidfile=/run/aprender/celerybeat.pid \
     --logfile=/var/log/aprender/celerybeat.log \
-    --loglevel=INFO \
-    --scheduler=django_celery_beat.schedulers:DatabaseScheduler
+    --loglevel=INFO
 
 Restart=on-failure
 RestartSec=10


### PR DESCRIPTION
## Resumo
Alinha a execução do Celery Beat em systemd com a agenda declarada em código (pp.conf.beat_schedule), eliminando o risco de backups não agendarem por falta de entries no django_celery_beat.

Closes #571

## O que foi alterado
- 2/infra/systemd/aprender-celerybeat.service
  - remove --scheduler=django_celery_beat.schedulers:DatabaseScheduler
  - mantém scheduler padrão do Celery (PersistentScheduler), compatível com config/celery.py
  - adiciona comentário operacional sobre quando usar DatabaseScheduler
- 2/docs/RUNBOOK.md
  - documenta a decisão operacional (scheduler padrão em produção/systemd)
  - esclarece pré-requisito para uso de DatabaseScheduler (PeriodicTask no banco)

## Resultado esperado
- Tarefas de backup declaradas em config/celery.py passam a ser respeitadas no modo systemd.
- Reduz risco de falso verde operacional (beat em execução sem agenda efetiva).

## Testes / validação
- Validação estática do unit file (comando ExecStart e flags).
- Revisão cruzada com a configuração do Celery em 2/backend/config/celery.py.

## Risco e rollback
- Risco baixo e reversível.
- Rollback: revert deste PR.