### PR TITLE
fix(security): bump django-allauth para 65.14.1 (CVE-2026-27982)

### DIFF
--- a/v2/backend/requirements.txt
+++ b/v2/backend/requirements.txt
@@ -19,7 +19,7 @@ Django==5.1.15
 # ================================================================
 # Authentication & Authorization
 # ================================================================
-django-allauth==65.13.0
+django-allauth==65.14.1
 django-celery-beat==2.7.0
 django-celery-results==2.5.1
 django-cors-headers==4.4.0


### PR DESCRIPTION
## Resumo
Atualiza django-allauth de 65.13.0 para 65.14.1 para corrigir a vulnerabilidade reportada no gate Python Dependencies.

## Contexto
pip-audit identificou:
- CVE-2026-27982 (GHSA-2jpr-83rg-v67j)
- pacote afetado: django-allauth==65.13.0
- versão com correção: 65.14.1

## Alteração
- 2/backend/requirements.txt
  - django-allauth==65.13.0 -> django-allauth==65.14.1

## Resultado esperado
- Check Python Dependencies deixa de falhar por essa CVE.

## Risco
- Baixo (patch update de segurança em mesma major/minor).