### PR TITLE
ASQ-003: remover N+1 em batch approve/reject

### DIFF
--- a/v2/backend/apps/core/services/solicitacao_approval.py
+++ b/v2/backend/apps/core/services/solicitacao_approval.py
@@ -72,6 +72,32 @@ def _raise_invalid_status_error(solicitacao: Solicitacao) -> None:
     )
 
 
+def _build_batch_status_errors(ids: list[int], found_ids: set[int]) -> list[dict[str, Any]]:
+    """
+    Build per-ID errors for batch actions without N+1 queries.
+
+    Strategy:
+    - Pending/locked IDs are in `found_ids` and will be processed.
+    - For the remaining IDs, fetch status in a single query and emit:
+      - \"Status já é 'X'\" when record exists but is not pending
+      - \"Solicitação não encontrada\" when record does not exist
+    """
+    status_by_id: dict[int, str] = dict(Solicitacao.objects.filter(id__in=ids).values_list("id", "status"))
+    errors: list[dict[str, Any]] = []
+
+    for sol_id in ids:
+        if sol_id in found_ids:
+            continue
+
+        existing_status = status_by_id.get(sol_id)
+        if existing_status is None:
+            errors.append({"id": sol_id, "detail": "Solicitação não encontrada"})
+        else:
+            errors.append({"id": sol_id, "detail": f"Status já é '{existing_status}'"})
+
+    return errors
+
+
 def approve_solicitacao(
     solicitacao: Solicitacao,
     user: Usuario,
@@ -251,14 +277,7 @@ def batch_approve_solicitacoes(
         )
         found_ids = {sol.id for sol in solicitacoes}
 
-        # Record errors for not found or already processed IDs
-        for sol_id in ids:
-            if sol_id not in found_ids:
-                sol = Solicitacao.objects.filter(id=sol_id).first()
-                if sol:
-                    errors.append({"id": sol_id, "detail": f"Status já é '{sol.status}'"})
-                else:
-                    errors.append({"id": sol_id, "detail": "Solicitação não encontrada"})
+        errors.extend(_build_batch_status_errors(ids, found_ids))
 
         # Approve in batch
         for sol in solicitacoes:
@@ -344,14 +363,7 @@ def batch_reject_solicitacoes(
         )
         found_ids = {sol.id for sol in solicitacoes}
 
-        # Record errors for not found or already processed IDs
-        for sol_id in ids:
-            if sol_id not in found_ids:
-                sol = Solicitacao.objects.filter(id=sol_id).first()
-                if sol:
-                    errors.append({"id": sol_id, "detail": f"Status já é '{sol.status}'"})
-                else:
-                    errors.append({"id": sol_id, "detail": "Solicitação não encontrada"})
+        errors.extend(_build_batch_status_errors(ids, found_ids))
 
         # Reject in batch
         for sol in solicitacoes:


### PR DESCRIPTION
## Contexto\nEsta PR implementa a otimização principal da issue #776 (ASQ-003), removendo consultas por ID dentro de loop nos fluxos de batch approve/reject.\n\n## O que foi feito\n- adicionada função auxiliar _build_batch_status_errors para coletar erros de IDs em lote com query única;\n- substituída a lógica N+1 em atch_approve_solicitacoes;\n- substituída a lógica N+1 em atch_reject_solicitacoes.\n\n## Impacto esperado\n- elimina chamadas ilter(id=sol_id).first() por item não pendente/inexistente;\n- melhora latência em lotes grandes e reduz carga no banco.\n\n## Validação\n- validação de sintaxe via python -m compileall no arquivo alterado;\n- execução local de pytest não foi possível neste ambiente (dependência pytest ausente).\n\nCloses #776