### PR TITLE
fix(ci): rename GITHUB_REF_NAME to avoid built-in collision

### DIFF
--- a/.github/workflows/dockerhub-rebuild.yml
+++ b/.github/workflows/dockerhub-rebuild.yml
@@ -48,14 +48,14 @@ jobs:
         id: publish-mode
         env:
           EVENT_NAME: ${{ github.event_name }}
-          GITHUB_REF_NAME: ${{ github.ref }}
+          GH_REF: ${{ github.ref }}
           DISPATCH_PUBLISH_IMAGES: ${{ inputs.publish_images }}
         run: |
           set -euo pipefail
           publish_images="false"
           publish_reason="manual-skip"
 
-          if [ "$GITHUB_REF_NAME" != "refs/heads/main" ]; then
+          if [ "$GH_REF" != "refs/heads/main" ]; then
             publish_images="false"
             publish_reason="non-main-ref"
           elif [ "$EVENT_NAME" = "schedule" ]; then


### PR DESCRIPTION
## Summary
- The `dockerhub-rebuild.yml` workflow's **Resolve publish mode** step defined a custom env var `GITHUB_REF_NAME` mapped to `${{ github.ref }}` (`refs/heads/main`)
- GitHub Actions **built-in** `GITHUB_REF_NAME` (value: `main`) takes precedence at runtime
- The comparison `!= "refs/heads/main"` always evaluated to `true` ("main" ≠ "refs/heads/main"), causing all Docker Hub publish steps to be **skipped**
- Renamed to `GH_REF` to avoid the collision

## Root cause
Run [22860845995](https://github.com/matheusnorjosa/aprender_sistema/actions/runs/22860845995) log:
```
Publish images: false (non-main-ref)
```
Even though it was dispatched on `main`.

## Test plan
- [ ] Merge this PR
- [ ] Trigger `dockerhub-rebuild` workflow manually
- [ ] Verify publish steps run (Login + Build and push)