### PR TITLE
fix(infra): prevent deploy job skip cascade in deploy.yaml

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -323,6 +323,7 @@ jobs:
       - build_and_push
       - validate_existing_tag
     if: |
+      always() &&
       needs.prepare.result == 'success' &&
       (needs.build_and_push.result == 'success' || needs.build_and_push.result == 'skipped') &&
       (needs.validate_existing_tag.result == 'success' || needs.validate_existing_tag.result == 'skipped')


### PR DESCRIPTION
## Summary

- Add `always()` to the deploy job `if` condition to prevent automatic skip cascade

## Problem

GitHub Actions automatically skips dependent jobs when any upstream job in `needs` is skipped — even if the `if` condition explicitly handles `skipped` status. In the staging flow, `validate_existing_tag` is correctly skipped (it's only for promotion/rollback), but this caused the `deploy` job to be skipped too, preventing the actual deploy.

## Fix

Adding `always()` forces GitHub Actions to evaluate the `if` condition instead of auto-skipping. The condition still validates that `prepare` succeeded and the relevant upstream job (build or validate) succeeded.

## Test plan

- [ ] Merge triggers deploy.yaml on push to main
- [ ] Deploy job runs (not skipped) after build_and_push succeeds
- [ ] Portainer API call executes and redeploys stack