### PR TITLE
fix(infra): add Redis service to stack and nginx DNS resolver

### DIFF
--- a/v2/frontend/nginx.conf
+++ b/v2/frontend/nginx.conf
@@ -8,6 +8,10 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Docker internal DNS resolver — re-resolves on every request so that
+    # container IP changes after redeploy are picked up automatically.
+    resolver 127.0.0.11 valid=10s ipv6=off;
+
     # Gzip compression
     gzip on;
     gzip_vary on;
@@ -29,7 +33,8 @@ server {
 
     # Prometheus metrics endpoint (must bypass SPA fallback and API rate limits)
     location = /metrics {
-        proxy_pass http://web:8000/metrics;
+        set $backend http://web:8000;
+        proxy_pass $backend/metrics;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -41,7 +46,8 @@ server {
 
     # Keep compatibility for trailing slash probes
     location /metrics/ {
-        proxy_pass http://web:8000/metrics/;
+        set $backend http://web:8000;
+        proxy_pass $backend/metrics/;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -59,11 +65,13 @@ server {
     }
 
     # API proxy (reverse proxy to backend)
+    # Uses $backend variable to force DNS re-resolution via Docker resolver.
     # X-Forwarded-Proto: use value from upstream proxy if present, otherwise $scheme.
     # This ensures Django sees "https" when behind NPM SSL termination and
     # does not loop on SECURE_SSL_REDIRECT.
     location /api/ {
-        proxy_pass http://web:8000;
+        set $backend http://web:8000;
+        proxy_pass $backend;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';

--- a/v2/infra/docker-compose.prod.yml
+++ b/v2/infra/docker-compose.prod.yml
@@ -1,10 +1,10 @@
 # =============================================================================
-# Docker Compose - Production Configuration (Golden Cloud — topologia 3-VMs)
+# Docker Compose - Production Configuration
 # =============================================================================
 # Topologia:
-#   VM01_App  — esta stack (web, worker, beat, frontend, watchtower)
+#   VM01_App  — esta stack (web, worker, beat, frontend, redis, watchtower)
 #   VM02_Banco — PostgreSQL externo (DB_HOST apontando para IP da VM02)
-#   VM03_Redis — Redis externo (REDIS_HOST apontando para IP da VM03)
+#   Redis — container local nesta stack (serviço "redis")
 #
 # Uso:
 #   IMAGE_TAG=latest docker compose -f docker-compose.prod.yml up -d
@@ -16,7 +16,7 @@
 # Variaveis obrigatorias no .env (ou stack.env no Portainer):
 #   IMAGE_TAG=latest
 #   DB_HOST, DB_NAME, DB_USER, DB_PASSWORD
-#   REDIS_HOST, REDIS_PORT, SECRET_KEY
+#   REDIS_HOST, REDIS_PASSWORD, REDIS_PORT, SECRET_KEY
 #   WATCHTOWER_TOKEN  (token para acionar o deploy via HTTP API)
 #   DOCKER_HUB_TOKEN  (access token do Docker Hub para evitar rate limit)
 # =============================================================================
@@ -36,6 +36,8 @@ services:
       SERVICE_NAME: web
     ports:
       - "8000:8000"
+    depends_on:
+      - redis
     labels:
       com.centurylinklabs.watchtower.enable: "true"
     healthcheck:
@@ -45,6 +47,16 @@ services:
       retries: 3
       start_period: 40s
     restart: unless-stopped
+
+  redis:
+    image: redis:7-alpine
+    command: redis-server --requirepass "${REDIS_PASSWORD}"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "${REDIS_PASSWORD}", "ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
 
   worker:
     image: norjosamatheus/aprender-backend:${IMAGE_TAG:?IMAGE_TAG is required}
@@ -56,6 +68,8 @@ services:
       DEBUG: "False"
       REQUIRE_DOCKER: "1"
       SERVICE_NAME: worker
+    depends_on:
+      - redis
     labels:
       com.centurylinklabs.watchtower.enable: "true"
     healthcheck:
@@ -76,6 +90,8 @@ services:
       DEBUG: "False"
       REQUIRE_DOCKER: "1"
       SERVICE_NAME: beat
+    depends_on:
+      - redis
     labels:
       com.centurylinklabs.watchtower.enable: "true"
     healthcheck:


### PR DESCRIPTION
## Summary
- Add `redis:7-alpine` service to `docker-compose.prod.yml` with password auth and healthcheck — replaces unreachable external Redis on VM03
- Add `depends_on: [redis]` for web, worker, and beat services
- Add nginx `resolver 127.0.0.11` directive to re-resolve container IPs after redeploys, preventing 504 Gateway Timeout errors
- Use `$backend` variable pattern in `/api/`, `/metrics`, `/metrics/` proxy locations

## Context
During production deployment on 2026-03-10, we discovered:
1. VM03 never had Docker/Redis installed — Redis was unreachable
2. Nginx cached backend DNS at startup, causing 504s after container IP changes

Both fixes are already validated and running in production via Portainer.

## Test plan
- [ ] `docker compose -f v2/infra/docker-compose.prod.yml config` parses without errors
- [ ] CI checks pass
- [ ] Production already running these changes successfully