### PR TITLE
fix(infra): add shared_proxy network for NPM persistence

### DIFF
--- a/v2/infra/docker-compose.prod.yml
+++ b/v2/infra/docker-compose.prod.yml
@@ -108,6 +108,9 @@ services:
       - "${FRONTEND_PORT:-81}:80"
     depends_on:
       - web
+    networks:
+      - default
+      - shared_proxy
     labels:
       com.centurylinklabs.watchtower.enable: "true"
     healthcheck:
@@ -133,3 +136,9 @@ services:
     ports:
       - "8080:8080"
     restart: unless-stopped
+
+# Rede externa compartilhada com NPM (Nginx Proxy Manager).
+# Deve ser criada uma vez na VM01: docker network create shared_proxy
+networks:
+  shared_proxy:
+    external: true


### PR DESCRIPTION
## Summary
- Add external `shared_proxy` network to `docker-compose.prod.yml`
- Frontend container joins both `default` and `shared_proxy` networks
- NPM (Nginx Proxy Manager) also joins `shared_proxy`, ensuring connectivity survives stack redeploys

## Context
Currently, NPM is manually connected to `aprender_prod_default` network via Portainer. When the stack is redeployed, this connection can be lost, causing the site to go down with 504 errors until manually reconnected.

With an external shared network, both stacks declare the same network and Docker maintains the connectivity automatically.

## Setup required on VM01 (one-time)
```bash
docker network create shared_proxy
```
Then update NPM's compose to also use `shared_proxy` network.

## Test plan
- [ ] CI checks pass
- [ ] Create `shared_proxy` network on VM01
- [ ] Update Portainer stack and NPM compose
- [ ] Verify site works after stack redeploy