### PR TITLE
fix(tests): stabilize test_config_get_endpoint for xdist

### DIFF
--- a/v2/backend/apps/core/tests/test_config_api.py
+++ b/v2/backend/apps/core/tests/test_config_api.py
@@ -72,6 +72,13 @@ def test_config_get_endpoint(client: APIClient, dat_user: Any) -> None:
     When: DAT user calls GET /api/config/
     Then: Response is 200 with default values
     """
+    # xdist safety: clear stale Config records and cache from parallel workers
+    Config.objects.all().delete()
+    from apps.core.services.config_service import bust_cfg
+
+    for key in ("availability", "gcal_sync", "session", "features"):
+        bust_cfg(key)
+
     client.force_authenticate(user=dat_user)
 
     url = reverse("core:config")


### PR DESCRIPTION
## Summary

- Clear stale `Config` records and cache at test start to prevent cross-worker contamination in xdist
- Root cause: `test_config_put_endpoint` in a parallel worker inserts Config rows (e.g., `TRAVEL_BUFFER_MINUTES=90`) that leak into `test_config_get_endpoint` which expects defaults (`120`)

## Evidence

xdist canary report (2026-03-12):
- 1/4 matrix runs failing
- Signature: `assert # == #` (count/value mismatch)
- Test: `test_config_get_endpoint`

## Test plan

- [ ] CI passes (lint + tests)
- [ ] xdist canary shows 0/4 failures on next run