### PR TITLE
feat(infra): staging gate — validação local pré-merge

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,6 +16,11 @@
 - [ ] Testes criados/ajustados para comportamento novo ou corrigido
 - [ ] Evidencias anexadas (logs, screenshots, outputs de teste) quando aplicavel
 
+## Staging Gate
+
+- [ ] `make staging-full` executado com sucesso (8/8 PASS)
+- [ ] Evidencia anexada no PR (trecho de log contendo "ALL 8 CHECKS PASSED")
+
 ## Validacoes
 
 - [ ] Checks `[required]` verdes (somente gates bloqueantes)

--- a/v2/infra/ENVIRONMENTS.md
+++ b/v2/infra/ENVIRONMENTS.md
@@ -73,7 +73,62 @@ make build-prod-image
 8. Em `staging/producao`, `docker-compose.override.yml` nao e aplicado.
 9. Em producao Golden Cloud (3-VMs), `docker-compose.prod.yml` usa DB/Redis externos (VM02/VM03); a stack da VM01 sobe `web/worker/beat/frontend`.
 
-## 5) Evidencias Minimas por Mudanca
+## 5) Staging Gate — Validacao Local Pre-Merge
+
+Pipeline local que builda imagens prod, sobe stack staging, roda smoke tests e reporta PASS/FAIL.
+Objetivo: validar Dockerfile.prod + integracao de servicos antes do merge.
+
+### Quick start
+
+```bash
+cd v2/infra
+make staging-full    # build → up → smoke test → teardown (trap EXIT)
+```
+
+### O que valida (8 checks)
+
+| # | Check | Endpoint/Comando | Criterio |
+| --- | ----- | ---------------- | -------- |
+| 1 | Backend readyz | `GET /api/readyz/` | HTTP 200 + `"healthy"` |
+| 2 | Backend version | `GET /api/version/` | HTTP 200 + version != "unknown" |
+| 3 | CSRF endpoint | `GET /api/csrf/` | HTTP 200 + `csrfToken` presente |
+| 4 | Auth pipeline | `POST /api/auth/login/` | HTTP 4xx (Django processa, nao 301) |
+| 5 | Celery worker | `celery inspect ping` | resposta `pong` (retry 12x) |
+| 6 | Celery beat | `compose ps` + `compose top` | container running + processo ativo |
+| 7 | Frontend HTTP | `GET /` (frontend) | HTTP 200 + `<div id="root"` |
+| 8 | Frontend health | `GET /health` (nginx) | HTTP 200 |
+
+### Portas (dev vs staging)
+
+| Servico | Dev | Staging |
+| ------- | --- | ------- |
+| Backend | 8002 | 18002 |
+| Frontend | 5173 | 15173 |
+| DB | 5434 | 15434 |
+| Redis | 6380 | 16380 |
+
+### Targets individuais
+
+```bash
+make staging-precheck   # valida suporte a !reset no compose
+make staging-build      # build imagens prod (backend + frontend)
+make staging-up         # sobe stack + migrations
+make staging-test       # roda smoke tests (pode rodar com stack ja up)
+make staging-down       # derruba stack + remove volumes
+```
+
+### Nota: X-Forwarded-Proto
+
+Staging roda com `DEBUG=0` e `SECURE_SSL_REDIRECT=1`. Todos os curls para o backend
+incluem `-H X-Forwarded-Proto:https` para evitar redirect 301.
+
+### Pre-requisitos
+
+- Docker Compose v2.24.6+ (suporte a `!reset`)
+- Git Bash (Windows) para execucao dos targets `staging-*`
+- Imagens devem ser buildadas localmente antes de `staging-up`
+
+## 6) Evidencias Minimas por Mudanca
 
 1. Comando executado e ambiente alvo.
 2. Resultado de `check-env-*`.

--- a/v2/infra/Makefile
+++ b/v2/infra/Makefile
@@ -8,7 +8,8 @@
 	check-env-dev up-dev health-dev down-dev \
 	check-env-staging pull-staging up-staging health-staging down-staging \
 	check-env-prod pull-prod up-prod health-prod down-prod \
-	check-env-prod-like pull-prod-like up-prod-like health-prod-like down-prod-like
+	check-env-prod-like pull-prod-like up-prod-like health-prod-like down-prod-like \
+	staging-precheck staging-build staging-up staging-test staging-down staging-full
 
 # Variáveis
 COMPOSE_FILE := docker-compose.yml
@@ -28,6 +29,15 @@ DEV_COMPOSE := docker compose --env-file $(ENV_FILE_DEV) -f $(COMPOSE_FILE) -f $
 STAGING_COMPOSE := docker compose --env-file $(ENV_FILE_STAGING) -f $(COMPOSE_FILE)
 PROD_COMPOSE := docker compose --env-file $(ENV_FILE_PROD) -f $(COMPOSE_PROD_FILE)
 PRODLIKE_COMPOSE := docker compose --env-file $(ENV_FILE_PRODLIKE) -f $(COMPOSE_PROD_FILE)
+
+# Staging Gate (local pre-merge validation)
+STAGING_TAG := staging-local
+GIT_SHA := $(shell git rev-parse --short HEAD)
+BUILD_DATE := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+COMPOSE_STAGING_GATE := docker-compose.staging-gate.yml
+STAGING_GATE_COMPOSE = IMAGE_TAG=$(STAGING_TAG) docker compose --env-file $(ENV_FILE_STAGING) -f $(COMPOSE_FILE) -f $(COMPOSE_STAGING_GATE)
+BACKEND_IMAGE := norjosamatheus/aprender-backend:$(STAGING_TAG)
+FRONTEND_IMAGE := norjosamatheus/aprender-frontend:$(STAGING_TAG)
 
 # ================================================================
 # Help
@@ -358,6 +368,69 @@ health:  ## Verificar health dos serviços
 stats:  ## Ver estatísticas de uso (CPU, memória)
 	@echo "📊 Estatísticas dos containers:"
 	docker stats --no-stream --format "table {{.Container}}\t{{.CPUPerc}}\t{{.MemUsage}}" $(shell $(DEV_COMPOSE) ps -q)
+
+# ================================================================
+# Staging Gate (Epic #838)
+# ================================================================
+# Local pre-merge validation: build prod images, run staging stack,
+# execute smoke tests. Run via Git Bash on Windows.
+# Transitório: usa docker-compose.staging-gate.yml com !reset para
+# remover volumes de dev do frontend. Solução estrutural: #857.
+# ================================================================
+
+staging-precheck: ## Validar compose com !reset override
+	@if ! IMAGE_TAG=$(STAGING_TAG) docker compose --env-file $(ENV_FILE_STAGING) \
+	    -f $(COMPOSE_FILE) -f $(COMPOSE_STAGING_GATE) config > /dev/null 2>&1; then \
+	  echo "❌ staging-precheck falhou: compose override com !reset não suportado ou inválido."; \
+	  echo "   Ação: atualize Docker Compose para versão com suporte a !reset (v2.24.6+)"; \
+	  echo "   ou aplique fallback de arquitetura (mover binds dev para docker-compose.override.yml)."; \
+	  exit 2; \
+	fi
+	@echo "✅ staging-precheck ok"
+
+staging-build: ## Build backend+frontend PROD images para staging gate
+	@echo "=============================================="
+	@echo "   STAGING GATE — Build"
+	@echo "=============================================="
+	@echo "🔨 [STAGING] building backend ($(BACKEND_IMAGE))..."
+	docker build -f $(DOCKERFILE_PROD) \
+	  --build-arg GIT_SHA=$(GIT_SHA) \
+	  --build-arg BUILD_DATE=$(BUILD_DATE) \
+	  --build-arg APP_VERSION=$(STAGING_TAG) \
+	  -t $(BACKEND_IMAGE) ..
+	@echo "🔨 [STAGING] building frontend ($(FRONTEND_IMAGE))..."
+	docker build -f ../frontend/Dockerfile.prod \
+	  -t $(FRONTEND_IMAGE) ../frontend
+	@echo "✅ [STAGING] build concluído"
+
+staging-up: staging-precheck ## Subir stack staging + migrations
+	@echo "🚀 [STAGING] subindo ambiente..."
+	@docker image inspect $(BACKEND_IMAGE) > /dev/null 2>&1 || \
+	  (echo "❌ Imagem backend não encontrada: $(BACKEND_IMAGE)"; echo "   Execute: make staging-build"; exit 1)
+	@docker image inspect $(FRONTEND_IMAGE) > /dev/null 2>&1 || \
+	  (echo "❌ Imagem frontend não encontrada: $(FRONTEND_IMAGE)"; echo "   Execute: make staging-build"; exit 1)
+	$(STAGING_GATE_COMPOSE) up -d --no-build
+	$(STAGING_GATE_COMPOSE) run --rm web python manage.py migrate --noinput
+	@echo "✅ [STAGING] ambiente pronto"
+	@echo "🌐 [STAGING] backend: http://localhost:18002"
+	@echo "🌐 [STAGING] frontend: http://localhost:15173"
+
+staging-test: ## Executar smoke tests no staging
+	@echo "=============================================="
+	@echo "   STAGING GATE — Smoke Tests"
+	@echo "=============================================="
+	@bash scripts/smoke_test_staging.sh
+
+staging-down: ## Derrubar stack staging (com volumes)
+	@echo "⏹️  [STAGING] derrubando ambiente..."
+	-$(STAGING_GATE_COMPOSE) down -v
+	@echo "✅ [STAGING] ambiente finalizado"
+
+staging-full: ## Pipeline completo: precheck → build → up → test → teardown
+	@echo "=============================================="
+	@echo "   STAGING GATE — Full Validation Pipeline"
+	@echo "=============================================="
+	@bash -lc 'set -euo pipefail; trap "$(MAKE) staging-down || true" EXIT; $(MAKE) staging-precheck && $(MAKE) staging-build && $(MAKE) staging-up && $(MAKE) staging-test'
 
 # ================================================================
 # Deploy

--- a/v2/infra/docker-compose.staging-gate.yml
+++ b/v2/infra/docker-compose.staging-gate.yml
@@ -1,0 +1,15 @@
+# ================================================================
+# Staging Gate Override
+# ================================================================
+# Remove dev volume mounts from frontend for prod-like fidelity.
+# Used by: make staging-* targets
+# Requires: Docker Compose with !reset support (v2.24.6+)
+#
+# Transitório: este override existe porque docker-compose.yml base
+# monta volumes de dev no frontend. A solução estrutural (#857) é
+# mover esses binds para docker-compose.override.yml (dev-only).
+# ================================================================
+
+services:
+  frontend:
+    volumes: !reset []

--- a/v2/infra/scripts/smoke_test_staging.sh
+++ b/v2/infra/scripts/smoke_test_staging.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+# ================================================================
+# smoke_test_staging.sh — Staging Gate Smoke Test (Epic #838)
+# ================================================================
+# 8 checks validating prod-like staging stack health.
+# Follows test_dr.sh patterns: colored output, numbered steps, exit codes.
+#
+# Usage:
+#   bash scripts/smoke_test_staging.sh          # from v2/infra/
+#   BACKEND_URL=http://localhost:18002 bash ...  # custom URLs
+#
+# Exit codes:
+#   0 - All checks passed
+#   1 - One or more checks failed
+#   2 - Configuration error
+# ================================================================
+
+set -euo pipefail
+
+# ── Paths ────────────────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INFRA_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# ── Configuration ────────────────────────────────────────────────
+BACKEND_URL="${BACKEND_URL:-http://localhost:18002}"
+FRONTEND_URL="${FRONTEND_URL:-http://localhost:15173}"
+MAX_WAIT="${MAX_WAIT:-120}"
+STAGING_TAG="${STAGING_TAG:-staging-local}"
+
+# Python interpreter (Windows has 'python', Linux has 'python3')
+PYTHON="${PYTHON:-$(command -v python3 2>/dev/null || command -v python 2>/dev/null || true)}"
+
+# Backend curl: -s silent, -f fail on HTTP errors, X-Forwarded-Proto for SECURE_SSL_REDIRECT
+BACKEND_CURL="curl -sf -H X-Forwarded-Proto:https"
+
+# ── Compose helper (anchored to INFRA_DIR) ───────────────────────
+compose_cmd() {
+  (
+    cd "${INFRA_DIR}"
+    IMAGE_TAG="${STAGING_TAG}" docker compose \
+      --env-file .env.staging \
+      -f docker-compose.yml \
+      -f docker-compose.staging-gate.yml \
+      "$@"
+  )
+}
+
+# ── Colors ───────────────────────────────────────────────────────
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+# ── State ────────────────────────────────────────────────────────
+TOTAL=8
+PASSED=0
+FAILED=0
+CHECK=0
+RESULTS=()
+
+# ── Helpers ──────────────────────────────────────────────────────
+pass() {
+  local label="$1"; shift
+  local detail="${1:-}"
+  PASSED=$((PASSED + 1))
+  CHECK=$((CHECK + 1))
+  if [ -n "$detail" ]; then
+    RESULTS+=("[${CHECK}/${TOTAL}] ${label}: ${GREEN}PASS${NC} (${detail})")
+  else
+    RESULTS+=("[${CHECK}/${TOTAL}] ${label}: ${GREEN}PASS${NC}")
+  fi
+}
+
+fail() {
+  local label="$1"; shift
+  local detail="${1:-}"
+  FAILED=$((FAILED + 1))
+  CHECK=$((CHECK + 1))
+  if [ -n "$detail" ]; then
+    RESULTS+=("[${CHECK}/${TOTAL}] ${label}: ${RED}FAIL${NC} (${detail})")
+  else
+    RESULTS+=("[${CHECK}/${TOTAL}] ${label}: ${RED}FAIL${NC}")
+  fi
+}
+
+# Retry helper: retry <max_attempts> <sleep_seconds> <command...>
+retry() {
+  local max="$1"; shift
+  local delay="$1"; shift
+  local attempt=1
+  while [ "$attempt" -le "$max" ]; do
+    if "$@" 2>/dev/null; then
+      return 0
+    fi
+    echo -e "  ${YELLOW}retry ${attempt}/${max}...${NC}"
+    sleep "$delay"
+    attempt=$((attempt + 1))
+  done
+  return 1
+}
+
+# ── Preflight ────────────────────────────────────────────────────
+if [ -z "$PYTHON" ]; then
+  echo -e "${RED}ERROR: python3 or python not found in PATH${NC}"
+  exit 2
+fi
+
+echo "=============================================="
+echo "   STAGING GATE SMOKE TEST"
+echo "=============================================="
+echo "Backend:  ${BACKEND_URL}"
+echo "Frontend: ${FRONTEND_URL}"
+echo "Tag:      ${STAGING_TAG}"
+echo ""
+
+# ── [1/8] Backend readiness ──────────────────────────────────────
+echo -n "[1/${TOTAL}] Backend readyz: waiting..."
+ELAPSED=0
+READY=false
+while [ "$ELAPSED" -lt "$MAX_WAIT" ]; do
+  BODY="$($BACKEND_CURL "${BACKEND_URL}/api/readyz/" 2>/dev/null || true)"
+  if echo "$BODY" | grep -q "healthy"; then
+    READY=true
+    break
+  fi
+  sleep 2
+  ELAPSED=$((ELAPSED + 2))
+  echo -n "."
+done
+echo ""
+
+if $READY; then
+  pass "Backend readyz"
+else
+  fail "Backend readyz" "not healthy after ${MAX_WAIT}s"
+fi
+
+# ── [2/8] Backend version ────────────────────────────────────────
+echo -n "[2/${TOTAL}] Backend version: "
+VERSION_BODY="$($BACKEND_CURL "${BACKEND_URL}/api/version/" 2>/dev/null || true)"
+if [ -n "$VERSION_BODY" ]; then
+  APP_VER="$($PYTHON -c "import json,sys; d=json.loads(sys.stdin.read()); print(d.get('version','unknown'))" <<< "$VERSION_BODY" 2>/dev/null || echo "unknown")"
+  GIT_SHA="$($PYTHON -c "import json,sys; d=json.loads(sys.stdin.read()); print(d.get('git_sha','unknown'))" <<< "$VERSION_BODY" 2>/dev/null || echo "unknown")"
+  if [ "$APP_VER" != "unknown" ]; then
+    pass "Backend version" "v=${APP_VER}, sha=${GIT_SHA}"
+  else
+    fail "Backend version" "version=unknown"
+  fi
+else
+  fail "Backend version" "no response"
+fi
+echo ""
+
+# ── [3/8] CSRF endpoint ─────────────────────────────────────────
+echo -n "[3/${TOTAL}] CSRF endpoint: "
+CSRF_BODY="$($BACKEND_CURL "${BACKEND_URL}/api/csrf/" 2>/dev/null || true)"
+if echo "$CSRF_BODY" | grep -q "csrfToken"; then
+  pass "CSRF endpoint"
+else
+  fail "CSRF endpoint" "csrfToken not found"
+fi
+echo ""
+
+# ── [4/8] Auth pipeline ─────────────────────────────────────────
+# NOTE: Does NOT use BACKEND_CURL (-f would fail on 4xx).
+# We expect Django to process the request and return 4xx (not 301 redirect).
+echo -n "[4/${TOTAL}] Auth pipeline: "
+AUTH_CODE="$(curl -sS -o /dev/null -w '%{http_code}' \
+  -H 'X-Forwarded-Proto: https' \
+  -X POST "${BACKEND_URL}/api/auth/login/" \
+  -H 'Content-Type: application/json' -d '{}' 2>/dev/null || echo "000")"
+if [ "$AUTH_CODE" -ge 400 ] 2>/dev/null && [ "$AUTH_CODE" -lt 500 ] 2>/dev/null; then
+  pass "Auth pipeline" "HTTP ${AUTH_CODE}"
+else
+  fail "Auth pipeline" "HTTP ${AUTH_CODE} (expected 4xx)"
+fi
+echo ""
+
+# ── [5/8] Celery worker ─────────────────────────────────────────
+echo -n "[5/${TOTAL}] Celery worker: "
+worker_ping() {
+  compose_cmd exec -T worker celery -A config inspect ping --timeout=10 2>/dev/null | grep -q "pong"
+}
+if retry 12 5 worker_ping; then
+  pass "Celery worker"
+else
+  fail "Celery worker" "no pong after 12 attempts"
+fi
+echo ""
+
+# ── [6/8] Celery beat ───────────────────────────────────────────
+echo -n "[6/${TOTAL}] Celery beat: "
+beat_check() {
+  # Container must be running
+  compose_cmd ps --status running beat 2>/dev/null | grep -q "beat" || return 1
+  # Process must be active (host-side inspection via compose top)
+  compose_cmd top beat 2>/dev/null | grep -qE "celery.*beat|celery -A config beat" || return 1
+  return 0
+}
+if retry 12 5 beat_check; then
+  pass "Celery beat"
+  # Complementary: show beat log tail as evidence
+  echo "  (beat logs):"
+  compose_cmd logs --tail=3 beat 2>/dev/null | sed 's/^/    /' || true
+else
+  fail "Celery beat" "not running after 12 attempts"
+fi
+echo ""
+
+# ── [7/8] Frontend HTTP ─────────────────────────────────────────
+echo -n "[7/${TOTAL}] Frontend HTTP: "
+FE_BODY="$(curl -sf "${FRONTEND_URL}/" 2>/dev/null || true)"
+if echo "$FE_BODY" | grep -q '<div id="root"'; then
+  pass "Frontend HTTP"
+else
+  fail "Frontend HTTP" "root div not found"
+fi
+echo ""
+
+# ── [8/8] Frontend health ────────────────────────────────────────
+echo -n "[8/${TOTAL}] Frontend health: "
+FE_HEALTH="$(curl -sf -o /dev/null -w '%{http_code}' "${FRONTEND_URL}/health" 2>/dev/null || echo "000")"
+if [ "$FE_HEALTH" = "200" ]; then
+  pass "Frontend health"
+else
+  fail "Frontend health" "HTTP ${FE_HEALTH}"
+fi
+echo ""
+
+# ── Results ──────────────────────────────────────────────────────
+echo ""
+echo "=============================================="
+echo "   STAGING GATE SMOKE TEST RESULTS"
+echo "=============================================="
+for LINE in "${RESULTS[@]}"; do
+  echo -e "$LINE"
+done
+echo ""
+
+if [ "$FAILED" -eq 0 ]; then
+  echo -e "${GREEN}ALL ${TOTAL} CHECKS PASSED${NC}"
+  echo "=============================================="
+  exit 0
+else
+  echo -e "${RED}${FAILED}/${TOTAL} CHECKS FAILED${NC}"
+  echo "=============================================="
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Implements **`make staging-full`** — a local pre-merge validation pipeline that builds prod Docker images, starts a staging stack, runs 8 smoke tests, and reports PASS/FAIL with guaranteed teardown via `trap EXIT`.

Part of epic #838.
Related to #857 (compose modularization), #854.

### What's included

- **`docker-compose.staging-gate.yml`** (#841): `volumes: !reset []` removes frontend dev mounts for prod-like fidelity. Transitório — a solução estrutural (#857) é mover binds para `docker-compose.override.yml`.
- **Makefile: 6 staging-* targets** (#839): `staging-precheck`, `staging-build`, `staging-up`, `staging-test`, `staging-down`, `staging-full`
- **`smoke_test_staging.sh`** (#840): 8 checks — backend readyz, version, CSRF, auth pipeline, Celery worker, Celery beat, frontend HTTP, frontend health
- **ENVIRONMENTS.md** (#843): Staging Gate Workflow section with quick start, checks table, ports, prerequisites
- **PR template** (#844): Staging gate checklist items

### Key design decisions

- All backend curls include `X-Forwarded-Proto: https` (staging runs `SECURE_SSL_REDIRECT=1`)
- Auth check (step 4) uses `curl -sS` (not `BACKEND_CURL` with `-f`) to allow 4xx responses
- Worker/beat checks use retry (12x, 5s) for async service startup
- Beat check uses `compose top` for deterministic host-side process inspection
- `compose_cmd()` is a bash function anchored to `INFRA_DIR` (works from any cwd)
- All `exec` commands use `-T` (no TTY — Git Bash + CI compatible)

### Closes

- #839 (Makefile targets)
- #840 (Smoke test script)
- #841 (Compose override)
- #843 (Documentation)
- #844 (PR template)

## Test plan

- [ ] `make staging-precheck` validates `!reset` support
- [ ] `make staging-full` completes with 8/8 PASS
- [ ] `make staging-down` is idempotent
- [ ] Frontend has no dev volume mounts: `docker compose ... config | grep -Ei "frontend([/\\])(src|public)"` returns 0 results
- [ ] All backend curls include `X-Forwarded-Proto` header
- [ ] All `exec` commands use `-T` flag