### PR TITLE
refactor(frontend): break Cadastros circular dependency

### DIFF
--- a/v2/frontend/src/pages/DATModule/Cadastros/columns.tsx
+++ b/v2/frontend/src/pages/DATModule/Cadastros/columns.tsx
@@ -13,40 +13,9 @@ import {
 import dayjs from 'dayjs';
 import { PLATAFORMAS } from './constants';
 import { renderStatusIcon, getStepStatus, getCurrentStep } from './helpers';
-import type { ID } from '../../../types';
+import type { CadastroRecord } from './types';
 
 const { Text } = Typography;
-
-/**
- * Cadastro record interface
- */
-export interface CadastroRecord {
-  id: ID;
-  projeto_geral_nome: string;
-  municipio_nome: string;
-  uf: string;
-  quantidade_alunos?: number;
-  quantidade_professores?: number;
-  quantidade_codigos?: number;
-  status_criacao_curso?: string;
-  data_criacao_curso?: string;
-  status_chaves?: string;
-  data_chaves?: string;
-  status_instrucoes?: string;
-  data_instrucoes?: string;
-  status_envio?: string;
-  data_envio?: string;
-  status_recebidos?: string;
-  quantidade_recebidos?: number;
-  status_validados?: string;
-  quantidade_validados?: number;
-  status_importados?: string;
-  quantidade_importados?: number;
-  link_planilha?: string;
-  link_plataforma?: string;
-  // Index signature for dynamic property access
-  [key: string]: unknown;
-}
 
 /**
  * Column handlers interface

--- a/v2/frontend/src/pages/DATModule/Cadastros/helpers.tsx
+++ b/v2/frontend/src/pages/DATModule/Cadastros/helpers.tsx
@@ -10,7 +10,7 @@ import {
   MinusCircleFilled,
 } from '@ant-design/icons';
 import type { Etapa } from './constants';
-import type { CadastroRecord } from './columns';
+import type { CadastroRecord } from './types';
 
 /**
  * Status type for workflow steps

--- a/v2/frontend/src/pages/DATModule/Cadastros/types.ts
+++ b/v2/frontend/src/pages/DATModule/Cadastros/types.ts
@@ -1,0 +1,36 @@
+/**
+ * Shared types for Cadastros page modules.
+ */
+
+import type { ID } from '../../../types';
+
+/**
+ * Cadastro record interface.
+ * Kept in a dedicated module to avoid circular imports between view helpers.
+ */
+export interface CadastroRecord {
+  id: ID;
+  projeto_geral_nome: string;
+  municipio_nome: string;
+  uf: string;
+  quantidade_alunos?: number;
+  quantidade_professores?: number;
+  quantidade_codigos?: number;
+  status_criacao_curso?: string;
+  data_criacao_curso?: string;
+  status_chaves?: string;
+  data_chaves?: string;
+  status_instrucoes?: string;
+  data_instrucoes?: string;
+  status_envio?: string;
+  data_envio?: string;
+  status_recebidos?: string;
+  quantidade_recebidos?: number;
+  status_validados?: string;
+  quantidade_validados?: number;
+  status_importados?: string;
+  quantidade_importados?: number;
+  link_planilha?: string;
+  link_plataforma?: string;
+  [key: string]: unknown;
+}


### PR DESCRIPTION
## Summary
- break circular import between columns.tsx and helpers.tsx in DAT Cadastros
- move shared CadastroRecord type to dedicated 	ypes.ts
- keep behavior unchanged (type-only refactor)

## Why
- removes a real frontend cycle detected by madge
- advances modularization epic by reducing cross-module coupling

## Validation
- 
px -y madge --extensions ts,tsx --circular src -> no cycles
- 
pm run lint
- 
pm run typecheck

## Scope notes
- CI architecture guardrails are tracked in #858 (this PR focuses on cycle removal only)

Related to #856
Related to #854