### PR TITLE
refactor(infra): move frontend dev binds to compose override

### DIFF
--- a/v2/infra/ENVIRONMENTS.md
+++ b/v2/infra/ENVIRONMENTS.md
@@ -72,6 +72,7 @@ make build-prod-image
 7. `staging` exige `IMAGE_TAG` explicita da release; em `producao` a stack opera com `IMAGE_TAG=latest` e promocao controlada por `promotion_tag` no workflow.
 8. Em `staging/producao`, `docker-compose.override.yml` nao e aplicado.
 9. Em producao Golden Cloud (3-VMs), `docker-compose.prod.yml` usa DB/Redis externos (VM02/VM03); a stack da VM01 sobe `web/worker/beat/frontend`.
+10. O `docker-compose.yml` base e prod-like: binds de codigo do frontend (`src/public`) ficam apenas no `docker-compose.override.yml` (dev-only).
 
 ## 5) Staging Gate — Validacao Local Pre-Merge
 

--- a/v2/infra/docker-compose.override.yml
+++ b/v2/infra/docker-compose.override.yml
@@ -45,3 +45,7 @@ services:
     build:
       context: ../frontend
       dockerfile: Dockerfile
+    volumes:
+      # Mount frontend code as read-only for hot reload in local dev
+      - ../frontend/src:/app/src:ro
+      - ../frontend/public:/app/public:ro

--- a/v2/infra/docker-compose.yml
+++ b/v2/infra/docker-compose.yml
@@ -171,9 +171,6 @@ services:
       PROXY_TARGET: http://web:8000 # Proxy server-side para o backend interno
     ports:
       - "${FRONTEND_HOST_PORT:-5173}:${FRONTEND_CONTAINER_PORT:-5173}"
-    volumes:
-      - ../frontend/src:/app/src:ro # Hot reload do código fonte
-      - ../frontend/public:/app/public:ro
     depends_on:
       - web
     healthcheck:


### PR DESCRIPTION
## Summary
- remove frontend source binds from `v2/infra/docker-compose.yml` base
- move frontend dev-only binds (`../frontend/src`, `../frontend/public`) to `v2/infra/docker-compose.override.yml`
- document compose policy in `v2/infra/ENVIRONMENTS.md`

## Why
- makes compose base prod-like and environment-neutral
- keeps hot-reload behavior only in local dev override
- reduces staging/prod coupling to development mounts

## Validation
- `cd v2/infra; IMAGE_TAG=dev-local docker compose --env-file .env.dev -f docker-compose.yml -f docker-compose.override.yml config`
- `cd v2/infra; IMAGE_TAG=staging-local docker compose --env-file .env.staging -f docker-compose.yml -f docker-compose.staging-gate.yml config`
- `rg -n ../frontend/(src|public) v2/infra/docker-compose.yml v2/infra/docker-compose.override.yml`
  - result: binds only in override

Closes #857
Related to #854