### PR TITLE
feat(core): motor de prazo com calendário útil BR/CE/Fortaleza (#870)

### DIFF
--- a/v2/backend/apps/core/models/acoes_notificacao.py
+++ b/v2/backend/apps/core/models/acoes_notificacao.py
@@ -301,18 +301,21 @@ class AcaoInstancia(models.Model):
         if self.estado == EstadoAcaoChoices.CONCLUIDA:
             raise ValidationError("Nao e permitido alterar ancora de acao concluida.")
 
-        if self.estado == EstadoAcaoChoices.AGUARDANDO_ANCORA:
-            self.estado = EstadoAcaoChoices.EM_ANDAMENTO
+        from apps.core.services.prazo_engine_service import PrazoEngineService
 
-        self.data_ancora = data_ancora
-        self.save(update_fields=["estado", "data_ancora", "updated_at"])
+        with transaction.atomic():
+            PrazoEngineService.recalculate_action(
+                self,
+                explicit_anchor_date=data_ancora,
+                save=True,
+            )
 
-        return RegistroAncora.objects.create(
-            acao_instancia=self,
-            data_ancora=data_ancora,
-            observacao=observacao,
-            registrado_por=usuario,
-        )
+            return RegistroAncora.objects.create(
+                acao_instancia=self,
+                data_ancora=data_ancora,
+                observacao=observacao,
+                registrado_por=usuario,
+            )
 
     def concluir(
         self,
@@ -329,6 +332,8 @@ class AcaoInstancia(models.Model):
             raise ValidationError({"observacao": "Observacao e obrigatoria para concluir a acao."})
 
         with transaction.atomic():
+            from apps.core.services.prazo_engine_service import PrazoEngineService
+
             self.estado = EstadoAcaoChoices.CONCLUIDA
             self.data_realizacao = data_realizacao
             self.observacao_conclusao = obs
@@ -348,12 +353,14 @@ class AcaoInstancia(models.Model):
             if RegistroConclusaoAcao.objects.filter(acao_instancia=self).exists():
                 raise ValidationError("Registro de conclusao ja existe para esta acao.")
 
-            return RegistroConclusaoAcao.objects.create(
+            registro = RegistroConclusaoAcao.objects.create(
                 acao_instancia=self,
                 data_realizacao=data_realizacao,
                 observacao=obs,
                 registrado_por=usuario,
             )
+            PrazoEngineService.recalculate_dependents(self)
+            return registro
 
 
 class RegistroAncora(models.Model):

--- a/v2/backend/apps/core/services/business_calendar_service.py
+++ b/v2/backend/apps/core/services/business_calendar_service.py
@@ -1,0 +1,105 @@
+"""
+Calendar service for business day calculations (issue #870).
+"""
+
+# pyright: reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from functools import lru_cache
+
+
+class BusinessCalendarService:
+    """
+    Handles business-day arithmetic for BR/CE/Fortaleza scope.
+    """
+
+    @staticmethod
+    def easter_sunday(year: int) -> date:
+        """
+        Computes Easter Sunday (Gregorian algorithm).
+        """
+        a = year % 19
+        b = year // 100
+        c = year % 100
+        d = b // 4
+        e = b % 4
+        f = (b + 8) // 25
+        g = (b - f + 1) // 3
+        h = (19 * a + b - d - g + 15) % 30
+        i = c // 4
+        k = c % 4
+        ell = (32 + 2 * e + 2 * i - h - k) % 7
+        m = (a + 11 * h + 22 * ell) // 451
+        month = (h + ell - 7 * m + 114) // 31
+        day = ((h + ell - 7 * m + 114) % 31) + 1
+        return date(year, month, day)
+
+    @classmethod
+    @lru_cache(maxsize=64)
+    def _base_holidays_for_year(cls, year: int) -> frozenset[date]:
+        easter = cls.easter_sunday(year)
+        good_friday = easter - timedelta(days=2)
+
+        # Feriados nacionais (Brasil)
+        national = {
+            date(year, 1, 1),  # Confraternizacao Universal
+            good_friday,  # Paixao de Cristo
+            date(year, 4, 21),  # Tiradentes
+            date(year, 5, 1),  # Dia do Trabalho
+            date(year, 9, 7),  # Independencia do Brasil
+            date(year, 10, 12),  # Nossa Senhora Aparecida
+            date(year, 11, 2),  # Finados
+            date(year, 11, 15),  # Proclamacao da Republica
+            date(year, 11, 20),  # Dia da Consciencia Negra (nacional)
+            date(year, 12, 25),  # Natal
+        }
+
+        # Feriados estaduais (Ceara)
+        ceara = {
+            date(year, 3, 19),  # Sao Jose
+            date(year, 3, 25),  # Data Magna do Ceara
+        }
+
+        # Feriados municipais (Fortaleza)
+        fortaleza = {
+            date(year, 4, 13),  # Aniversario de Fortaleza
+            date(year, 8, 15),  # Nossa Senhora da Assuncao
+            date(year, 12, 8),  # Nossa Senhora da Conceicao
+        }
+
+        return frozenset(national | ceara | fortaleza)
+
+    @classmethod
+    def get_holidays(cls, year: int, *, include_db: bool = True) -> set[date]:
+        holidays: set[date] = set(cls._base_holidays_for_year(year))
+        if not include_db:
+            return holidays
+
+        from apps.core.models import FeriadoLocal
+
+        custom_dates = FeriadoLocal.objects.filter(ativo=True, data__year=year).values_list("data", flat=True)
+        holidays.update(custom_dates)
+        return holidays
+
+    @classmethod
+    def is_business_day(cls, day: date, *, include_db: bool = True) -> bool:
+        if day.weekday() >= 5:
+            return False
+        return day not in cls.get_holidays(day.year, include_db=include_db)
+
+    @classmethod
+    def add_business_days(cls, anchor: date, days: int, *, include_db: bool = True) -> date:
+        if days < 0:
+            raise ValueError("days must be >= 0")
+        if days == 0:
+            return anchor
+
+        current = anchor
+        counted = 0
+        while counted < days:
+            current += timedelta(days=1)
+            if cls.is_business_day(current, include_db=include_db):
+                counted += 1
+        return current

--- a/v2/backend/apps/core/services/prazo_engine_service.py
+++ b/v2/backend/apps/core/services/prazo_engine_service.py
@@ -1,0 +1,175 @@
+"""
+Prazo engine for action instances (issue #870).
+"""
+
+# pyright: reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportAttributeAccessIssue=false
+
+from __future__ import annotations
+
+from datetime import date
+from typing import TYPE_CHECKING
+
+from django.db import transaction
+from django.utils import timezone
+
+from apps.core.models.acoes_notificacao import EstadoAcaoChoices, TipoAncoraChoices
+from apps.core.services.business_calendar_service import BusinessCalendarService
+
+if TYPE_CHECKING:
+    from apps.core.models import AcaoInstancia, CicloAcoes
+
+
+class PrazoEngineService:
+    """
+    Calculates anchor, due-date and operational state for actions.
+    """
+
+    SEMESTRE_ANCHOR_BY_CODE: dict[str, tuple[int, int]] = {
+        "1S": (3, 1),
+        "2S": (8, 1),
+    }
+
+    @classmethod
+    def semestre_anchor_date(cls, *, semestre: str, ano: int) -> date | None:
+        month_day = cls.SEMESTRE_ANCHOR_BY_CODE.get(semestre)
+        if month_day is None:
+            return None
+        month, day = month_day
+        return date(ano, month, day)
+
+    @classmethod
+    def resolve_anchor_date(
+        cls,
+        action_instance: "AcaoInstancia",
+        *,
+        explicit_anchor_date: date | None = None,
+    ) -> date | None:
+        if explicit_anchor_date is not None:
+            return explicit_anchor_date
+
+        template = action_instance.template
+        anchor_type = template.tipo_ancora
+
+        if anchor_type == TipoAncoraChoices.EVENTO_EXTERNO:
+            return action_instance.data_ancora
+
+        if anchor_type == TipoAncoraChoices.ACAO_ANTERIOR:
+            ref_template_id = template.ref_acao_template_id
+            if ref_template_id is None:
+                return None
+
+            from apps.core.models import AcaoInstancia
+
+            ref_action = AcaoInstancia.objects.filter(
+                ciclo_id=action_instance.ciclo_id,
+                template_id=ref_template_id,
+            ).first()
+            if ref_action is None:
+                return None
+            return ref_action.data_realizacao
+
+        if anchor_type == TipoAncoraChoices.MARCO_CALENDARIO:
+            return cls.semestre_anchor_date(
+                semestre=action_instance.ciclo.semestre,
+                ano=action_instance.ciclo.ano,
+            )
+
+        return None
+
+    @classmethod
+    def calculate_due_date(cls, *, anchor_date: date, business_days: int) -> date:
+        return BusinessCalendarService.add_business_days(anchor_date, business_days)
+
+    @classmethod
+    def evaluate_state(
+        cls,
+        action_instance: "AcaoInstancia",
+        *,
+        reference_date: date | None = None,
+    ) -> str:
+        if action_instance.estado == EstadoAcaoChoices.CONCLUIDA:
+            return EstadoAcaoChoices.CONCLUIDA
+
+        if action_instance.data_ancora is None or action_instance.data_vencimento is None:
+            return EstadoAcaoChoices.AGUARDANDO_ANCORA
+
+        today = reference_date or timezone.localdate()
+        if today > action_instance.data_vencimento:
+            return EstadoAcaoChoices.ATRASADA
+        return EstadoAcaoChoices.EM_ANDAMENTO
+
+    @classmethod
+    def recalculate_action(
+        cls,
+        action_instance: "AcaoInstancia",
+        *,
+        explicit_anchor_date: date | None = None,
+        reference_date: date | None = None,
+        save: bool = True,
+    ) -> "AcaoInstancia":
+        resolved_anchor = cls.resolve_anchor_date(
+            action_instance,
+            explicit_anchor_date=explicit_anchor_date,
+        )
+
+        if resolved_anchor is None:
+            action_instance.data_ancora = None
+            action_instance.data_vencimento = None
+        else:
+            action_instance.data_ancora = resolved_anchor
+            action_instance.data_vencimento = cls.calculate_due_date(
+                anchor_date=resolved_anchor,
+                business_days=action_instance.template.dias_prazo_uteis,
+            )
+
+        if action_instance.estado != EstadoAcaoChoices.CONCLUIDA:
+            action_instance.estado = cls.evaluate_state(
+                action_instance,
+                reference_date=reference_date,
+            )
+
+        if save:
+            update_fields = [
+                "data_ancora",
+                "data_vencimento",
+                "updated_at",
+            ]
+            if action_instance.estado != EstadoAcaoChoices.CONCLUIDA:
+                update_fields.append("estado")
+            action_instance.save(update_fields=update_fields)
+
+        return action_instance
+
+    @classmethod
+    def recalculate_cycle(
+        cls,
+        ciclo: "CicloAcoes",
+        *,
+        reference_date: date | None = None,
+    ) -> None:
+        from apps.core.models import AcaoInstancia
+
+        actions = AcaoInstancia.objects.select_related("template", "ciclo").filter(ciclo=ciclo).order_by("ordem")
+        with transaction.atomic():
+            for action in actions:
+                cls.recalculate_action(action, reference_date=reference_date, save=True)
+
+    @classmethod
+    def recalculate_dependents(
+        cls,
+        source_action: "AcaoInstancia",
+        *,
+        reference_date: date | None = None,
+    ) -> int:
+        from apps.core.models import AcaoInstancia
+
+        dependents = AcaoInstancia.objects.select_related("template", "ciclo").filter(
+            ciclo_id=source_action.ciclo_id,
+            template__ref_acao_template_id=source_action.template_id,
+        )
+        updated = 0
+        with transaction.atomic():
+            for action in dependents:
+                cls.recalculate_action(action, reference_date=reference_date, save=True)
+                updated += 1
+        return updated

--- a/v2/backend/apps/core/tests/test_business_calendar_service.py
+++ b/v2/backend/apps/core/tests/test_business_calendar_service.py
@@ -1,0 +1,53 @@
+"""
+Tests for BusinessCalendarService (issue #870).
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportOptionalMemberAccess=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportMissingTypeArgument=false, reportCallIssue=false, reportIndexIssue=false, reportOperatorIssue=false, reportOptionalSubscript=false, reportUnknownLambdaType=false
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from apps.core.models import FeriadoLocal
+from apps.core.services.business_calendar_service import BusinessCalendarService
+
+
+@pytest.mark.django_db
+def test_is_business_day_false_for_weekend():
+    assert BusinessCalendarService.is_business_day(date(2026, 3, 14)) is False  # Saturday
+    assert BusinessCalendarService.is_business_day(date(2026, 3, 15)) is False  # Sunday
+
+
+@pytest.mark.django_db
+def test_is_business_day_false_for_national_holiday():
+    # Dia da Consciencia Negra (nacional)
+    assert BusinessCalendarService.is_business_day(date(2026, 11, 20)) is False
+
+
+@pytest.mark.django_db
+def test_holidays_include_ce_and_fortaleza():
+    holidays = BusinessCalendarService.get_holidays(2026)
+    assert date(2026, 3, 19) in holidays  # Sao Jose (CE)
+    assert date(2026, 3, 25) in holidays  # Data Magna (CE)
+    assert date(2026, 4, 13) in holidays  # Aniversario de Fortaleza
+
+
+@pytest.mark.django_db
+def test_add_business_days_skips_weekend_and_holiday():
+    # 19/03 (feriado CE) e fim de semana devem ser ignorados.
+    due = BusinessCalendarService.add_business_days(date(2026, 3, 18), 2)
+    assert due == date(2026, 3, 23)
+
+
+@pytest.mark.django_db
+def test_custom_feriado_local_affects_due_date():
+    FeriadoLocal.objects.create(
+        data=date(2026, 3, 20),
+        nome="Feriado de Teste",
+        abrangencia="MUNICIPAL_FORTALEZA",
+        ativo=True,
+    )
+    due = BusinessCalendarService.add_business_days(date(2026, 3, 18), 1)
+    assert due == date(2026, 3, 23)

--- a/v2/backend/apps/core/tests/test_prazo_engine_service.py
+++ b/v2/backend/apps/core/tests/test_prazo_engine_service.py
@@ -1,0 +1,173 @@
+"""
+Tests for PrazoEngineService (issue #870).
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportOptionalMemberAccess=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportMissingTypeArgument=false, reportCallIssue=false, reportIndexIssue=false, reportOperatorIssue=false, reportOptionalSubscript=false, reportUnknownLambdaType=false
+
+from __future__ import annotations
+
+from datetime import date
+
+from django.utils import timezone
+
+import pytest
+
+from apps.core.models import AcaoInstancia, AcaoTemplate, CicloAcoes, Municipio, Projeto, Usuario
+from apps.core.services.prazo_engine_service import PrazoEngineService
+
+
+@pytest.fixture
+def usuario(db):
+    return Usuario.objects.create_user(
+        username="prazo_user",
+        email="prazo_user@example.com",
+        password="testpass123",
+        cpf="12312312312",
+    )
+
+
+@pytest.fixture
+def ciclo(db, usuario):
+    projeto = Projeto.objects.create(nome="Projeto Prazo Engine")
+    municipio = Municipio.objects.create(nome="Municipio Prazo Engine", uf="CE")
+    return CicloAcoes.objects.create(
+        projeto=projeto,
+        municipio=municipio,
+        semestre="1S",
+        ano=2026,
+        created_by=usuario,
+    )
+
+
+@pytest.fixture
+def template_evento(db):
+    return AcaoTemplate.objects.create(
+        ordem=201,
+        nome="Acao Evento Externo",
+        descricao_prazo="Teste prazo 2 dias uteis",
+        tipo_ancora="EVENTO_EXTERNO",
+        ref_evento_externo="EVENTO_TESTE",
+        dias_prazo_uteis=2,
+    )
+
+
+@pytest.fixture
+def acao_evento(ciclo, template_evento):
+    return AcaoInstancia.objects.create(
+        ciclo=ciclo,
+        template=template_evento,
+        ordem=201,
+        estado="AGUARDANDO_ANCORA",
+    )
+
+
+@pytest.mark.django_db
+def test_recalculate_without_anchor_keeps_aguardando(acao_evento):
+    PrazoEngineService.recalculate_action(acao_evento)
+    acao_evento.refresh_from_db()
+    assert acao_evento.estado == "AGUARDANDO_ANCORA"
+    assert acao_evento.data_ancora is None
+    assert acao_evento.data_vencimento is None
+
+
+@pytest.mark.django_db
+def test_recalculate_with_explicit_anchor_sets_due_and_em_andamento(acao_evento):
+    PrazoEngineService.recalculate_action(
+        acao_evento,
+        explicit_anchor_date=date(2026, 3, 16),
+        reference_date=date(2026, 3, 17),
+    )
+    acao_evento.refresh_from_db()
+    assert acao_evento.data_ancora == date(2026, 3, 16)
+    assert acao_evento.data_vencimento == date(2026, 3, 18)
+    assert acao_evento.estado == "EM_ANDAMENTO"
+
+
+@pytest.mark.django_db
+def test_marks_atrasada_when_reference_date_after_due(acao_evento):
+    PrazoEngineService.recalculate_action(
+        acao_evento,
+        explicit_anchor_date=date(2026, 3, 16),
+        reference_date=date(2026, 3, 21),
+    )
+    acao_evento.refresh_from_db()
+    assert acao_evento.estado == "ATRASADA"
+
+
+@pytest.mark.django_db
+def test_action_anterior_uses_previous_action_completion(ciclo, usuario):
+    template_a = AcaoTemplate.objects.create(
+        ordem=202,
+        nome="Acao Base",
+        descricao_prazo="Sem prazo relevante",
+        tipo_ancora="EVENTO_EXTERNO",
+        ref_evento_externo="EVENTO_BASE",
+        dias_prazo_uteis=1,
+    )
+    template_b = AcaoTemplate.objects.create(
+        ordem=203,
+        nome="Acao Dependente",
+        descricao_prazo="2 dias apos acao anterior",
+        tipo_ancora="ACAO_ANTERIOR",
+        ref_acao_template=template_a,
+        dias_prazo_uteis=2,
+    )
+
+    acao_a = AcaoInstancia.objects.create(ciclo=ciclo, template=template_a, ordem=202, estado="AGUARDANDO_ANCORA")
+    acao_b = AcaoInstancia.objects.create(ciclo=ciclo, template=template_b, ordem=203, estado="AGUARDANDO_ANCORA")
+
+    PrazoEngineService.recalculate_action(acao_b)
+    acao_b.refresh_from_db()
+    assert acao_b.estado == "AGUARDANDO_ANCORA"
+    assert acao_b.data_ancora is None
+
+    acao_a.registrar_ancora(data_ancora=timezone.localdate(), usuario=usuario, observacao="ancora base")
+    acao_a.concluir(
+        data_realizacao=timezone.localdate(),
+        observacao="base concluida",
+        usuario=usuario,
+    )
+    acao_b.refresh_from_db()
+
+    assert acao_b.data_ancora == timezone.localdate()
+    assert acao_b.data_vencimento is not None
+    assert acao_b.estado in {"EM_ANDAMENTO", "ATRASADA"}
+
+
+@pytest.mark.django_db
+def test_marco_calendario_uses_semestre_anchor(ciclo):
+    template = AcaoTemplate.objects.create(
+        ordem=204,
+        nome="Acao Marco Calendario",
+        descricao_prazo="1 dia util apos inicio semestre",
+        tipo_ancora="MARCO_CALENDARIO",
+        ref_evento_externo="INICIO_SEMESTRE",
+        dias_prazo_uteis=1,
+    )
+    action = AcaoInstancia.objects.create(
+        ciclo=ciclo,
+        template=template,
+        ordem=204,
+        estado="AGUARDANDO_ANCORA",
+    )
+
+    PrazoEngineService.recalculate_action(
+        action,
+        reference_date=date(2026, 3, 1),
+    )
+    action.refresh_from_db()
+    assert action.data_ancora == date(2026, 3, 1)
+    assert action.data_vencimento == date(2026, 3, 2)
+    assert action.estado == "EM_ANDAMENTO"
+
+
+@pytest.mark.django_db
+def test_registrar_ancora_recalculates_due_immediately(acao_evento, usuario):
+    acao_evento.registrar_ancora(
+        data_ancora=date(2026, 3, 16),
+        usuario=usuario,
+        observacao="registro manual",
+    )
+    acao_evento.refresh_from_db()
+    assert acao_evento.data_vencimento == date(2026, 3, 18)
+    assert acao_evento.estado == "EM_ANDAMENTO"


### PR DESCRIPTION
## Summary
- adiciona BusinessCalendarService para cálculo de dias úteis
- inclui base anual de feriados nacionais (BR), estaduais (CE) e municipais (Fortaleza)
- combina base anual com FeriadoLocal ativo no banco
- adiciona PrazoEngineService para resolver âncora, calcular vencimento e estado (AGUARDANDO_ANCORA, EM_ANDAMENTO, ATRASADA, CONCLUIDA)
- integra recálculo imediato no egistrar_ancora
- integra recálculo de ações dependentes (ACAO_ANTERIOR) após concluir

## Aceite #870 coberto
- sem âncora: ação não entra em atraso
- registro de âncora recalcula vencimento imediatamente
- cálculo consistente em fins de semana e feriados
- suporte aos tipos de âncora: evento externo, ação anterior e marco de calendário

## Arquivos
- 2/backend/apps/core/services/business_calendar_service.py
- 2/backend/apps/core/services/prazo_engine_service.py
- 2/backend/apps/core/models/acoes_notificacao.py
- 2/backend/apps/core/tests/test_business_calendar_service.py
- 2/backend/apps/core/tests/test_prazo_engine_service.py

## Validação (Docker)
- lack --check (escopo alterado)
- isort --check-only (escopo alterado)
- lake8 (escopo alterado)
- pyright (escopo alterado)
- python manage.py makemigrations --check
- pytest -q apps/core/tests/test_business_calendar_service.py apps/core/tests/test_prazo_engine_service.py apps/core/tests/test_acoes_notificacao_models.py
- pytest -q apps/core/tests/test_seed_acoes_notificacao.py apps/core/tests/test_rbac_permissions.py apps/dev_tools/tests/test_seed_e2e_users.py apps/dev_tools/tests/test_seed_frontend_contract_data.py apps/dat_ingest/tests/test_etl_commands_coverage.py::TestBackfillUserGroups::test_error_when_groups_missing

Resultados:
- 17 passed (suite de prazo/calendário/models)
- 28 passed (regressão dirigida core/dev_tools/ingest)

Closes #870