### PR TITLE
chore(config): rename startup message

### DIFF
--- a/v2/backend/config/settings.py
+++ b/v2/backend/config/settings.py
@@ -34,7 +34,7 @@ DEBUG = os.getenv("DEBUG", "0") == "1"
 # Detect if running under pytest (for disabling debug toolbar during tests)
 TESTING = "pytest" in sys.modules or "PYTEST_CURRENT_TEST" in os.environ
 
-print("AS v2 inicializado; legado arquivado e bloqueado")
+print("Aprender Sistema Inicializado")
 # ================================================================
 # SECRET KEY
 # ================================================================


### PR DESCRIPTION
## Summary
- Rename startup print from `AS v2 inicializado; legado arquivado e bloqueado` to `Aprender Sistema Inicializado`

## Test plan
- [ ] `docker exec aprender_prod-web-1 python -c "import config.settings"` shows new message