### PR TITLE
ci/security: migrate Safety step to modern scan command (#892)

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -49,12 +49,32 @@ jobs:
 
       - name: Install security tools
         run: |
-          pip install safety bandit pip-audit
+          pip install "safety>=3,<4" bandit pip-audit
 
-      - name: Run Safety (CVE check)
+      - name: Run Safety scan (modern CLI, complementary)
+        env:
+          SAFETY_API_KEY: ${{ secrets.SAFETY_API_KEY }}
         run: |
+          set -euo pipefail
           cd v2/backend
-          safety check -r requirements.txt --output json > safety-report.json
+
+          if [ -n "${SAFETY_API_KEY:-}" ]; then
+            set +e
+            safety --key "$SAFETY_API_KEY" scan --target . --output json > safety-report.json
+            safety_exit=$?
+            set -e
+
+            if [ "$safety_exit" -ne 0 ]; then
+              echo "Safety scan exit=${safety_exit}; pip-audit remains the blocking CVE gate."
+            fi
+          else
+            printf '%s\n' '{"tool":"safety","mode":"scan","status":"skipped","reason":"SAFETY_API_KEY not configured"}' > safety-report.json
+            echo "Safety scan skipped: SAFETY_API_KEY not configured. pip-audit remains blocking."
+          fi
+
+          if [ ! -s safety-report.json ]; then
+            printf '%s\n' '{"tool":"safety","mode":"scan","status":"error","reason":"empty report output"}' > safety-report.json
+          fi
 
       - name: Run pip-audit (PyPI Advisory Database)
         run: |

--- a/v2/docs/plans/2026-03-09_simplificacao-pipeline-deploy.md
+++ b/v2/docs/plans/2026-03-09_simplificacao-pipeline-deploy.md
@@ -47,7 +47,7 @@ código → PR → merge main
 | `ci.yaml` | push/PR | Testes, lint, coverage | ✅ Manter |
 | `release.yaml` | workflow_dispatch | Build + push + deploy | ❌ Deprecar |
 | `dockerhub-rebuild.yml` | cron semanal + dispatch | Rebuild security + push | ❌ Deprecar |
-| `security-scan.yml` | push/PR/cron | Safety, Trivy, Bandit, Gitleaks, TruffleHog | ✅ Manter |
+| `security-scan.yml` | push/PR/cron | Safety scan (CLI v3), pip-audit, Trivy, Bandit, Gitleaks, TruffleHog | ✅ Manter |
 | `strict-security-headers.yml` | cron diário | Playwright headers check | ✅ Manter |
 | `dependency-review-scorecard.yml` | PR | Dependency review + OpenSSF | ✅ Manter |
 | `docs.yml` | - | Documentação | ✅ Manter |
@@ -202,7 +202,7 @@ código → PR → CI (ci.yaml) → merge main
 
 **Escopo**: Deprecar **apenas** esses dois workflows. Manter intactos:
 
-- `security-scan.yml` (Safety, Trivy, Bandit, Gitleaks, TruffleHog)
+- `security-scan.yml` (Safety scan CLI v3 + pip-audit, Trivy, Bandit, Gitleaks, TruffleHog)
 - `strict-security-headers.yml` (Playwright headers)
 - `dependency-review-scorecard.yml` (Dependency review + OpenSSF)
 - Todos os demais workflows existentes


### PR DESCRIPTION
﻿## Summary
- migrate Python security workflow from legacy `safety check` to modern `safety scan` (CLI v3)
- keep `pip-audit` as deterministic blocking CVE gate
- keep Safety as complementary scanner with artifact output even when API key is not configured
- update CI/CD pipeline documentation to reflect `safety scan + pip-audit`

## Changes
- `.github/workflows/security-scan.yml`
  - install `safety>=3,<4`
  - replace legacy step with `safety scan --target . --output json`
  - add non-interactive CI behavior:
    - uses `SAFETY_API_KEY` when available
    - writes structured fallback JSON when key is missing
    - guarantees `safety-report.json` is always present for artifact upload
- `v2/docs/plans/2026-03-09_simplificacao-pipeline-deploy.md`
  - update workflow inventory and scope text to reflect the new scanner model

## Why
Issue #892 requests removal of deprecated/legacy Safety usage while preserving a sustainable, deterministic required gate. This change keeps blocking behavior on `pip-audit` and keeps Safety as a complementary report source.

## Validation
- workflow YAML parsed successfully with `yq`
- `actionlint` run still reports pre-existing shellcheck style/info warnings elsewhere in the same workflow (no new syntax errors introduced by this change)

Closes #892
