### PR TITLE
ci/backend: alinhar tooling do docker parity ao requirements (remove hardcode)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -599,14 +599,11 @@ jobs:
           aprender-backend:ci-parity-${{ github.sha }} \
           bash -lc '
             set -euo pipefail
-            pip install --no-cache-dir \
-              pytest==8.3.2 \
-              pytest-django==4.8.0 \
-              black==24.8.0 \
-              isort==5.13.2 \
-              flake8==7.1.1 \
-              faker==28.4.1 \
-              factory-boy==3.3.1
+            # Use project baseline to avoid CI drift with hardcoded tool versions.
+            pip install --no-cache-dir -r requirements.txt
+            if [ -f requirements-dev.txt ]; then
+              pip install --no-cache-dir -r requirements-dev.txt
+            fi
             black --check apps/core/auth_backends.py apps/core/models/__init__.py
             isort --check-only apps/core/auth_backends.py
             flake8 apps/core/auth_backends.py


### PR DESCRIPTION
## Objetivo
Alinhar o job docker-parity-backend ao baseline real do projeto, removendo versões hardcoded de ferramentas no CI.

## O que mudou
- Remove instalação fixa de pytest, pytest-django, lack, isort, lake8, aker, actory-boy no container de parity.
- Passa a instalar via:
  - pip install -r requirements.txt
  - pip install -r requirements-dev.txt (quando existir)

## Benefício
- Evita drift entre CI e ambiente real do backend.
- Reduz manutenção manual de versões duplicadas no workflow.

Closes #894