### PR TITLE
ci/security: completar pinagem SHA nos workflows críticos de PR

### DIFF
--- a/.github/workflows/agent-browser-smoke.yml
+++ b/.github/workflows/agent-browser-smoke.yml
@@ -1,4 +1,4 @@
-name: agent-browser-smoke
+﻿name: agent-browser-smoke
 
 on:
   pull_request:
@@ -28,10 +28,10 @@ jobs:
         working-directory: v2/frontend
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Node.js 20.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20.x"
           cache: "npm"
@@ -81,7 +81,7 @@ jobs:
           fi
 
       - name: Upload agent-browser artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: agent-browser-smoke-results

--- a/.github/workflows/backend-xdist-canary.yml
+++ b/.github/workflows/backend-xdist-canary.yml
@@ -1,4 +1,4 @@
-name: Backend xdist Canary (non-blocking)
+﻿name: Backend xdist Canary (non-blocking)
 
 on:
   schedule:
@@ -62,10 +62,10 @@ jobs:
           - 6379:6379
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
           cache: "pip"
@@ -165,7 +165,7 @@ jobs:
 
       - name: Upload xdist canary artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: xdist-canary-${{ matrix.workers }}w-${{ matrix.dist }}
           path: |
@@ -183,15 +183,15 @@ jobs:
     if: always()
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
       - name: Download xdist canary artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: xdist-canary-*
           path: xdist-canary-artifacts
@@ -205,7 +205,7 @@ jobs:
 
       - name: Upload consolidated report artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: xdist-canary-report
           path: |

--- a/.github/workflows/ci-runtime-telemetry.yml
+++ b/.github/workflows/ci-runtime-telemetry.yml
@@ -1,4 +1,4 @@
-name: CI Runtime Telemetry
+﻿name: CI Runtime Telemetry
 
 on:
   schedule:
@@ -21,10 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
@@ -48,7 +48,7 @@ jobs:
 
       - name: Upload telemetry artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ci-runtime-telemetry
           path: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: CI – Continuous Integration
+﻿name: CI – Continuous Integration
 
 on:
   push:
@@ -30,7 +30,7 @@ jobs:
       changed_files_count: ${{ steps.detect.outputs.changed_files_count }}
       backend_changed_count: ${{ steps.detect.outputs.backend_changed_count }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         fetch-depth: 0
 
@@ -112,10 +112,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
           cache: 'pip'
@@ -175,10 +175,10 @@ jobs:
           - 6379:6379
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Set up Python 3.12
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: '3.12'
         cache: 'pip'
@@ -262,7 +262,7 @@ jobs:
 
     - name: Upload core coverage artifact
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: backend-coverage-core
         path: v2/backend/.coverage.core
@@ -306,10 +306,10 @@ jobs:
           - 6379:6379
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Set up Python 3.12
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: '3.12'
         cache: 'pip'
@@ -384,7 +384,7 @@ jobs:
 
     - name: Upload ingest/devtools coverage artifact
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: backend-coverage-ingest-devtools
         path: v2/backend/.coverage.ingest_devtools
@@ -405,10 +405,10 @@ jobs:
       - backend-tests-ingest-devtools
     if: always() && needs.backend-impact.outputs.backend_changed == 'true'
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Set up Python 3.12
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: '3.12'
         cache: 'pip'
@@ -435,7 +435,7 @@ jobs:
         echo "Split backend test jobs passed."
 
     - name: Download backend coverage artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       with:
         pattern: backend-coverage-*
         path: /tmp/backend-coverage
@@ -469,7 +469,7 @@ jobs:
         } >> "${GITHUB_STEP_SUMMARY}"
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
       with:
         file: ./v2/backend/coverage.xml
         flags: backend
@@ -490,10 +490,10 @@ jobs:
       - backend-impact
     if: needs.backend-impact.outputs.backend_changed == 'true'
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Set up Python 3.12
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: '3.12'
         cache: 'pip'
@@ -556,7 +556,7 @@ jobs:
           - 6379:6379
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Build backend image (Dockerfile.prod)
       run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-name: Documentation
+﻿name: Documentation
 
 on:
   push:
@@ -37,15 +37,15 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
 
       - name: Cache pip dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-docs-${{ hashFiles('requirements-docs.txt') }}

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,4 +1,4 @@
-name: frontend-ci
+﻿name: frontend-ci
 
 on:
   push:
@@ -31,7 +31,7 @@ jobs:
     timeout-minutes: 12
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         # React Doctor gate here runs full score mode (no git diff analysis),
         # so shallow checkout is enough and faster.
@@ -39,7 +39,7 @@ jobs:
         fetch-depth: 1
 
     - name: Setup Node.js 20.x
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version: '20.x'
         cache: 'npm'
@@ -64,10 +64,10 @@ jobs:
         working-directory: v2/frontend
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Setup Node.js 20.x
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version: '20.x'
         cache: 'npm'
@@ -89,7 +89,7 @@ jobs:
       run: npm run size
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: frontend-build
         path: v2/frontend/dist
@@ -111,10 +111,10 @@ jobs:
         working-directory: v2/frontend
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Setup Node.js 20.x
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version: '20.x'
         cache: 'npm'
@@ -194,7 +194,7 @@ jobs:
       run: IMAGE_TAG=latest docker compose -f v2/infra/docker-compose.yml -f v2/infra/docker-compose.override.yml down -v || true
 
     - name: Upload test results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       if: always()
       with:
         name: checklist-test-results
@@ -215,10 +215,10 @@ jobs:
         working-directory: v2/frontend
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Setup Node.js 20.x
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version: '20.x'
         cache: 'npm'
@@ -229,7 +229,7 @@ jobs:
 
     - name: Setup Chrome
       id: setup-chrome
-      uses: browser-actions/setup-chrome@v1
+      uses: browser-actions/setup-chrome@c785b87e244131f27c9f19c1a33e2ead956ab7ce # v1
       with:
         chrome-version: stable
 
@@ -237,7 +237,7 @@ jobs:
       run: ${{ steps.setup-chrome.outputs.chrome-path }} --version
 
     - name: Download build artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       with:
         name: frontend-build
         path: v2/frontend/dist
@@ -250,7 +250,7 @@ jobs:
       continue-on-error: true
 
     - name: Upload Lighthouse results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       if: always()
       with:
         name: lighthouse-results

--- a/.github/workflows/strict-security-headers.yml
+++ b/.github/workflows/strict-security-headers.yml
@@ -1,4 +1,4 @@
-name: Strict Security Headers
+﻿name: Strict Security Headers
 
 on:
   workflow_dispatch:
@@ -29,7 +29,7 @@ jobs:
         working-directory: v2/frontend
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Resolve target URL
       id: target
@@ -66,7 +66,7 @@ jobs:
 
     - name: Setup Node.js 20.x
       if: steps.target.outputs.skip_run != '1'
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version: '20.x'
         cache: 'npm'
@@ -90,7 +90,7 @@ jobs:
         STRICT_SECURITY_HEADERS: '1'
 
     - name: Upload strict security headers artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       if: always() && steps.target.outputs.skip_run != '1'
       with:
         name: strict-security-headers-results

--- a/v2/docs/plans/PLAN_ci_security_hardening_2026-02-23.md
+++ b/v2/docs/plans/PLAN_ci_security_hardening_2026-02-23.md
@@ -141,7 +141,27 @@ Critério de aceite:
 
 ---
 
-## 5) Referências
+## 5) Política de Pinagem SHA em Workflows (Issue #895)
+
+Regra operacional:
+- Em workflows de PR críticos, toda action externa deve usar pinagem por commit SHA (`owner/action@<40-hex>`).
+- O comentário da linha deve manter a tag humana de referência (`# v4`, `# v5`, etc.) para facilitar auditoria.
+- Não usar tags móveis (`@v4`, `@v5`, `@main`) em workflows protegidos por ruleset.
+
+Processo de atualização:
+1. Abrir PR dedicado de manutenção (sem misturar com feature).
+2. Atualizar SHAs somente após validar release/tag upstream.
+3. Executar auditoria local antes do PR:
+   - `rg --line-number "uses:\\s*[^#\\n]+@v[0-9]" .github/workflows/ci.yaml .github/workflows/frontend-ci.yml .github/workflows/docs.yml .github/workflows/strict-security-headers.yml .github/workflows/agent-browser-smoke.yml .github/workflows/backend-xdist-canary.yml .github/workflows/ci-runtime-telemetry.yml`
+4. Exigir CI verde completo e merge squash.
+
+Cadência:
+- Revisão mensal de SHAs em workflows críticos.
+- Revisão extraordinária imediata quando houver advisory/CVE da action usada.
+
+---
+
+## 6) Referências
 
 - Epic atual: `#620`
 - Issues deste ciclo: `#627`, `#628`, `#629`, `#630`, `#633`


### PR DESCRIPTION
## Objetivo
Completar a pinagem por commit SHA nas actions ainda com tags móveis nos workflows críticos de PR.

## Workflows ajustados
- .github/workflows/ci.yaml
- .github/workflows/frontend-ci.yml
- .github/workflows/docs.yml
- .github/workflows/strict-security-headers.yml
- .github/workflows/agent-browser-smoke.yml
- .github/workflows/backend-xdist-canary.yml
- .github/workflows/ci-runtime-telemetry.yml

## O que foi feito
- Substituição de referências @vX por @<SHA> nas actions aplicáveis.
- Pinagem explícita também para actions de terceiros usadas nesses fluxos (codecov, rowser-actions).
- Inclusão de política de atualização de SHAs e auditoria no documento de hardening:
  - 2/docs/plans/PLAN_ci_security_hardening_2026-02-23.md

## Validação local
- Auditoria de tags móveis nos workflows alvo:
  - g --line-number uses:\\s*[^#\\n]+@v[0-9] ... (sem resultados)
- Parse YAML dos workflows alterados: OK

Closes #895