### PR TITLE
feat(ci): enable GitHub Environments governance for deploy/release

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -30,6 +30,7 @@ env:
 
 permissions:
   contents: read
+  deployments: write
 
 concurrency:
   group: deploy-${{ github.event_name == 'push' && 'staging' || github.event.inputs.target_environment || 'production' }}
@@ -318,6 +319,8 @@ jobs:
   deploy:
     name: Deploy via Portainer CE API
     runs-on: ubuntu-latest
+    environment:
+      name: ${{ needs.prepare.outputs.target_environment }}
     needs:
       - prepare
       - build_and_push

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,6 +23,7 @@ env:
 
 permissions:
   contents: read
+  deployments: write
 
 concurrency:
   group: release-${{ github.event.inputs.environment }}
@@ -32,8 +33,11 @@ jobs:
   release:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
+    environment:
+      name: ${{ github.event.inputs.environment }}
     permissions:
       contents: write
+      deployments: write
       id-token: write
       attestations: write
 

--- a/docs/operations/deploy.md
+++ b/docs/operations/deploy.md
@@ -18,6 +18,22 @@ Comportamento atual:
 - Publica imagens Docker e executa deploy real por comando configurado para o ambiente selecionado.
 - Se não houver comando configurado, o workflow falha explicitamente (não há falso sinal de deploy concluído).
 - Gera artefato `deploy-evidence-<run_id>` com evidências da execução.
+- Registra deployment no GitHub Environments (`staging` ou `production`) para trilha auditável.
+
+### GitHub Environments (governança de promoção)
+
+Configurar no repositório (`Settings` -> `Environments`):
+
+1. Criar environment `staging`:
+   - sem reviewers obrigatórios (fluxo ágil).
+2. Criar environment `production`:
+   - exigir reviewers obrigatórios;
+   - opcional: wait timer para janela operacional.
+
+Comportamento esperado:
+- `workflow_dispatch` para `production` fica **aguardando aprovação** antes do job de deploy/release.
+- `staging` segue execução direta.
+- histórico de Deployments mostra environment e aprovadores.
 
 Configuração obrigatória por ambiente:
 - `STAGING_DEPLOY_COMMAND` (secret ou variável de repositório)


### PR DESCRIPTION
﻿## Summary
- adds GitHub Environments binding to deploy/release workflows:
  - `.github/workflows/deploy.yaml` -> deploy job now uses dynamic environment from target (`staging` / `production`)
  - `.github/workflows/release.yaml` -> release job now uses environment from workflow input
- grants `deployments: write` permission in both workflows for deployment tracking/status
- documents environment governance setup in `docs/operations/deploy.md`

## Issue
- Closes #891
- Parent epic: #888

## Why
This enforces native GitHub promotion governance:
- `production` can require explicit approval via protected environment
- `staging` remains fast
- deployments become auditable in GitHub Environments history

## Validation
- YAML parse validation (`python + yaml.safe_load`) for:
  - `.github/workflows/deploy.yaml`
  - `.github/workflows/release.yaml`

## Post-merge repo setting (one-time)
In `Settings -> Environments`:
1. Ensure `staging` exists with no mandatory reviewer.
2. Ensure `production` exists with required reviewers (and optional wait timer).

Expected runtime behavior:
- `workflow_dispatch` to `production` waits for environment approval before deploy job starts.
- `staging` proceeds without approval gate.
