### PR TITLE
fix(ci): enforce immutable tags for production promotion/rollback (#815)

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -58,6 +58,22 @@ jobs:
         run: |
           set -euo pipefail
 
+          validate_immutable_tag() {
+            local tag_value="$1"
+            local input_name="$2"
+            local immutable_regex='^v[0-9]{4}\.[0-9]{2}\.[0-9]{2}-[0-9A-Za-z._-]+$'
+
+            if [ "$tag_value" = "latest" ]; then
+              echo "Invalid ${input_name}: 'latest' is not allowed for production promotion/rollback. Use an immutable release tag." >&2
+              exit 1
+            fi
+
+            if ! printf '%s' "$tag_value" | grep -Eq "$immutable_regex"; then
+              echo "Invalid ${input_name}: '${tag_value}'. Expected format: vYYYY.MM.DD-<sha-or-id>." >&2
+              exit 1
+            fi
+          }
+
           short_sha="${GIT_SHA:0:7}"
           auto_version="v$(date -u +%Y.%m.%d)-${short_sha}"
           build_date="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
@@ -98,9 +114,11 @@ jobs:
               if [ -n "$promotion_tag" ]; then
                 release_mode="production-promotion"
                 release_version="$promotion_tag"
+                validate_immutable_tag "$release_version" "promotion_tag"
               else
                 release_mode="production-rollback"
                 release_version="$rollback_tag"
+                validate_immutable_tag "$release_version" "rollback_tag"
               fi
               should_build="false"
             else
@@ -225,7 +243,6 @@ jobs:
           push: true
           tags: |
             ${{ env.BACKEND_IMAGE }}:${{ needs.prepare.outputs.release_version }}
-            ${{ env.BACKEND_IMAGE }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
@@ -241,7 +258,6 @@ jobs:
           push: true
           tags: |
             ${{ env.FRONTEND_IMAGE }}:${{ needs.prepare.outputs.release_version }}
-            ${{ env.FRONTEND_IMAGE }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -312,6 +328,17 @@ jobs:
           RELEASE_VERSION: ${{ needs.prepare.outputs.release_version }}
         run: |
           set -euo pipefail
+
+          if [ "$RELEASE_VERSION" = "latest" ]; then
+            echo "Invalid production tag: 'latest' is not allowed. Use immutable tag vYYYY.MM.DD-<sha-or-id>." >&2
+            exit 1
+          fi
+
+          if ! printf '%s' "$RELEASE_VERSION" | grep -Eq '^v[0-9]{4}\.[0-9]{2}\.[0-9]{2}-[0-9A-Za-z._-]+$'; then
+            echo "Invalid production tag format: '$RELEASE_VERSION'. Expected vYYYY.MM.DD-<sha-or-id>." >&2
+            exit 1
+          fi
+
           docker buildx imagetools inspect "${{ env.BACKEND_IMAGE }}:${RELEASE_VERSION}" >/dev/null
           docker buildx imagetools inspect "${{ env.FRONTEND_IMAGE }}:${RELEASE_VERSION}" >/dev/null
           echo "Tag ${RELEASE_VERSION} exists for backend and frontend."

--- a/docs/operations/deploy.md
+++ b/docs/operations/deploy.md
@@ -14,6 +14,11 @@ Comportamento:
   - `target_environment=production` + `promotion_tag`: promoção de tag imutável.
   - `target_environment=production` + `rollback_tag`: rollback para tag imutável.
 
+Regra de tag em produção:
+- `promotion_tag` e `rollback_tag` devem seguir `vYYYY.MM.DD-<sha-or-id>`.
+- `latest` é rejeitada explicitamente no workflow.
+- O publish de imagens no CI gera somente a tag imutável da release (sem retag `latest`).
+
 ## Governança por environment
 
 O job de deploy usa GitHub Environments:

--- a/v2/docs/DEPLOY_CHECKLIST.md
+++ b/v2/docs/DEPLOY_CHECKLIST.md
@@ -58,6 +58,10 @@ gh workflow run deploy.yaml -f target_environment=production -f promotion_tag=vY
 gh workflow run deploy.yaml -f target_environment=production -f rollback_tag=vYYYY.MM.DD-<sha-anterior>
 ```
 
+Observação:
+- O workflow rejeita `latest` em produção. Use apenas tag imutável no formato `vYYYY.MM.DD-<sha-or-id>`.
+- O build/publish do pipeline usa somente a tag imutável da release (sem retag `latest`).
+
 ## 5. Evidências obrigatórias
 
 - [ ] Artifact `deploy-evidence-<run_id>` disponível

--- a/v2/docs/RUNBOOK.md
+++ b/v2/docs/RUNBOOK.md
@@ -30,6 +30,11 @@ Comportamento:
   - `target_environment=production` + `promotion_tag`,
   - `target_environment=production` + `rollback_tag`.
 
+Regra de produção:
+- usar somente tag imutável `vYYYY.MM.DD-<sha-or-id>`;
+- `latest` é bloqueada para promoção/rollback.
+- o pipeline publica apenas a tag imutável da release (sem retag `latest`).
+
 ### Variáveis obrigatórias por ambiente
 
 Portainer:

--- a/v2/infra/.env.production
+++ b/v2/infra/.env.production
@@ -2,7 +2,7 @@
 # Ambiente de producao (PRODUCAO)
 # -----------------------------------------------------------------------------
 # Uso recomendado:
-#   IMAGE_TAG=latest docker compose --env-file .env.production \
+#   IMAGE_TAG=vYYYY.MM.DD-<sha> docker compose --env-file .env.production \
 #     -f docker-compose.prod.yml up -d
 #
 # IMPORTANTE:
@@ -13,13 +13,12 @@ COMPOSE_PROJECT_NAME=aprender_prod
 # Para validacao local controlada usa este proprio arquivo;
 # em Portainer, deixe APP_ENV_FILE vazio para usar stack.env (default no compose).
 APP_ENV_FILE=.env.production
-# Tag publicada (promocao controlada pelo workflow)
-IMAGE_TAG=latest
+# Tag imutavel publicada (promocao/rollback controlados pelo workflow)
+IMAGE_TAG=vYYYY.MM.DD-<sha>
 # Porta publicada do backend (VM01 padrao: 8000)
 BACKEND_HOST_PORT=8000
 FRONTEND_PORT=81
 DOCKER_HUB_TOKEN=CHANGE_ME_DOCKER_HUB_TOKEN
-WATCHTOWER_TOKEN=CHANGE_ME_WATCHTOWER_TOKEN
 
 ENVIRONMENT=production
 DEBUG=0

--- a/v2/infra/.env.production.example
+++ b/v2/infra/.env.production.example
@@ -2,7 +2,7 @@
 # Ambiente de producao (PRODUCAO) - TEMPLATE PUBLICO
 # -----------------------------------------------------------------------------
 # Uso recomendado:
-#   IMAGE_TAG=latest docker compose --env-file .env.production \
+#   IMAGE_TAG=vYYYY.MM.DD-<sha> docker compose --env-file .env.production \
 #     -f docker-compose.prod.yml up -d
 #
 # IMPORTANTE:
@@ -11,13 +11,12 @@
 
 COMPOSE_PROJECT_NAME=aprender_prod
 APP_ENV_FILE=.env.production
-# Tag publicada (promocao controlada pelo workflow)
-IMAGE_TAG=latest
+# Tag imutavel publicada (promocao/rollback controlados pelo workflow)
+IMAGE_TAG=vYYYY.MM.DD-<sha>
 # Porta publicada do backend (VM01 padrao: 8000)
 BACKEND_HOST_PORT=8000
 FRONTEND_PORT=81
 DOCKER_HUB_TOKEN=CHANGE_ME_DOCKER_HUB_TOKEN
-WATCHTOWER_TOKEN=CHANGE_ME_WATCHTOWER_TOKEN
 
 ENVIRONMENT=production
 DEBUG=0

--- a/v2/infra/ENVIRONMENTS.md
+++ b/v2/infra/ENVIRONMENTS.md
@@ -69,7 +69,7 @@ make build-prod-image
 4. Para deploy real em VM, registrar `IMAGE_TAG` usada como evidencia.
 5. Arquivos `.env.*` deste diretorio sao templates e nao devem conter segredos reais.
 6. `staging/producao` devem usar imagem publicada gerada com `Dockerfile.prod`.
-7. `staging` exige `IMAGE_TAG` explicita da release; em `producao` a stack opera com `IMAGE_TAG=latest` e promocao controlada por `promotion_tag` no workflow.
+7. `staging` e `producao` exigem `IMAGE_TAG` explicita e imutavel (`vYYYY.MM.DD-<sha-or-id>`); `latest` nao e permitido em promocao/rollback de producao.
 8. Em `staging/producao`, `docker-compose.override.yml` nao e aplicado.
 9. Em producao Golden Cloud (3-VMs), `docker-compose.prod.yml` usa DB/Redis externos (VM02/VM03); a stack da VM01 sobe `web/worker/beat/frontend`.
 10. O `docker-compose.yml` base e prod-like: binds de codigo do frontend (`src/public`) ficam apenas no `docker-compose.override.yml` (dev-only).

--- a/v2/infra/Makefile
+++ b/v2/infra/Makefile
@@ -170,7 +170,7 @@ check-env-prod: ## Validar configuração do ambiente PRODUÇÃO
 	$(PROD_COMPOSE) config > /dev/null
 	@echo "✅ [PROD] configuração válida"
 
-pull-prod: ## Pull das imagens do ambiente PRODUÇÃO (latest promovida)
+pull-prod: ## Pull das imagens do ambiente PRODUÇÃO (tag imutavel promovida)
 	@echo "📥 [PROD] puxando imagens publicadas..."
 	$(PROD_COMPOSE) pull
 	@echo "✅ [PROD] pull concluido"

--- a/v2/infra/README.md
+++ b/v2/infra/README.md
@@ -127,7 +127,7 @@ cp .env.prodlike.example .env.prodlike.local
 
 Important:
 - keep placeholders only in these files (real secrets outside Git).
-- `staging` uses explicit `IMAGE_TAG`; `prod` stays on `IMAGE_TAG=latest` with controlled promotion by workflow.
+- `staging` and `prod` use explicit immutable `IMAGE_TAG` (`vYYYY.MM.DD-<sha-or-id>`).
 - `staging/prod` do not use local build; use published images (`pull + up --no-build`).
 
 ## Backend Dockerfiles
@@ -156,10 +156,9 @@ DB_USER=aprender_user
 DB_PASSWORD=your-db-password
 REDIS_HOST=redis.externo.local
 REDIS_PORT=6379
-IMAGE_TAG=latest
+IMAGE_TAG=vYYYY.MM.DD-<sha-or-id>
 FRONTEND_PORT=81
 DOCKER_HUB_TOKEN=your-docker-hub-token
-WATCHTOWER_TOKEN=your-watchtower-token
 ```
 
 ## VM Architecture


### PR DESCRIPTION
## Summary
- enforce immutable-tag validation for `production` dispatch inputs (`promotion_tag`/`rollback_tag`) in `deploy.yaml`
- explicitly reject `latest` in production promotion/rollback (prepare + validate_existing_tag)
- stop publishing `:latest` in CI image push (publish immutable release tag only)
- align docs/templates/runbooks with immutable tag policy
- remove residual `WATCHTOWER_TOKEN` references from production env templates/docs

## Why
Issue #815 requires rollback/promotion by immutable tag (auditável/reprodutível), without `latest` retag as operational mechanism.

## Files changed
- `.github/workflows/deploy.yaml`
- `docs/operations/deploy.md`
- `v2/docs/DEPLOY_CHECKLIST.md`
- `v2/docs/RUNBOOK.md`
- `v2/infra/.env.production`
- `v2/infra/.env.production.example`
- `v2/infra/ENVIRONMENTS.md`
- `v2/infra/Makefile`
- `v2/infra/README.md`

## Validation
- `python` parse of workflow YAML (`yaml_parse_ok`)
- manual diff review for immutable tag gates and docs consistency

Closes #815