### PR TITLE
feat(ci): add auditable staging gate evidence check for PRs (#851)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,8 +18,15 @@
 
 ## Staging Gate
 
+<!-- Obrigatorio para PRs com impacto em runtime (v2/backend, v2/frontend, v2/infra). -->
 - [ ] `make staging-full` executado com sucesso (8/8 PASS)
 - [ ] Evidencia anexada no PR (trecho de log contendo "ALL 8 CHECKS PASSED")
+
+### Evidencia Staging Gate (obrigatorio para merge)
+
+```text
+ALL 8 CHECKS PASSED
+```
 
 ## Validacoes
 

--- a/.github/workflows/staging-gate-audit.yml
+++ b/.github/workflows/staging-gate-audit.yml
@@ -1,0 +1,118 @@
+name: Staging Gate Evidence
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  staging-gate-evidence:
+    name: "[required] staging gate evidence"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect runtime-impact scope
+        id: scope
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --prune --depth=1 origin "$BASE_SHA" "$HEAD_SHA"
+          changed_files="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")"
+          printf '%s\n' "$changed_files"
+
+          requires_staging_gate=false
+          if echo "$changed_files" | grep -Eq '^(v2/backend/|v2/frontend/|v2/infra/)'; then
+            requires_staging_gate=true
+          fi
+
+          echo "requires_staging_gate=$requires_staging_gate" >> "$GITHUB_OUTPUT"
+
+      - name: Validate PR checklist and staging gate evidence
+        if: steps.scope.outputs.requires_staging_gate == 'true'
+        env:
+          PR_BODY: ${{ github.event.pull_request.body || '' }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_DRAFT: ${{ github.event.pull_request.draft }}
+        run: |
+          set -euo pipefail
+
+          if [ "$PR_DRAFT" = "true" ]; then
+            echo "PR #$PR_NUMBER is draft. Staging gate evidence check skipped until ready for review."
+            {
+              echo "## Staging Gate Evidence"
+              echo
+              echo "- Status: skipped (draft PR)"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          body_file="$(mktemp)"
+          printf '%s' "$PR_BODY" > "$body_file"
+
+          has_staging_full_checkbox=false
+          has_evidence_checkbox=false
+          has_pass_marker=false
+
+          if grep -Eiq -- "-[[:space:]]*\[[xX]\][[:space:]]*`make staging-full`[[:space:]]+executado[[:space:]]+com[[:space:]]+sucesso[[:space:]]*\(8/8[[:space:]]+PASS\)" "$body_file"; then
+            has_staging_full_checkbox=true
+          fi
+
+          if grep -Eiq -- "-[[:space:]]*\[[xX]\][[:space:]]*Evidencia[[:space:]]+anexada[[:space:]]+no[[:space:]]+PR" "$body_file"; then
+            has_evidence_checkbox=true
+          fi
+
+          if grep -Fqi "ALL 8 CHECKS PASSED" "$body_file"; then
+            has_pass_marker=true
+          fi
+
+          {
+            echo "## Staging Gate Evidence"
+            echo
+            echo "- PR: #$PR_NUMBER"
+            echo "- `make staging-full` checklist: $has_staging_full_checkbox"
+            echo "- Evidence checklist: $has_evidence_checkbox"
+            echo "- Marker `ALL 8 CHECKS PASSED` in PR body: $has_pass_marker"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$has_staging_full_checkbox" != "true" ] || \
+             [ "$has_evidence_checkbox" != "true" ] || \
+             [ "$has_pass_marker" != "true" ]; then
+            echo "Staging gate evidence missing or incomplete in PR body." >&2
+            echo "Expected in PR body:" >&2
+            echo "1) Checkbox marcado para \`make staging-full\` (8/8 PASS)" >&2
+            echo "2) Checkbox marcado para evidencia anexada" >&2
+            echo "3) Trecho com \`ALL 8 CHECKS PASSED\`" >&2
+            exit 1
+          fi
+
+          echo "Staging gate evidence validated."
+
+      - name: Skip evidence check for non-runtime scope
+        if: steps.scope.outputs.requires_staging_gate != 'true'
+        run: |
+          {
+            echo "## Staging Gate Evidence"
+            echo
+            echo "- Status: skipped (PR sem impacto em runtime backend/frontend/infra)"
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "Staging gate evidence skipped for non-runtime scope."

--- a/docs/operations/deploy.md
+++ b/docs/operations/deploy.md
@@ -53,6 +53,17 @@ Cada execução gera artifact `deploy-evidence-<run_id>` com:
 - `post-deploy-debug.txt`
 - `portainer-stack-update-attempts.txt` (quando aplicável)
 
+## Política de promoção (com rastreabilidade)
+
+Antes de promover para produção, o PR que originou a mudança deve ter:
+- check `[required] staging gate evidence` verde;
+- checklist de staging gate marcado no PR;
+- evidência textual com `ALL 8 CHECKS PASSED` no corpo do PR.
+
+Escopo do check:
+- obrigatório para PR com impacto em runtime (`v2/backend/**`, `v2/frontend/**`, `v2/infra/**`);
+- PRs somente de documentação/CI ficam `skipped` nesse check.
+
 ## Deprecação (issue #814)
 
 Workflows removidos:

--- a/v2/docs/DEPLOY_CHECKLIST.md
+++ b/v2/docs/DEPLOY_CHECKLIST.md
@@ -70,14 +70,21 @@ Observação:
 - [ ] `post-deploy-version-response.txt` presente
 - [ ] Em caso de falha de update: `portainer-stack-update-attempts.txt`
 
-## 6. Variáveis obsoletas (remover)
+## 6. Gate de PR (staging)
+
+- [ ] Check `[required] staging gate evidence` verde no PR
+- [ ] PR contém `ALL 8 CHECKS PASSED` no corpo (evidência auditável)
+- [ ] Checklist `make staging-full` marcado no PR
+- [ ] PR com impacto em runtime (`v2/backend/**`, `v2/frontend/**`, `v2/infra/**`); se não houver impacto, o check pode ficar `skipped`
+
+## 7. Variáveis obsoletas (remover)
 
 As variáveis abaixo não são mais usadas após a depreciação do `release.yaml`:
 
 - `STAGING_DEPLOY_COMMAND`
 - `PRODUCTION_DEPLOY_COMMAND`
 
-## 7. Critérios de aceite do deploy
+## 8. Critérios de aceite do deploy
 
 - [ ] Deploy de `staging` conclui sem erro opaco
 - [ ] Deploy de `production` exige aprovação do environment

--- a/v2/docs/RUNBOOK.md
+++ b/v2/docs/RUNBOOK.md
@@ -34,6 +34,7 @@ Regra de produção:
 - usar somente tag imutável `vYYYY.MM.DD-<sha-or-id>`;
 - `latest` é bloqueada para promoção/rollback.
 - o pipeline publica apenas a tag imutável da release (sem retag `latest`).
+- promoção deve partir de PR com check `[required] staging gate evidence` aprovado.
 
 ### Variáveis obrigatórias por ambiente
 


### PR DESCRIPTION
## Summary
- add new workflow `.github/workflows/staging-gate-audit.yml` with required check `[required] staging gate evidence`
- validate PR body for:
  - checked item: ``make staging-full`` (8/8 PASS)
  - checked evidence item
  - explicit marker `ALL 8 CHECKS PASSED`
- keep draft PRs non-blocking (check is skipped while draft)
- reinforce policy in docs/runbook/checklist and PR template

## Why
Issue #851 requires staging gate execution to be auditable before approval/promotion. This PR operationalizes that with an automated PR check and standardized evidence format.

## Validation
- YAML parse for new workflow: `parse_ok`
- manual review of policy alignment in:
  - `.github/pull_request_template.md`
  - `docs/operations/deploy.md`
  - `v2/docs/DEPLOY_CHECKLIST.md`
  - `v2/docs/RUNBOOK.md`

Closes #851