### PR TITLE
perf(ci): optimize lightweight jobs with ubuntu-slim

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -27,7 +27,8 @@ env:
 jobs:
   react-doctor:
     name: "[required] react doctor quality gate"
-    runs-on: ubuntu-latest
+    # Job lightweight (lint-like), apto para runner econômico 1 vCPU.
+    runs-on: ubuntu-slim
     timeout-minutes: 12
 
     steps:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -201,7 +201,8 @@ jobs:
   # ================================================================
   frontend-security:
     name: "[required] Frontend Dependencies"
-    runs-on: ubuntu-latest
+    # npm audit de dependências de produção é workload leve de CPU.
+    runs-on: ubuntu-slim
     timeout-minutes: 12
     steps:
       - name: Checkout code

--- a/docs/operations/ci-check-policy.md
+++ b/docs/operations/ci-check-policy.md
@@ -51,4 +51,13 @@ Executados por `schedule` ou `workflow_dispatch`:
 - Só checks `required` entram no ruleset.
 - Workflow que publica check `required` não deve usar `paths` no gatilho de `pull_request`.
 - Checks `info` podem usar `continue-on-error`, com artifact/log para análise posterior.
-- Não usar runners `self-hosted` nos gates de PR; manter `ubuntu-latest` hospedado pelo GitHub.
+- Não usar runners `self-hosted` nos gates de PR.
+- Preferir `ubuntu-slim` para jobs leves (lint/quality gates sem Docker) com timeout <= 15 min.
+- Manter `ubuntu-latest` para jobs com Docker, Playwright/Lighthouse, build pesado ou timeout > 15 min.
+
+## Monitoramento de custo (GitHub Actions)
+
+- Revisão operacional mensal via API de billing:
+  - `gh api /repos/<owner>/<repo>/actions/billing/usage`
+- Correlacionar custo com a telemetria de duração:
+  - workflow `[monitoring] ci runtime baseline (median/p95)` em `.github/workflows/ci-runtime-telemetry.yml`.


### PR DESCRIPTION
## Contexto
Implementa parte da otimização de custo do CI com baixo risco operacional, movendo apenas jobs leves para runner econômico.

## O que foi feito
- `frontend-ci.yml`
  - `react-doctor` agora roda em `ubuntu-slim`.
- `security-scan.yml`
  - `frontend-security` agora roda em `ubuntu-slim`.
- `docs/operations/ci-check-policy.md`
  - Política de seleção de runner atualizada (`ubuntu-slim` para jobs leves, `ubuntu-latest` para jobs pesados).
  - Adicionada seção de monitoramento de custo (`gh api /repos/<owner>/<repo>/actions/billing/usage`).

## Racional
- Os dois jobs migrados não usam Docker/Playwright/Lighthouse e já têm timeout <= 15 min.
- Jobs pesados permanecem em `ubuntu-latest` para evitar regressão de estabilidade.

## Issue
Closes #527