### PR TITLE
fix(admin-dat): bloquear criação sem CPF e exibir erro de validação

### DIFF
--- a/v2/frontend/src/api/__tests__/adminDAT.test.ts
+++ b/v2/frontend/src/api/__tests__/adminDAT.test.ts
@@ -153,4 +153,19 @@ describe('adminDAT API wrappers', () => {
 
     await expect(createUser({ username: 'dup' })).rejects.toThrow('Email já existe');
   });
+
+  test('apiRequest exposes field-level validation errors when backend sends errors payload', async () => {
+    postMock.mockRejectedValue({
+      response: {
+        status: 400,
+        data: {
+          code: 'INVALID',
+          detail: 'Erro de validação.',
+          errors: { cpf: ['Este campo é obrigatório.'] },
+        },
+      },
+    });
+
+    await expect(createUser({ username: 'sem-cpf' })).rejects.toThrow('Este campo é obrigatório.');
+  });
 });

--- a/v2/frontend/src/api/adminDAT.ts
+++ b/v2/frontend/src/api/adminDAT.ts
@@ -162,7 +162,10 @@ export interface ListParams {
  * Axios error with response
  */
 interface AxiosErrorWithResponse extends AxiosError {
-  response?: AxiosResponse<{ detail?: string }>;
+  response?: AxiosResponse<{
+    detail?: string;
+    errors?: Record<string, string[] | string>;
+  }>;
 }
 
 /**
@@ -181,7 +184,16 @@ async function apiRequest<T>(requestFn: () => Promise<AxiosResponse<T>>): Promis
     } else if (axiosError.response?.status === 404) {
       message = 'Recurso não encontrado.';
     } else {
-      message = axiosError.response?.data?.detail || axiosError.message || `Erro HTTP ${axiosError.response?.status}`;
+      const backendErrors = axiosError.response?.data?.errors;
+      const firstBackendError = backendErrors
+        ? Object.values(backendErrors).flatMap((value) => (Array.isArray(value) ? value : [value]))[0]
+        : null;
+      message = String(
+        firstBackendError
+        || axiosError.response?.data?.detail
+        || axiosError.message
+        || `Erro HTTP ${axiosError.response?.status}`
+      );
     }
 
     throw new Error(message);

--- a/v2/frontend/src/pages/AdminDAT/UsuariosPage.tsx
+++ b/v2/frontend/src/pages/AdminDAT/UsuariosPage.tsx
@@ -582,6 +582,7 @@ export default function UsuariosPage(): JSX.Element {
             name="cpf"
             label="CPF"
             rules={[
+              { required: true, message: 'CPF é obrigatório' },
               {
                 pattern: /^[0-9]{11}$/,
                 message: 'CPF deve conter exatamente 11 dígitos numéricos',


### PR DESCRIPTION
## Contexto
No fluxo `/dat/admin/usuarios`, a API exige `cpf` obrigatório. A UI permitia submit sem CPF e retornava `400` genérico.

## O que foi ajustado
- `UsuariosPage`: campo `CPF` agora é obrigatório no formulário.
- `adminDAT.ts` (`apiRequest`): quando backend responde `errors` por campo, o frontend mostra a primeira mensagem real de validação.
- Teste frontend novo para garantir parsing de `errors` no wrapper da API.

## Arquivos
- `v2/frontend/src/pages/AdminDAT/UsuariosPage.tsx`
- `v2/frontend/src/api/adminDAT.ts`
- `v2/frontend/src/api/__tests__/adminDAT.test.ts`

## Validação
- `cd v2/frontend && npm run test -- src/api/__tests__/adminDAT.test.ts`
- `cd v2/frontend && npm run lint`
- `cd v2/frontend && npm run build`

## Staging Gate Evidence
- [x] `make staging-full` executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

ALL 8 CHECKS PASSED