### PR TITLE
feat(controle): mover coordenadores e remover valores de compras

### DIFF
--- a/v2/frontend/src/components/AppRoutes.tsx
+++ b/v2/frontend/src/components/AppRoutes.tsx
@@ -94,6 +94,7 @@ export function AppRoutes({ user, permissions }: AppRoutesProps): JSX.Element {
         <Route path="/controle" element={canControle ? <ControlePage /> : <Forbidden />} />
         <Route path="/controle/acoes" element={canControle ? <AcoesPage /> : <Forbidden />} />
         <Route path="/controle/compras" element={(canControle || canDAT) ? <DATComprasPage /> : <Forbidden />} />
+        <Route path="/controle/coordenadores" element={canControle ? <CoordenadoresPage /> : <Forbidden />} />
         <Route path="/compras-materiais" element={(canControle || canDAT) ? <DATComprasPage /> : <Forbidden />} />
         <Route path="/deslocamentos" element={(canControle || canCoordenador || canDAT) ? <DeslocamentosPage /> : <Forbidden />} />
         <Route path="/controle/formacoes" element={canControle ? <FormacoesPage /> : <Forbidden />} />
@@ -118,7 +119,7 @@ export function AppRoutes({ user, permissions }: AppRoutesProps): JSX.Element {
         <Route path="/dat/admin/equipe-gerencia" element={canDAT ? <EquipeGerenciaImportPage /> : <Forbidden />} />
         <Route path="/dat/cadastros" element={canDAT ? <CadastrosPage /> : <Forbidden />} />
         <Route path="/dat/compras-materiais" element={(canControle || canDAT) ? <DATComprasPage /> : <Forbidden />} />
-        <Route path="/dat/coordenadores" element={canDAT ? <CoordenadoresPage /> : <Forbidden />} />
+        <Route path="/dat/coordenadores" element={canControle ? <CoordenadoresPage /> : <Forbidden />} />
         <Route path="/dat/importacao" element={canDAT ? <DATPage /> : <Forbidden />} />
         <Route path="/dat/registros" element={canDAT ? <DATRegistrosPage /> : <Forbidden />} />
       </Routes>

--- a/v2/frontend/src/components/AppSidebar.tsx
+++ b/v2/frontend/src/components/AppSidebar.tsx
@@ -30,6 +30,7 @@ const ROUTE_TO_MENU_KEY: Record<string, string> = {
   '/controle': 'controle-ops',
   '/controle/acoes': 'controle-acoes',
   '/controle/compras': 'controle-compras',
+  '/controle/coordenadores': 'controle-coordenadores',
   '/controle/formacoes': 'controle-formacoes',
   '/controle/plano-formacoes': 'controle-plano-formacoes',
   '/controle/pre-agenda': 'controle-pre-agenda',
@@ -50,7 +51,7 @@ const ROUTE_TO_MENU_KEY: Record<string, string> = {
   '/dat/admin/equipe-gerencia': 'dat-admin-equipe-gerencia',
   '/dat/cadastros': 'dat-cadastros',
   '/dat/compras-materiais': 'controle-compras',
-  '/dat/coordenadores': 'dat-coordenadores',
+  '/dat/coordenadores': 'controle-coordenadores',
   '/dat/importacao': 'dat-importacao',
   '/dat/registros': 'dat-registros',
   '/disponibilidade': 'grade-mensal',
@@ -62,6 +63,7 @@ const MENU_KEY_TO_PARENT: Record<string, string> = {
   'controle-ops': 'controle-submenu',
   'controle-acoes': 'controle-submenu',
   'controle-compras': 'controle-submenu',
+  'controle-coordenadores': 'controle-submenu',
   'controle-formacoes': 'controle-submenu',
   'controle-plano-formacoes': 'controle-submenu',
   'controle-pre-agenda': 'controle-submenu',
@@ -77,7 +79,6 @@ const MENU_KEY_TO_PARENT: Record<string, string> = {
   'dat-admin-colecoes': 'dat-submenu',
   'dat-admin-equipe-gerencia': 'dat-submenu',
   'dat-cadastros': 'dat-submenu',
-  'dat-coordenadores': 'dat-submenu',
   'dat-etl-reports': 'dat-submenu',
   'dat-importacao': 'dat-submenu',
   'dat-registros': 'dat-submenu',
@@ -274,6 +275,7 @@ export function AppSidebar({
               <SubMenu key="controle-submenu" icon={<CheckCircleOutlined />} title="Controle">
                 <Menu.Item key="controle-acoes"><Link to="/controle/acoes">Ações</Link></Menu.Item>
                 <Menu.Item key="controle-compras"><Link to="/controle/compras">Compras</Link></Menu.Item>
+                <Menu.Item key="controle-coordenadores"><Link to="/controle/coordenadores">Coordenadores</Link></Menu.Item>
                 <Menu.Item key="controle-formacoes"><Link to="/controle/formacoes">Formações</Link></Menu.Item>
                 <Menu.Item key="controle-ops"><Link to="/controle">Painel de Controle</Link></Menu.Item>
                 <Menu.Item key="controle-plano-formacoes"><Link to="/controle/plano-formacoes">Plano Anual</Link></Menu.Item>
@@ -329,7 +331,6 @@ export function AppSidebar({
                 <Menu.Item key="dat-admin-colecoes"><Link to="/dat/admin/colecoes">Importar Coleções</Link></Menu.Item>
                 <Menu.Item key="dat-admin-equipe-gerencia"><Link to="/dat/admin/equipe-gerencia">Importar Vínculos</Link></Menu.Item>
                 <Menu.Item key="dat-cadastros"><Link to="/dat/cadastros">Cadastros</Link></Menu.Item>
-                <Menu.Item key="dat-coordenadores"><Link to="/dat/coordenadores">Coordenadores</Link></Menu.Item>
                 <Menu.Item key="dat-importacao"><Link to="/dat/importacao">Importação</Link></Menu.Item>
                 <Menu.Item key="dat-registros"><Link to="/dat/registros">Registros de Turmas</Link></Menu.Item>
                 <Menu.Item key="dat-etl-reports"><Link to="/dat/etl-reports">Relatórios ETL</Link></Menu.Item>

--- a/v2/frontend/src/pages/DATModule/ComprasPage.tsx
+++ b/v2/frontend/src/pages/DATModule/ComprasPage.tsx
@@ -42,7 +42,6 @@ import {
   ShoppingCartOutlined,
   InboxOutlined,
   CheckCircleOutlined,
-  DollarOutlined,
 } from '@ant-design/icons';
 import type { RadioChangeEvent } from 'antd/es/radio';
 import {
@@ -89,7 +88,6 @@ interface CompraRecord {
   municipio_nome: string;
   quantidade: number;
   quantidade_utilizada: number | null;
-  valor_unitario: number | null;
   [key: string]: any;
 }
 
@@ -107,7 +105,6 @@ interface ComprasStats {
   total_itens: number;
   total_produtos: number;
   total_disponivel: number;
-  valor_total: number;
 }
 
 interface MunicipioOption {
@@ -457,37 +454,6 @@ export default function ComprasPage(): JSX.Element {
       },
     },
     {
-      title: 'Valor Unit.',
-      dataIndex: 'valor_unitario',
-      key: 'valor_unitario',
-      width: 100,
-      align: 'right' as const,
-      render: (val: number | null) =>
-        val ? (
-          <Text type="secondary">
-            R$ {val.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}
-          </Text>
-        ) : (
-          '-'
-        ),
-    },
-    {
-      title: 'Valor Total',
-      key: 'valor_total',
-      width: 120,
-      align: 'right' as const,
-      render: (_: unknown, record: CompraRecord) => {
-        const total = (record.quantidade || 0) * (record.valor_unitario || 0);
-        return total > 0 ? (
-          <Text strong>
-            R$ {total.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}
-          </Text>
-        ) : (
-          '-'
-        );
-      },
-    },
-    {
       title: 'Ações',
       key: 'acoes',
       width: 100,
@@ -560,7 +526,7 @@ export default function ComprasPage(): JSX.Element {
       {/* Stats Cards */}
       {stats && (
         <Row gutter={16} className="mb-4">
-          <Col xs={24} sm={12} md={6}>
+          <Col xs={24} sm={12} md={8}>
             <Card>
               <Statistic
                 title="Total de Itens"
@@ -570,7 +536,7 @@ export default function ComprasPage(): JSX.Element {
               />
             </Card>
           </Col>
-          <Col xs={24} sm={12} md={6}>
+          <Col xs={24} sm={12} md={8}>
             <Card>
               <Statistic
                 title="Produtos Diferentes"
@@ -580,7 +546,7 @@ export default function ComprasPage(): JSX.Element {
               />
             </Card>
           </Col>
-          <Col xs={24} sm={12} md={6}>
+          <Col xs={24} sm={12} md={8}>
             <Card>
               <Statistic
                 title="Disponíveis"
@@ -588,18 +554,6 @@ export default function ComprasPage(): JSX.Element {
                 valueStyle={{ color: '#52c41a' }}
                 prefix={<CheckCircleOutlined />}
                 formatter={(value) => value.toLocaleString('pt-BR')}
-              />
-            </Card>
-          </Col>
-          <Col xs={24} sm={12} md={6}>
-            <Card>
-              <Statistic
-                title="Valor Total"
-                value={stats.valor_total || 0}
-                valueStyle={{ color: '#722ed1' }}
-                prefix={<DollarOutlined />}
-                precision={2}
-                formatter={(value) => `R$ ${value.toLocaleString('pt-BR')}`}
               />
             </Card>
           </Col>
@@ -784,10 +738,6 @@ export default function ComprasPage(): JSX.Element {
             const totalQtd = pageData.reduce((sum: number, r: any) => sum + (r.quantidade || 0), 0);
             const totalUtilizado = pageData.reduce((sum: number, r: any) => sum + (r.quantidade_utilizada || 0), 0);
             const totalDisponivel = totalQtd - totalUtilizado;
-            const totalValor = pageData.reduce(
-              (sum: number, r: any) => sum + (r.quantidade || 0) * (r.valor_unitario || 0),
-              0
-            );
 
             return (
               <Table.Summary fixed>
@@ -806,11 +756,7 @@ export default function ComprasPage(): JSX.Element {
                       {totalDisponivel.toLocaleString('pt-BR')}
                     </Text>
                   </Table.Summary.Cell>
-                  <Table.Summary.Cell index={7} colSpan={2} />
-                  <Table.Summary.Cell index={9} align="right">
-                    R$ {totalValor.toLocaleString('pt-BR', { minimumFractionDigits: 2 })}
-                  </Table.Summary.Cell>
-                  <Table.Summary.Cell index={10} />
+                  <Table.Summary.Cell index={7} colSpan={4} />
                 </Table.Summary.Row>
               </Table.Summary>
             );
@@ -1050,17 +996,6 @@ export default function ComprasPage(): JSX.Element {
               <Col xs={12} sm={6}>
                 <Form.Item name="data_entrega" label="Data Entrega">
                   <DatePicker style={{ width: '100%' }} format="DD/MM/YYYY" />
-                </Form.Item>
-              </Col>
-              <Col xs={12} sm={6}>
-                <Form.Item name="valor_unitario" label="Valor Unitário">
-                  <InputNumber
-                    min={0}
-                    precision={2}
-                    style={{ width: '100%' }}
-                    formatter={(value) => `R$ ${value}`.replace(/\B(?=(\d{3})+(?!\d))/g, '.')}
-                    parser={(value) => (value?.replace(/R\$\s?|\.(?=\d{3})/g, '').replace(',', '.') || '0') as unknown as 0}
-                  />
                 </Form.Item>
               </Col>
               <Col xs={12} sm={6}>


### PR DESCRIPTION
## Resumo Este PR aplica dois ajustes funcionais no m?dulo de Controle:  1. Move a p?gina de Coordenadores para a se??o **Controle**. 2. Remove dados financeiros da p?gina **/controle/compras** (exibi??o e formul?rio de cria??o/edi??o).  ## Altera??es ### 1) Coordenadores no m?dulo Controle - adiciona rota: `/controle/coordenadores` - mant?m rota legada `/dat/coordenadores` apontando para a mesma tela (com permiss?o de Controle) - move item de menu ?Coordenadores? do submenu `DAT` para o submenu `Controle` - ajusta mapeamento de chave de menu para destacar corretamente o submenu Controle  Arquivos: - `v2/frontend/src/components/AppRoutes.tsx` - `v2/frontend/src/components/AppSidebar.tsx`  ### 2) Compras sem contexto financeiro Na tela de compras (`/controle/compras`), remove: - coluna **Valor Unit.** - coluna **Valor Total** - card de estat?stica **Valor Total** - soma de valor no rodap? da tabela - campo **Valor Unit?rio** no modal de cria??o/edi??o  Arquivos: - `v2/frontend/src/pages/DATModule/ComprasPage.tsx`  ## Valida??o - `npm run lint` (frontend container): ? - `npm run build` (frontend container): ?  ## Impacto esperado - Navega??o de Coordenadores alinhada ao m?dulo Controle. - Tela de Compras coerente com escopo operacional (sem indicadores financeiros). 


## Staging Gate Evidence
- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

ALL 8 CHECKS PASSED
