### PR TITLE
feat(frontend): ocultar etl-reports da interface

### DIFF
--- a/v2/frontend/src/components/AppRoutes.tsx
+++ b/v2/frontend/src/components/AppRoutes.tsx
@@ -8,7 +8,6 @@ import type { CurrentUser } from '../types';
 const DisponibilidadeBlocks = lazy(() => import('../pages/Disponibilidade'));
 const MonthlyPage = lazy(() => import('../pages/Disponibilidade/MonthlyPage'));
 const ControlePage = lazy(() => import('../pages/Controle/ControlePage'));
-const EtlReportsPage = lazy(() => import('../pages/Controle/EtlReportsPage'));
 const DATPage = lazy(() => import('../pages/DAT/DATPage'));
 const NewSolicitacaoWizard = lazy(() => import('../pages/Solicitacoes/NewSolicitacaoWizard'));
 const EditSolicitacaoPage = lazy(() => import('../pages/Solicitacoes/EditSolicitacaoPage'));
@@ -106,7 +105,6 @@ export function AppRoutes({ user, permissions }: AppRoutesProps): JSX.Element {
         <Route path="/acoes-notificacao" element={canAcoesInternas ? <AcoesNotificacaoPage /> : <Forbidden />} />
         <Route path="/acoes-notificacao/timeline" element={canAcoesInternas ? <AcoesTimelinePage /> : <Forbidden />} />
         <Route path="/notificacoes-internas" element={canAcoesInternas ? <NotificacoesInternasPage /> : <Forbidden />} />
-        <Route path="/dat/etl-reports" element={canDAT ? <EtlReportsPage /> : <Forbidden />} />
 
         {/* DAT Module */}
         <Route path="/dat/admin" element={canDAT ? <AdminDATHomePage /> : <Forbidden />} />

--- a/v2/frontend/src/components/AppSidebar.tsx
+++ b/v2/frontend/src/components/AppSidebar.tsx
@@ -39,7 +39,6 @@ const ROUTE_TO_MENU_KEY: Record<string, string> = {
   '/acoes-notificacao': 'acoes-notificacao-ciclo',
   '/acoes-notificacao/timeline': 'acoes-notificacao-timeline',
   '/notificacoes-internas': 'acoes-notificacao-inbox',
-  '/dat/etl-reports': 'dat-etl-reports',
   '/deslocamentos': 'deslocamentos',
   '/dashboards': 'dashboard-geral',
   '/dashboards/compras': 'dashboard-compras',
@@ -79,7 +78,6 @@ const MENU_KEY_TO_PARENT: Record<string, string> = {
   'dat-admin-colecoes': 'dat-submenu',
   'dat-admin-equipe-gerencia': 'dat-submenu',
   'dat-cadastros': 'dat-submenu',
-  'dat-etl-reports': 'dat-submenu',
   'dat-importacao': 'dat-submenu',
   'dat-registros': 'dat-submenu',
   'minhas-solicitacoes': 'solicitacoes-submenu',
@@ -333,7 +331,6 @@ export function AppSidebar({
                 <Menu.Item key="dat-cadastros"><Link to="/dat/cadastros">Cadastros</Link></Menu.Item>
                 <Menu.Item key="dat-importacao"><Link to="/dat/importacao">Importação</Link></Menu.Item>
                 <Menu.Item key="dat-registros"><Link to="/dat/registros">Registros de Turmas</Link></Menu.Item>
-                <Menu.Item key="dat-etl-reports"><Link to="/dat/etl-reports">Relatórios ETL</Link></Menu.Item>
               </SubMenu>
             )}
 


### PR DESCRIPTION
ï»¿## Resumo
Remove a exposi??o da p?gina `/dat/etl-reports` no frontend.

## O que foi alterado
- removida rota frontend para `/dat/etl-reports`
- removido item de menu "Relat?rios ETL" do submenu DAT
- removidos mapeamentos internos de chave de menu da rota

## O que N?O foi alterado
- API/backend de ETL **permanece intacta** para consumo t?cnico via backend

## Arquivos
- `v2/frontend/src/components/AppRoutes.tsx`
- `v2/frontend/src/components/AppSidebar.tsx`

## Valida??o
- `npm run lint` ?
- `npm run build` ?



## Staging Gate Evidence
- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

ALL 8 CHECKS PASSED
