### PR TITLE
fix(docs): corrigir referência logger.js → logger.ts (#596)

### DIFF
--- a/v2/docs/LOGGING.md
+++ b/v2/docs/LOGGING.md
@@ -74,7 +74,7 @@ class Command(BaseCommand):
 
 ### Logger Condicional
 
-O frontend usa `src/utils/logger.js` que só loga em desenvolvimento.
+O frontend usa `src/utils/logger.ts` que só loga em desenvolvimento.
 
 ```javascript
 import logger from '@/utils/logger';
@@ -91,7 +91,7 @@ logger.api('Request', { url, method });
 ### Implementação
 
 ```javascript
-// src/utils/logger.js
+// src/utils/logger.ts
 const isDev = import.meta.env.DEV;
 
 const logger = {


### PR DESCRIPTION
## Summary
- Corrige referência `src/utils/logger.js` → `src/utils/logger.ts` no LOGGING.md
- O arquivo real é TypeScript desde a migração

Closes #596