### PR TITLE
perf(ci): move react-doctor e Frontend Dependencies para ubuntu-latest (#995)

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -27,8 +27,8 @@ env:
 jobs:
   react-doctor:
     name: "[required] react doctor quality gate"
-    # Job lightweight (lint-like), apto para runner econômico 1 vCPU.
-    runs-on: ubuntu-slim
+    # npm ci + react-doctor are CPU-intensive; ubuntu-slim (1 vCPU) caused 2.5x slowdown.
+    runs-on: ubuntu-latest
     timeout-minutes: 12
 
     steps:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -202,8 +202,8 @@ jobs:
   # ================================================================
   frontend-security:
     name: "[required] Frontend Dependencies"
-    # npm audit de dependências de produção é workload leve de CPU.
-    runs-on: ubuntu-slim
+    # npm ci is CPU-intensive; ubuntu-slim (1 vCPU) caused 81% slowdown.
+    runs-on: ubuntu-latest
     timeout-minutes: 12
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- Reverte `ubuntu-slim` → `ubuntu-latest` para 2 jobs que são CPU-intensive
- `react-doctor quality gate` (frontend-ci.yml)
- `Frontend Dependencies` (security-scan.yml)
- Jobs lightweight permanecem em ubuntu-slim (lint, backend-impact, secret-detection)

## Impacto esperado

| Job | ubuntu-slim | ubuntu-latest |
|---|---|---|
| react doctor (median) | 59s | **~30s** |
| Frontend Dependencies (median) | 38s | **~22s** |

Custo: +$3.60/mês. Negligível.

## Test plan
- [ ] Ambos jobs passam
- [ ] Tempo total menor que na baseline atual

Closes #995