### PR TITLE
fix(infra): fix runtime dirs for read-only containers + staging-local compose

### DIFF
--- a/v2/frontend/Dockerfile.prod
+++ b/v2/frontend/Dockerfile.prod
@@ -44,8 +44,13 @@ COPY nginx.conf /etc/nginx/conf.d/default.conf
 # Copiar arquivos buildados do stage anterior
 COPY --from=builder /app/dist /usr/share/nginx/html
 
-# SEC-006: Ensure nginx dirs are writable by non-root
-RUN chown -R nginx:nginx /var/cache/nginx /var/log/nginx /usr/share/nginx/html \
+# SEC-006: Pre-create nginx runtime dirs and ensure writable by non-root.
+# Nginx master creates client_temp/proxy_temp/etc at startup — they must exist.
+RUN mkdir -p /var/cache/nginx/client_temp /var/cache/nginx/proxy_temp \
+             /var/cache/nginx/fastcgi_temp /var/cache/nginx/uwsgi_temp \
+             /var/cache/nginx/scgi_temp \
+ && chown -R nginx:nginx /var/cache/nginx /var/log/nginx /usr/share/nginx/html \
+             /etc/nginx/conf.d \
  && touch /var/run/nginx.pid && chown nginx:nginx /var/run/nginx.pid
 
 EXPOSE 80

--- a/v2/infra/docker-compose.prod.yml
+++ b/v2/infra/docker-compose.prod.yml
@@ -60,6 +60,7 @@ services:
       - /tmp:size=100M
       - /run:size=10M
       - /home/appuser:size=10M
+      - /app/out_etl:size=50M
 
   redis:
     image: redis:7-alpine
@@ -106,6 +107,7 @@ services:
       - /tmp:size=100M
       - /run:size=10M
       - /home/appuser:size=10M
+      - /app/out_etl:size=50M
 
   beat:
     image: norjosamatheus/aprender-backend:${IMAGE_TAG:?IMAGE_TAG is required}
@@ -136,6 +138,7 @@ services:
       - /tmp:size=50M
       - /run:size=10M
       - /home/appuser:size=10M
+      - /app/out_etl:size=10M
 
   frontend:
     image: norjosamatheus/aprender-frontend:${IMAGE_TAG:?IMAGE_TAG is required}
@@ -157,11 +160,9 @@ services:
       - no-new-privileges:true
     cap_drop:
       - ALL
-    read_only: true
-    tmpfs:
-      - /tmp:size=10M
-      - /var/cache/nginx:size=50M
-      - /var/run:size=10M
+    # Note: read_only not used for nginx — it needs writable /var/cache/nginx,
+    # /etc/nginx/conf.d (entrypoint IPv6 config), and /var/run (pid file).
+    # Hardening via non-root (USER nginx) + cap_drop: ALL + no-new-privileges.
 
 # Rede externa compartilhada com NPM (Nginx Proxy Manager).
 # Deve ser criada uma vez na VM01: docker network create shared_proxy

--- a/v2/infra/docker-compose.staging-local.yml
+++ b/v2/infra/docker-compose.staging-local.yml
@@ -1,0 +1,180 @@
+# =============================================================================
+# Staging-Local: prod-like stack on local machine
+# =============================================================================
+# Uses locally-built prod images (multi-stage, non-root) with
+# local DB/Redis from the dev stack. Separate ports to coexist with dev.
+#
+# Usage:
+#   docker compose -f infra/docker-compose.staging-local.yml up -d
+#   docker compose -f infra/docker-compose.staging-local.yml down
+#
+# Requires: dev stack running (for db + redis on default network)
+#   OR standalone db/redis (uncomment services below)
+# =============================================================================
+
+name: aprender_staging
+
+services:
+  web:
+    image: aprender-backend:staging-local
+    command: gunicorn config.wsgi:application --config /app/infra/gunicorn.conf.py
+    environment:
+      ENVIRONMENT: staging
+      DEBUG: "False"
+      REQUIRE_DOCKER: "1"
+      SERVICE_NAME: web
+      SECRET_KEY: staging-local-key-not-for-production
+      DB_HOST: db
+      DB_PORT: "5432"
+      DB_NAME: aprender_db
+      DB_USER: aprender
+      DB_PASSWORD: aprender
+      REDIS_HOST: redis
+      REDIS_PORT: "6379"
+      GCAL_CLIENT: fake
+      TZ: America/Fortaleza
+    ports:
+      - "8003:8000"
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/api/readyz/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    read_only: true
+    tmpfs:
+      - /tmp:size=100M
+      - /run:size=10M
+      - /home/appuser:size=10M
+      - /app/out_etl:size=50M
+
+  worker:
+    image: aprender-backend:staging-local
+    command: celery -A config worker -l info
+    environment:
+      ENVIRONMENT: staging
+      DEBUG: "False"
+      REQUIRE_DOCKER: "1"
+      SERVICE_NAME: worker
+      SECRET_KEY: staging-local-key-not-for-production
+      DB_HOST: db
+      DB_PORT: "5432"
+      DB_NAME: aprender_db
+      DB_USER: aprender
+      DB_PASSWORD: aprender
+      REDIS_HOST: redis
+      REDIS_PORT: "6379"
+      GCAL_CLIENT: fake
+      TZ: America/Fortaleza
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    read_only: true
+    tmpfs:
+      - /tmp:size=100M
+      - /run:size=10M
+      - /home/appuser:size=10M
+      - /app/out_etl:size=50M
+
+  beat:
+    image: aprender-backend:staging-local
+    command: celery -A config beat -l info --schedule /tmp/celerybeat-schedule
+    environment:
+      ENVIRONMENT: staging
+      DEBUG: "False"
+      REQUIRE_DOCKER: "1"
+      SERVICE_NAME: beat
+      SECRET_KEY: staging-local-key-not-for-production
+      DB_HOST: db
+      DB_PORT: "5432"
+      DB_NAME: aprender_db
+      DB_USER: aprender
+      DB_PASSWORD: aprender
+      REDIS_HOST: redis
+      REDIS_PORT: "6379"
+      GCAL_CLIENT: fake
+      TZ: America/Fortaleza
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    read_only: true
+    tmpfs:
+      - /tmp:size=50M
+      - /run:size=10M
+      - /home/appuser:size=10M
+      - /app/out_etl:size=10M
+
+  frontend:
+    image: aprender-frontend:staging-local
+    ports:
+      - "8081:80"
+    depends_on:
+      - web
+    healthcheck:
+      test: ["CMD-SHELL", "wget --quiet --tries=1 --spider http://127.0.0.1:80/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    # Note: nginx needs writable /var/cache/nginx and /etc/nginx/conf.d at runtime.
+    # Hardening via non-root (USER nginx) + cap_drop + no-new-privileges.
+
+  db:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_DB: aprender_db
+      POSTGRES_USER: aprender
+      POSTGRES_PASSWORD: aprender
+    volumes:
+      - staging_db_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U aprender"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+  redis:
+    image: redis:7-alpine
+    command: redis-server --save 60 1 --loglevel warning
+    volumes:
+      - staging_redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
+
+volumes:
+  staging_db_data:
+  staging_redis_data:


### PR DESCRIPTION
## Summary

Fixes 3 issues discovered during staging-local testing of hardened containers (PR #1001):

### 1. Backend: `/app/out_etl` read-only crash
`controle_imports.py` calls `OUT_DIR.mkdir()` on module import. With `read_only: true`,
this crashes with `OSError: Read-only file system`.

**Fix**: Add `tmpfs /app/out_etl` to web, worker, and beat in both `docker-compose.prod.yml`
and `docker-compose.staging-local.yml`.

### 2. Frontend: nginx Permission denied
Nginx entrypoint creates `client_temp`/`proxy_temp` dirs and modifies `/etc/nginx/conf.d`
at startup. With `read_only: true` + `USER nginx`, both fail.

**Fix**:
- Pre-create all 5 nginx temp dirs in `Dockerfile.prod` (`mkdir -p`)
- `chown nginx:nginx /etc/nginx/conf.d` for entrypoint IPv6 config
- Remove `read_only: true` from frontend compose (nginx needs runtime writes;
  hardened via non-root + cap_drop + no-new-privileges)

### 3. New: `docker-compose.staging-local.yml`
Prod-like stack for local testing with hardened images + local DB/Redis.
Ports: 8003 (backend), 8081 (frontend).

## Files changed

| File | Change |
|---|---|
| `v2/frontend/Dockerfile.prod` | Pre-create nginx runtime dirs, chown conf.d |
| `v2/infra/docker-compose.prod.yml` | Add tmpfs `/app/out_etl`, remove frontend read_only |
| `v2/infra/docker-compose.staging-local.yml` | New file — local staging compose |

## Test plan
- [x] 12 containers (6 dev + 6 staging) running healthy simultaneously
- [x] Backend staging: `curl localhost:8003/api/readyz/` → healthy
- [x] Frontend staging: `curl localhost:8081/health` → ok
- [x] Backend runs as `appuser` (non-root)
- [x] Frontend runs as `nginx` (non-root)

## Staging gate
- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

ALL 8 CHECKS PASSED