### PR TITLE
fix(infra): remove internal:true from frontend-proxy network

### DIFF
--- a/v2/infra/docker-compose.prod.yml
+++ b/v2/infra/docker-compose.prod.yml
@@ -235,13 +235,17 @@ volumes:
 
 # SEC-015: Network segmentation
 # backend-internal: web ↔ redis ↔ worker ↔ beat (needs egress to VM02 PostgreSQL)
-# frontend-proxy: frontend ↔ web only (internal, no egress)
+# frontend-proxy: frontend ↔ web (NPM routes traffic through this network)
 # shared_proxy: frontend ↔ Nginx Proxy Manager (external)
+#
+# Security model: Redis/worker/beat are isolated in backend-internal.
+# Frontend and web are in frontend-proxy (reachable by NPM via shared_proxy).
+# No container on frontend-proxy can reach Redis or Celery directly.
 networks:
   backend-internal:
     # Note: NOT internal — backend services need egress to VM02 (PostgreSQL)
     driver: bridge
   frontend-proxy:
-    internal: true
+    driver: bridge
   shared_proxy:
     external: true


### PR DESCRIPTION
## Summary
- Remove `internal: true` from `frontend-proxy` Docker network
- This was blocking NPM → frontend → web communication, causing 503s on `aprendersistema.com.br` and HTTP 000 in post-deploy verification

## Security model preserved
- **backend-internal**: Redis, worker, beat — isolated, not reachable from frontend
- **frontend-proxy**: frontend ↔ web only — NPM routes through this + shared_proxy
- **shared_proxy**: external network for NPM

No container on frontend-proxy can reach Redis or Celery directly.

## Staging gate
- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

ALL 8 CHECKS PASSED