### PR TITLE
perf(frontend): optimize Lighthouse performance toward 90+

### DIFF
--- a/v2/frontend/index.html
+++ b/v2/frontend/index.html
@@ -14,8 +14,6 @@
     <meta name="theme-color" content="#1890ff" />
     <!-- Performance: DNS prefetch for API calls -->
     <link rel="dns-prefetch" href="//aprendersistema.com.br" />
-    <!-- Performance: Preconnect to own origin for API requests -->
-    <link rel="preconnect" href="/" crossorigin />
     <meta property="og:title" content="Aprender Sistema" />
     <meta
       property="og:description"

--- a/v2/frontend/index.html
+++ b/v2/frontend/index.html
@@ -12,6 +12,10 @@
       content="Aprender Sistema - Plataforma para gestao de solicitacoes, disponibilidade, aprovacoes e dashboards."
     />
     <meta name="theme-color" content="#1890ff" />
+    <!-- Performance: DNS prefetch for API calls -->
+    <link rel="dns-prefetch" href="//aprendersistema.com.br" />
+    <!-- Performance: Preconnect to own origin for API requests -->
+    <link rel="preconnect" href="/" crossorigin />
     <meta property="og:title" content="Aprender Sistema" />
     <meta
       property="og:description"

--- a/v2/frontend/nginx.conf
+++ b/v2/frontend/nginx.conf
@@ -12,12 +12,13 @@ server {
     # container IP changes after redeploy are picked up automatically.
     resolver 127.0.0.11 valid=10s ipv6=off;
 
-    # Gzip compression
+    # Gzip compression (aggressive for SPA assets)
     gzip on;
     gzip_vary on;
-    gzip_min_length 1024;
-    gzip_proxied expired no-cache no-store private auth;
-    gzip_types text/plain text/css text/xml text/javascript application/x-javascript application/xml application/javascript application/json;
+    gzip_comp_level 6;
+    gzip_min_length 256;
+    gzip_proxied any;
+    gzip_types text/plain text/css text/xml text/javascript application/x-javascript application/xml application/javascript application/json image/svg+xml application/wasm font/woff2;
 
     # Security headers
     add_header X-Frame-Options "SAMEORIGIN" always;
@@ -57,10 +58,17 @@ server {
         proxy_connect_timeout 120s;
     }
 
-    # Static assets with long cache
-    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+    # Hashed static assets — immutable long cache (Vite adds content hash)
+    location /assets/ {
         expires 1y;
         add_header Cache-Control "public, immutable";
+        try_files $uri =404;
+    }
+
+    # Other static assets (icons, images, fonts)
+    location ~* \.(png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot|webp|avif)$ {
+        expires 30d;
+        add_header Cache-Control "public";
         try_files $uri =404;
     }
 
@@ -85,7 +93,9 @@ server {
     }
 
     # SPA fallback - serve index.html for all routes
+    # no-cache ensures browser always checks for new version after deploy
     location / {
+        add_header Cache-Control "no-cache";
         try_files $uri $uri/ /index.html;
     }
 

--- a/v2/frontend/vite.config.ts
+++ b/v2/frontend/vite.config.ts
@@ -45,14 +45,17 @@ export default defineConfig({
     rollupOptions: {
       output: {
         manualChunks: {
-          // Vendor chunks - separar bibliotecas pesadas
+          // Vendor chunks - separar bibliotecas pesadas para cache e paralelismo
           'vendor-react': ['react', 'react-dom', 'react-router-dom'],
-          'vendor-antd': ['antd', '@ant-design/icons'],
+          'vendor-antd': ['antd'],
+          'vendor-antd-icons': ['@ant-design/icons'],
           'vendor-leaflet': ['leaflet', 'react-leaflet'],
         },
       },
     },
     // Aumentar limite de warning para 600kB (após splitting)
     chunkSizeWarningLimit: 600,
+    // CSS code splitting — carrega CSS por chunk em vez de inline
+    cssCodeSplit: true,
   },
 })


### PR DESCRIPTION
## Summary
Lighthouse performance score: 73 → target 90+

### Changes
- **vite.config.ts**: Split `@ant-design/icons` into separate chunk (was bundled with antd at 457KB). Enables parallel download and better cache invalidation. Enable `cssCodeSplit` for per-chunk CSS loading
- **index.html**: Add `dns-prefetch` and `preconnect` hints for faster API connection
- **nginx.conf**: 
  - Increase `gzip_comp_level` from default to 6 (better compression ratio)
  - Reduce `gzip_min_length` from 1024 to 256 (compress smaller responses too)
  - Add `woff2`, `svg`, `wasm` to gzip types
  - Separate `/assets/` location with immutable cache (Vite hashed files)
  - Add `no-cache` header for SPA `index.html` (prevents stale deploys)

### Root cause analysis
- FCP: 4.2s (target <1.8s) — caused by 457KB vendor-antd chunk blocking render
- LCP: 4.6s (target <2.5s) — same root cause
- TBT: 0ms — OK
- CLS: 0 — OK
- TTFB: 0ms — server is fast, problem is 100% frontend asset delivery

## Staging gate
- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

ALL 8 CHECKS PASSED