### PR TITLE
feat(security): implement Security Group B (SEC-005/007/008/009/010)

### DIFF
--- a/v2/backend/apps/core/utils/csv_sanitize.py
+++ b/v2/backend/apps/core/utils/csv_sanitize.py
@@ -1,0 +1,37 @@
+"""
+SEC-007: CSV Injection sanitization helper.
+
+Prevents spreadsheet formula injection by escaping values that start
+with characters interpreted as formulas by Excel, LibreOffice, and
+Google Sheets (=, +, -, @, TAB, CR, LF).
+
+Usage:
+    from apps.core.utils.csv_sanitize import sanitize_csv_value
+
+    writer.writerow([sanitize_csv_value(v) for v in row])
+"""
+
+import re
+
+# Characters that trigger formula execution in spreadsheet applications
+_FORMULA_CHARS = re.compile(r"^[=+\-@\t\r\n]")
+
+
+def sanitize_csv_value(value: object) -> str:
+    """Sanitize a value for safe CSV export.
+
+    Prefixes dangerous characters with a single quote to prevent
+    spreadsheet applications from interpreting them as formulas.
+
+    Args:
+        value: Any value to be written to CSV.
+
+    Returns:
+        Sanitized string safe for CSV export.
+    """
+    if value is None:
+        return ""
+    s = str(value)
+    if _FORMULA_CHARS.match(s):
+        return f"'{s}"
+    return s

--- a/v2/backend/apps/core/views/dat.py
+++ b/v2/backend/apps/core/views/dat.py
@@ -177,6 +177,8 @@ class DATRegistroViewSet(viewsets.ModelViewSet):
 
         from django.http import HttpResponse
 
+        from apps.core.utils.csv_sanitize import sanitize_csv_value
+
         # Apply filters
         queryset = self.filter_queryset(self.get_queryset())
 
@@ -206,26 +208,26 @@ class DATRegistroViewSet(viewsets.ModelViewSet):
             ]
         )
 
-        # Rows
+        # SEC-007: Rows sanitized against CSV injection
         for r in queryset:
             writer.writerow(
                 [
-                    r.municipio.nome,
-                    r.municipio.uf,
-                    r.projeto_geral.nome,
-                    r.projeto.nome,
+                    sanitize_csv_value(r.municipio.nome),
+                    sanitize_csv_value(r.municipio.uf),
+                    sanitize_csv_value(r.projeto_geral.nome),
+                    sanitize_csv_value(r.projeto.nome),
                     r.aluno_qtde,
                     r.professor_qtde or "",
-                    r.reuniao_dat or "",
-                    r.turma_formar_id or "",
+                    sanitize_csv_value(r.reuniao_dat or ""),
+                    sanitize_csv_value(r.turma_formar_id or ""),
                     r.nr_codigos or "",
-                    r.chaves_inscricao_status,
-                    r.instrucoes_status,
-                    r.envio_codigos_status,
+                    sanitize_csv_value(r.chaves_inscricao_status),
+                    sanitize_csv_value(r.instrucoes_status),
+                    sanitize_csv_value(r.envio_codigos_status),
                     "Sim" if r.usa_avaliar else "Não",
-                    r.alunos_recebidos_status,
-                    r.alunos_validados_status,
-                    r.alunos_importados_status,
+                    sanitize_csv_value(r.alunos_recebidos_status),
+                    sanitize_csv_value(r.alunos_validados_status),
+                    sanitize_csv_value(r.alunos_importados_status),
                 ]
             )
 

--- a/v2/backend/apps/core/views_gcal/detail.py
+++ b/v2/backend/apps/core/views_gcal/detail.py
@@ -144,7 +144,9 @@ class DashboardEventsExportView(APIView):
             ]
         )
 
-        # Escrever linhas (chunk_size required when using iterator() with prefetch_related)
+        from apps.core.utils.csv_sanitize import sanitize_csv_value
+
+        # SEC-007: Rows sanitized against CSV injection
         for s in qs.iterator(chunk_size=2000):
             # Determinar fluxo (SUPER ou NAO_SUPER)
             fluxo = s.projeto.fluxo if s.projeto else ""
@@ -152,18 +154,18 @@ class DashboardEventsExportView(APIView):
             writer.writerow(
                 [
                     s.id,
-                    s.municipio.nome if s.municipio else "",
-                    s.projeto.nome if s.projeto else "",
-                    s.tipo_evento.nome if s.tipo_evento else "",
+                    sanitize_csv_value(s.municipio.nome if s.municipio else ""),
+                    sanitize_csv_value(s.projeto.nome if s.projeto else ""),
+                    sanitize_csv_value(s.tipo_evento.nome if s.tipo_evento else ""),
                     s.inicio.isoformat() if s.inicio else "",
                     s.fim.isoformat() if s.fim else "",
-                    s.usuario.username if s.usuario else "",
-                    s.coordenador.username if s.coordenador else "",
-                    fluxo,
+                    sanitize_csv_value(s.usuario.username if s.usuario else ""),
+                    sanitize_csv_value(s.coordenador.username if s.coordenador else ""),
+                    sanitize_csv_value(fluxo),
                     s.gcal_status,
                     s.external_event_id or "",
                     s.gcal_last_sync_at.isoformat() if s.gcal_last_sync_at else "",
-                    s.gcal_last_error or "",
+                    sanitize_csv_value(s.gcal_last_error or ""),
                     s.meet_link or "",
                     s.gcal_payload_hash or "",
                     s.updated_at.isoformat() if s.updated_at else "",

--- a/v2/backend/config/settings.py
+++ b/v2/backend/config/settings.py
@@ -438,9 +438,11 @@ SPECTACULAR_SETTINGS = {
     "SCHEMA_PATH_PREFIX": "/api/",
     # SEC-005: Restrict schema/docs to authenticated staff users in production
     "SERVE_PERMISSIONS": [
-        "rest_framework.permissions.IsAdminUser"
-        if ENVIRONMENT == "production"
-        else "rest_framework.permissions.AllowAny"
+        (
+            "rest_framework.permissions.IsAdminUser"
+            if ENVIRONMENT == "production"
+            else "rest_framework.permissions.AllowAny"
+        )
     ],
     # Contact info
     "CONTACT": {

--- a/v2/backend/config/settings.py
+++ b/v2/backend/config/settings.py
@@ -354,20 +354,24 @@ CELERY_CIRCUIT_BREAKER_COUNTDOWN = int(os.getenv("CELERY_CB_COUNTDOWN", 60))  # 
 FORMAR_PLATFORM_BASE_URL = os.getenv("FORMAR_PLATFORM_URL", "https://www.aprenderformar.com.br/plataforma")
 
 # ================================================================
-# CORS
+# CORS — SEC-009: strict allowlist per environment
 # ================================================================
+_CORS_DEV_DEFAULTS = "http://localhost:3000,http://localhost:5173,http://localhost:5174,http://localhost:5175,http://localhost:5176,http://localhost:8000,http://localhost:8002"
+_CORS_PROD_DEFAULTS = "https://aprendersistema.com.br"
 CORS_ALLOWED_ORIGINS = os.getenv(
     "CORS_ALLOWED_ORIGINS",
-    "http://localhost:3000,http://localhost:5173,http://localhost:5174,http://localhost:5175,http://localhost:5176,http://localhost:8000,http://localhost:8002",
+    _CORS_PROD_DEFAULTS if ENVIRONMENT == "production" else _CORS_DEV_DEFAULTS,
 ).split(",")
 CORS_ALLOW_CREDENTIALS = True
 
 # ================================================================
-# CSRF
+# CSRF — SEC-009: strict allowlist per environment
 # ================================================================
+_CSRF_DEV_DEFAULTS = "http://localhost:3000,http://localhost:5173,http://localhost:5174,http://localhost:5175,http://localhost:5176,http://localhost:8000,http://localhost:8002"
+_CSRF_PROD_DEFAULTS = "https://aprendersistema.com.br"
 CSRF_TRUSTED_ORIGINS = os.getenv(
     "CSRF_TRUSTED_ORIGINS",
-    "http://localhost:3000,http://localhost:5173,http://localhost:5174,http://localhost:5175,http://localhost:5176,http://localhost:8000,http://localhost:8002",
+    _CSRF_PROD_DEFAULTS if ENVIRONMENT == "production" else _CSRF_DEV_DEFAULTS,
 ).split(",")
 CSRF_COOKIE_SAMESITE = "Lax"
 # Issue #135: XSS protection - JavaScript não pode ler o cookie diretamente
@@ -432,6 +436,12 @@ SPECTACULAR_SETTINGS = {
     "SERVE_INCLUDE_SCHEMA": False,
     "COMPONENT_SPLIT_REQUEST": True,
     "SCHEMA_PATH_PREFIX": "/api/",
+    # SEC-005: Restrict schema/docs to authenticated staff users in production
+    "SERVE_PERMISSIONS": [
+        "rest_framework.permissions.IsAdminUser"
+        if ENVIRONMENT == "production"
+        else "rest_framework.permissions.AllowAny"
+    ],
     # Contact info
     "CONTACT": {
         "name": "Equipe AS v2",
@@ -447,13 +457,13 @@ SPECTACULAR_SETTINGS = {
         {"name": "options", "description": "Opções para formulários"},
         {"name": "admin", "description": "Administração de entidades"},
     ],
-    # Swagger UI settings (Issue #415)
+    # SEC-008: Swagger UI settings — disable persistAuthorization in production
     "SWAGGER_UI_SETTINGS": {
         "deepLinking": True,
-        "persistAuthorization": True,
+        "persistAuthorization": ENVIRONMENT != "production",
         "displayOperationId": True,
         "filter": True,
-        "tryItOutEnabled": True,
+        "tryItOutEnabled": ENVIRONMENT != "production",
     },
 }
 


### PR DESCRIPTION
## Summary
Implements 5 security issues from the hardening program.

### SEC-005: Restrict docs/schema to admin (#803)
- `SERVE_PERMISSIONS: [IsAdminUser]` in production
- `/api/schema/`, `/api/docs/`, `/api/redoc/` require staff login in prod
- Dev remains AllowAny for convenience

### SEC-007: Mitigate CSV Injection (#805)
- Created `apps/core/utils/csv_sanitize.py` with `sanitize_csv_value()`
- Prefixes `=`, `+`, `-`, `@`, TAB, CR, LF with single quote
- Applied to DAT registros export and GCal events export

### SEC-008: Disable persistAuthorization in production (#806)
- `persistAuthorization: False` in production Swagger UI
- `tryItOutEnabled: False` in production
- Dev retains both for convenience

### SEC-009: CORS/CSRF strict allowlist (#807)
- Production defaults: `https://aprendersistema.com.br` only
- Dev defaults: localhost ports (3000, 5173-5176, 8000, 8002)
- Configurable via env vars `CORS_ALLOWED_ORIGINS` / `CSRF_TRUSTED_ORIGINS`

### SEC-010: Server-side RBAC verification (#808)
- **Already implemented** — all endpoints use DRF permission classes
- Auth via HTTP session cookies, not localStorage
- No code changes needed (verified via audit)

## Staging gate
- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

ALL 8 CHECKS PASSED