### PR TITLE
fix(frontend): merge antd-icons into antd-core chunk to fix createContext crash

### DIFF
--- a/v2/frontend/vite.config.ts
+++ b/v2/frontend/vite.config.ts
@@ -49,9 +49,8 @@ export default defineConfig({
           if (id.includes('node_modules/react-dom')) return 'vendor-react';
           if (id.includes('node_modules/react-router')) return 'vendor-react';
           if (id.includes('node_modules/react/')) return 'vendor-react';
-          if (id.includes('node_modules/@ant-design/icons')) return 'vendor-antd-icons';
           if (id.includes('node_modules/antd/es/table') || id.includes('node_modules/antd/es/date-picker') || id.includes('node_modules/antd/es/calendar') || id.includes('node_modules/antd/es/upload') || id.includes('node_modules/antd/es/tree') || id.includes('node_modules/antd/es/transfer') || id.includes('node_modules/antd/es/color-picker') || id.includes('node_modules/antd/es/cascader')) return 'vendor-antd-heavy';
-          if (id.includes('node_modules/antd')) return 'vendor-antd-core';
+          if (id.includes('node_modules/antd') || id.includes('node_modules/@ant-design/icons')) return 'vendor-antd-core';
           if (id.includes('node_modules/leaflet') || id.includes('node_modules/react-leaflet')) return 'vendor-leaflet';
         },
       },


### PR DESCRIPTION
## Summary
- Merge `@ant-design/icons` into `vendor-antd-core` chunk instead of separate `vendor-antd-icons`
- Fixes `Cannot read properties of undefined (reading 'createContext')` crash in production
- Root cause: separate antd-icons chunk could load before vendor-react, breaking `React.createContext`

## Changes
- `v2/frontend/vite.config.ts`: Remove separate `vendor-antd-icons` rule, add `@ant-design/icons` to `vendor-antd-core` match

## Test plan
- [x] `npm run build` succeeds — no `vendor-antd-icons` chunk in output
- [x] Deploy to production and verify page loads without console errors
- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

```
ALL 8 CHECKS PASSED
```

## Staging Gate
- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR