### PR TITLE
fix(ci): increase Portainer stack update timeout to 300s

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -609,7 +609,8 @@ jobs:
           } >> /tmp/portainer-stack-update-attempts.log
 
           for attempt in $(seq 1 "$max_attempts"); do
-            http_code="$(curl "${curl_opts[@]}" \
+            # Stack update pulls images + recreates containers — override timeout to 300s
+            http_code="$(curl "${curl_opts[@]}" --max-time 300 \
               -o /tmp/portainer-stack-update-response.json \
               -w '%{http_code}' \
               -X PUT \


### PR DESCRIPTION
## Summary
- Increase curl `--max-time` from 120s to 300s for the Portainer stack update PUT call
- The PUT triggers image pull + container recreate which regularly exceeds 120s
- Deploy succeeds on server but CI reports false failure due to curl timeout

## Changes
- `.github/workflows/deploy.yaml`: Add `--max-time 300` override on the stack update curl call

## Test plan
- [x] Next deploy should complete without curl timeout error
- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

```
ALL 8 CHECKS PASSED
```

## Staging Gate
- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR