### PR TITLE
fix(frontend): unify all antd chunks to fix circular dependency crash

### DIFF
--- a/v2/frontend/vite.config.ts
+++ b/v2/frontend/vite.config.ts
@@ -49,8 +49,7 @@ export default defineConfig({
           if (id.includes('node_modules/react-dom')) return 'vendor-react';
           if (id.includes('node_modules/react-router')) return 'vendor-react';
           if (id.includes('node_modules/react/')) return 'vendor-react';
-          if (id.includes('node_modules/antd/es/table') || id.includes('node_modules/antd/es/date-picker') || id.includes('node_modules/antd/es/calendar') || id.includes('node_modules/antd/es/upload') || id.includes('node_modules/antd/es/tree') || id.includes('node_modules/antd/es/transfer') || id.includes('node_modules/antd/es/color-picker') || id.includes('node_modules/antd/es/cascader')) return 'vendor-antd-heavy';
-          if (id.includes('node_modules/antd') || id.includes('node_modules/@ant-design/icons')) return 'vendor-antd-core';
+          if (id.includes('node_modules/antd') || id.includes('node_modules/@ant-design/icons')) return 'vendor-antd';
           if (id.includes('node_modules/leaflet') || id.includes('node_modules/react-leaflet')) return 'vendor-leaflet';
         },
       },


### PR DESCRIPTION
## Summary
- Merge `vendor-antd-heavy` and `vendor-antd-core` into a single `vendor-antd` chunk
- Fixes `Cannot access 'Ql' before initialization` crash in production
- Root cause: splitting antd into multiple chunks created circular inter-chunk dependencies that Rollup cannot resolve ordering for

## Context
PR #1084 fixed the `@ant-design/icons` chunk but the same class of error persisted in `vendor-antd-heavy` which depends on modules in `vendor-antd-core`. The only safe approach is a single unified chunk for all antd modules.

## Changes
- `v2/frontend/vite.config.ts`: Replace `vendor-antd-heavy` + `vendor-antd-core` with single `vendor-antd`

## Test plan
- [x] `npm run build` succeeds — single `vendor-antd` chunk in output, no heavy/core/icons split
- [x] Deploy and verify no console errors on page load
- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

```
ALL 8 CHECKS PASSED
```

## Staging Gate
- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR