### PR TITLE
docs(security): SEC-011 encryption runbook + SEC-012 asymmetric crypto ADR

### DIFF
--- a/docs/architecture/project-decisions/ADR-016-asymmetric-crypto-strategy.md
+++ b/docs/architecture/project-decisions/ADR-016-asymmetric-crypto-strategy.md
@@ -1,0 +1,59 @@
+# ADR-016: Estratégia de Criptografia Assimétrica
+
+**Status:** Accepted
+**Date:** 2026-04-13
+**Decider:** Matheus Norjosa
+
+## Context
+
+O sistema usa criptografia simétrica (Fernet/AES-128) para tokens OAuth em repouso. Não há uso de criptografia assimétrica (RSA/ECC/EdDSA) na aplicação. É necessário definir formalmente se e quando adotar.
+
+## Decision
+
+**Não adotar criptografia assimétrica no momento.** A criptografia simétrica via Fernet atende todos os requisitos atuais de proteção de tokens OAuth.
+
+### Justificativa
+
+- Tokens OAuth são segredos internos (server-to-server), não precisam de não-repúdio
+- Não há troca de chaves entre partes distintas (cenário clássico de assimétrica)
+- Fernet (AES-128-CBC + HMAC-SHA256) é suficiente para encryption-at-rest
+- Complexidade de gestão de chaves assimétricas (PKI, revogação, rotação) não se justifica
+
+### Gatilhos de Adoção
+
+Criptografia assimétrica será **obrigatória** quando qualquer cenário abaixo surgir:
+
+1. **Assinatura de payloads B2B** — webhooks enviados a terceiros que precisam verificar autenticidade
+2. **Validação de webhooks recebidos** — verificar assinatura de providers externos
+3. **Tokens com chave pública** — emitir JWTs assinados consumidos por serviços externos
+4. **Não-repúdio** — auditoria legal que exija prova criptográfica de autoria
+
+### Padrão Técnico Futuro (quando adotado)
+
+| Aspecto | Padrão |
+| ------- | ------ |
+| Algoritmo de assinatura | Ed25519 (preferido) ou ECDSA P-256 |
+| Algoritmo de criptografia | RSA-OAEP com SHA-256 (interop) ou X25519 |
+| Biblioteca | `cryptography` (já usada para Fernet) |
+| Gestão de chaves | Variável de ambiente + rotação via management command |
+| Formato de chave | PEM (privada) / JWK (pública, se API) |
+
+## Consequences
+
+**Positivo:**
+
+- Zero complexidade adicional de PKI
+- Decisão documentada evita ambiguidade futura
+- Gatilhos objetivos permitem adoção deliberada quando necessário
+
+**Negativo:**
+
+- Risco residual: se um cenário de gatilho surgir sem ser identificado, pode haver delay na adoção
+
+**Risco Residual:** Aceito. Revisão programada no próximo ciclo de segurança.
+
+## References
+
+- SEC-012: Issue #865
+- SEC-011: Governança de criptografia OAuth (#864)
+- OWASP Cryptographic Failures

--- a/docs/architecture/project-decisions/README.md
+++ b/docs/architecture/project-decisions/README.md
@@ -23,6 +23,7 @@ Cada ADR documenta: contexto (problema), decisão (o que foi escolhido e por qu�
 | [ADR-013](ADR-013-axios-pinning-fetch-migration.md) | Pin Axios + Migração Fetch API | Accepted | 2026-03-31 |
 | [ADR-014](ADR-014-stateless-horizontal-scaling.md) | Arquitetura Stateless para Scaling | Accepted | 2026-01-12 |
 | [ADR-015](ADR-015-testing-policy.md) | Política de Testes | Accepted | 2026-02-24 |
+| [ADR-016](ADR-016-asymmetric-crypto-strategy.md) | Estratégia de Criptografia Assimétrica | Accepted | 2026-04-13 |
 
 ## Como Adicionar um Novo ADR
 

--- a/v2/docs/GUIDE_GCAL.md
+++ b/v2/docs/GUIDE_GCAL.md
@@ -647,7 +647,47 @@ logger.info(f"GCal response: {result}")
 - [Service Account Authentication](https://developers.google.com/identity/protocols/oauth2/service-account)
 - [GCAL_SEND_UPDATES.md](../backend/GCAL_SEND_UPDATES.md)
 
-## 8. Histórico
+## 8. Criptografia de Tokens OAuth (SEC-011)
+
+### Visão Geral
+
+Tokens OAuth (access/refresh) são criptografados em repouso usando **Fernet** (AES-128-CBC + HMAC-SHA256) via `GCAL_ENCRYPTION_KEY`.
+
+### Configuração por Ambiente
+
+| Ambiente       | Comportamento                                                             |
+| -------------- | ------------------------------------------------------------------------- |
+| **Produção**   | `GCAL_ENCRYPTION_KEY` obrigatória. Ausência causa `ValueError` (fail-fast) |
+| **Dev/Staging** | Fallback para chave derivada de `SECRET_KEY` com warning no log           |
+
+### Rotação de Chave
+
+A rotação é zero-downtime via management command:
+
+```bash
+# 1. Gerar nova chave Fernet
+python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+
+# 2. Executar rotação (descriptografa com antiga, re-criptografa com nova)
+python manage.py rotate_gcal_encryption_key \
+  --old-key="CHAVE_ATUAL" \
+  --new-key="CHAVE_NOVA_GERADA"
+
+# 3. Atualizar GCAL_ENCRYPTION_KEY no Portainer com a nova chave
+
+# 4. Reiniciar containers (web, worker, beat)
+```
+
+A rotação cria entrada no AuditLog com ação `GCAL_ENCRYPTION_KEY_ROTATION`.
+
+### Arquivos Relevantes
+
+- `apps/core/services/oauth/token_manager.py` — encrypt/decrypt/rotate
+- `apps/core/management/commands/rotate_gcal_encryption_key.py` — comando
+- `apps/core/models/integracao.py` — GoogleOAuthCredential (BinaryField)
+- `apps/core/tests/test_google_oauth.py` — testes de encrypt/decrypt/rotation
+
+## 9. Histórico
 
 - **PR19** (RF05/RF06): Implementação inicial (GCal + Meet integration)
 - **2025-10-23**: Guia criado


### PR DESCRIPTION
## Summary
- **SEC-011** (#864): Add encryption key rotation documentation to GUIDE_GCAL.md — Fernet config, per-environment policy, zero-downtime rotation steps
- **SEC-012** (#865): ADR-016 formally decides against asymmetric crypto, defines objective adoption triggers

## Changes
- `v2/docs/GUIDE_GCAL.md`: New section 8 — Criptografia de Tokens OAuth
- `docs/architecture/project-decisions/ADR-016-asymmetric-crypto-strategy.md`: New ADR
- `docs/architecture/project-decisions/README.md`: Index updated

## Test plan
- [x] Documentation only — no code changes
- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

```
ALL 8 CHECKS PASSED
```

## Staging Gate
- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Closes #864, Closes #865