### PR TITLE
feat(security): SEC-004 CSP Report-Only mode + security headers hardening

### DIFF
--- a/v2/backend/apps/core/middleware_security.py
+++ b/v2/backend/apps/core/middleware_security.py
@@ -15,9 +15,14 @@ Refs:
 
 from __future__ import annotations
 
+import os
 from typing import Callable
 
 from django.http import HttpRequest, HttpResponse
+
+# SEC-004: CSP mode — "enforce" (default) or "report-only"
+# Use report-only in production to collect violation data before enforcing.
+CSP_MODE = os.getenv("CSP_MODE", "enforce")
 
 
 class SecurityHeadersMiddleware:
@@ -89,7 +94,8 @@ class SecurityHeadersMiddleware:
         if worker_src:
             csp_directives.insert(5, worker_src)
 
-        response["Content-Security-Policy"] = "; ".join(csp_directives)
+        csp_header = "Content-Security-Policy-Report-Only" if CSP_MODE == "report-only" else "Content-Security-Policy"
+        response[csp_header] = "; ".join(csp_directives)
 
         # ================================================================
         # Permissions-Policy (antiga Feature-Policy)

--- a/v2/infra/configs/vm01/nginx.conf
+++ b/v2/infra/configs/vm01/nginx.conf
@@ -70,8 +70,14 @@ http {
         # Security headers
         add_header X-Frame-Options "SAMEORIGIN" always;
         add_header X-Content-Type-Options "nosniff" always;
-        add_header X-XSS-Protection "1; mode=block" always;
+        add_header X-XSS-Protection "0" always;
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Cross-Origin-Opener-Policy "same-origin" always;
+
+        # SEC-004: CSP in Report-Only mode — collects violations without blocking.
+        # Promote to Content-Security-Policy after analyzing reports.
+        add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests" always;
 
         # Static files
         location /static/ {


### PR DESCRIPTION
## Summary
- Add CSP `Report-Only` mode for gradual rollout (no blocking, only reports violations)
- Add missing security headers to production nginx (Referrer-Policy, COOP)
- Modernize X-XSS-Protection from "1; mode=block" to "0" (CSP replaces it)

## Changes
- `v2/backend/apps/core/middleware_security.py`: CSP_MODE env var toggles "enforce"/"report-only"
- `v2/infra/configs/vm01/nginx.conf`: Add CSP-Report-Only, Referrer-Policy, COOP headers

## Deployment notes
- **No action needed** — defaults to enforce mode (current behavior)
- To enable Report-Only in production: set `CSP_MODE=report-only` in Portainer
- After 1-2 weeks analyzing violations, remove unsafe-inline/unsafe-eval and promote to enforce

## Test plan
- [x] Default mode (enforce) unchanged — no regression
- [x] Report-Only mode sends `Content-Security-Policy-Report-Only` header
- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

```
ALL 8 CHECKS PASSED
```

## Staging Gate
- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Refs #802