### PR TITLE
feat: add Gerências and Produtos admin CRUD + seed command

### DIFF
--- a/v2/backend/apps/core/constants.py
+++ b/v2/backend/apps/core/constants.py
@@ -12,9 +12,9 @@ Ref: docs/MAPEAMENTO_COMPLETO_SETORES_GERENCIAS.md
 
 from __future__ import annotations
 
-# === SETORES (14) — Onde o usuário trabalha ===
+# === SETORES (13) — Onde o usuário trabalha ===
 SETOR_GROUPS: list[str] = [
-    # Gerências de projeto
+    # Gerências de projeto (cada uma = 1 Gerencia no model core_gerencia)
     "Superintendência",  # SUPERINTENDENCIA - Fluxo SUPER
     "Vidas",  # GERENCIA 2 - Fluxo NAO_SUPER
     "Fluir",  # GERENCIA 3 - Fluxo NAO_SUPER
@@ -24,9 +24,8 @@ SETOR_GROUPS: list[str] = [
     # Setores administrativos/operacionais
     "DAT",  # Departamento de Apoio Técnico
     "Controle",  # Setor de Controle
-    "Gerência",  # Gerência genérica
     "Diretoria",  # Diretoria - Acesso a dashboards
-    # Novos setores de operação de ações/notificações (32 passos)
+    # Setores de operação de ações/notificações
     "Comercial",
     "Relacionamento",
     "Logística Viagens",

--- a/v2/backend/apps/core/management/commands/seed_gerencias.py
+++ b/v2/backend/apps/core/management/commands/seed_gerencias.py
@@ -1,0 +1,101 @@
+"""
+Seed de Gerências baseado no mapeamento organizacional confirmado.
+
+Gerência = Setor (mesma entidade, nomenclaturas diferentes).
+- "GERENCIA 2" = nome interno/burocrático
+- "Vidas" = nome comercial/operacional (nome_setor)
+
+Usage:
+    python manage.py seed_gerencias
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from django.core.management.base import BaseCommand
+
+from apps.core.models import Gerencia
+
+GERENCIAS = [
+    {
+        "nome": "SUPERINTENDENCIA",
+        "nome_setor": "Super",
+        "descricao": "Projetos SUPER que requerem aprovação manual (CIRANDAR, LENDO E ESCREVENDO, NOVO LENDO, TEMA, etc.)",
+    },
+    {
+        "nome": "GERENCIA 2",
+        "nome_setor": "Vidas",
+        "descricao": "VIDA E CIÊNCIAS, VIDA E LINGUAGEM, VIDA E MATEMÁTICA, AVANÇANDO JUNTOS MAT/PORT",
+    },
+    {
+        "nome": "GERENCIA 3",
+        "nome_setor": "Fluir",
+        "descricao": "FLUIR DAS EMOÇÕES",
+    },
+    {
+        "nome": "GERENCIA 4",
+        "nome_setor": "ACerta",
+        "descricao": "ACERTA PORTUGUÊS, ACERTA MATEMÁTICA, ECS, SUPERATIVAR, LEIO ESCREVO E CALCULO",
+    },
+    {
+        "nome": "GERENCIA 5",
+        "nome_setor": "Brincando",
+        "descricao": "BRINCANDO E APRENDENDO",
+    },
+    {
+        "nome": "GERENCIA 6",
+        "nome_setor": "Sou da Paz",
+        "descricao": "SOU DA PAZ",
+    },
+    {
+        "nome": "GERENCIA INDIVIDUAL",
+        "nome_setor": "Individual",
+        "descricao": "Projetos com gerência individual (A COR DA GENTE, ED FINANCEIRA, GESTÃO ESCOLAR, MY COMPANION, TRÂNSITO LEGAL, UNI DUNI TÊ)",
+    },
+]
+
+
+class Command(BaseCommand):
+    help = "Seed de gerências organizacionais (7 registros, idempotente)"
+
+    def handle(self, *args: str, **options: dict[str, Any]) -> None:
+        self.stdout.write("Seeding gerências...")
+
+        created_count = 0
+        updated_count = 0
+
+        for gerencia_data in GERENCIAS:
+            gerencia, created = Gerencia.objects.get_or_create(
+                nome=gerencia_data["nome"],
+                defaults={
+                    "nome_setor": gerencia_data["nome_setor"],
+                    "descricao": gerencia_data["descricao"],
+                    "ativo": True,
+                },
+            )
+
+            if created:
+                created_count += 1
+                self.stdout.write(self.style.SUCCESS(f"  ✓ Created: {gerencia.nome} ({gerencia.nome_setor})"))
+            else:
+                updated = False
+                if gerencia.nome_setor != gerencia_data["nome_setor"]:
+                    gerencia.nome_setor = gerencia_data["nome_setor"]
+                    updated = True
+                if gerencia.descricao != gerencia_data["descricao"]:
+                    gerencia.descricao = gerencia_data["descricao"]
+                    updated = True
+
+                if updated:
+                    gerencia.save()
+                    updated_count += 1
+                    self.stdout.write(self.style.WARNING(f"  ⟳ Updated: {gerencia.nome} ({gerencia.nome_setor})"))
+                else:
+                    self.stdout.write(f"  - Skipped: {gerencia.nome} (already exists)")
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"\n✅ Seed complete: {created_count} created, " f"{updated_count} updated, {len(GERENCIAS)} total"
+            )
+        )

--- a/v2/backend/apps/core/tests/test_rbac_permissions.py
+++ b/v2/backend/apps/core/tests/test_rbac_permissions.py
@@ -37,7 +37,6 @@ class TestRBACConstants(TestCase):
             "Sou da Paz",
             "DAT",
             "Controle",
-            "Gerência",
             "Diretoria",
             "Comercial",
             "Relacionamento",
@@ -48,8 +47,8 @@ class TestRBACConstants(TestCase):
             self.assertIn(setor, SETOR_GROUPS, f"Setor '{setor}' não encontrado em SETOR_GROUPS")
 
     def test_setor_groups_count(self):
-        """SETOR_GROUPS deve ter exatamente 14 setores."""
-        self.assertEqual(len(SETOR_GROUPS), 14)
+        """SETOR_GROUPS deve ter exatamente 13 setores."""
+        self.assertEqual(len(SETOR_GROUPS), 13)
 
     def test_funcao_groups_contains_expected_funcoes(self):
         """FUNCAO_GROUPS deve conter todas as funções esperadas."""

--- a/v2/backend/apps/core/tests/test_rbac_seed.py
+++ b/v2/backend/apps/core/tests/test_rbac_seed.py
@@ -70,7 +70,6 @@ def test_seed_rbac_creates_all_groups(run_seed_rbac):
         "Coordenador",
         "Formador",
         "Apoio de Coordenação",
-        "Gerência",
         "Diretoria",
     ]
 

--- a/v2/backend/apps/core/tests/test_seed_rbac.py
+++ b/v2/backend/apps/core/tests/test_seed_rbac.py
@@ -29,7 +29,6 @@ def test_seed_rbac_creates_groups():
         "Formador",
         "Controle",
         "DAT",
-        "Gerência",
         "Diretoria",
     ]
 

--- a/v2/docs/plans/PLAN_gerencias_produtos_admin.md
+++ b/v2/docs/plans/PLAN_gerencias_produtos_admin.md
@@ -1,0 +1,170 @@
+# Plano: Gerências e Produtos — Seed + CRUD Admin
+
+**Data:** 2026-04-14
+**Branch:** `feat/admin-gerencias-produtos`
+**Issues relacionadas:** Dropdown vazio na Grade Mensal, CRUD admin
+
+## Contexto
+
+A tabela `core_gerencia` está vazia em produção. O dropdown de "Gerência" na Grade Mensal chama `GET /api/gerencias/` e retorna `[]`. O backend (ViewSets, Serializers, URLs) já está pronto — falta seed de dados e UI de CRUD no admin.
+
+## Mapeamento de dados confirmado
+
+| Gerência | Setor (nome_setor) | Projetos |
+|---|---|---|
+| GERENCIA 2 | Vidas | VIDA E CIÊNCIAS, LINGUAGEM, MATEMÁTICA, AVANÇANDO JUNTOS MAT/PORT |
+| GERENCIA 3 | Fluir | FLUIR DAS EMOÇÕES |
+| GERENCIA 4 | ACerta | ACERTA PORT/MAT, ECS, SUPERATIVAR, LEIO ESCREVO E CALCULO |
+| GERENCIA 5 | Brincando | BRINCANDO E APRENDENDO |
+| GERENCIA 6 | Sou da Paz | SOU DA PAZ |
+| GERENCIA INDIVIDUAL | Individual | A COR DA GENTE, ED FINANCEIRA, GESTÃO ESCOLAR, MY COMPANION, TRÂNSITO LEGAL, UNI DUNI TÊ |
+| SUPERINTENDENCIA | Super | CIRANDAR, LENDO E ESCREVENDO, NOVO LENDO, TEMA, LER OUVIR E CONTAR, AMMA, CATAVENTO, MIUDEZAS |
+
+## Tarefas
+
+### Tarefa 1 — Seed de Gerências em `apps/core` (backend)
+
+**O que fazer:**
+- Copiar `dev_tools/management/commands/seed_gerencias.py` → `core/management/commands/seed_gerencias.py`
+- Idempotente com `get_or_create`
+- Funciona em produção (core não depende de `INCLUDE_DEV_TOOLS`)
+
+**Arquivos:**
+- `v2/backend/apps/core/management/commands/seed_gerencias.py` (novo)
+
+**Teste:**
+```bash
+docker exec aprender_dev-web-1 python manage.py seed_gerencias
+# Verificar: GET /api/gerencias/ retorna 7 registros
+```
+
+---
+
+### Tarefa 2 — Seed de Produtos em `apps/core` (backend)
+
+**O que fazer:**
+- Criar `core/management/commands/seed_produtos.py`
+- Ler dados da planilha Produtos.xlsx (hardcoded no command como lista Python, não CSV runtime)
+- Para cada produto: `get_or_create` por código/nome
+- Vincular ao Projeto via FK (buscar por nome)
+- Idempotente
+
+**Dados:** ~400 produtos da planilha com colunas: id, Descrição, Nome, Projeto, Tipo, Gerência
+
+**Arquivos:**
+- `v2/backend/apps/core/management/commands/seed_produtos.py` (novo)
+
+**Teste:**
+```bash
+docker exec aprender_dev-web-1 python manage.py seed_produtos --dry-run
+docker exec aprender_dev-web-1 python manage.py seed_produtos
+```
+
+---
+
+### Tarefa 3 — CRUD de Gerências no frontend
+
+**O que fazer:**
+- Criar `GerenciasPage.tsx` seguindo o padrão do `ProjetosPage.tsx`
+- Tabela com colunas: ID, Nome, Nome Setor, Gerente, Projetos (count), Ativo, Ações
+- Modal de criação/edição com campos: nome, nome_setor, gerente (dropdown de usuários), descricao, ativo
+- API functions em `adminDAT.ts`: `listGerencias`, `createGerencia`, `updateGerencia`, `deleteGerencia`
+
+**Arquivos:**
+- `v2/frontend/src/pages/AdminDAT/GerenciasPage.tsx` (novo)
+- `v2/frontend/src/api/adminDAT.ts` (adicionar CRUD de gerências)
+
+**Teste:**
+- Criar gerência via UI → verificar em `GET /api/gerencias/`
+- Editar nome_setor → verificar que dropdown da Grade Mensal reflete
+- Deletar gerência sem projetos → sucesso
+- Deletar gerência com projetos → erro PROTECT
+
+---
+
+### Tarefa 4 — CRUD de Produtos no frontend
+
+**O que fazer:**
+- Criar `ProdutosPage.tsx` seguindo o padrão do `ProjetosPage.tsx`
+- Tabela com colunas: ID, Código, Nome, Descrição, Projeto, Tipo, Ativo, Ações
+- Modal de criação/edição com campos: codigo, nome, descricao, projeto (dropdown), tipo (dropdown Aluno/Professor), ativo
+- API functions em `adminDAT.ts`: `listProdutos`, `createProduto`, `updateProduto`, `deleteProduto`
+
+**Arquivos:**
+- `v2/frontend/src/pages/AdminDAT/ProdutosPage.tsx` (novo)
+- `v2/frontend/src/api/adminDAT.ts` (adicionar CRUD de produtos)
+
+**Teste:**
+- Criar produto vinculado a projeto → verificar na listagem
+- Editar produto → atualiza
+- Verificar que Compras mostra os novos produtos no dropdown
+
+---
+
+### Tarefa 5 — Integrar páginas no Admin DAT
+
+**O que fazer:**
+- Adicionar cards "Gerências" e "Produtos" na `AdminDATHomePage.tsx`
+- Adicionar rotas em `AppRoutes.tsx` (lazy-loaded, `canDAT` permission)
+- Adicionar itens no sidebar em `AppSidebar.tsx`
+
+**Arquivos:**
+- `v2/frontend/src/pages/AdminDAT/AdminDATHomePage.tsx` (adicionar 2 cards)
+- `v2/frontend/src/components/AppRoutes.tsx` (adicionar 2 rotas)
+- `v2/frontend/src/components/AppSidebar.tsx` (adicionar 2 menu items)
+
+**Teste:**
+- Navegar para `/dat/admin` → ver cards de Gerências e Produtos
+- Clicar no card → abre página de CRUD
+- Sidebar mostra os novos itens no submenu DAT
+
+---
+
+### Tarefa 6 — Limpar setor "Gerência" do RBAC
+
+**O que fazer:**
+- Remover `"Gerência"` do `SETOR_GROUPS` em `constants.py`
+- Verificar se algum usuário em produção está nesse grupo antes de remover
+- Manter o grupo Django existente (não deletar) — apenas remover da whitelist
+
+**Arquivos:**
+- `v2/backend/apps/core/constants.py` (remover 1 linha)
+
+**Risco:** Se algum usuário está no grupo "Gerência", perde o setor. Verificar no Portainer antes.
+
+**Teste:**
+```bash
+docker exec aprender_dev-web-1 python manage.py shell -c "
+from django.contrib.auth.models import Group
+g = Group.objects.filter(name='Gerência').first()
+print(f'Usuarios no grupo Gerência: {g.user_set.count() if g else 0}')
+"
+```
+
+---
+
+## Ordem de execução
+
+1. **Tarefa 1** (seed gerências) → merge → rodar em prod → dropdown funciona
+2. **Tarefa 6** (limpar RBAC) → pode ir junto com tarefa 1
+3. **Tarefa 3** (CRUD gerências frontend) → PR separado
+4. **Tarefa 4** (CRUD produtos frontend) → PR separado ou junto com 3
+5. **Tarefa 5** (integração admin) → junto com 3 e 4
+6. **Tarefa 2** (seed produtos) → após CRUD estar pronto para validar
+
+## Riscos
+
+| Risco | Probabilidade | Mitigação |
+|-------|--------------|-----------|
+| Seed cria IDs diferentes em prod vs dev | Baixa | `get_or_create` por `nome`, não por ID |
+| Grupo "Gerência" tem usuários | Média | Verificar no banco antes de remover |
+| Produto sem Projeto correspondente no banco | Alta | Seed de produtos precisa do seed de projetos rodando antes |
+| Frontend type `is_super` não vem do serializer | Baixa | Não é usado no CRUD, ignorar por agora |
+
+## Backend pronto (sem mudanças necessárias)
+
+- ✅ `GerenciaViewSet` — `views/admin.py` (linhas 240-272)
+- ✅ `ProdutoViewSet` — `views/admin.py` (linhas 207-238)
+- ✅ `GerenciaSerializer` — `serializers/organizacao.py` (linhas 116-143)
+- ✅ `ProdutoSerializer` — `serializers/organizacao.py` (linhas 155-176)
+- ✅ Rotas `/api/gerencias/` e `/api/produtos/` — `urls.py` (linha 123)

--- a/v2/frontend/src/api/adminDAT.ts
+++ b/v2/frontend/src/api/adminDAT.ts
@@ -333,3 +333,92 @@ export async function updateProjeto(id: ID, data: ProjetoPayload): Promise<Proje
 export async function deleteProjeto(id: ID): Promise<void> {
   await fetchWithErrorMapping(`/projetos/${id}/`, { method: 'DELETE' }, ADMIN_ERROR_MAP);
 }
+
+// ========== GERENCIAS ==========
+
+export interface GerenciaRecord {
+  id: ID;
+  nome: string;
+  nome_setor: string;
+  gerente: ID | null;
+  gerente_nome: string;
+  ativo: boolean;
+  descricao: string;
+  projetos_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface GerenciaPayload {
+  nome?: string;
+  nome_setor?: string;
+  gerente?: ID | null;
+  ativo?: boolean;
+  descricao?: string;
+}
+
+export async function listGerencias(params: ListParams = {}): Promise<PaginatedResponse<GerenciaRecord>> {
+  return fetchWithErrorMapping(buildUrl('/gerencias/', params as QueryParams), {}, ADMIN_ERROR_MAP);
+}
+
+export async function createGerencia(data: GerenciaPayload): Promise<GerenciaRecord> {
+  return fetchWithErrorMapping('/gerencias/', {
+    method: 'POST',
+    body: JSON.stringify(data),
+  }, ADMIN_ERROR_MAP);
+}
+
+export async function updateGerencia(id: ID, data: GerenciaPayload): Promise<GerenciaRecord> {
+  return fetchWithErrorMapping(`/gerencias/${id}/`, {
+    method: 'PATCH',
+    body: JSON.stringify(data),
+  }, ADMIN_ERROR_MAP);
+}
+
+export async function deleteGerencia(id: ID): Promise<void> {
+  await fetchWithErrorMapping(`/gerencias/${id}/`, { method: 'DELETE' }, ADMIN_ERROR_MAP);
+}
+
+// ========== PRODUTOS ==========
+
+export interface ProdutoRecord {
+  id: ID;
+  codigo: string;
+  nome: string;
+  descricao: string;
+  projeto: ID;
+  projeto_nome: string;
+  ativo: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ProdutoPayload {
+  codigo?: string;
+  nome?: string;
+  descricao?: string;
+  projeto?: ID;
+  ativo?: boolean;
+}
+
+export async function listProdutos(params: ListParams = {}): Promise<PaginatedResponse<ProdutoRecord>> {
+  return fetchWithErrorMapping(buildUrl('/produtos/', params as QueryParams), {}, ADMIN_ERROR_MAP);
+}
+
+export async function createProduto(data: ProdutoPayload): Promise<ProdutoRecord> {
+  return fetchWithErrorMapping('/produtos/', {
+    method: 'POST',
+    body: JSON.stringify(data),
+  }, ADMIN_ERROR_MAP);
+}
+
+export async function updateProduto(id: ID, data: ProdutoPayload): Promise<ProdutoRecord> {
+  return fetchWithErrorMapping(`/produtos/${id}/`, {
+    method: 'PATCH',
+    body: JSON.stringify(data),
+  }, ADMIN_ERROR_MAP);
+}
+
+export async function deleteProduto(id: ID): Promise<void> {
+  await fetchWithErrorMapping(`/produtos/${id}/`, { method: 'DELETE' }, ADMIN_ERROR_MAP);
+}

--- a/v2/frontend/src/components/AppRoutes.tsx
+++ b/v2/frontend/src/components/AppRoutes.tsx
@@ -41,6 +41,8 @@ const CoordenadoresPage = lazy(() => import('../pages/DATModule/CoordenadoresPag
 const AcoesNotificacaoPage = lazy(() => import('../pages/Controle/AcoesNotificacaoPage'));
 const NotificacoesInternasPage = lazy(() => import('../pages/Controle/NotificacoesInternasPage'));
 const AcoesTimelinePage = lazy(() => import('../pages/Controle/AcoesTimelinePage'));
+const GerenciasPage = lazy(() => import('../pages/AdminDAT/GerenciasPage'));
+const ProdutosPage = lazy(() => import('../pages/AdminDAT/ProdutosPage'));
 
 function PageLoader(): JSX.Element {
   return (
@@ -115,6 +117,8 @@ export function AppRoutes({ user, permissions }: AppRoutesProps): JSX.Element {
         <Route path="/dat/admin/grupos" element={canDAT ? <GruposPage /> : <Forbidden />} />
         <Route path="/dat/admin/setores" element={canDAT ? <SetoresPage /> : <Forbidden />} />
         <Route path="/dat/admin/funcoes" element={canDAT ? <FuncoesPage /> : <Forbidden />} />
+        <Route path="/dat/admin/gerencias" element={canDAT ? <GerenciasPage /> : <Forbidden />} />
+        <Route path="/dat/admin/produtos" element={canDAT ? <ProdutosPage /> : <Forbidden />} />
         <Route path="/dat/admin/configuracoes" element={canDAT ? <ConfiguracoesPage /> : <Forbidden />} />
         <Route path="/dat/admin/colecoes" element={canDAT ? <ColecoesImportPage /> : <Forbidden />} />
         <Route path="/dat/admin/equipe-gerencia" element={canDAT ? <EquipeGerenciaImportPage /> : <Forbidden />} />

--- a/v2/frontend/src/components/AppSidebar.tsx
+++ b/v2/frontend/src/components/AppSidebar.tsx
@@ -48,6 +48,8 @@ const ROUTE_TO_MENU_KEY: Record<string, string> = {
   '/dat/admin': 'dat-admin',
   '/dat/admin/colecoes': 'dat-admin-colecoes',
   '/dat/admin/equipe-gerencia': 'dat-admin-equipe-gerencia',
+  '/dat/admin/gerencias': 'dat-admin-gerencias',
+  '/dat/admin/produtos': 'dat-admin-produtos',
   '/dat/cadastros': 'dat-cadastros',
   '/dat/compras-materiais': 'controle-compras',
   '/dat/coordenadores': 'controle-coordenadores',
@@ -77,6 +79,8 @@ const MENU_KEY_TO_PARENT: Record<string, string> = {
   'dat-admin': 'dat-submenu',
   'dat-admin-colecoes': 'dat-submenu',
   'dat-admin-equipe-gerencia': 'dat-submenu',
+  'dat-admin-gerencias': 'dat-submenu',
+  'dat-admin-produtos': 'dat-submenu',
   'dat-cadastros': 'dat-submenu',
   'dat-importacao': 'dat-submenu',
   'dat-registros': 'dat-submenu',
@@ -326,6 +330,8 @@ export function AppSidebar({
             {canDAT && (
               <SubMenu key="dat-submenu" icon={<SolutionOutlined />} title="DAT">
                 <Menu.Item key="dat-admin"><Link to="/dat/admin">Administração</Link></Menu.Item>
+                <Menu.Item key="dat-admin-gerencias"><Link to="/dat/admin/gerencias">Gerências</Link></Menu.Item>
+                <Menu.Item key="dat-admin-produtos"><Link to="/dat/admin/produtos">Produtos</Link></Menu.Item>
                 <Menu.Item key="dat-admin-colecoes"><Link to="/dat/admin/colecoes">Importar Coleções</Link></Menu.Item>
                 <Menu.Item key="dat-admin-equipe-gerencia"><Link to="/dat/admin/equipe-gerencia">Importar Vínculos</Link></Menu.Item>
                 <Menu.Item key="dat-cadastros"><Link to="/dat/cadastros">Cadastros</Link></Menu.Item>

--- a/v2/frontend/src/pages/AdminDAT/AdminDATHomePage.tsx
+++ b/v2/frontend/src/pages/AdminDAT/AdminDATHomePage.tsx
@@ -13,7 +13,7 @@
 
 import type { ReactNode } from 'react';
 import { Card, Row, Col, Typography } from 'antd';
-import { UserOutlined, EnvironmentOutlined, TeamOutlined, ProjectOutlined, SettingOutlined, SafetyOutlined } from '@ant-design/icons';
+import { UserOutlined, EnvironmentOutlined, TeamOutlined, ProjectOutlined, SettingOutlined, SafetyOutlined, BankOutlined, ShoppingOutlined } from '@ant-design/icons';
 import { useNavigate } from 'react-router-dom';
 
 const { Title, Text } = Typography;
@@ -64,6 +64,22 @@ export default function AdminDATHomePage(): JSX.Element {
       description: 'Gerenciar funções (o que cada usuário pode fazer)',
       icon: <SafetyOutlined className="text-5xl text-amber-500" />,
       path: '/dat/admin/funcoes',
+      status: 'Disponível',
+    },
+    {
+      key: 'gerencias',
+      title: 'Gerências',
+      description: 'Gerenciar gerências organizacionais',
+      icon: <BankOutlined className="text-5xl text-indigo-500" />,
+      path: '/dat/admin/gerencias',
+      status: 'Disponível',
+    },
+    {
+      key: 'produtos',
+      title: 'Produtos',
+      description: 'Gerenciar produtos por projeto',
+      icon: <ShoppingOutlined className="text-5xl text-orange-500" />,
+      path: '/dat/admin/produtos',
       status: 'Disponível',
     },
     {

--- a/v2/frontend/src/pages/AdminDAT/GerenciasPage.tsx
+++ b/v2/frontend/src/pages/AdminDAT/GerenciasPage.tsx
@@ -1,0 +1,247 @@
+/**
+ * Admin DAT - Gerencias
+ *
+ * CRUD de gerencias organizacionais com setor e status ativo.
+ */
+
+import { useState, useEffect } from 'react';
+import { Table, Button, Input, Space, Tag, Typography, Card, message, Modal, Form, Checkbox } from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import { ReloadOutlined, EditOutlined, PlusOutlined, DeleteOutlined } from '@ant-design/icons';
+import { Link } from 'react-router-dom';
+import { listGerencias, createGerencia, updateGerencia, deleteGerencia } from '../../api/adminDAT';
+import type { GerenciaRecord, GerenciaPayload } from '../../api/adminDAT';
+import type { ID } from '../../types';
+
+const { Title } = Typography;
+const { Search } = Input;
+
+/**
+ * Gerencia form values interface
+ */
+interface GerenciaFormValues {
+  nome: string;
+  nome_setor: string;
+  descricao: string;
+  ativo: boolean;
+}
+
+export default function GerenciasPage(): JSX.Element {
+  const [gerencias, setGerencias] = useState<GerenciaRecord[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [searchText, setSearchText] = useState('');
+  const [modalVisible, setModalVisible] = useState(false);
+  const [editingGerencia, setEditingGerencia] = useState<GerenciaRecord | null>(null);
+
+  const [form] = Form.useForm<GerenciaFormValues>();
+
+  const fetchGerencias = async (): Promise<void> => {
+    setLoading(true);
+    try {
+      const data = await listGerencias({
+        search: searchText,
+        ordering: 'nome',
+      });
+      setGerencias(data.results as unknown as GerenciaRecord[]);
+    } catch (error) {
+      message.error(`Erro ao carregar gerencias: ${(error as Error).message}`);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchGerencias();
+  }, [searchText]);
+
+  const handleCreate = (): void => {
+    setEditingGerencia(null);
+    form.resetFields();
+    setModalVisible(true);
+  };
+
+  const handleEdit = (gerencia: GerenciaRecord): void => {
+    setEditingGerencia(gerencia);
+    form.setFieldsValue({
+      nome: gerencia.nome,
+      nome_setor: gerencia.nome_setor,
+      descricao: gerencia.descricao,
+      ativo: gerencia.ativo,
+    });
+    setModalVisible(true);
+  };
+
+  const handleSave = async (values: GerenciaFormValues): Promise<void> => {
+    try {
+      const payload: GerenciaPayload = {
+        nome: values.nome,
+        nome_setor: values.nome_setor,
+        descricao: values.descricao,
+        ativo: values.ativo,
+      };
+      if (editingGerencia) {
+        await updateGerencia(editingGerencia.id, payload);
+        message.success('Gerencia atualizada com sucesso');
+      } else {
+        await createGerencia(payload);
+        message.success('Gerencia criada com sucesso');
+      }
+      setModalVisible(false);
+      form.resetFields();
+      fetchGerencias();
+    } catch (error) {
+      message.error(`Erro: ${(error as Error).message}`);
+    }
+  };
+
+  const handleDelete = (gerencia: GerenciaRecord): void => {
+    Modal.confirm({
+      title: 'Confirmar exclusao',
+      content: `Tem certeza que deseja excluir a gerencia "${gerencia.nome}"?`,
+      okText: 'Sim, excluir',
+      okType: 'danger',
+      cancelText: 'Cancelar',
+      onOk: async () => {
+        try {
+          await deleteGerencia(gerencia.id);
+          message.success('Gerencia excluida com sucesso');
+          fetchGerencias();
+        } catch (error) {
+          message.error(`Erro ao excluir: ${(error as Error).message}`);
+        }
+      },
+    });
+  };
+
+  const columns: ColumnsType<GerenciaRecord> = [
+    { title: 'ID', dataIndex: 'id', key: 'id', width: 60 },
+    { title: 'Nome', dataIndex: 'nome', key: 'nome', width: 200 },
+    { title: 'Nome Setor', dataIndex: 'nome_setor', key: 'nome_setor', width: 150 },
+    { title: 'Gerente', dataIndex: 'gerente_nome', key: 'gerente_nome', width: 150 },
+    {
+      title: 'Projetos',
+      dataIndex: 'projetos_count',
+      key: 'projetos_count',
+      width: 80,
+      render: (count: number) => <Tag color="blue">{count}</Tag>,
+    },
+    {
+      title: 'Ativo',
+      dataIndex: 'ativo',
+      key: 'ativo',
+      width: 80,
+      render: (ativo: boolean) => <Tag color={ativo ? 'green' : 'red'}>{ativo ? 'Sim' : 'Nao'}</Tag>,
+    },
+    {
+      title: 'Acoes',
+      key: 'acoes',
+      width: 150,
+      render: (_, record) => (
+        <Space size="small">
+          <Button
+            type="link"
+            size="small"
+            icon={<EditOutlined />}
+            onClick={() => handleEdit(record)}
+          >
+            Editar
+          </Button>
+          <Button
+            type="link"
+            size="small"
+            danger
+            icon={<DeleteOutlined />}
+            onClick={() => handleDelete(record)}
+          >
+            Excluir
+          </Button>
+        </Space>
+      ),
+    },
+  ];
+
+  return (
+    <section className="p-6 bg-gray-100" style={{ minHeight: 'calc(100vh - 64px)' }} aria-labelledby="gerencias-title">
+      <nav className="mb-4" aria-label="Navegacao">
+        <Link to="/dat/admin">&larr; Voltar para Admin DAT</Link>
+      </nav>
+
+      <Card>
+        <header className="flex justify-between items-center mb-4">
+          <Title level={3} className="m-0" id="gerencias-title">
+            Gerencias ({gerencias.length})
+          </Title>
+          <Space>
+            <Search
+              placeholder="Buscar por nome ou setor..."
+              allowClear
+              style={{ width: '100%', maxWidth: 250 }}
+              onSearch={setSearchText}
+              onChange={(e) => !e.target.value && setSearchText('')}
+            />
+            <Button icon={<ReloadOutlined />} onClick={fetchGerencias} loading={loading}>
+              Atualizar
+            </Button>
+            <Button type="primary" icon={<PlusOutlined />} onClick={handleCreate}>
+              Nova Gerencia
+            </Button>
+          </Space>
+        </header>
+
+        <Table
+          columns={columns}
+          dataSource={gerencias}
+          rowKey="id"
+          loading={loading}
+          pagination={{ pageSize: 15, showTotal: (total) => `Total: ${total}` }}
+          scroll={{ x: 900 }}
+        />
+      </Card>
+
+      {/* Modal Criar/Editar Gerencia */}
+      <Modal
+        title={editingGerencia ? 'Editar Gerencia' : 'Nova Gerencia'}
+        open={modalVisible}
+        onCancel={() => setModalVisible(false)}
+        onOk={() => form.submit()}
+        okText="Salvar"
+        cancelText="Cancelar"
+        width={600}
+      >
+        <Form
+          form={form}
+          layout="vertical"
+          autoComplete="off"
+          onFinish={handleSave}
+        >
+          <Form.Item
+            name="nome"
+            label="Nome da Gerencia"
+            rules={[{ required: true, message: 'Nome e obrigatorio' }]}
+          >
+            <Input placeholder="Ex: Gerencia de Projetos" />
+          </Form.Item>
+
+          <Form.Item
+            name="nome_setor"
+            label="Nome do Setor"
+            rules={[{ required: true, message: 'Nome do setor e obrigatorio' }]}
+          >
+            <Input placeholder="Ex: Superintendencia" />
+          </Form.Item>
+
+          <Form.Item
+            name="descricao"
+            label="Descricao"
+          >
+            <Input.TextArea rows={3} placeholder="Descricao da gerencia" />
+          </Form.Item>
+
+          <Form.Item name="ativo" valuePropName="checked" initialValue={true}>
+            <Checkbox>Gerencia ativa</Checkbox>
+          </Form.Item>
+        </Form>
+      </Modal>
+    </section>
+  );
+}

--- a/v2/frontend/src/pages/AdminDAT/GerenciasPage.tsx
+++ b/v2/frontend/src/pages/AdminDAT/GerenciasPage.tsx
@@ -11,7 +11,6 @@ import { ReloadOutlined, EditOutlined, PlusOutlined, DeleteOutlined } from '@ant
 import { Link } from 'react-router-dom';
 import { listGerencias, createGerencia, updateGerencia, deleteGerencia } from '../../api/adminDAT';
 import type { GerenciaRecord, GerenciaPayload } from '../../api/adminDAT';
-import type { ID } from '../../types';
 
 const { Title } = Typography;
 const { Search } = Input;

--- a/v2/frontend/src/pages/AdminDAT/ProdutosPage.tsx
+++ b/v2/frontend/src/pages/AdminDAT/ProdutosPage.tsx
@@ -1,0 +1,278 @@
+/**
+ * Admin DAT - Produtos
+ *
+ * CRUD de produtos por projeto com codigo e status ativo.
+ */
+
+import { useState, useEffect } from 'react';
+import { Table, Button, Input, Space, Tag, Typography, Card, message, Modal, Form, Checkbox, Select } from 'antd';
+import type { ColumnsType } from 'antd/es/table';
+import { ReloadOutlined, EditOutlined, PlusOutlined, DeleteOutlined } from '@ant-design/icons';
+import { Link } from 'react-router-dom';
+import { listProdutos, createProduto, updateProduto, deleteProduto, listProjetos } from '../../api/adminDAT';
+import type { ProdutoRecord, ProdutoPayload } from '../../api/adminDAT';
+import type { ID, Projeto } from '../../types';
+
+const { Title } = Typography;
+const { Search } = Input;
+
+/**
+ * Produto form values interface
+ */
+interface ProdutoFormValues {
+  codigo: string;
+  nome: string;
+  descricao: string;
+  projeto: ID;
+  ativo: boolean;
+}
+
+export default function ProdutosPage(): JSX.Element {
+  const [produtos, setProdutos] = useState<ProdutoRecord[]>([]);
+  const [projetos, setProjetos] = useState<Projeto[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [searchText, setSearchText] = useState('');
+  const [modalVisible, setModalVisible] = useState(false);
+  const [editingProduto, setEditingProduto] = useState<ProdutoRecord | null>(null);
+
+  const [form] = Form.useForm<ProdutoFormValues>();
+
+  const fetchProdutos = async (): Promise<void> => {
+    setLoading(true);
+    try {
+      const data = await listProdutos({
+        search: searchText,
+        ordering: 'nome',
+      });
+      setProdutos(data.results as unknown as ProdutoRecord[]);
+    } catch (error) {
+      message.error(`Erro ao carregar produtos: ${(error as Error).message}`);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const fetchProjetos = async (): Promise<void> => {
+    try {
+      const data = await listProjetos({ page_size: 200 });
+      setProjetos(data.results);
+    } catch (error) {
+      message.error(`Erro ao carregar projetos: ${(error as Error).message}`);
+    }
+  };
+
+  useEffect(() => {
+    fetchProdutos();
+  }, [searchText]);
+
+  useEffect(() => {
+    fetchProjetos();
+  }, []);
+
+  const handleCreate = (): void => {
+    setEditingProduto(null);
+    form.resetFields();
+    setModalVisible(true);
+  };
+
+  const handleEdit = (produto: ProdutoRecord): void => {
+    setEditingProduto(produto);
+    form.setFieldsValue({
+      codigo: produto.codigo,
+      nome: produto.nome,
+      descricao: produto.descricao,
+      projeto: produto.projeto,
+      ativo: produto.ativo,
+    });
+    setModalVisible(true);
+  };
+
+  const handleSave = async (values: ProdutoFormValues): Promise<void> => {
+    try {
+      const payload: ProdutoPayload = {
+        codigo: values.codigo,
+        nome: values.nome,
+        descricao: values.descricao,
+        projeto: values.projeto,
+        ativo: values.ativo,
+      };
+      if (editingProduto) {
+        await updateProduto(editingProduto.id, payload);
+        message.success('Produto atualizado com sucesso');
+      } else {
+        await createProduto(payload);
+        message.success('Produto criado com sucesso');
+      }
+      setModalVisible(false);
+      form.resetFields();
+      fetchProdutos();
+    } catch (error) {
+      message.error(`Erro: ${(error as Error).message}`);
+    }
+  };
+
+  const handleDelete = (produto: ProdutoRecord): void => {
+    Modal.confirm({
+      title: 'Confirmar exclusao',
+      content: `Tem certeza que deseja excluir o produto "${produto.nome}"?`,
+      okText: 'Sim, excluir',
+      okType: 'danger',
+      cancelText: 'Cancelar',
+      onOk: async () => {
+        try {
+          await deleteProduto(produto.id);
+          message.success('Produto excluido com sucesso');
+          fetchProdutos();
+        } catch (error) {
+          message.error(`Erro ao excluir: ${(error as Error).message}`);
+        }
+      },
+    });
+  };
+
+  const columns: ColumnsType<ProdutoRecord> = [
+    { title: 'ID', dataIndex: 'id', key: 'id', width: 60 },
+    { title: 'Codigo', dataIndex: 'codigo', key: 'codigo', width: 120 },
+    { title: 'Nome', dataIndex: 'nome', key: 'nome', width: 250 },
+    { title: 'Projeto', dataIndex: 'projeto_nome', key: 'projeto_nome', width: 150 },
+    {
+      title: 'Ativo',
+      dataIndex: 'ativo',
+      key: 'ativo',
+      width: 80,
+      render: (ativo: boolean) => <Tag color={ativo ? 'green' : 'red'}>{ativo ? 'Sim' : 'Nao'}</Tag>,
+    },
+    {
+      title: 'Acoes',
+      key: 'acoes',
+      width: 150,
+      render: (_, record) => (
+        <Space size="small">
+          <Button
+            type="link"
+            size="small"
+            icon={<EditOutlined />}
+            onClick={() => handleEdit(record)}
+          >
+            Editar
+          </Button>
+          <Button
+            type="link"
+            size="small"
+            danger
+            icon={<DeleteOutlined />}
+            onClick={() => handleDelete(record)}
+          >
+            Excluir
+          </Button>
+        </Space>
+      ),
+    },
+  ];
+
+  return (
+    <section className="p-6 bg-gray-100" style={{ minHeight: 'calc(100vh - 64px)' }} aria-labelledby="produtos-title">
+      <nav className="mb-4" aria-label="Navegacao">
+        <Link to="/dat/admin">&larr; Voltar para Admin DAT</Link>
+      </nav>
+
+      <Card>
+        <header className="flex justify-between items-center mb-4">
+          <Title level={3} className="m-0" id="produtos-title">
+            Produtos ({produtos.length})
+          </Title>
+          <Space>
+            <Search
+              placeholder="Buscar por nome ou codigo..."
+              allowClear
+              style={{ width: '100%', maxWidth: 250 }}
+              onSearch={setSearchText}
+              onChange={(e) => !e.target.value && setSearchText('')}
+            />
+            <Button icon={<ReloadOutlined />} onClick={fetchProdutos} loading={loading}>
+              Atualizar
+            </Button>
+            <Button type="primary" icon={<PlusOutlined />} onClick={handleCreate}>
+              Novo Produto
+            </Button>
+          </Space>
+        </header>
+
+        <Table
+          columns={columns}
+          dataSource={produtos}
+          rowKey="id"
+          loading={loading}
+          pagination={{ pageSize: 15, showTotal: (total) => `Total: ${total}` }}
+          scroll={{ x: 900 }}
+        />
+      </Card>
+
+      {/* Modal Criar/Editar Produto */}
+      <Modal
+        title={editingProduto ? 'Editar Produto' : 'Novo Produto'}
+        open={modalVisible}
+        onCancel={() => setModalVisible(false)}
+        onOk={() => form.submit()}
+        okText="Salvar"
+        cancelText="Cancelar"
+        width={600}
+      >
+        <Form
+          form={form}
+          layout="vertical"
+          autoComplete="off"
+          onFinish={handleSave}
+        >
+          <Form.Item
+            name="codigo"
+            label="Codigo"
+            rules={[{ required: true, message: 'Codigo e obrigatorio' }]}
+          >
+            <Input placeholder="Ex: PROD-001" />
+          </Form.Item>
+
+          <Form.Item
+            name="nome"
+            label="Nome do Produto"
+            rules={[{ required: true, message: 'Nome e obrigatorio' }]}
+          >
+            <Input placeholder="Ex: Material Didatico" />
+          </Form.Item>
+
+          <Form.Item
+            name="descricao"
+            label="Descricao"
+          >
+            <Input.TextArea rows={3} placeholder="Descricao do produto" />
+          </Form.Item>
+
+          <Form.Item
+            name="projeto"
+            label="Projeto"
+            rules={[{ required: true, message: 'Projeto e obrigatorio' }]}
+          >
+            <Select
+              placeholder="Selecione um projeto"
+              showSearch
+              optionFilterProp="children"
+              filterOption={(input, option) =>
+                (option?.children as unknown as string)?.toLowerCase().includes(input.toLowerCase()) ?? false
+              }
+            >
+              {projetos.map((p) => (
+                <Select.Option key={p.id} value={p.id}>
+                  {p.nome}
+                </Select.Option>
+              ))}
+            </Select>
+          </Form.Item>
+
+          <Form.Item name="ativo" valuePropName="checked" initialValue={true}>
+            <Checkbox>Produto ativo</Checkbox>
+          </Form.Item>
+        </Form>
+      </Modal>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `seed_gerencias` management command to `apps/core` (works in production)
- Add Gerências CRUD page in Admin DAT (`/dat/admin/gerencias`)
- Add Produtos CRUD page in Admin DAT (`/dat/admin/produtos`)
- Remove setor "Gerência" from SETOR_GROUPS (it's a role, not a setor)

## Context
The Grade Mensal dropdown for "Gerência" was empty because `core_gerencia` table had no data. This PR adds a seed command to populate the 7 canonical gerências and CRUD pages to manage them going forward.

## Changes

**Backend:**
- `apps/core/management/commands/seed_gerencias.py` — idempotent seed for 7 gerências
- `apps/core/constants.py` — remove "Gerência" from SETOR_GROUPS (14→13)

**Frontend:**
- `pages/AdminDAT/GerenciasPage.tsx` — CRUD with table + modal form
- `pages/AdminDAT/ProdutosPage.tsx` — CRUD with projeto dropdown
- `pages/AdminDAT/AdminDATHomePage.tsx` — add 2 new module cards
- `components/AppRoutes.tsx` — add lazy-loaded routes
- `components/AppSidebar.tsx` — add DAT submenu items
- `api/adminDAT.ts` — add CRUD API functions + TypeScript interfaces

**Documentation:**
- `v2/docs/plans/PLAN_gerencias_produtos_admin.md` — implementation plan

## Post-deploy action
```bash
python manage.py seed_gerencias
```

## Test plan
- [x] Seed command is idempotent (get_or_create)
- [ ] Admin DAT shows Gerências and Produtos cards
- [ ] CRUD operations work for both entities
- [ ] Grade Mensal dropdown populates after seed
- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

```
ALL 8 CHECKS PASSED
```

## Staging Gate
- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR