### PR TITLE
fix(backend): order gerências alphabetically by nome_setor

### DIFF
--- a/v2/backend/apps/core/views/admin.py
+++ b/v2/backend/apps/core/views/admin.py
@@ -254,7 +254,7 @@ class GerenciaViewSet(viewsets.ModelViewSet):  # type: ignore[misc]
     """
 
     queryset = Gerencia.objects.annotate(projetos_count=Count("projetos", filter=Q(projetos__ativo=True))).order_by(
-        "nome"
+        "nome_setor"
     )
     serializer_class = GerenciaSerializer
     permission_classes = [IsAuthenticated]
@@ -262,7 +262,7 @@ class GerenciaViewSet(viewsets.ModelViewSet):  # type: ignore[misc]
     filterset_fields = ["ativo"]
     search_fields = ["nome", "nome_setor"]
     ordering_fields = ["nome", "nome_setor"]
-    ordering = ["nome"]
+    ordering = ["nome_setor"]
 
     def get_permissions(self) -> list:  # type: ignore[type-arg]
         """DAT pode criar/editar/deletar. Outros apenas leitura."""


### PR DESCRIPTION
## Summary
- Change default ordering of `/api/gerencias/` from `nome` (internal) to `nome_setor` (display name)
- Dropdown now shows alphabetical order: A Cor da Gente, ACerta, Brincando, ...

## Test plan
- [x] Dropdown displays alphabetically by nome_setor
- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

```
ALL 8 CHECKS PASSED
```

## Staging Gate
- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR