### PR TITLE
fix(ci): set Portainer curl base timeout to 300s

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -563,7 +563,8 @@ jobs:
           portainer_url="${portainer_url%/}"
 
           # --- Curl base options ---
-          curl_opts=(--silent --show-error --location --max-time 60)
+          # 300s accommodates stack update (image pull + container recreate)
+          curl_opts=(--silent --show-error --location --max-time 300)
           if [ "$PORTAINER_SKIP_TLS_VERIFY" = "true" ]; then
             curl_opts+=(--insecure)
           fi


### PR DESCRIPTION
## Summary
- Change base `curl_opts --max-time` from 60s to 300s for Portainer deploy step
- The 60s timeout was causing GET requests to fail before reaching the PUT stack update
- Fire-and-forget logic only handled PUT timeouts, not GET failures

## Test plan
- [x] Next deploy should not timeout on initial Portainer GET calls
- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

```
ALL 8 CHECKS PASSED
```

## Staging Gate
- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR