### PR TITLE
feat(api): formalize /api/ as canonical, deprecate /api/v1/ (#792-#797)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -139,6 +139,45 @@ jobs:
           cd v2/backend
           flake8 apps/ config/
 
+      - name: Guard rail — no new /api/v1/ references (#796)
+        run: |
+          # Allowlist: files that legitimately reference /api/v1/
+          ALLOWLIST=(
+            "v2/backend/config/urls.py"               # URL alias definition
+            "v2/backend/config/settings.py"           # Middleware registration + comments
+            "v2/backend/apps/core/tests/test_versioning.py"  # Tests for alias
+            "v2/backend/apps/core/deprecation.py"     # Decorator example
+            "v2/backend/apps/core/middleware.py"       # Deprecation middleware
+            "v2/backend/apps/core/api_schemas.py"     # Example URLs in docstrings
+            "v2/backend/apps/core/views_solicitacao.py"  # Curl example in docstring
+            "v2/backend/apps/core/management/commands/sync_municipios_ibge.py"  # IBGE external API
+            "v2/docs/"                                 # Documentation
+            ".claude/"                                 # AI context
+          )
+
+          PATTERN='/api/v1/'
+          violations=0
+
+          while IFS= read -r file; do
+            allowed=false
+            for entry in "${ALLOWLIST[@]}"; do
+              if [[ "$file" == "$entry"* ]]; then
+                allowed=true
+                break
+              fi
+            done
+            if [ "$allowed" = false ]; then
+              echo "::error file=$file::Found /api/v1/ reference — use /api/ instead (see #796)"
+              violations=$((violations + 1))
+            fi
+          done < <(grep -rl --include='*.py' --include='*.ts' --include='*.tsx' --include='*.js' "$PATTERN" v2/ .github/ || true)
+
+          if [ "$violations" -gt 0 ]; then
+            echo "::error::Found $violations file(s) with /api/v1/ outside allowlist. Use /api/ as canonical path."
+            exit 1
+          fi
+          echo "✓ No new /api/v1/ references found outside allowlist."
+
   # ----------------------------------------------------------------
   # Job 2a: Backend tests - core suite (serial)
   # ----------------------------------------------------------------

--- a/v2/backend/apps/core/middleware.py
+++ b/v2/backend/apps/core/middleware.py
@@ -3,6 +3,7 @@ Middleware para AS v2.
 
 Inclui:
 - RequestIDMiddleware: Adiciona correlation ID (request_id) único por requisição
+- APIv1DeprecationMiddleware: Adds deprecation headers to /api/v1/ requests (#793)
 """
 
 from __future__ import annotations
@@ -61,3 +62,29 @@ class RequestIDMiddleware:
                 delattr(threading.current_thread(), "request_id")
             except AttributeError:
                 pass
+
+
+class APIv1DeprecationMiddleware:
+    """
+    Adds RFC 8594 Deprecation + Sunset headers to /api/v1/ requests.
+
+    Signals to clients that the /api/v1/ prefix is deprecated and will be
+    removed. The canonical path is /api/ (#793).
+    """
+
+    # Sunset date: 60 days from deployment (2026-06-15)
+    SUNSET_DATE = "Sun, 14 Jun 2026 23:59:59 GMT"
+
+    def __init__(self, get_response: Callable[[HttpRequest], HttpResponse]) -> None:
+        self.get_response = get_response
+
+    def __call__(self, request: HttpRequest) -> HttpResponse:
+        response = self.get_response(request)
+
+        if request.path.startswith("/api/v1/"):
+            response["Deprecation"] = "true"
+            response["Sunset"] = self.SUNSET_DATE
+            canonical = request.path.replace("/api/v1/", "/api/", 1)
+            response["Link"] = f'<{canonical}>; rel="successor-version"'
+
+        return response

--- a/v2/backend/apps/core/tests/test_versioning.py
+++ b/v2/backend/apps/core/tests/test_versioning.py
@@ -17,7 +17,6 @@ from rest_framework.decorators import api_view
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.test import APIClient
-from rest_framework.views import APIView
 
 from apps.core.deprecation import deprecated_endpoint
 from apps.core.models import Usuario
@@ -115,14 +114,45 @@ class TestDeprecationDecorator(TestCase):
 
 
 class TestVersioningConfiguration(TestCase):
-    """Tests for versioning DRF configuration."""
+    """Tests for versioning DRF configuration (#792)."""
 
-    def test_versioning_config_in_settings(self) -> None:
-        """Versioning configuration should be in REST_FRAMEWORK settings."""
+    def test_no_url_path_versioning(self) -> None:
+        """URLPathVersioning should NOT be configured — /api/ is canonical."""
         from django.conf import settings
 
         rf_settings = settings.REST_FRAMEWORK
 
-        self.assertEqual(rf_settings.get("DEFAULT_VERSIONING_CLASS"), "rest_framework.versioning.URLPathVersioning")
-        self.assertEqual(rf_settings.get("DEFAULT_VERSION"), "v1")
-        self.assertIn("v1", rf_settings.get("ALLOWED_VERSIONS", []))
+        self.assertNotIn("DEFAULT_VERSIONING_CLASS", rf_settings)
+        self.assertNotIn("DEFAULT_VERSION", rf_settings)
+        self.assertNotIn("ALLOWED_VERSIONS", rf_settings)
+
+    def test_v1_alias_still_works(self) -> None:
+        """The /api/v1/ alias must remain functional during deprecation window."""
+        client = APIClient()
+        response = client.get("/api/v1/csrf/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+
+class TestAPIv1DeprecationMiddleware(TestCase):
+    """Tests for the /api/v1/ deprecation middleware (#793)."""
+
+    def setUp(self) -> None:
+        self.client = APIClient()
+
+    def test_v1_returns_deprecation_headers(self) -> None:
+        """Requests to /api/v1/ should include Deprecation + Sunset headers."""
+        response = self.client.get("/api/v1/csrf/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response["Deprecation"], "true")
+        self.assertIn("Sunset", response)
+        self.assertIn("Link", response)
+        self.assertIn('/api/csrf/', response["Link"])
+
+    def test_canonical_api_has_no_deprecation_headers(self) -> None:
+        """Requests to /api/ should NOT have deprecation headers."""
+        response = self.client.get("/api/csrf/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertNotIn("Deprecation", response)
+        self.assertNotIn("Sunset", response)

--- a/v2/backend/apps/core/tests/test_versioning.py
+++ b/v2/backend/apps/core/tests/test_versioning.py
@@ -147,7 +147,7 @@ class TestAPIv1DeprecationMiddleware(TestCase):
         self.assertEqual(response["Deprecation"], "true")
         self.assertIn("Sunset", response)
         self.assertIn("Link", response)
-        self.assertIn('/api/csrf/', response["Link"])
+        self.assertIn("/api/csrf/", response["Link"])
 
     def test_canonical_api_has_no_deprecation_headers(self) -> None:
         """Requests to /api/ should NOT have deprecation headers."""

--- a/v2/backend/config/settings.py
+++ b/v2/backend/config/settings.py
@@ -138,6 +138,7 @@ AUTHENTICATION_BACKENDS = [
 MIDDLEWARE = [
     "django_prometheus.middleware.PrometheusBeforeMiddleware",  # MP1: Metrics start
     "apps.core.middleware.RequestIDMiddleware",  # MP2: Correlation ID for structured logging
+    "apps.core.middleware.APIv1DeprecationMiddleware",  # #793: Deprecation headers on /api/v1/
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "corsheaders.middleware.CorsMiddleware",
@@ -419,11 +420,10 @@ REST_FRAMEWORK = {
     "EXCEPTION_HANDLER": "apps.core.exceptions.custom_exception_handler",
     # API Schema (drf-spectacular)
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
-    # API Versioning (#410)
-    "DEFAULT_VERSIONING_CLASS": "rest_framework.versioning.URLPathVersioning",
-    "DEFAULT_VERSION": "v1",
-    "ALLOWED_VERSIONS": ["v1"],
-    "VERSION_PARAM": "version",
+    # API Versioning — /api/ is canonical, /api/v1/ is deprecated alias (#792)
+    # URLPathVersioning removed: canonical path has no version prefix.
+    # The /api/v1/ alias remains in urls.py for backwards compatibility
+    # until the deprecation window closes (see API-006).
 }
 
 # ================================================================

--- a/v2/backend/config/urls.py
+++ b/v2/backend/config/urls.py
@@ -90,19 +90,19 @@ urlpatterns = [
     path("healthz/detailed/", healthz_detailed, name="healthz_detailed"),
     # Prometheus metrics (MP1) - django_prometheus.urls defines 'metrics' internally
     path("", include("django_prometheus.urls")),
-    # API canonica (v2): /api/*
+    # API canonical: /api/* (#792)
     path("api/", include("apps.core.urls")),
-    # Alias temporario de compatibilidade: /api/v1/*
+    # DEPRECATED alias — will be removed after deprecation window (#797)
     path("api/v1/", include("apps.core.urls", namespace="core-v1")),
 ]
 
 # Incluir URLs do ETL apenas se o app estiver instalado (INCLUDE_ETL=true)
 if "apps.dat_ingest" in settings.INSTALLED_APPS:
-    # Alias temporario de compatibilidade: /api/v1/*
+    # DEPRECATED alias — will be removed after deprecation window (#797)
     urlpatterns.append(
         path("api/v1/", include("apps.dat_ingest.urls", namespace="dat-v1")),
     )
-    # API canonica (v2): /api/*
+    # API canonical: /api/*
     urlpatterns.append(
         path("api/", include("apps.dat_ingest.urls")),  # Fase 5: ETL Observability
     )

--- a/v2/docs/API_REFERENCE.md
+++ b/v2/docs/API_REFERENCE.md
@@ -13,13 +13,24 @@
 ## 🧭 Política Canônica de Rotas
 
 - **Base path canônico oficial**: `/api/`
-- **Alias de compatibilidade temporário**: `/api/v1/`
+- **Alias deprecated**: `/api/v1/` (retorna headers `Deprecation: true` + `Sunset`)
 
 Regras:
 
 - Toda documentação nova deve usar `/api/*`.
 - Todo código novo (frontend/backend/tests/scripts) deve usar `/api/*`.
-- `/api/v1/*` existe apenas para compatibilidade e não deve ser usado em novas integrações.
+- CI bloqueia novas referências a `/api/v1/` fora do allowlist (#796).
+- `/api/v1/*` existe apenas para compatibilidade e será removido após a janela de deprecação.
+
+### Plano de corte do `/api/v1/` (#797)
+
+| Fase | Data | Ação |
+|------|------|------|
+| Deprecation headers | 2026-04-15 | Headers RFC 8594 em todas as respostas `/api/v1/` |
+| CI guard rail | 2026-04-15 | Bloqueia novo código com `/api/v1/` |
+| Service worker migrado | 2026-04-15 | SW usa `/api/` (cache v3 força refresh) |
+| Monitoramento | 2026-04-15 a 2026-06-14 | Observar se há tráfego residual em `/api/v1/` |
+| Remoção do alias | Após 2026-06-14 | Remover `path("api/v1/", ...)` de `config/urls.py` |
 
 Observação:
 

--- a/v2/frontend/public/sw.js
+++ b/v2/frontend/public/sw.js
@@ -5,7 +5,7 @@
  * and network-first with cache fallback for API requests.
  */
 
-const CACHE_VERSION = 'v2';
+const CACHE_VERSION = 'v3';
 const STATIC_CACHE_NAME = `aprender-v2-static-${CACHE_VERSION}`;
 const API_CACHE_NAME = `aprender-v2-api-${CACHE_VERSION}`;
 
@@ -20,9 +20,9 @@ const STATIC_ASSETS = [
 
 // API routes that can be cached for offline use
 const CACHEABLE_API_ROUTES = [
-  '/api/v1/options/',
-  '/api/v1/me/',
-  '/api/v1/config/',
+  '/api/options/',
+  '/api/me/',
+  '/api/config/',
 ];
 
 // Install: cache static assets


### PR DESCRIPTION
## Summary
- Formalize `/api/` as the canonical API prefix, deprecate `/api/v1/` alias
- Add RFC 8594 deprecation middleware with Sunset header (2026-06-15)
- Migrate service worker from `/api/v1/` to `/api/`
- Add CI guard rail to prevent new `/api/v1/` references
- Covers issues #792, #793, #794, #795, #796, #797

## Changes
| Issue | What |
|-------|------|
| API-001 (#792) | Remove `URLPathVersioning` from DRF settings |
| API-002 (#793) | `APIv1DeprecationMiddleware` — Deprecation + Sunset + Link headers |
| API-003 (#794) | Service worker migrated to `/api/`, cache bumped to v3 |
| API-004 (#795) | Swagger/ReDoc already working (CSP allowlist in place) |
| API-005 (#796) | CI guard rail: grep blocks new `/api/v1/` outside allowlist |
| API-006 (#797) | Sunset timeline documented in `API_REFERENCE.md` |

## Test plan
- [x] `pytest apps/core/tests/test_versioning.py` — 10/10 passed
- [x] Deprecation headers verified on `/api/v1/` requests
- [x] Canonical `/api/` has no deprecation headers
- [x] `/api/v1/` alias still functional during deprecation window
- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

```
ALL 8 CHECKS PASSED
```

## Staging Gate
- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR