### PR TITLE
perf(backend): optimize metrics endpoints with SQL aggregation (#781)

### DIFF
--- a/v2/backend/apps/core/views/metrics/dashboard_metrics.py
+++ b/v2/backend/apps/core/views/metrics/dashboard_metrics.py
@@ -71,29 +71,26 @@ def productivity_metrics(request: Request) -> Response:
     rejected = stats["rejected"] or 0
     approval_rate = (approved / total * 100) if total > 0 else 0.0
 
-    # Calculate average approval time (only for approved events)
+    # Approved-only stats in a single query: avg time + gcal counts (#781)
     approved_qs = qs.filter(status="aprovado")
-    avg_time_seconds = approved_qs.aggregate(
+    approved_stats = approved_qs.aggregate(
         avg_time=Avg(
             (F("updated_at") - F("created_at")),
             output_field=None,
-        )
-    )["avg_time"]
+        ),
+        published=Count(Case(When(gcal_status="PUBLISHED", then=1))),
+        errors=Count(Case(When(gcal_status="ERROR", then=1))),
+    )
 
     # Convert timedelta to hours (handle None case)
+    avg_time_seconds = approved_stats["avg_time"]
     if avg_time_seconds is not None:
         avg_approval_time_hours = round(avg_time_seconds.total_seconds() / 3600, 2)
     else:
         avg_approval_time_hours = 0.0
 
-    # GCal metrics
-    gcal_stats = approved_qs.aggregate(
-        published=Count(Case(When(gcal_status="PUBLISHED", then=1))),
-        errors=Count(Case(When(gcal_status="ERROR", then=1))),
-    )
-
-    gcal_published = gcal_stats["published"] or 0
-    gcal_errors = gcal_stats["errors"] or 0
+    gcal_published = approved_stats["published"] or 0
+    gcal_errors = approved_stats["errors"] or 0
     gcal_error_rate = (gcal_errors / approved * 100) if approved > 0 else 0.0
 
     return Response(
@@ -179,7 +176,7 @@ def quality_metrics(request: Request) -> Response:
         .values_list("details__solicitacao_id", flat=True)
         .distinct()
     )
-    reworked_count = len(list(reworked_ids))
+    reworked_count = reworked_ids.count()
     rework_rate = (reworked_count / total * 100) if total > 0 else 0.0
 
     # Average approval time (approved events only)

--- a/v2/backend/apps/core/views/metrics/formador_metrics.py
+++ b/v2/backend/apps/core/views/metrics/formador_metrics.py
@@ -19,7 +19,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.throttling import ScopedRateThrottle
 
-from apps.core.models import Participation, Usuario
+from apps.core.models import Participation
 from apps.core.permissions import IsControle, IsGerencia
 
 
@@ -66,9 +66,14 @@ def formadores_metrics(request: Request) -> Response:
         usuario__isnull=False,  # Exclude guest participations
     ).select_related("usuario", "solicitacao")
 
-    # Aggregate by usuario
+    # Aggregate by usuario — include username to avoid N+1 fallback (#781)
     formadores_stats = (
-        participations.values("usuario_id", "usuario__first_name", "usuario__last_name")
+        participations.values(
+            "usuario_id",
+            "usuario__first_name",
+            "usuario__last_name",
+            "usuario__username",
+        )
         .annotate(
             eventos=Count("solicitacao_id", distinct=True),
             # Calculate hours worked: sum of (solicitacao.fim - solicitacao.inicio)
@@ -89,15 +94,10 @@ def formadores_metrics(request: Request) -> Response:
         if stat["horas_trabalhadas"] is not None:
             horas = round(stat["horas_trabalhadas"].total_seconds() / 3600, 1)
 
-        # Build full name
+        # Build full name — use username from same query as fallback
         nome = f"{stat['usuario__first_name']} {stat['usuario__last_name']}".strip()
         if not nome:
-            # Fallback to username if no first/last name
-            try:
-                usuario = Usuario.objects.get(id=stat["usuario_id"])
-                nome = usuario.username
-            except Usuario.DoesNotExist:
-                nome = f"Usuário #{stat['usuario_id']}"
+            nome = stat["usuario__username"] or f"Usuário #{stat['usuario_id']}"
 
         formadores_list.append(
             {

--- a/v2/backend/apps/core/views/metrics/formador_metrics.py
+++ b/v2/backend/apps/core/views/metrics/formador_metrics.py
@@ -64,7 +64,7 @@ def formadores_metrics(request: Request) -> Response:
         solicitacao__status="aprovado",
         solicitacao__created_at__gte=cutoff,
         usuario__isnull=False,  # Exclude guest participations
-    ).select_related("usuario", "solicitacao")
+    )
 
     # Aggregate by usuario — include username to avoid N+1 fallback (#781)
     formadores_stats = (

--- a/v2/backend/apps/core/views_reports.py
+++ b/v2/backend/apps/core/views_reports.py
@@ -11,7 +11,8 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from typing import Any
 
-from django.db.models import Count, QuerySet
+from django.db.models import Count
+from django.db.models.functions import TruncWeek
 from django.utils import timezone
 from rest_framework.decorators import api_view, permission_classes, throttle_classes
 from rest_framework.request import Request
@@ -75,16 +76,19 @@ def reports_status_counts(request: Request) -> Response:
     counts = queryset.values("status").annotate(count=Count("id"))
     counts_dict = {item["status"]: item["count"] for item in counts}
 
+    # Derive total from already-fetched counts instead of extra COUNT query (#781)
+    counts_data = {
+        "pendente": counts_dict.get("pendente", 0),
+        "aprovado": counts_dict.get("aprovado", 0),
+        "reprovado": counts_dict.get("reprovado", 0),
+        "publicado": counts_dict.get("publicado", 0),
+    }
+
     # Response consistency (#411)
     return APIResponse.success(
         data={
-            "counts": {
-                "pendente": counts_dict.get("pendente", 0),
-                "aprovado": counts_dict.get("aprovado", 0),
-                "reprovado": counts_dict.get("reprovado", 0),
-                "publicado": counts_dict.get("publicado", 0),
-            },
-            "total": queryset.count(),
+            "counts": counts_data,
+            "total": sum(counts_data.values()),
         },
         meta={"range": {"start": str(start_date), "end": str(end_date)}},
     )
@@ -196,33 +200,27 @@ def reports_weekly_approved(request: Request) -> Response:
     end_date = timezone.now().date()
     start_date = end_date - timedelta(weeks=weeks)
 
-    # Query only approved - filtrar por data do evento (inicio)
-    queryset = Solicitacao.objects.filter(status="aprovado", inicio__date__gte=start_date, inicio__date__lte=end_date)
-
-    # Se não há nenhuma solicitação aprovada, retornar array vazio
-    if queryset.count() == 0:
-        return APIResponse.list(items=[], total=0, meta={"weeks": weeks})
-
-    # Group by week (simplified - use created_at week)
-    weeks_data = []
-    current_date = start_date
-
-    while current_date <= end_date:
-        week_end = current_date + timedelta(days=6)
-        if week_end > end_date:
-            week_end = end_date
-
-        week_count = queryset.filter(inicio__date__gte=current_date, inicio__date__lte=week_end).count()
-
-        weeks_data.append(
-            {
-                "week": f"{current_date.year}-W{current_date.isocalendar()[1]:02d}",
-                "count": week_count,
-                "start_date": str(current_date),
-            }
+    # Single aggregated query: GROUP BY week instead of N COUNT queries (#781)
+    weekly_counts = (
+        Solicitacao.objects.filter(
+            status="aprovado",
+            inicio__date__gte=start_date,
+            inicio__date__lte=end_date,
         )
+        .annotate(week_start=TruncWeek("inicio"))
+        .values("week_start")
+        .annotate(count=Count("id"))
+        .order_by("week_start")
+    )
 
-        current_date = week_end + timedelta(days=1)
+    weeks_data = [
+        {
+            "week": f"{row['week_start'].year}-W{row['week_start'].isocalendar()[1]:02d}",
+            "count": row["count"],
+            "start_date": str(row["week_start"].date()),
+        }
+        for row in weekly_counts
+    ]
 
     # Response consistency (#411)
     return APIResponse.list(items=weeks_data[-weeks:], meta={"weeks": weeks})  # Last N weeks


### PR DESCRIPTION
## Summary
- Replace N weekly COUNT queries with single `TruncWeek` aggregate in `reports_weekly_approved`
- Derive total from counts dict instead of extra COUNT query in `reports_status_counts`
- Include `username` in formador metrics GROUP BY to eliminate N+1 `Usuario.objects.get()` fallback
- Use `.count()` instead of `len(list(...))` in `quality_metrics` rework rate
- Combine `avg_time` + gcal stats into single aggregate query in `productivity_metrics`

## Query reduction summary
| Endpoint | Before | After |
|----------|--------|-------|
| `weekly-approved` (12 weeks) | ~13 queries | 1 query |
| `status-counts` | 2 queries | 1 query |
| `formadores-metrics` (10 results) | up to 11 queries | 1 query |
| `productivity-metrics` | 3 queries | 2 queries |
| `quality-metrics` | materializes full list | COUNT in DB |

## Test plan
- [x] 1523 tests passed, 0 failed
- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

```
ALL 8 CHECKS PASSED
```

## Staging Gate
- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Closes #781