### PR TITLE
feat(security): Security Group C — RECON + AUTH + INFRA hardening

### DIFF
--- a/.github/workflows/backend-xdist-canary.yml
+++ b/.github/workflows/backend-xdist-canary.yml
@@ -39,7 +39,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:15
+        image: postgres:15.13
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: test_aprender
@@ -52,7 +52,7 @@ jobs:
           - 5432:5432
 
       redis:
-        image: redis:7
+        image: redis:7.4
         options: >-
           --health-cmd "redis-cli ping"
           --health-interval 10s

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -191,7 +191,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:15
+        image: postgres:15.13
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: test_aprender
@@ -204,7 +204,7 @@ jobs:
           - 5432:5432
 
       redis:
-        image: redis:7
+        image: redis:7.4
         options: >-
           --health-cmd "redis-cli ping"
           --health-interval 10s
@@ -312,7 +312,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:15
+        image: postgres:15.13
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: test_aprender
@@ -325,7 +325,7 @@ jobs:
           - 5432:5432
 
       redis:
-        image: redis:7
+        image: redis:7.4
         options: >-
           --health-cmd "redis-cli ping"
           --health-interval 10s
@@ -531,7 +531,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:15
+        image: postgres:15.13
         env:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: test_aprender
@@ -544,7 +544,7 @@ jobs:
           - 5432:5432
 
       redis:
-        image: redis:7
+        image: redis:7.4
         options: >-
           --health-cmd "redis-cli ping"
           --health-interval 10s

--- a/v2/backend/apps/core/tests/test_prod_guard_rails.py
+++ b/v2/backend/apps/core/tests/test_prod_guard_rails.py
@@ -158,24 +158,24 @@ class ProductionGuardRailsTests(TestCase):
         # Aceitar exit code 0 (sucesso) ou != 1 (warnings OK, mas não critical errors)
         self.assertNotEqual(result.returncode, 1, f"Django check falhou inesperadamente. Stderr: {result.stderr}")
 
-    def test_startup_warns_with_short_secret_key(self):
+    def test_startup_fails_with_short_secret_key(self):
         """
-        P1.4 - Startup DEVE avisar (WARNING) se SECRET_KEY < 50 chars
+        SEC-AUTH-02 - Startup DEVE falhar se SECRET_KEY < 50 chars em produção
 
         Cenário:
         - ENVIRONMENT=production
         - SECRET_KEY com apenas 20 caracteres
 
         Expectativa:
-        - settings.py imprime WARNING no stderr
-        - Mas NÃO chama sys.exit() (apenas warning, não bloqueio)
-        - Django check pode passar (exit code 0 ou com warnings)
+        - settings.py detecta SECRET_KEY curta
+        - sys.exit(1) com mensagem de erro
+        - Processo termina com exit code 1
         """
         env = os.environ.copy()
         env["ENVIRONMENT"] = "production"
         env["DEBUG"] = "0"
         env["ALLOWED_HOSTS"] = "example.com"
-        env["SECRET_KEY"] = "a" * 20  # Apenas 20 chars (< 50 recomendado)
+        env["SECRET_KEY"] = "a" * 20  # Apenas 20 chars (< 50 mínimo)
         env["DB_NAME"] = "test_db"
         env["DB_USER"] = "test_user"
         env["DB_PASSWORD"] = "test_password"
@@ -183,19 +183,18 @@ class ProductionGuardRailsTests(TestCase):
         env["DB_PORT"] = "5434"
 
         # Rodar Django check em subprocess
-        # P1.4 FIX: Correct path - manage.py is at /app/manage.py (container root)
         result = subprocess.run(
             [sys.executable, "manage.py", "check", "--deploy"],
-            cwd=str(Path(settings.BASE_DIR)),  # Project root where manage.py is located
+            cwd=str(Path(settings.BASE_DIR)),
             env=env,
             capture_output=True,
             text=True,
             timeout=10,
         )
 
-        # Validar que NÃO falhou criticamente (exit code != 1)
-        self.assertNotEqual(result.returncode, 1)
+        # SEC-AUTH-02: Short SECRET_KEY now causes sys.exit(1)
+        self.assertEqual(result.returncode, 1)
 
-        # Validar que warning aparece no stderr
+        # Validar mensagem de erro no stderr
         self.assertIn("SECRET_KEY muito curta", result.stderr)
-        self.assertIn("WARNING", result.stderr)
+        self.assertIn("ERRO CRÍTICO", result.stderr)

--- a/v2/backend/apps/core/tests/test_readyz.py
+++ b/v2/backend/apps/core/tests/test_readyz.py
@@ -9,6 +9,10 @@ Cobertura:
 
 Endpoint testado:
 - GET /readyz
+
+SEC-RECON-03: readyz now returns conditional payload:
+- Anonymous: {"status": "healthy"} (no checks)
+- Staff/admin: {"status": "healthy", "checks": {...}} (full details)
 """
 
 # pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportOptionalMemberAccess=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportMissingTypeArgument=false, reportCallIssue=false, reportIndexIssue=false, reportOperatorIssue=false, reportOptionalSubscript=false, reportUnknownLambdaType=false
@@ -17,6 +21,7 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+from django.contrib.auth import get_user_model
 from django.urls import reverse
 from rest_framework.test import APIClient
 
@@ -24,15 +29,25 @@ import pytest
 
 pytestmark = pytest.mark.django_db
 
+User = get_user_model()
+
+
+def _staff_client() -> APIClient:
+    """Create an APIClient authenticated as staff (required for full readyz payload)."""
+    user = User.objects.create_user("readyz_staff", "rz@test.com", "pass1234", is_staff=True)
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
 
 # ============================================================================
-# TESTES DE ESTRUTURA DA RESPOSTA
+# TESTES DE ESTRUTURA DA RESPOSTA (staff — full payload)
 # ============================================================================
 
 
 def test_readyz_returns_200_when_healthy():
     """GET /readyz retorna 200 quando sistema está healthy."""
-    client = APIClient()
+    client = _staff_client()
     url = reverse("core:readyz")
     res = client.get(url)
 
@@ -46,7 +61,7 @@ def test_readyz_returns_200_when_healthy():
 
 def test_readyz_checks_database():
     """Readyz verifica conexão com banco de dados."""
-    client = APIClient()
+    client = _staff_client()
     url = reverse("core:readyz")
     res = client.get(url)
 
@@ -59,7 +74,7 @@ def test_readyz_checks_database():
 
 def test_readyz_checks_cache():
     """Readyz verifica conexão com cache (Redis ou LocMem)."""
-    client = APIClient()
+    client = _staff_client()
     url = reverse("core:readyz")
     res = client.get(url)
 
@@ -72,19 +87,19 @@ def test_readyz_checks_cache():
 
 
 # ============================================================================
-# TESTES DE FALHAS
+# TESTES DE FALHAS (staff — needs full payload to verify check details)
 # ============================================================================
 
 
-@patch("django.db.connection.cursor")
-def test_readyz_returns_503_when_database_fails(mock_cursor):
+def test_readyz_returns_503_when_database_fails():
     """Readyz retorna 503 se banco de dados falhar."""
-    # Simular erro de conexão
-    mock_cursor.side_effect = Exception("Connection refused")
-
-    client = APIClient()
+    # Create staff user BEFORE mocking cursor (needs real DB)
+    client = _staff_client()
     url = reverse("core:readyz")
-    res = client.get(url)
+
+    with patch("django.db.connection.cursor") as mock_cursor:
+        mock_cursor.side_effect = Exception("Connection refused")
+        res = client.get(url)
 
     assert res.status_code == 503, "Readyz deve retornar 503 quando database falha"
 
@@ -99,7 +114,7 @@ def test_readyz_cache_failure_is_warning_not_503(mock_cache_set):
     # Simular erro no cache
     mock_cache_set.side_effect = Exception("Redis connection refused")
 
-    client = APIClient()
+    client = _staff_client()
     url = reverse("core:readyz")
     res = client.get(url)
 
@@ -112,7 +127,7 @@ def test_readyz_cache_failure_is_warning_not_503(mock_cache_set):
 
 
 # ============================================================================
-# TESTES DE AUTENTICAÇÃO
+# TESTES DE AUTENTICAÇÃO (SEC-RECON-03)
 # ============================================================================
 
 
@@ -126,8 +141,32 @@ def test_readyz_does_not_require_authentication():
     assert res.status_code in [200, 503], "Readyz não deve requerer autenticação"
 
 
+def test_readyz_anonymous_gets_minimal_payload():
+    """SEC-RECON-03: Anonymous users get only status, no checks."""
+    client = APIClient()
+    url = reverse("core:readyz")
+    res = client.get(url)
+
+    assert res.status_code == 200
+    data = res.json()
+    assert "status" in data
+    assert "checks" not in data
+
+
+def test_readyz_staff_gets_full_payload():
+    """SEC-RECON-03: Staff users get full payload with checks."""
+    client = _staff_client()
+    url = reverse("core:readyz")
+    res = client.get(url)
+
+    assert res.status_code == 200
+    data = res.json()
+    assert "status" in data
+    assert "checks" in data
+
+
 # ============================================================================
-# TESTES DE EDGE CASES
+# TESTES DE EDGE CASES (staff)
 # ============================================================================
 
 
@@ -137,7 +176,7 @@ def test_readyz_database_returns_unexpected_result():
         mock_cursor_instance = mock_cursor.return_value.__enter__.return_value
         mock_cursor_instance.fetchone.return_value = (999,)  # Não é 1
 
-        client = APIClient()
+        client = _staff_client()
         url = reverse("core:readyz")
         res = client.get(url)
 
@@ -150,7 +189,7 @@ def test_readyz_database_returns_unexpected_result():
 
 def test_readyz_json_format():
     """Readyz retorna JSON válido."""
-    client = APIClient()
+    client = _staff_client()
     url = reverse("core:readyz")
     res = client.get(url)
 
@@ -163,13 +202,13 @@ def test_readyz_json_format():
 
 
 # ============================================================================
-# TESTES DE INTEGRAÇÃO
+# TESTES DE INTEGRAÇÃO (staff)
 # ============================================================================
 
 
 def test_readyz_works_with_real_database():
     """Readyz funciona com banco de dados real (não mock)."""
-    client = APIClient()
+    client = _staff_client()
     url = reverse("core:readyz")
     res = client.get(url)
 
@@ -183,7 +222,7 @@ def test_readyz_works_with_real_database():
 
 def test_readyz_works_with_real_cache():
     """Readyz funciona com cache real (LocMem ou Redis)."""
-    client = APIClient()
+    client = _staff_client()
     url = reverse("core:readyz")
     res = client.get(url)
 

--- a/v2/backend/apps/core/tests/test_security_hardening.py
+++ b/v2/backend/apps/core/tests/test_security_hardening.py
@@ -14,8 +14,7 @@ Covers:
 
 from __future__ import annotations
 
-import pytest
-from django.test import RequestFactory, TestCase, override_settings
+from django.test import TestCase, override_settings
 
 from apps.core.views_auth import (
     _clear_failed_attempts,
@@ -217,13 +216,13 @@ class TestAllowedHostsProductionGuard(TestCase):
 
     def test_dev_hosts_detected(self):
         """Default hosts are all dev hosts."""
-        dev_hosts = {"localhost", "127.0.0.1", "testserver", "web", "0.0.0.0"}
+        dev_hosts = {"localhost", "127.0.0.1", "testserver", "web", "0.0.0.0"}  # nosec B104
         default_hosts = ["localhost", "127.0.0.1", "testserver", "web"]
         assert dev_hosts.issuperset(default_hosts)
 
     def test_production_hosts_accepted(self):
         """Real production hosts are not a subset of dev hosts."""
-        dev_hosts = {"localhost", "127.0.0.1", "testserver", "web", "0.0.0.0"}
+        dev_hosts = {"localhost", "127.0.0.1", "testserver", "web", "0.0.0.0"}  # nosec B104
         prod_hosts = ["aprender.example.com", "www.aprender.example.com"]
         assert not dev_hosts.issuperset(prod_hosts)
 
@@ -231,4 +230,4 @@ class TestAllowedHostsProductionGuard(TestCase):
         """0.0.0.0 should no longer be in default ALLOWED_HOSTS."""
         from django.conf import settings
 
-        assert "0.0.0.0" not in settings.ALLOWED_HOSTS
+        assert "0.0.0.0" not in settings.ALLOWED_HOSTS  # nosec B104

--- a/v2/backend/apps/core/tests/test_security_hardening.py
+++ b/v2/backend/apps/core/tests/test_security_hardening.py
@@ -1,0 +1,234 @@
+"""
+Security Hardening Tests — SEC-RECON, SEC-AUTH, INFRA
+
+Covers:
+- SEC-RECON-01: /healthz minimal payload, /healthz/detailed auth (#1126)
+- SEC-RECON-02: /metrics auth gate (#1127)
+- SEC-RECON-03: /api/readyz/ conditional payload, /api/version/ conditional (#1128)
+- SEC-AUTH-01: Compound lockout key IP+username (#1130)
+- SEC-AUTH-02: SECRET_KEY production guard (#1131)
+- SEC-AUTH-03: ALLOWED_HOSTS production guard (#1132)
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportOptionalMemberAccess=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportMissingTypeArgument=false, reportCallIssue=false, reportIndexIssue=false, reportOperatorIssue=false, reportOptionalSubscript=false, reportUnknownLambdaType=false
+
+from __future__ import annotations
+
+import pytest
+from django.test import RequestFactory, TestCase, override_settings
+
+from apps.core.views_auth import (
+    _clear_failed_attempts,
+    _get_failed_attempts,
+    _get_lockout_key,
+    _increment_failed_attempts,
+    _is_account_locked,
+)
+
+
+# ================================================================
+# SEC-RECON-01: /healthz endpoints (#1126)
+# ================================================================
+class TestHealthzMinimalPayload(TestCase):
+    """SEC-RECON-01: /healthz/ must return minimal payload without sensitive data."""
+
+    def test_healthz_returns_ok_without_environment(self):
+        response = self.client.get("/healthz/")
+        assert response.status_code == 200
+        data = response.json()
+        assert data == {"status": "ok"}
+        assert "environment" not in data
+        assert "debug" not in data
+        assert "timezone" not in data
+
+    def test_healthz_detailed_anonymous_external_returns_403(self):
+        response = self.client.get("/healthz/detailed/", REMOTE_ADDR="203.0.113.1")
+        assert response.status_code == 403
+
+    def test_healthz_detailed_internal_ip_returns_200(self):
+        response = self.client.get("/healthz/detailed/", REMOTE_ADDR="127.0.0.1")
+        assert response.status_code == 200
+        data = response.json()
+        assert "checks" in data
+        assert "environment" not in data  # removed sensitive field
+
+    def test_healthz_detailed_superuser_returns_200(self):
+        from django.contrib.auth import get_user_model
+
+        User = get_user_model()
+        admin = User.objects.create_superuser("admin_health", "a@b.com", "pass1234")
+        self.client.force_login(admin)
+        response = self.client.get("/healthz/detailed/", REMOTE_ADDR="203.0.113.1")
+        assert response.status_code == 200
+        data = response.json()
+        assert "checks" in data
+
+
+# ================================================================
+# SEC-RECON-02: /metrics auth gate (#1127)
+# ================================================================
+class TestMetricsAuthGate(TestCase):
+    """SEC-RECON-02: /metrics must require staff or internal IP."""
+
+    def test_metrics_anonymous_external_returns_403(self):
+        response = self.client.get("/metrics", REMOTE_ADDR="203.0.113.1")
+        assert response.status_code == 403
+
+    def test_metrics_internal_ip_returns_200(self):
+        response = self.client.get("/metrics", REMOTE_ADDR="127.0.0.1")
+        # Should return 200 with prometheus metrics (or at least not 403)
+        assert response.status_code != 403
+
+    def test_metrics_staff_returns_200(self):
+        from django.contrib.auth import get_user_model
+
+        User = get_user_model()
+        staff = User.objects.create_user("staff_metrics", "s@b.com", "pass1234", is_staff=True)
+        self.client.force_login(staff)
+        response = self.client.get("/metrics", REMOTE_ADDR="203.0.113.1")
+        assert response.status_code != 403
+
+
+# ================================================================
+# SEC-RECON-03: /api/readyz/ and /api/version/ (#1128)
+# ================================================================
+class TestReadyzConditionalPayload(TestCase):
+    """SEC-RECON-03: readyz anonymous gets minimal, admin gets full."""
+
+    def test_readyz_anonymous_returns_status_only(self):
+        response = self.client.get("/api/readyz/")
+        assert response.status_code == 200
+        data = response.json()
+        assert "status" in data
+        assert "checks" not in data
+
+    def test_readyz_admin_returns_full_payload(self):
+        from django.contrib.auth import get_user_model
+
+        User = get_user_model()
+        admin = User.objects.create_user("admin_readyz", "r@b.com", "pass1234", is_staff=True)
+        self.client.force_login(admin)
+        response = self.client.get("/api/readyz/")
+        assert response.status_code == 200
+        data = response.json()
+        assert "status" in data
+        assert "checks" in data
+
+
+class TestVersionConditionalPayload(TestCase):
+    """SEC-RECON-03: version anonymous gets only version tag, admin gets full."""
+
+    def test_version_anonymous_no_git_sha(self):
+        response = self.client.get("/api/version/")
+        assert response.status_code == 200
+        data = response.json()
+        assert "version" in data
+        assert "git_sha" not in data
+        assert "build_date" not in data
+
+    def test_version_admin_gets_git_sha(self):
+        from django.contrib.auth import get_user_model
+
+        User = get_user_model()
+        admin = User.objects.create_user("admin_ver", "v@b.com", "pass1234", is_staff=True)
+        self.client.force_login(admin)
+        response = self.client.get("/api/version/")
+        assert response.status_code == 200
+        data = response.json()
+        assert "version" in data
+        assert "git_sha" in data
+        assert "build_date" in data
+
+
+# ================================================================
+# SEC-AUTH-01: Compound lockout key (#1130)
+# ================================================================
+class TestCompoundLockout(TestCase):
+    """SEC-AUTH-01: Lockout keyed by IP+username, with global fallback."""
+
+    def setUp(self):
+        from django.core.cache import cache
+
+        cache.clear()
+
+    def test_lockout_key_includes_ip(self):
+        key = _get_lockout_key("admin", "192.168.1.1")
+        assert "admin" in key
+        assert "192.168.1.1" in key
+
+    def test_lockout_key_global_when_no_ip(self):
+        key = _get_lockout_key("admin")
+        assert "global" in key
+        assert "admin" in key
+
+    def test_lockout_key_case_insensitive(self):
+        key1 = _get_lockout_key("Admin", "1.2.3.4")
+        key2 = _get_lockout_key("admin", "1.2.3.4")
+        assert key1 == key2
+
+    @override_settings(ACCOUNT_LOCKOUT_THRESHOLD=3, ACCOUNT_LOCKOUT_DURATION=60)
+    def test_lockout_by_ip_username(self):
+        """Same IP hitting same username gets locked after threshold."""
+        for _ in range(3):
+            _increment_failed_attempts("victim", "10.0.0.1")
+        assert _is_account_locked("victim", "10.0.0.1") is True
+
+    @override_settings(ACCOUNT_LOCKOUT_THRESHOLD=3, ACCOUNT_LOCKOUT_DURATION=60)
+    def test_different_ip_not_locked(self):
+        """Different IP for same username is NOT locked by IP-specific threshold."""
+        for _ in range(3):
+            _increment_failed_attempts("victim", "10.0.0.1")
+        # Different IP should not be locked (IP-specific threshold not reached)
+        assert _is_account_locked("victim", "10.0.0.2") is False
+
+    @override_settings(ACCOUNT_LOCKOUT_THRESHOLD=3, ACCOUNT_LOCKOUT_DURATION=60)
+    def test_lockout_cleared_on_success(self):
+        """Login success clears both IP-specific and global counters."""
+        for _ in range(2):
+            _increment_failed_attempts("user1", "10.0.0.1")
+        _clear_failed_attempts("user1", "10.0.0.1")
+        assert _get_failed_attempts("user1", "10.0.0.1") == 0
+        assert _get_failed_attempts("user1") == 0  # global also cleared
+
+
+# ================================================================
+# SEC-AUTH-02: SECRET_KEY production guard (#1131)
+# ================================================================
+class TestSecretKeyProductionGuard(TestCase):
+    """SEC-AUTH-02: Production must reject insecure SECRET_KEY."""
+
+    def test_insecure_key_detected(self):
+        """The default key starts with 'django-insecure' and would be blocked."""
+        default_key = "django-insecure-dev-key-CHANGE-IN-PRODUCTION-abcd1234efgh5678ijkl9012mnop3456qrst"
+        assert default_key.startswith("django-insecure")
+
+    def test_secure_key_accepted(self):
+        """A proper production key does not start with 'django-insecure'."""
+        secure_key = "a" * 64
+        assert not secure_key.startswith("django-insecure")
+        assert len(secure_key) >= 50
+
+
+# ================================================================
+# SEC-AUTH-03: ALLOWED_HOSTS production guard (#1132)
+# ================================================================
+class TestAllowedHostsProductionGuard(TestCase):
+    """SEC-AUTH-03: Production must reject dev-only hosts."""
+
+    def test_dev_hosts_detected(self):
+        """Default hosts are all dev hosts."""
+        dev_hosts = {"localhost", "127.0.0.1", "testserver", "web", "0.0.0.0"}
+        default_hosts = ["localhost", "127.0.0.1", "testserver", "web"]
+        assert dev_hosts.issuperset(default_hosts)
+
+    def test_production_hosts_accepted(self):
+        """Real production hosts are not a subset of dev hosts."""
+        dev_hosts = {"localhost", "127.0.0.1", "testserver", "web", "0.0.0.0"}
+        prod_hosts = ["aprender.example.com", "www.aprender.example.com"]
+        assert not dev_hosts.issuperset(prod_hosts)
+
+    def test_0_0_0_0_removed_from_defaults(self):
+        """0.0.0.0 should no longer be in default ALLOWED_HOSTS."""
+        from django.conf import settings
+
+        assert "0.0.0.0" not in settings.ALLOWED_HOSTS

--- a/v2/backend/apps/core/views_auth.py
+++ b/v2/backend/apps/core/views_auth.py
@@ -35,65 +35,91 @@ from apps.core.views.utils import _get_client_ip
 
 from .models import AuditLog
 
-
 # ================================================================
-# Account Lockout (Security Audit 2025-01)
+# Account Lockout (Security Audit 2025-01, SEC-AUTH-01)
 # ================================================================
-def _get_lockout_key(username: str) -> str:
-    """Gera chave Redis para tracking de tentativas de login."""
-    return f"login_attempts:{username.lower()}"
+# Two-level lockout:
+# 1. Per IP+username (threshold=10, 15min) — prevents single-source brute force
+# 2. Global per username (threshold=50, 30min) — prevents distributed credential stuffing
+
+_GLOBAL_LOCKOUT_THRESHOLD = 50
+_GLOBAL_LOCKOUT_DURATION = 1800  # 30 minutes
 
 
-def _get_failed_attempts(username: str) -> int:
+def _get_lockout_key(username: str, ip: str = "") -> str:
+    """Gera chave Redis para tracking de tentativas de login por IP+username."""
+    if ip:
+        return f"login_attempts:{username.lower()}:{ip}"
+    return f"login_attempts_global:{username.lower()}"
+
+
+def _get_failed_attempts(username: str, ip: str = "") -> int:
     """Retorna número de tentativas falhas de login."""
-    key = _get_lockout_key(username)
+    key = _get_lockout_key(username, ip)
     attempts = cache.get(key)
     return int(attempts) if attempts else 0
 
 
-def _increment_failed_attempts(username: str) -> int:
+def _increment_failed_attempts(username: str, ip: str) -> int:
     """
-    Incrementa contador de tentativas falhas.
-    Retorna o novo total de tentativas.
+    Incrementa contadores de tentativas falhas (IP-specific e global).
+    Retorna o novo total de tentativas IP-specific.
     """
-    key = _get_lockout_key(username)
     lockout_duration = getattr(settings, "ACCOUNT_LOCKOUT_DURATION", 900)
 
-    # Usa Redis INCR com TTL
+    # Increment IP-specific counter
+    ip_key = _get_lockout_key(username, ip)
+    ip_attempts = _safe_increment(ip_key, lockout_duration)
+
+    # Increment global counter
+    global_key = _get_lockout_key(username)
+    _safe_increment(global_key, _GLOBAL_LOCKOUT_DURATION)
+
+    return ip_attempts
+
+
+def _safe_increment(key: str, timeout: int) -> int:
+    """Safely increment a Redis counter with TTL."""
     try:
-        # Se a chave não existe, cria com valor 1
         current = cache.get(key)
         if current is None:
-            cache.set(key, 1, timeout=lockout_duration)
+            cache.set(key, 1, timeout=timeout)
             return 1
-        else:
-            new_value = int(current) + 1
-            cache.set(key, new_value, timeout=lockout_duration)
-            return new_value
+        new_value = int(current) + 1
+        cache.set(key, new_value, timeout=timeout)
+        return new_value
     except Exception:
-        # Fallback: apenas retorna 1 se cache falhar
         return 1
 
 
-def _clear_failed_attempts(username: str) -> None:
-    """Limpa contador de tentativas após login bem-sucedido."""
-    key = _get_lockout_key(username)
-    cache.delete(key)
+def _clear_failed_attempts(username: str, ip: str) -> None:
+    """Limpa contadores de tentativas após login bem-sucedido."""
+    cache.delete(_get_lockout_key(username, ip))
+    cache.delete(_get_lockout_key(username))
 
 
-def _is_account_locked(username: str) -> bool:
-    """Verifica se a conta está bloqueada por excesso de tentativas."""
+def _is_account_locked(username: str, ip: str) -> bool:
+    """Verifica se a conta está bloqueada (IP-specific OU global)."""
     threshold = getattr(settings, "ACCOUNT_LOCKOUT_THRESHOLD", 10)
-    attempts = _get_failed_attempts(username)
-    return attempts >= threshold
+
+    # Check IP-specific lockout
+    if _get_failed_attempts(username, ip) >= threshold:
+        return True
+
+    # Check global lockout (distributed attack protection)
+    if _get_failed_attempts(username) >= _GLOBAL_LOCKOUT_THRESHOLD:
+        return True
+
+    return False
 
 
-def _get_lockout_remaining_time(username: str) -> int | None:
+def _get_lockout_remaining_time(username: str, ip: str) -> int | None:
     """Retorna tempo restante de bloqueio em segundos, ou None se não bloqueado."""
-    key = _get_lockout_key(username)
-    ttl = cache.ttl(key) if hasattr(cache, "ttl") else None
-    if ttl and ttl > 0:
-        return ttl
+    # Check IP-specific first, then global
+    for key in [_get_lockout_key(username, ip), _get_lockout_key(username)]:
+        ttl = cache.ttl(key) if hasattr(cache, "ttl") else None
+        if ttl and ttl > 0:
+            return ttl
     return None
 
 
@@ -171,10 +197,13 @@ def login(request: Request) -> Response:
     if not username or not password:
         return Response({"error": "Username e password são obrigatórios."}, status=status.HTTP_400_BAD_REQUEST)
 
+    # SEC-AUTH-01: compound lockout key (IP + username)
+    client_ip = _get_client_ip(request)
+
     # Security hardening #745:
     # - Keep a generic client response for all auth failures
     # - Preserve detailed reason only in AuditLog
-    is_locked = _is_account_locked(username)
+    is_locked = _is_account_locked(username, client_ip)
 
     user = authenticate(request, username=username, password=password)
     if user is None:
@@ -183,8 +212,8 @@ def login(request: Request) -> Response:
 
     if is_locked:
         threshold = getattr(settings, "ACCOUNT_LOCKOUT_THRESHOLD", 10)
-        attempts = _get_failed_attempts(username)
-        lockout_remaining_seconds = _get_lockout_remaining_time(username)
+        attempts = _get_failed_attempts(username, client_ip)
+        lockout_remaining_seconds = _get_lockout_remaining_time(username, client_ip)
 
         # Log tentativa de login em conta bloqueada (detalhes só internamente)
         AuditLog.objects.create(
@@ -193,7 +222,7 @@ def login(request: Request) -> Response:
             model_name="Usuario",
             details={
                 "username": username,
-                "ip_address": _get_client_ip(request),
+                "ip_address": client_ip,
                 "user_agent": request.META.get("HTTP_USER_AGENT", "")[:200],
                 "reason": "account_locked",
                 "attempts": attempts,
@@ -206,7 +235,7 @@ def login(request: Request) -> Response:
 
     if user is None:
         # Incrementa contador de tentativas falhas (estado interno)
-        attempts = _increment_failed_attempts(username)
+        attempts = _increment_failed_attempts(username, client_ip)
         threshold = getattr(settings, "ACCOUNT_LOCKOUT_THRESHOLD", 10)
 
         # Log tentativa falha
@@ -216,7 +245,7 @@ def login(request: Request) -> Response:
             model_name="Usuario",
             details={
                 "username": username,
-                "ip_address": _get_client_ip(request),
+                "ip_address": client_ip,
                 "user_agent": request.META.get("HTTP_USER_AGENT", "")[:200],
                 "reason": "invalid_credentials",
                 "attempts": attempts,
@@ -228,7 +257,7 @@ def login(request: Request) -> Response:
 
     if not user.is_active:
         # Defensive fallback for alternate backends that might return inactive users.
-        attempts = _increment_failed_attempts(username)
+        attempts = _increment_failed_attempts(username, client_ip)
         threshold = getattr(settings, "ACCOUNT_LOCKOUT_THRESHOLD", 10)
         AuditLog.objects.create(
             usuario=None,
@@ -236,7 +265,7 @@ def login(request: Request) -> Response:
             model_name="Usuario",
             details={
                 "username": username,
-                "ip_address": _get_client_ip(request),
+                "ip_address": client_ip,
                 "user_agent": request.META.get("HTTP_USER_AGENT", "")[:200],
                 "reason": "inactive_user",
                 "attempts": attempts,
@@ -245,8 +274,8 @@ def login(request: Request) -> Response:
         )
         return _invalid_credentials_response()
 
-    # Login bem-sucedido: limpa contador de tentativas
-    _clear_failed_attempts(username)
+    # Login bem-sucedido: limpa contadores de tentativas (IP-specific e global)
+    _clear_failed_attempts(username, client_ip)
 
     # Realiza login
     django_login(request, user)

--- a/v2/backend/apps/core/views_health.py
+++ b/v2/backend/apps/core/views_health.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from django.core.cache import cache
 from django.db import connection
 from django.http import JsonResponse
-from rest_framework.decorators import api_view, permission_classes
+from rest_framework.decorators import api_view, permission_classes, throttle_classes
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -21,6 +21,7 @@ from rest_framework.response import Response
 
 @api_view(["GET"])
 @permission_classes([AllowAny])
+@throttle_classes([])  # Health check — no throttling
 def readyz(request: Request) -> Response:
     """
     Health check: DB + Redis.
@@ -68,6 +69,7 @@ def readyz(request: Request) -> Response:
 
 @api_view(["GET"])
 @permission_classes([AllowAny])
+@throttle_classes([])  # Version check — no throttling
 def versionz(request: Request) -> JsonResponse:
     """
     Returns the deployed version.

--- a/v2/backend/apps/core/views_health.py
+++ b/v2/backend/apps/core/views_health.py
@@ -9,38 +9,27 @@ from __future__ import annotations
 import json
 import os
 from pathlib import Path
-from typing import Any
 
 from django.core.cache import cache
 from django.db import connection
-from django.db.models import QuerySet
 from django.http import JsonResponse
 from rest_framework.decorators import api_view, permission_classes
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 
 
+@api_view(["GET"])
+@permission_classes([AllowAny])
 def readyz(request: Request) -> Response:
     """
     Health check: DB + Redis.
 
-    Returns 200 OK if database is responsive.
-    Returns 503 Service Unavailable if database check fails.
-    Cache failures are warnings only (don't cause 503).
+    SEC-RECON-03: Anonymous users get minimal payload; admin gets full details.
 
     GET /api/readyz/
-
-    Response format:
-    {
-        "status": "healthy" | "unhealthy",
-        "checks": {
-            "database": "ok" | "error: <message>",
-            "cache": "ok" | "warning: <message>"
-        }
-    }
     """
-    checks = {}
+    checks: dict[str, str] = {}
 
     # Database check (critical - causes 503 if fails)
     try:
@@ -68,26 +57,24 @@ def readyz(request: Request) -> Response:
     # Only database failures cause unhealthy status
     db_ok = checks["database"] == "ok"
     status_code = 200 if db_ok else 503
-    status = "healthy" if db_ok else "unhealthy"
+    health_status = "healthy" if db_ok else "unhealthy"
 
-    return JsonResponse({"status": status, "checks": checks}, status=status_code)
+    # Anonymous: minimal payload; admin: full details
+    is_admin = request.user and request.user.is_authenticated and request.user.is_staff
+    if is_admin:
+        return JsonResponse({"status": health_status, "checks": checks}, status=status_code)
+    return JsonResponse({"status": health_status}, status=status_code)
 
 
+@api_view(["GET"])
+@permission_classes([AllowAny])
 def versionz(request: Request) -> JsonResponse:
     """
-    Returns the deployed version of the application.
+    Returns the deployed version.
 
-    Reads from BUILD_INFO.json baked into the image at build time.
-    Used by CI/CD (release.yaml) to verify the correct version is running.
+    SEC-RECON-03: anonymous gets only version tag; admin gets git_sha + build_date.
 
     GET /api/version/
-
-    Response format:
-    {
-        "version": "v2026.03.05-abc1234",
-        "git_sha": "abc1234",
-        "build_date": "2026-03-05"
-    }
     """
     build_info_path = Path("/app/BUILD_INFO.json")
     try:
@@ -96,13 +83,15 @@ def versionz(request: Request) -> JsonResponse:
     except (FileNotFoundError, json.JSONDecodeError):
         data = {"version": "unknown", "git_sha": "unknown", "build_date": "unknown"}
 
-    return JsonResponse(
-        {
-            "version": data.get("version", "unknown"),
-            "git_sha": data.get("git_sha", "unknown"),
-            "build_date": data.get("build_date", "unknown"),
-        }
-    )
+    payload: dict[str, str] = {"version": data.get("version", "unknown")}
+
+    # Admin gets full recon info (git SHA, build date)
+    is_admin = request.user and request.user.is_authenticated and request.user.is_staff
+    if is_admin:
+        payload["git_sha"] = data.get("git_sha", "unknown")
+        payload["build_date"] = data.get("build_date", "unknown")
+
+    return JsonResponse(payload)
 
 
 @api_view(["GET"])

--- a/v2/backend/config/settings.py
+++ b/v2/backend/config/settings.py
@@ -67,7 +67,7 @@ if ENVIRONMENT == "production":
         sys.exit(1)
 
     # SEC-AUTH-03: Block dev-only hosts in production
-    _dev_hosts = {"localhost", "127.0.0.1", "testserver", "web", "0.0.0.0"}
+    _dev_hosts = {"localhost", "127.0.0.1", "testserver", "web", "0.0.0.0"}  # nosec B104
     if _dev_hosts.issuperset(ALLOWED_HOSTS):
         print("❌ ERRO CRÍTICO: ALLOWED_HOSTS contém apenas hosts de desenvolvimento", file=sys.stderr)
         print("   Configure ALLOWED_HOSTS com domínios reais de produção", file=sys.stderr)
@@ -804,7 +804,7 @@ try:
     if DEBUG:
         INSTALLED_APPS += ["debug_toolbar"]
         MIDDLEWARE.insert(0, "debug_toolbar.middleware.DebugToolbarMiddleware")
-        INTERNAL_IPS = ["127.0.0.1", "localhost", "0.0.0.0"]
+        INTERNAL_IPS = ["127.0.0.1", "localhost", "0.0.0.0"]  # nosec B104
         DEBUG_TOOLBAR_CONFIG: dict[str, object] = {
             # Disable toolbar during tests to avoid NoReverseMatch errors
             "SHOW_TOOLBAR_CALLBACK": lambda request: DEBUG and not TESTING,  # type: ignore[misc]

--- a/v2/backend/config/settings.py
+++ b/v2/backend/config/settings.py
@@ -47,7 +47,7 @@ SECRET_KEY = os.getenv(
 # ALLOWED HOSTS
 # ================================================================
 # MP1: Include 'web' for Prometheus internal scraping
-ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", "localhost,127.0.0.1,0.0.0.0,testserver,web").split(",")
+ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", "localhost,127.0.0.1,testserver,web").split(",")
 
 # ================================================================
 # PRODUCTION GUARD RAILS (P1.4)
@@ -66,10 +66,25 @@ if ENVIRONMENT == "production":
         print("   Configure ALLOWED_HOSTS com domínios específicos", file=sys.stderr)
         sys.exit(1)
 
-    # WARNING: SECRET_KEY muito curta
+    # SEC-AUTH-03: Block dev-only hosts in production
+    _dev_hosts = {"localhost", "127.0.0.1", "testserver", "web", "0.0.0.0"}
+    if _dev_hosts.issuperset(ALLOWED_HOSTS):
+        print("❌ ERRO CRÍTICO: ALLOWED_HOSTS contém apenas hosts de desenvolvimento", file=sys.stderr)
+        print("   Configure ALLOWED_HOSTS com domínios reais de produção", file=sys.stderr)
+        sys.exit(1)
+
+    # SEC-AUTH-02: Block insecure SECRET_KEY in production
+    if SECRET_KEY.startswith("django-insecure"):
+        print("❌ ERRO CRÍTICO: SECRET_KEY default insegura em produção", file=sys.stderr)
+        print(
+            "   Gere uma chave segura: python -c 'from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())'",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     if len(SECRET_KEY) < 50:
-        print("⚠️  WARNING: SECRET_KEY muito curta (recomendado: 50+ caracteres)", file=sys.stderr)
-        print("   Gere uma chave mais segura para produção", file=sys.stderr)
+        print("❌ ERRO CRÍTICO: SECRET_KEY muito curta (mínimo: 50 caracteres)", file=sys.stderr)
+        sys.exit(1)
 
     # WARNING: GCAL_CLIENT=fake em produção
     if os.getenv("GCAL_CLIENT", "fake") == "fake":

--- a/v2/backend/config/urls.py
+++ b/v2/backend/config/urls.py
@@ -2,6 +2,8 @@
 URL configuration for AS v2 project.
 """
 
+# pyright: reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportAttributeAccessIssue=false, reportReturnType=false
+
 from __future__ import annotations
 
 from typing import Any

--- a/v2/backend/config/urls.py
+++ b/v2/backend/config/urls.py
@@ -8,31 +8,49 @@ from typing import Any
 
 from django.conf import settings
 from django.conf.urls.static import static
-from django.http import HttpRequest, JsonResponse
+from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.urls import include, path
 
 from apps.core.admin_site import admin_site  # Custom admin site (superusers only)
 
 
+def _metrics_gate(request: HttpRequest) -> HttpResponse:
+    """SEC-RECON-02: Proxy to django_prometheus only for staff or internal IPs."""
+    ip = request.META.get("HTTP_X_FORWARDED_FOR", request.META.get("REMOTE_ADDR", ""))
+    if "," in ip:
+        ip = ip.split(",")[0].strip()
+    is_internal = ip.startswith(("127.", "10.", "172.", "192.168.", "::1"))
+    is_staff = hasattr(request, "user") and request.user.is_authenticated and request.user.is_staff  # type: ignore[union-attr]
+
+    if not is_internal and not is_staff:
+        return JsonResponse({"error": "Forbidden"}, status=403)
+
+    from django_prometheus.exports import ExportToDjangoView
+
+    return ExportToDjangoView(request)
+
+
 def healthz(request: HttpRequest) -> JsonResponse:
-    """Health check endpoint for Docker/K8s"""
-    return JsonResponse(
-        {
-            "status": "ok",
-            "environment": settings.ENVIRONMENT,
-            "debug": settings.DEBUG,
-            "timezone": settings.TIME_ZONE,
-        }
-    )
+    """Health check endpoint for Docker/K8s — minimal payload (no sensitive data)."""
+    return JsonResponse({"status": "ok"})
 
 
 def healthz_detailed(request: HttpRequest) -> JsonResponse:
     """
-    Detailed health check for monitoring (Gap 7 - PLAN_maturity_gaps.md).
+    Detailed health check for monitoring — requires superuser or internal IP.
 
     Checks database, Redis cache, and GCal circuit breaker status.
-    Use this endpoint for comprehensive health monitoring.
     """
+    # SEC-RECON-01: restrict to superuser or internal network
+    ip = request.META.get("HTTP_X_FORWARDED_FOR", request.META.get("REMOTE_ADDR", ""))
+    if "," in ip:
+        ip = ip.split(",")[0].strip()
+    is_internal = ip.startswith(("127.", "10.", "172.", "192.168.", "::1"))
+    is_superuser = hasattr(request, "user") and request.user.is_authenticated and request.user.is_superuser  # type: ignore[union-attr]
+
+    if not is_internal and not is_superuser:
+        return JsonResponse({"error": "Forbidden"}, status=403)
+
     from django.core.cache import cache
     from django.db import connection
 
@@ -73,13 +91,7 @@ def healthz_detailed(request: HttpRequest) -> JsonResponse:
     else:
         status = "degraded"
 
-    return JsonResponse(
-        {
-            "status": status,
-            "environment": settings.ENVIRONMENT,
-            "checks": checks,
-        }
-    )
+    return JsonResponse({"status": status, "checks": checks})
 
 
 urlpatterns = [
@@ -88,8 +100,8 @@ urlpatterns = [
     # Health check
     path("healthz/", healthz, name="healthz"),
     path("healthz/detailed/", healthz_detailed, name="healthz_detailed"),
-    # Prometheus metrics (MP1) - django_prometheus.urls defines 'metrics' internally
-    path("", include("django_prometheus.urls")),
+    # Prometheus metrics (MP1) — SEC-RECON-02: protected by staff_member_required
+    path("metrics", _metrics_gate, name="prometheus-metrics"),
     # API canonical: /api/* (#792)
     path("api/", include("apps.core.urls")),
     # DEPRECATED alias — will be removed after deprecation window (#797)

--- a/v2/frontend/nginx.conf
+++ b/v2/frontend/nginx.conf
@@ -2,6 +2,9 @@
 # Nginx Configuration for Aprender Sistema Frontend
 # =============================================================================
 
+# INFRA-03: Rate limiting zones (defense-in-depth beyond Django throttling)
+limit_req_zone $binary_remote_addr zone=api:10m rate=30r/s;
+
 server {
     listen 80;
     server_name localhost;
@@ -26,6 +29,8 @@ server {
     add_header X-XSS-Protection "0" always;
     add_header Cross-Origin-Opener-Policy "same-origin" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
     add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'" always;
 
     # Health check endpoint
@@ -35,31 +40,10 @@ server {
         add_header Content-Type text/plain;
     }
 
-    # Prometheus metrics endpoint (must bypass SPA fallback and API rate limits)
-    location = /metrics {
-        set $backend http://web:8000;
-        proxy_pass $backend/metrics;
-        proxy_http_version 1.1;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
-        proxy_read_timeout 120s;
-        proxy_connect_timeout 120s;
-    }
-
-    # Keep compatibility for trailing slash probes
-    location /metrics/ {
-        set $backend http://web:8000;
-        proxy_pass $backend/metrics/;
-        proxy_http_version 1.1;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
-        proxy_read_timeout 120s;
-        proxy_connect_timeout 120s;
-    }
+    # SEC-RECON-02: /metrics removed from public proxy.
+    # Prometheus scrapes directly via Docker network (web:8000/metrics).
+    location = /metrics  { return 404; }
+    location   /metrics/ { return 404; }
 
     # Hashed static assets — immutable long cache (Vite adds content hash)
     location /assets/ {
@@ -76,11 +60,9 @@ server {
     }
 
     # API proxy (reverse proxy to backend)
-    # Uses $backend variable to force DNS re-resolution via Docker resolver.
-    # X-Forwarded-Proto: use value from upstream proxy if present, otherwise $scheme.
-    # This ensures Django sees "https" when behind NPM SSL termination and
-    # does not loop on SECURE_SSL_REDIRECT.
+    # INFRA-03: rate limiting at nginx layer (burst=50 allows short spikes)
     location /api/ {
+        limit_req zone=api burst=50 nodelay;
         set $backend http://web:8000;
         proxy_pass $backend;
         proxy_http_version 1.1;

--- a/v2/infra/entrypoint.sh
+++ b/v2/infra/entrypoint.sh
@@ -42,7 +42,7 @@ log_error() {
 
 log_info "Aguardando PostgreSQL..."
 
-until pg_isready -h ${DB_HOST:-db} -p ${DB_PORT:-5432} -U ${DB_USER:-aprender_user}; do
+until pg_isready -h "${DB_HOST:-db}" -p "${DB_PORT:-5432}" -U "${DB_USER:-aprender_user}"; do
     log_warning "PostgreSQL indisponível - aguardando..."
     sleep 2
 done
@@ -55,7 +55,7 @@ log_success "PostgreSQL disponível!"
 
 log_info "Aguardando Redis..."
 
-until redis-cli -h ${REDIS_HOST:-redis} -p ${REDIS_PORT:-6379} ping | grep -q PONG; do
+until redis-cli -h "${REDIS_HOST:-redis}" -p "${REDIS_PORT:-6379}" ping | grep -q PONG; do
     log_warning "Redis indisponível - aguardando..."
     sleep 2
 done
@@ -109,6 +109,6 @@ fi
 # ================================================================
 
 log_info "Iniciando aplicação..."
-log_info "Comando: $@"
+log_info "Comando: $*"
 
 exec "$@"


### PR DESCRIPTION
## Summary
- **SEC-RECON** (#1125): Restrict public reconnaissance surface — /healthz, /metrics, /readyz, /version
- **SEC-AUTH** (#1129): Harden authentication config — compound lockout, SECRET_KEY/ALLOWED_HOSTS guards
- **INFRA-HARDEN** (#1120): Pin CI images, nginx rate limiting + headers, shell quoting

## Issues Resolved
Closes #1126, closes #1127, closes #1128, closes #1130, closes #1131, closes #1132, closes #1121, closes #1123, closes #1124

Relates to #1125, #1129, #1120

## Changes

### SEC-RECON (P0)
| File | Change |
|------|--------|
| `config/urls.py` | `/healthz/` returns only `{"status": "ok"}`; `/healthz/detailed/` requires superuser or internal IP; `/metrics` protected by staff/IP gate |
| `nginx.conf` | Removed `/metrics` proxy (return 404) |
| `views_health.py` | `readyz` and `versionz` converted to DRF views with conditional payloads |

### SEC-AUTH (P1)
| File | Change |
|------|--------|
| `views_auth.py` | Compound lockout: `login_attempts:{user}:{ip}` (threshold=10) + `login_attempts_global:{user}` (threshold=50) |
| `settings.py` | `sys.exit(1)` if SECRET_KEY starts with `django-insecure` or < 50 chars in prod; reject dev-only ALLOWED_HOSTS in prod; removed `0.0.0.0` from defaults |

### INFRA-HARDEN
| File | Change |
|------|--------|
| `ci.yaml`, `backend-xdist-canary.yml` | Pin `postgres:15.13`, `redis:7.4` |
| `nginx.conf` | Add `Referrer-Policy`, `Permissions-Policy` headers; rate limiting 30r/s burst=50 on `/api/` |
| `entrypoint.sh` | Quote shell variables |

## Test plan
- [x] 22 new tests in `test_security_hardening.py` — all passing
- [x] Existing auth tests (15) pass with zero regressions
- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

```
ALL 8 CHECKS PASSED
```

## Staging Gate
- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR