### PR TITLE
feat(security): enforce CSP without unsafe-eval in production

### DIFF
--- a/v2/backend/apps/core/middleware_security.py
+++ b/v2/backend/apps/core/middleware_security.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import os
 from typing import Callable
 
+from django.conf import settings
 from django.http import HttpRequest, HttpResponse
 
 # SEC-004: CSP mode — "enforce" (default) or "report-only"
@@ -63,7 +64,10 @@ class SecurityHeadersMiddleware:
         # - 'unsafe-inline': Necessário para Ant Design inline styles
         # - data:: Necessário para imagens base64 (ícones, avatars)
         # - blob:: Necessário para download de arquivos
-        script_src = "script-src 'self' 'unsafe-inline' 'unsafe-eval'"
+        # SEC-CSP-01: only allow unsafe-eval in development (React hot reload needs it)
+        script_src = "script-src 'self' 'unsafe-inline'"
+        if settings.ENVIRONMENT != "production":
+            script_src += " 'unsafe-eval'"
         style_src = "style-src 'self' 'unsafe-inline'"
         font_src = "font-src 'self' data:"
         img_src = "img-src 'self' data: blob: https:"

--- a/v2/backend/apps/core/tests/test_middleware_security.py
+++ b/v2/backend/apps/core/tests/test_middleware_security.py
@@ -1,0 +1,77 @@
+"""
+Tests for SecurityHeadersMiddleware — CSP configuration.
+
+Covers:
+- SEC-CSP-01 (#1103): unsafe-eval conditional on environment
+- CSP mode (enforce vs report-only)
+- Permissions-Policy always present
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportOptionalMemberAccess=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportMissingTypeArgument=false, reportCallIssue=false, reportIndexIssue=false, reportOperatorIssue=false, reportOptionalSubscript=false, reportUnknownLambdaType=false
+
+from __future__ import annotations
+
+from django.test import TestCase, override_settings
+
+
+class TestCSPUnsafeEval(TestCase):
+    """SEC-CSP-01: unsafe-eval only in development."""
+
+    @override_settings(ENVIRONMENT="production")
+    def test_production_csp_no_unsafe_eval(self):
+        """Production CSP must NOT contain unsafe-eval in script-src."""
+        response = self.client.get("/healthz/")
+        csp = response.get("Content-Security-Policy", "") or response.get("Content-Security-Policy-Report-Only", "")
+        assert "unsafe-eval" not in csp, f"Production CSP should not have unsafe-eval: {csp}"
+
+    @override_settings(ENVIRONMENT="development")
+    def test_development_csp_has_unsafe_eval(self):
+        """Development CSP must contain unsafe-eval (React hot reload)."""
+        response = self.client.get("/healthz/")
+        csp = response.get("Content-Security-Policy", "") or response.get("Content-Security-Policy-Report-Only", "")
+        assert "unsafe-eval" in csp, f"Development CSP should have unsafe-eval: {csp}"
+
+    @override_settings(ENVIRONMENT="production")
+    def test_csp_always_has_unsafe_inline_for_styles(self):
+        """style-src must always include unsafe-inline (Ant Design needs it)."""
+        response = self.client.get("/healthz/")
+        csp = response.get("Content-Security-Policy", "") or response.get("Content-Security-Policy-Report-Only", "")
+        assert "style-src 'self' 'unsafe-inline'" in csp, f"style-src missing unsafe-inline: {csp}"
+
+    @override_settings(ENVIRONMENT="production")
+    def test_production_csp_has_unsafe_inline_for_scripts(self):
+        """script-src must still have unsafe-inline (needed for inline scripts)."""
+        response = self.client.get("/healthz/")
+        csp = response.get("Content-Security-Policy", "") or response.get("Content-Security-Policy-Report-Only", "")
+        assert "script-src 'self' 'unsafe-inline'" in csp, f"script-src missing unsafe-inline: {csp}"
+
+
+class TestCSPMode(TestCase):
+    """CSP mode: enforce vs report-only."""
+
+    def test_csp_header_present(self):
+        """CSP header must be present on responses."""
+        response = self.client.get("/healthz/")
+        has_csp = "Content-Security-Policy" in response or "Content-Security-Policy-Report-Only" in response
+        assert has_csp, "No CSP header found"
+
+    def test_csp_has_frame_ancestors_none(self):
+        """CSP must block framing (clickjacking prevention)."""
+        response = self.client.get("/healthz/")
+        csp = response.get("Content-Security-Policy", "") or response.get("Content-Security-Policy-Report-Only", "")
+        assert "frame-ancestors 'none'" in csp
+
+
+class TestPermissionsPolicy(TestCase):
+    """Permissions-Policy header tests."""
+
+    def test_permissions_policy_present(self):
+        """Permissions-Policy must be present."""
+        response = self.client.get("/healthz/")
+        assert "Permissions-Policy" in response
+
+    def test_permissions_policy_blocks_camera(self):
+        """Camera must be blocked."""
+        response = self.client.get("/healthz/")
+        pp = response.get("Permissions-Policy", "")
+        assert "camera=()" in pp

--- a/v2/frontend/nginx.conf
+++ b/v2/frontend/nginx.conf
@@ -31,7 +31,8 @@ server {
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
     add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'" always;
+    # SEC-CSP-02: unsafe-eval removed — production bundles are static, no eval needed
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'" always;
 
     # Health check endpoint
     location /health {

--- a/v2/infra/configs/vm01/nginx.conf
+++ b/v2/infra/configs/vm01/nginx.conf
@@ -75,9 +75,9 @@ http {
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Cross-Origin-Opener-Policy "same-origin" always;
 
-        # SEC-004: CSP in Report-Only mode — collects violations without blocking.
-        # Promote to Content-Security-Policy after analyzing reports.
-        add_header Content-Security-Policy-Report-Only "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests" always;
+        # SEC-CSP-03: CSP in enforce mode — blocks violations.
+        # Rollback: change Content-Security-Policy back to Content-Security-Policy-Report-Only
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests" always;
 
         # Static files
         location /static/ {


### PR DESCRIPTION
## Summary
- Remove `unsafe-eval` from CSP in production across all 3 layers (Django middleware, frontend nginx, VM01 nginx)
- Promote CSP from **Report-Only** to **enforce** mode on VM01
- `unsafe-inline` kept in `style-src` (required by Ant Design for inline CSS)

## Issues Resolved
Closes #1103, closes #1104, closes #1105

Relates to #1102, #802

## Changes

| Layer | File | Before | After |
|-------|------|--------|-------|
| Django middleware | `middleware_security.py` | `unsafe-eval` always | `unsafe-eval` only when `ENVIRONMENT != "production"` |
| Frontend nginx | `nginx.conf` | `script-src 'self' 'unsafe-inline' 'unsafe-eval'` | `script-src 'self' 'unsafe-inline'` |
| VM01 nginx | `vm01/nginx.conf` | `Content-Security-Policy-Report-Only` with `unsafe-eval` | `Content-Security-Policy` (enforce) without `unsafe-eval` |

## Risk mitigation
- `unsafe-inline` kept for styles — Ant Design requires it for CSS-in-JS
- Development retains `unsafe-eval` for React hot reload
- VM01 CSP rollback: change `Content-Security-Policy` back to `Content-Security-Policy-Report-Only` (documented in comment)

## Test plan
- [x] 8 new tests in `test_middleware_security.py` — all passing
- [x] Production CSP: no `unsafe-eval`, has `unsafe-inline` for styles
- [x] Development CSP: has `unsafe-eval`
- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

```
ALL 8 CHECKS PASSED
```

## Staging Gate
- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR