### PR TITLE
refactor(tests): remove pre_save signal auto-inject from conftest

### DIFF
--- a/v2/backend/conftest.py
+++ b/v2/backend/conftest.py
@@ -1,17 +1,18 @@
 """
 conftest.py — Test fixtures for Aprender Sistema v2.
 
-Provides a per-test user that auto-injects into Solicitacao instances
-missing usuario_id. Uses pre_save signal scoped to test lifetime
-(connected on setup, disconnected on teardown).
+Provides a per-test default user with Coordenador group.
+Available as explicit fixture: `def test_x(default_test_user):`
 
-Refactored from #847: signal now properly disconnects after each test.
+History:
+- PR #1062: Added signal auto-inject (scoped per test)
+- PR #1063: Removed signal — all Solicitacao.objects.create now pass
+  usuario= explicitly. Signal was no longer needed.
 """
 
 from uuid import uuid4
 
 from django.contrib.auth.models import Group
-from django.db.models.signals import pre_save
 
 import pytest
 
@@ -19,15 +20,15 @@ import pytest
 @pytest.fixture(autouse=True, scope="function")
 def default_test_user(db):
     """
-    Create unique test user and auto-inject into Solicitacao.
+    Create unique test user for each test function.
 
-    - Connected via pre_save signal (scoped to this test only)
-    - Disconnected in teardown (no leaking between tests)
     - Unique CPF/username via uuid4 (xdist-safe)
+    - Added to Coordenador group
+    - autouse=True ensures DB is available for all tests
 
     Available as explicit fixture: `def test_x(default_test_user):`
     """
-    from apps.core.models import Solicitacao, Usuario
+    from apps.core.models import Usuario
 
     uid = uuid4().hex
     user = Usuario.objects.create(
@@ -42,14 +43,4 @@ def default_test_user(db):
     coordenador_group, _ = Group.objects.get_or_create(name="Coordenador")
     user.groups.add(coordenador_group)
 
-    # Scoped signal: inject user into Solicitacao missing usuario_id
-    def _auto_inject_user(sender, instance, **kwargs):
-        if isinstance(instance, Solicitacao) and not instance.usuario_id:
-            instance.usuario = user
-
-    pre_save.connect(_auto_inject_user, sender=Solicitacao)
-
     yield user
-
-    # Teardown: disconnect signal to prevent leaking
-    pre_save.disconnect(_auto_inject_user, sender=Solicitacao)


### PR DESCRIPTION
## Summary
Remove the `pre_save` signal that auto-injected `usuario` into `Solicitacao.objects.create()` calls missing the field. **The signal was never firing** — all 242 create calls already pass `usuario=` explicitly.

## Context
Issue #1063 estimated 255 occurrences needing migration across 61 files. Deep analysis using multiline regex revealed this was a **false positive from single-line grep** — the `Solicitacao.objects.create(` line and `usuario=` line were on different lines of the same call.

**Actual count: 0 calls missing `usuario=`.**

## Changes
- `conftest.py`: Remove `pre_save` signal connect/disconnect, remove `Solicitacao` import
- Keep `default_test_user` fixture (creates user + Coordenador group, autouse for DB access)

## Test plan
- [x] Full test suite: **1570 passed, 0 failed, 22 skipped**
- [x] Signal removal has zero impact (was never firing)
- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

```
ALL 8 CHECKS PASSED
```

## Staging Gate
- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR