### PR TITLE
feat(frontend): extract useTableFilters hook for DATModule pages (#1116)

### DIFF
--- a/v2/frontend/src/hooks/__tests__/useTableFilters.test.ts
+++ b/v2/frontend/src/hooks/__tests__/useTableFilters.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Tests: useTableFilters Hook (Issue #1116)
+ *
+ * Covers:
+ * - initial state
+ * - auto-fetch on mount
+ * - filter → params mapping (default + custom buildParams)
+ * - pagination changes
+ * - stats endpoint (optional)
+ * - handleClearFilters resets to defaultFilters
+ * - error handling
+ */
+
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { useTableFilters } from '../useTableFilters';
+
+vi.mock('antd', () => ({
+  message: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { message } from 'antd';
+
+interface MockFilters extends Record<string, unknown> {
+  search: string;
+  uf: string | undefined;
+  municipio: number | undefined;
+}
+
+interface MockRecord {
+  id: number;
+  nome: string;
+}
+
+interface MockStats {
+  total: number;
+}
+
+const defaultFilters: MockFilters = {
+  search: '',
+  uf: undefined,
+  municipio: undefined,
+};
+
+const mockData: MockRecord[] = [
+  { id: 1, nome: 'A' },
+  { id: 2, nome: 'B' },
+];
+
+const mockPaginated = { results: mockData, count: 50 };
+
+describe('useTableFilters', () => {
+  const mockListFn = vi.fn();
+  const mockStatsFn = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListFn.mockResolvedValue(mockPaginated);
+    mockStatsFn.mockResolvedValue({ total: 50 });
+  });
+
+  test('starts with empty state and default filters', () => {
+    const { result } = renderHook(() =>
+      useTableFilters<MockFilters, MockRecord, MockStats>({
+        defaultFilters,
+        listFn: mockListFn,
+        autoFetch: false,
+      }),
+    );
+
+    expect(result.current.data).toEqual([]);
+    expect(result.current.stats).toBeNull();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.filters).toEqual(defaultFilters);
+    expect(result.current.pagination).toEqual({ current: 1, pageSize: 15, total: 0 });
+  });
+
+  test('auto-fetches on mount by default and populates data', async () => {
+    const { result } = renderHook(() =>
+      useTableFilters<MockFilters, MockRecord, MockStats>({
+        defaultFilters,
+        listFn: mockListFn,
+      }),
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(mockListFn).toHaveBeenCalledTimes(1);
+    expect(result.current.data).toEqual(mockData);
+    expect(result.current.pagination.total).toBe(50);
+  });
+
+  test('autoFetch=false skips initial fetch', async () => {
+    renderHook(() =>
+      useTableFilters<MockFilters, MockRecord, MockStats>({
+        defaultFilters,
+        listFn: mockListFn,
+        autoFetch: false,
+      }),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(mockListFn).not.toHaveBeenCalled();
+  });
+
+  test('default buildParams strips undefined and empty string', async () => {
+    const { result } = renderHook(() =>
+      useTableFilters<MockFilters, MockRecord, MockStats>({
+        defaultFilters,
+        listFn: mockListFn,
+      }),
+    );
+
+    await waitFor(() => expect(mockListFn).toHaveBeenCalled());
+    const params = mockListFn.mock.calls[0][0];
+    expect(params.search).toBeUndefined();
+    expect(params.uf).toBeUndefined();
+    expect(params.municipio).toBeUndefined();
+    expect(params.page).toBe(1);
+    expect(params.page_size).toBe(15);
+  });
+
+  test('default buildParams includes non-empty filter values', async () => {
+    const { result } = renderHook(() =>
+      useTableFilters<MockFilters, MockRecord, MockStats>({
+        defaultFilters,
+        listFn: mockListFn,
+      }),
+    );
+
+    await waitFor(() => expect(mockListFn).toHaveBeenCalled());
+
+    act(() => {
+      result.current.setFilters({ search: 'abc', uf: 'CE', municipio: 42 });
+    });
+
+    await waitFor(() => expect(mockListFn).toHaveBeenCalledTimes(2));
+    const params = mockListFn.mock.calls[1][0];
+    expect(params.search).toBe('abc');
+    expect(params.uf).toBe('CE');
+    expect(params.municipio).toBe(42);
+  });
+
+  test('custom buildParams is used when provided', async () => {
+    const buildParams = vi.fn((f: MockFilters) => ({
+      q: f.search,
+      ...(f.municipio ? { municipio_id: f.municipio } : {}),
+    }));
+
+    const { result } = renderHook(() =>
+      useTableFilters<MockFilters, MockRecord, MockStats>({
+        defaultFilters: { search: 'x', uf: undefined, municipio: 7 },
+        listFn: mockListFn,
+        buildParams,
+      }),
+    );
+
+    await waitFor(() => expect(mockListFn).toHaveBeenCalled());
+    const params = mockListFn.mock.calls[0][0];
+    expect(params.q).toBe('x');
+    expect(params.municipio_id).toBe(7);
+    expect(buildParams).toHaveBeenCalled();
+  });
+
+  test('defaultOrdering is injected into params', async () => {
+    renderHook(() =>
+      useTableFilters<MockFilters, MockRecord, MockStats>({
+        defaultFilters,
+        listFn: mockListFn,
+        defaultOrdering: '-updated_at',
+      }),
+    );
+
+    await waitFor(() => expect(mockListFn).toHaveBeenCalled());
+    expect(mockListFn.mock.calls[0][0].ordering).toBe('-updated_at');
+  });
+
+  test('statsFn is called when provided and result exposed via stats', async () => {
+    const { result } = renderHook(() =>
+      useTableFilters<MockFilters, MockRecord, MockStats>({
+        defaultFilters,
+        listFn: mockListFn,
+        statsFn: mockStatsFn,
+      }),
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(mockStatsFn).toHaveBeenCalledTimes(1);
+    expect(result.current.stats).toEqual({ total: 50 });
+  });
+
+  test('statsFn not called when not provided', async () => {
+    renderHook(() =>
+      useTableFilters<MockFilters, MockRecord, MockStats>({
+        defaultFilters,
+        listFn: mockListFn,
+      }),
+    );
+
+    await waitFor(() => expect(mockListFn).toHaveBeenCalled());
+    expect(mockStatsFn).not.toHaveBeenCalled();
+  });
+
+  test('handleTableChange updates pagination and fetches new page', async () => {
+    const { result } = renderHook(() =>
+      useTableFilters<MockFilters, MockRecord, MockStats>({
+        defaultFilters,
+        listFn: mockListFn,
+      }),
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => {
+      result.current.handleTableChange(3, 30);
+    });
+
+    await waitFor(() => expect(mockListFn).toHaveBeenCalledTimes(2));
+    expect(mockListFn.mock.calls[1][0].page).toBe(3);
+    expect(result.current.pagination.pageSize).toBe(30);
+  });
+
+  test('handleClearFilters resets to defaultFilters', async () => {
+    const { result } = renderHook(() =>
+      useTableFilters<MockFilters, MockRecord, MockStats>({
+        defaultFilters,
+        listFn: mockListFn,
+        autoFetch: false,
+      }),
+    );
+
+    act(() => {
+      result.current.setFilters({ search: 'abc', uf: 'CE', municipio: 42 });
+    });
+    expect(result.current.filters.search).toBe('abc');
+
+    act(() => {
+      result.current.handleClearFilters();
+    });
+    expect(result.current.filters).toEqual(defaultFilters);
+  });
+
+  test('handles non-paginated array response', async () => {
+    mockListFn.mockResolvedValueOnce(mockData);
+
+    const { result } = renderHook(() =>
+      useTableFilters<MockFilters, MockRecord, MockStats>({
+        defaultFilters,
+        listFn: mockListFn,
+      }),
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.data).toEqual(mockData);
+    expect(result.current.pagination.total).toBe(mockData.length);
+  });
+
+  test('surfaces errors via message.error and keeps state sane', async () => {
+    mockListFn.mockRejectedValueOnce(new Error('API down'));
+
+    const { result } = renderHook(() =>
+      useTableFilters<MockFilters, MockRecord, MockStats>({
+        defaultFilters,
+        listFn: mockListFn,
+        entityName: 'ações',
+      }),
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(message.error).toHaveBeenCalledWith(
+      expect.stringContaining('Erro ao carregar ações'),
+    );
+    expect(result.current.data).toEqual([]);
+  });
+
+  test('refresh re-fetches current page', async () => {
+    const { result } = renderHook(() =>
+      useTableFilters<MockFilters, MockRecord, MockStats>({
+        defaultFilters,
+        listFn: mockListFn,
+      }),
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => {
+      result.current.handleTableChange(2);
+    });
+    await waitFor(() => expect(result.current.pagination.current).toBe(2));
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    const lastCall = mockListFn.mock.calls[mockListFn.mock.calls.length - 1][0];
+    expect(lastCall.page).toBe(2);
+  });
+});

--- a/v2/frontend/src/hooks/useTableFilters.ts
+++ b/v2/frontend/src/hooks/useTableFilters.ts
@@ -1,0 +1,194 @@
+/**
+ * useTableFilters Hook — Standardized filters + pagination state for list pages
+ *
+ * Issue #1116 (Epic #1112): Reduce code duplication in DATModule pages
+ *
+ * Encapsulates: filters state, pagination state, loading state, and the
+ * fetch-with-filters-and-optional-stats pattern used across 7 DATModule pages.
+ *
+ * Usage:
+ *   const {
+ *     data, stats, loading, filters, setFilters,
+ *     pagination, handleTableChange, handleClearFilters, refresh,
+ *   } = useTableFilters<AcoesFilters, AcaoRecord, AcoesStats>({
+ *     defaultFilters: { search: '', uf: undefined, municipio: undefined, ... },
+ *     listFn: listAcoes,
+ *     statsFn: getAcoesStats,
+ *     buildParams: (f) => ({
+ *       ...(f.search && { search: f.search }),
+ *       ...(f.municipio && { municipio_id: f.municipio }),
+ *     }),
+ *     defaultOrdering: '-updated_at',
+ *   });
+ */
+
+import { useState, useCallback, useEffect, useRef, type Dispatch, type SetStateAction } from 'react';
+import { message } from 'antd';
+import type { PaginatedResponse } from '../types';
+import type { PaginationState } from './useCrudOperations';
+
+/**
+ * Query params produced by the hook for the list/stats endpoints.
+ * Matches the shape expected by the DAT module API clients (FilterParams).
+ */
+export type TableFilterParams = Record<string, string | number | boolean | undefined>;
+
+export type BuildParams<F> = (filters: F, pagination: PaginationState) => TableFilterParams;
+
+export interface UseTableFiltersConfig<F extends object, T, S = unknown> {
+  /** Initial filter state; also used as target for handleClearFilters. */
+  defaultFilters: F;
+  /** Paginated list endpoint. */
+  listFn: (params: TableFilterParams) => Promise<PaginatedResponse<T> | T[]>;
+  /** Optional stats endpoint; receives the same params as listFn. */
+  statsFn?: (params: TableFilterParams) => Promise<S>;
+  /**
+   * Maps the raw filter object to API query params. Receives current filters
+   * and pagination. Defaults to stripping undefined/empty-string values 1:1.
+   */
+  buildParams?: BuildParams<F>;
+  /** Default `ordering` query param injected into every request. */
+  defaultOrdering?: string;
+  /** Page size; defaults to 15. */
+  pageSize?: number;
+  /** Label used in error messages. */
+  entityName?: string;
+  /** Auto-fetch on mount and whenever filters change. Defaults to true. */
+  autoFetch?: boolean;
+}
+
+export interface UseTableFiltersReturn<F, T, S> {
+  data: T[];
+  setData: Dispatch<SetStateAction<T[]>>;
+  stats: S | null;
+  loading: boolean;
+  filters: F;
+  setFilters: Dispatch<SetStateAction<F>>;
+  pagination: PaginationState;
+  setPagination: Dispatch<SetStateAction<PaginationState>>;
+  fetchData: (page?: number) => Promise<void>;
+  handleClearFilters: () => void;
+  handleTableChange: (page: number, newPageSize?: number) => void;
+  refresh: () => Promise<void>;
+}
+
+function defaultBuildParams<F extends object>(filters: F): TableFilterParams {
+  const out: TableFilterParams = {};
+  for (const [k, v] of Object.entries(filters as Record<string, unknown>)) {
+    if (v === undefined || v === null || v === '') continue;
+    if (typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean') {
+      out[k] = v;
+    }
+  }
+  return out;
+}
+
+export function useTableFilters<F extends object, T, S = unknown>({
+  defaultFilters,
+  listFn,
+  statsFn,
+  buildParams,
+  defaultOrdering,
+  pageSize = 15,
+  entityName = 'dados',
+  autoFetch = true,
+}: UseTableFiltersConfig<F, T, S>): UseTableFiltersReturn<F, T, S> {
+  const [data, setData] = useState<T[]>([]);
+  const [stats, setStats] = useState<S | null>(null);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [filters, setFilters] = useState<F>(defaultFilters);
+  const [pagination, setPagination] = useState<PaginationState>({
+    current: 1,
+    pageSize,
+    total: 0,
+  });
+
+  // Keep a ref to defaultFilters so handleClearFilters stays stable
+  // even if the caller rebuilds the object identity on each render.
+  const defaultFiltersRef = useRef(defaultFilters);
+  defaultFiltersRef.current = defaultFilters;
+
+  const fetchData = useCallback(
+    async (page = 1): Promise<void> => {
+      setLoading(true);
+      try {
+        const mapped = buildParams
+          ? buildParams(filters, pagination)
+          : defaultBuildParams(filters);
+        const params: TableFilterParams = {
+          page,
+          page_size: pagination.pageSize,
+          ...(defaultOrdering ? { ordering: defaultOrdering } : {}),
+          ...mapped,
+        };
+
+        const [listResp, statsResp] = await Promise.all([
+          listFn(params),
+          statsFn ? statsFn(params) : Promise.resolve(undefined),
+        ]);
+
+        const results =
+          (listResp as PaginatedResponse<T>).results ??
+          (Array.isArray(listResp) ? (listResp as T[]) : []);
+        const total = (listResp as PaginatedResponse<T>).count ?? results.length;
+
+        setData(results);
+        setPagination((prev) => ({ ...prev, current: page, total }));
+
+        if (statsFn) {
+          setStats((statsResp as S) ?? null);
+        }
+      } catch (error) {
+        const err = error as Error;
+        message.error(`Erro ao carregar ${entityName}: ${err.message}`);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [buildParams, filters, listFn, statsFn, defaultOrdering, entityName, pagination.pageSize],
+  );
+
+  // Auto-fetch on mount and whenever filters change. Pagination changes are
+  // driven by handleTableChange (or manual fetchData calls), not this effect —
+  // otherwise changing pageSize would re-fire fetchData via the closure.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    if (!autoFetch) return;
+    void fetchData(1);
+  }, [autoFetch, filters]);
+
+  const handleClearFilters = useCallback((): void => {
+    setFilters(defaultFiltersRef.current);
+  }, []);
+
+  const handleTableChange = useCallback(
+    (page: number, newPageSize?: number): void => {
+      if (newPageSize && newPageSize !== pagination.pageSize) {
+        setPagination((prev) => ({ ...prev, current: page, pageSize: newPageSize }));
+      }
+      fetchData(page);
+    },
+    [fetchData, pagination.pageSize],
+  );
+
+  const refresh = useCallback((): Promise<void> => {
+    return fetchData(pagination.current);
+  }, [fetchData, pagination.current]);
+
+  return {
+    data,
+    setData,
+    stats,
+    loading,
+    filters,
+    setFilters,
+    pagination,
+    setPagination,
+    fetchData,
+    handleClearFilters,
+    handleTableChange,
+    refresh,
+  };
+}
+
+export default useTableFilters;

--- a/v2/frontend/src/pages/DATModule/AcoesPage.tsx
+++ b/v2/frontend/src/pages/DATModule/AcoesPage.tsx
@@ -9,6 +9,8 @@
  */
 
 import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useTableFilters, type TableFilterParams } from '../../hooks/useTableFilters';
+import type { PaginatedResponse } from '../../types';
 import {
   Table,
   Button,
@@ -101,12 +103,6 @@ interface AcoesStats {
   entregas_concluidas: number;
 }
 
-interface PaginationState {
-  current: number;
-  pageSize: number;
-  total: number;
-}
-
 interface MunicipioOption {
   id: number;
   nome: string;
@@ -132,20 +128,43 @@ const STATUS_OPTIONS = [
   { label: 'N/A', value: 'na' },
 ];
 
-export default function AcoesPage(): JSX.Element {
-  const [acoes, setAcoes] = useState<AcaoRecord[]>([]);
-  const [loading, setLoading] = useState<boolean>(false);
-  const [pagination, setPagination] = useState<PaginationState>({ current: 1, pageSize: 15, total: 0 });
-  const [stats, setStats] = useState<AcoesStats | null>(null);
+const DEFAULT_FILTERS: AcoesFilters = {
+  search: '',
+  uf: undefined,
+  municipio: undefined,
+  projeto: undefined,
+  coordenador: undefined,
+  status_geral: undefined,
+};
 
-  // Filter states
-  const [filters, setFilters] = useState<AcoesFilters>({
-    search: '',
-    uf: undefined,
-    municipio: undefined,
-    projeto: undefined,
-    coordenador: undefined,
-    status_geral: undefined,
+const buildAcoesParams = (f: AcoesFilters): TableFilterParams => ({
+  ...(f.search && { search: f.search }),
+  ...(f.uf && { uf: f.uf }),
+  ...(f.municipio !== undefined && { municipio_id: f.municipio }),
+  ...(f.projeto !== undefined && { projeto_id: f.projeto }),
+  ...(f.coordenador !== undefined && { coordenador_id: f.coordenador }),
+  ...(f.status_geral && { status_geral: f.status_geral }),
+});
+
+export default function AcoesPage(): JSX.Element {
+  const {
+    data: acoes,
+    stats,
+    loading,
+    filters,
+    setFilters,
+    pagination,
+    fetchData,
+    handleClearFilters,
+    handleTableChange,
+    refresh,
+  } = useTableFilters<AcoesFilters, AcaoRecord, AcoesStats>({
+    defaultFilters: DEFAULT_FILTERS,
+    listFn: listAcoes as unknown as (params: TableFilterParams) => Promise<PaginatedResponse<AcaoRecord>>,
+    statsFn: getAcoesStats as unknown as (params: TableFilterParams) => Promise<AcoesStats>,
+    buildParams: buildAcoesParams,
+    defaultOrdering: '-updated_at',
+    entityName: 'ações',
   });
 
   // Options for dropdowns
@@ -177,59 +196,6 @@ export default function AcoesPage(): JSX.Element {
     };
     loadOptions();
   }, []);
-
-  // Fetch data with filters
-  const fetchData = useCallback(async (page = 1) => {
-    setLoading(true);
-    try {
-      const params: Record<string, string | number> = {
-        page,
-        page_size: pagination.pageSize,
-        ordering: '-updated_at',
-      };
-
-      // Apply filters
-      if (filters.search) params.search = filters.search;
-      if (filters.uf) params.uf = filters.uf;
-      if (filters.municipio) params.municipio_id = filters.municipio;
-      if (filters.projeto) params.projeto_id = filters.projeto;
-      if (filters.coordenador) params.coordenador_id = filters.coordenador;
-      if (filters.status_geral) params.status_geral = filters.status_geral;
-
-      const [data, statsData] = await Promise.all([
-        listAcoes(params),
-        getAcoesStats(params),
-      ]);
-
-      setAcoes((data as any).results || data || []);
-      setPagination((prev) => ({
-        ...prev,
-        current: page,
-        total: data.count || ((data as any).results || data || []).length,
-      }));
-      setStats(statsData as unknown as AcoesStats);
-    } catch (error) {
-      message.error(`Erro ao carregar dados: ${(error as Error).message}`);
-    } finally {
-      setLoading(false);
-    }
-  }, [filters, pagination.pageSize]);
-
-  useEffect(() => {
-    fetchData();
-  }, [fetchData]);
-
-  // Clear all filters
-  const handleClearFilters = () => {
-    setFilters({
-      search: '',
-      uf: undefined,
-      municipio: undefined,
-      projeto: undefined,
-      coordenador: undefined,
-      status_geral: undefined,
-    });
-  };
 
   // CRUD handlers
   const handleCreate = () => {
@@ -270,7 +236,7 @@ export default function AcoesPage(): JSX.Element {
       }
       setModalVisible(false);
       form.resetFields();
-      fetchData(pagination.current);
+      void refresh();
     } catch (error) {
       message.error(`Erro: ${(error as Error).message}`);
     }
@@ -287,13 +253,13 @@ export default function AcoesPage(): JSX.Element {
         try {
           await deleteAcao(record.id);
           message.success('Ação excluída com sucesso');
-          fetchData(pagination.current);
+          void refresh();
         } catch (error) {
           message.error(`Erro ao excluir: ${(error as Error).message}`);
         }
       },
     });
-  }, [fetchData, pagination.current]);
+  }, [refresh]);
 
   // Status icon renderer - memoized (§3 Epic #459)
   const renderStatusIcon = useCallback((status: string | null) => {
@@ -746,10 +712,7 @@ export default function AcoesPage(): JSX.Element {
             ...pagination,
             showSizeChanger: true,
             showTotal: (total, range) => `Mostrando ${range[0]} a ${range[1]} de ${total} ações`,
-            onChange: (page, pageSize) => {
-              setPagination((prev) => ({ ...prev, current: page, pageSize }));
-              fetchData(page);
-            },
+            onChange: handleTableChange,
           }}
           size="middle"
         />

--- a/v2/frontend/src/pages/DATModule/CadastrosPage.tsx
+++ b/v2/frontend/src/pages/DATModule/CadastrosPage.tsx
@@ -7,7 +7,9 @@
  * Workflow AVALIAR: Recebidos → Validados → Importados
  */
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect } from 'react';
+import { useTableFilters, type TableFilterParams } from '../../hooks/useTableFilters';
+import type { PaginatedResponse } from '../../types';
 import {
   Table,
   Button,
@@ -118,20 +120,7 @@ interface ProjetoGeralOption {
 
 
 export default function CadastrosPage(): JSX.Element {
-  // Issue #303: State management - this page has complex logic (stats, tabs, filters)
-  // that doesn't fit useCrudOperations hook. Constants extracted to ./Cadastros/constants.js
-  const [cadastros, setCadastros] = useState<CadastroRecord[]>([]);
-  const [loading, setLoading] = useState<boolean>(false);
-  const [pagination, setPagination] = useState({
-    current: 1,
-    pageSize: 15,
-    total: 0,
-  });
-  const [stats, setStats] = useState<CadastrosStats | null>(null);
   const [activeTab, setActiveTab] = useState<'FORMAR' | 'AVALIAR'>('FORMAR');
-
-  // Filter states - using DEFAULT_FILTERS from constants
-  const [filters, setFilters] = useState<CadastrosFilters>(DEFAULT_FILTERS as CadastrosFilters);
 
   // Options for dropdowns
   const [municipios, setMunicipios] = useState<MunicipioOption[]>([]);
@@ -142,6 +131,39 @@ export default function CadastrosPage(): JSX.Element {
   const [editingCadastro, setEditingCadastro] = useState<CadastroRecord | null>(null);
 
   const [form] = Form.useForm<CadastroFormValues>();
+
+  const {
+    data: cadastros,
+    stats,
+    loading,
+    filters,
+    setFilters,
+    pagination,
+    fetchData,
+    handleClearFilters,
+    handleTableChange,
+    refresh,
+  } = useTableFilters<CadastrosFilters, CadastroRecord, CadastrosStats>({
+    defaultFilters: DEFAULT_FILTERS as CadastrosFilters,
+    listFn: listCadastros as unknown as (params: TableFilterParams) => Promise<PaginatedResponse<CadastroRecord>>,
+    statsFn: getCadastrosStats as unknown as (params: TableFilterParams) => Promise<CadastrosStats>,
+    buildParams: (f) => ({
+      ...(f.search && { search: f.search }),
+      ...(f.uf && { uf: f.uf }),
+      ...(f.municipio !== undefined && { municipio_id: f.municipio }),
+      ...(f.projeto_geral !== undefined && { projeto_geral_id: f.projeto_geral }),
+      ...(f.status_etapa && { status_etapa: f.status_etapa }),
+      plataforma: activeTab,
+    }),
+    defaultOrdering: '-updated_at',
+    entityName: 'cadastros',
+  });
+
+  // Refetch when tab changes (activeTab lives outside filters to avoid being cleared).
+  useEffect(() => {
+    void fetchData(1);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeTab]);
 
   // Load options on mount
   useEffect(() => {
@@ -159,52 +181,6 @@ export default function CadastrosPage(): JSX.Element {
     };
     loadOptions();
   }, []);
-
-  // Fetch data with filters
-  const fetchData = useCallback(async (page = 1) => {
-    setLoading(true);
-    try {
-      const params: Record<string, string | number> = {
-        page,
-        page_size: pagination.pageSize,
-        ordering: '-updated_at',
-        plataforma: activeTab,
-      };
-
-      // Apply filters
-      if (filters.search) params.search = filters.search;
-      if (filters.uf) params.uf = filters.uf;
-      if (filters.municipio) params.municipio_id = filters.municipio;
-      if (filters.projeto_geral) params.projeto_geral_id = filters.projeto_geral;
-      if (filters.status_etapa) params.status_etapa = filters.status_etapa;
-
-      const [data, statsData] = await Promise.all([
-        listCadastros(params),
-        getCadastrosStats(params),
-      ]);
-
-      setCadastros((data as any).results || data || []);
-      setPagination((prev) => ({
-        ...prev,
-        current: page,
-        total: data.count || ((data as any).results || data || []).length,
-      }));
-      setStats(statsData as unknown as CadastrosStats);
-    } catch (error) {
-      message.error(`Erro ao carregar dados: ${(error as Error).message}`);
-    } finally {
-      setLoading(false);
-    }
-  }, [filters, pagination.pageSize, activeTab]);
-
-  useEffect(() => {
-    fetchData();
-  }, [fetchData]);
-
-  // Clear all filters
-  const handleClearFilters = () => {
-    setFilters(DEFAULT_FILTERS);
-  };
 
   // CRUD handlers
   const handleCreate = () => {
@@ -251,7 +227,7 @@ export default function CadastrosPage(): JSX.Element {
       }
       setModalVisible(false);
       form.resetFields();
-      fetchData(pagination.current);
+      void refresh();
     } catch (error) {
       message.error(`Erro: ${(error as Error).message}`);
     }
@@ -268,7 +244,7 @@ export default function CadastrosPage(): JSX.Element {
         try {
           await deleteCadastro(record.id);
           message.success('Cadastro excluído com sucesso');
-          fetchData(pagination.current);
+          void refresh();
         } catch (error) {
           message.error(`Erro ao excluir: ${(error as Error).message}`);
         }
@@ -281,7 +257,7 @@ export default function CadastrosPage(): JSX.Element {
     try {
       await updateCadastroEtapa(record.id, etapa, newStatus);
       message.success('Status atualizado');
-      fetchData(pagination.current);
+      void refresh();
     } catch (error) {
       message.error(`Erro: ${(error as Error).message}`);
     }
@@ -534,10 +510,7 @@ export default function CadastrosPage(): JSX.Element {
             ...pagination,
             showSizeChanger: true,
             showTotal: (total, range) => `Mostrando ${range[0]} a ${range[1]} de ${total} cadastros`,
-            onChange: (page, pageSize) => {
-              setPagination((prev) => ({ ...prev, current: page, pageSize }));
-              fetchData(page);
-            },
+            onChange: handleTableChange,
           }}
           size="middle"
         />

--- a/v2/frontend/src/pages/DATModule/ComprasPage.tsx
+++ b/v2/frontend/src/pages/DATModule/ComprasPage.tsx
@@ -8,7 +8,7 @@
  * 1.798 registros, 502.771 itens, 307 produtos, 94 municípios
  */
 
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import {
   Table,
   Button,
@@ -49,7 +49,6 @@ import {
   getMunicipiosOptions,
   getProjetosOptions,
   getProdutosOptions,
-  type GenericRecord,
 } from '../../api/datModule';
 import {
   importCompras,
@@ -59,7 +58,7 @@ import {
   type ImportResult as OpsImportResult,
 } from '../../api/ops';
 import type { PaginatedResponse } from '../../types';
-import { useCrudOperations } from '../../hooks/useCrudOperations';
+import { useTableFilters, type TableFilterParams } from '../../hooks/useTableFilters';
 import ImportUploader from '../../components/ImportUploader';
 import type { ValidationResult, ApplyResult } from '../../components/ImportUploader';
 import dayjs from 'dayjs';
@@ -168,30 +167,30 @@ const ANO_OPTIONS = [currentYear - 1, currentYear, currentYear + 1].map(
   (year) => ({ label: String(year), value: year })
 );
 
+const DEFAULT_COMPRAS_FILTERS: ComprasFilters = {
+  search: '',
+  uf: undefined,
+  municipio: undefined,
+  projeto: undefined,
+  produto: undefined,
+  status: undefined,
+  ano_uso: undefined,
+  tipo_compra: undefined,
+};
+
+const buildComprasParams = (f: ComprasFilters): TableFilterParams => ({
+  ...(f.search && { search: f.search }),
+  ...(f.uf && { uf: f.uf }),
+  ...(f.municipio !== undefined && { municipio_id: f.municipio }),
+  ...(f.projeto !== undefined && { projeto_id: f.projeto }),
+  ...(f.produto !== undefined && { produto_id: f.produto }),
+  ...(f.status && { status: f.status }),
+  ...(f.ano_uso !== undefined && { ano_uso: f.ano_uso }),
+  ...(f.tipo_compra && { tipo_compra: f.tipo_compra }),
+});
+
 export default function ComprasPage(): JSX.Element {
   const [viewMode, setViewMode] = useState<ViewMode>('lista');
-
-  // Issue #302: Use useCrudOperations hook for standardized CRUD
-  const crud = useCrudOperations({
-    listFn: listCompras as unknown as (params: { page?: number; pageSize?: number; [key: string]: unknown }) => Promise<PaginatedResponse<GenericRecord>>,
-    createFn: createCompra,
-    updateFn: updateCompra,
-    deleteFn: deleteCompra,
-    entityName: 'Compra',
-    pageSize: 15,
-  });
-
-  // Filter states
-  const [filters, setFilters] = useState<ComprasFilters>({
-    search: '',
-    uf: undefined,
-    municipio: undefined,
-    projeto: undefined,
-    produto: undefined,
-    status: undefined,
-    ano_uso: undefined,
-    tipo_compra: undefined,
-  });
 
   // Options for dropdowns
   const [municipios, setMunicipios] = useState<MunicipioOption[]>([]);
@@ -203,6 +202,24 @@ export default function ComprasPage(): JSX.Element {
   const [editingCompra, setEditingCompra] = useState<CompraRecord | null>(null);
 
   const [form] = Form.useForm<CompraFormValues>();
+
+  const {
+    data: compras,
+    loading,
+    filters,
+    setFilters,
+    pagination,
+    fetchData,
+    handleClearFilters,
+    handleTableChange,
+    refresh,
+  } = useTableFilters<ComprasFilters, CompraRecord>({
+    defaultFilters: DEFAULT_COMPRAS_FILTERS,
+    listFn: listCompras as unknown as (params: TableFilterParams) => Promise<PaginatedResponse<CompraRecord>>,
+    buildParams: buildComprasParams,
+    defaultOrdering: '-updated_at',
+    entityName: 'compras',
+  });
 
   // Load options on mount
   useEffect(() => {
@@ -223,47 +240,6 @@ export default function ComprasPage(): JSX.Element {
     loadOptions();
   }, []);
 
-  // Fetch data with filters (uses crud hook internally)
-  const fetchData = useCallback(async (page = 1) => {
-    const params: Record<string, string | number> = {
-      page,
-      ordering: '-updated_at',
-    };
-
-    // Apply filters
-    if (filters.search) params.search = filters.search;
-    if (filters.uf) params.uf = filters.uf;
-    if (filters.municipio) params.municipio_id = filters.municipio;
-    if (filters.projeto) params.projeto_id = filters.projeto;
-    if (filters.produto) params.produto_id = filters.produto;
-    if (filters.status) params.status = filters.status;
-    if (filters.ano_uso) params.ano_uso = filters.ano_uso;
-    if (filters.tipo_compra) params.tipo_compra = filters.tipo_compra;
-
-    await crud.fetchData(params);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filters]);
-
-  // Initial load only
-  useEffect(() => {
-    fetchData();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  // Clear all filters
-  const handleClearFilters = () => {
-    setFilters({
-      search: '',
-      uf: undefined,
-      municipio: undefined,
-      projeto: undefined,
-      produto: undefined,
-      status: undefined,
-      ano_uso: undefined,
-      tipo_compra: undefined,
-    });
-  };
-
   // CRUD handlers
   const handleCreate = () => {
     setEditingCompra(null);
@@ -281,7 +257,6 @@ export default function ComprasPage(): JSX.Element {
     setModalVisible(true);
   };
 
-  // Issue #302: Simplified handleSave using crud hook
   const handleSave = async (values: CompraFormValues) => {
     const payload = {
       ...values,
@@ -289,20 +264,38 @@ export default function ComprasPage(): JSX.Element {
       data_entrega: values.data_entrega ? values.data_entrega.format('YYYY-MM-DD') : null,
     };
 
-    const result = await crud.handleSave(payload, editingCompra?.id);
-
-    if (result.success) {
+    try {
+      if (editingCompra) {
+        await updateCompra(editingCompra.id, payload);
+        message.success('Compra atualizada com sucesso');
+      } else {
+        await createCompra(payload);
+        message.success('Compra criada com sucesso');
+      }
       setModalVisible(false);
       form.resetFields();
-      fetchData(crud.pagination.current);
+      void refresh();
+    } catch (error) {
+      message.error(`Erro: ${(error as Error).message}`);
     }
   };
 
-  // Issue #302: Simplified handleDelete using crud hook
   const handleDelete = (record: CompraRecord) => {
-    crud.confirmDelete(record, {
-      nameField: 'produto_nome',
-      onSuccess: () => fetchData(crud.pagination.current),
+    Modal.confirm({
+      title: 'Excluir Compra?',
+      content: `Deseja excluir "${record.produto_nome}"? Esta ação não pode ser desfeita.`,
+      okText: 'Sim, excluir',
+      okType: 'danger',
+      cancelText: 'Cancelar',
+      onOk: async () => {
+        try {
+          await deleteCompra(record.id);
+          message.success('Compra excluída com sucesso');
+          void refresh();
+        } catch (error) {
+          message.error(`Erro ao excluir: ${(error as Error).message}`);
+        }
+      },
     });
   };
 
@@ -652,7 +645,7 @@ export default function ComprasPage(): JSX.Element {
           <Button icon={<ClearOutlined />} onClick={handleClearFilters}>
             Limpar
           </Button>
-          <Button icon={<ReloadOutlined />} onClick={() => fetchData(1)} loading={crud.loading}>
+          <Button icon={<ReloadOutlined />} onClick={() => fetchData(1)} loading={loading}>
             Atualizar
           </Button>
           <Button type="primary" icon={<FilterOutlined />} onClick={() => fetchData(1)}>
@@ -669,25 +662,22 @@ export default function ComprasPage(): JSX.Element {
         title={
           <Space>
             <Text strong>Resultados:</Text>
-            <Text type="danger" strong>{crud.pagination.total}</Text>
+            <Text type="danger" strong>{pagination.total}</Text>
             <Text>registros</Text>
           </Space>
         }
       >
         <Table
           columns={columns as any}
-          dataSource={crud.data}
+          dataSource={compras}
           rowKey="id"
-          loading={crud.loading}
+          loading={loading}
           scroll={{ x: 1400 }}
           pagination={{
-            ...crud.pagination,
+            ...pagination,
             showSizeChanger: true,
             showTotal: (total, range) => `Mostrando ${range[0]} a ${range[1]} de ${total} registros`,
-            onChange: (page, pageSize) => {
-              crud.setPagination((prev) => ({ ...prev, current: page, pageSize }));
-              fetchData(page);
-            },
+            onChange: handleTableChange,
           }}
           size="middle"
           summary={(pageData) => {

--- a/v2/frontend/src/pages/DATModule/CoordenadoresPage.tsx
+++ b/v2/frontend/src/pages/DATModule/CoordenadoresPage.tsx
@@ -8,6 +8,8 @@
  */
 
 import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useTableFilters, type TableFilterParams } from '../../hooks/useTableFilters';
+import type { PaginatedResponse } from '../../types';
 import {
   Table,
   Button,
@@ -99,11 +101,6 @@ interface CoordenadoresStats {
   media_projetos: string | number;
 }
 
-interface PaginationState {
-  current: number;
-  pageSize: number;
-  total: number;
-}
 
 interface AreaOption {
   id: number;
@@ -122,14 +119,44 @@ interface AlocacaoRecord {
 const { Panel } = Collapse;
 
 export default function CoordenadoresPage(): JSX.Element {
-  const [coordenadores, setCoordenadores] = useState<CoordenadorRecord[]>([]);
-  const [loading, setLoading] = useState<boolean>(false);
-  const [pagination, setPagination] = useState<PaginationState>({ current: 1, pageSize: 15, total: 0 });
-  const [stats, setStats] = useState<CoordenadoresStats | null>(null);
   const [viewMode, setViewMode] = useState<string>(VIEW_MODES.CARDS);
 
-  // Filter states - using DEFAULT_FILTERS from constants
-  const [filters, setFilters] = useState<CoordenadoresFilters>(DEFAULT_FILTERS as CoordenadoresFilters);
+  const {
+    data: coordenadores,
+    loading,
+    filters,
+    setFilters,
+    pagination,
+    fetchData,
+    handleClearFilters,
+    handleTableChange,
+    refresh,
+  } = useTableFilters<CoordenadoresFilters, CoordenadorRecord>({
+    defaultFilters: DEFAULT_FILTERS as CoordenadoresFilters,
+    listFn: listCoordenadoresDAT as unknown as (params: TableFilterParams) => Promise<PaginatedResponse<CoordenadorRecord>>,
+    buildParams: (f) => ({
+      ...(f.search && { search: f.search }),
+      ...(f.area && { area: f.area }),
+      ...(f.ativo !== undefined && { ativo: f.ativo }),
+    }),
+    defaultOrdering: 'nome',
+    entityName: 'coordenadores',
+  });
+
+  // Stats derived from current page (no API for stats on this entity).
+  const stats = useMemo<CoordenadoresStats>(() => {
+    const results = coordenadores;
+    const ativos = results.filter((c) => (c as any).ativo !== false).length;
+    const areasUnicas = [...new Set(results.map((c) => (c as any).area))].filter(Boolean).length;
+    const totalProjetos = results.reduce((sum, c) => sum + ((c as any).total_projetos || 0), 0);
+    const mediaProjetos = results.length > 0 ? (totalProjetos / results.length).toFixed(1) : 0;
+    return {
+      total: pagination.total,
+      ativos,
+      areas: areasUnicas,
+      media_projetos: mediaProjetos,
+    } as CoordenadoresStats;
+  }, [coordenadores, pagination.total]);
 
   // Options for dropdowns (projetos/municipios reserved for future use)
   const [areas, setAreas] = useState<(AreaOption | string)[]>([]);
@@ -170,59 +197,6 @@ export default function CoordenadoresPage(): JSX.Element {
     };
     loadOptions();
   }, []);
-
-  // Fetch data with filters
-  const fetchData = useCallback(async (page = 1) => {
-    setLoading(true);
-    try {
-      const params: Record<string, string | number | boolean> = {
-        page,
-        page_size: pagination.pageSize,
-        ordering: 'nome',
-      };
-
-      // Apply filters
-      if (filters.search) params.search = filters.search;
-      if (filters.area) params.area = filters.area;
-      if (filters.ativo !== undefined) params.ativo = filters.ativo;
-
-      const data = await listCoordenadoresDAT(params);
-
-      const results = (data as any).results || data || [];
-      setCoordenadores((results as any) as CoordenadorRecord[]);
-      setPagination((prev) => ({
-        ...prev,
-        current: page,
-        total: (data as any).count || (results as any[]).length,
-      }));
-
-      // Calculate stats
-      const ativos = (results as any[]).filter((c) => c.ativo !== false).length;
-      const areasUnicas = [...new Set((results as any[]).map((c) => c.area))].filter(Boolean).length;
-      const totalProjetos = (results as any[]).reduce((sum, c) => sum + (c.total_projetos || 0), 0);
-      const mediaProjetos = (results as any[]).length > 0 ? (totalProjetos / (results as any[]).length).toFixed(1) : 0;
-
-      setStats({
-        total: (data as any).count || (results as any[]).length,
-        ativos,
-        areas: areasUnicas,
-        media_projetos: mediaProjetos,
-      });
-    } catch (error) {
-      message.error(`Erro ao carregar dados: ${(error as Error).message}`);
-    } finally {
-      setLoading(false);
-    }
-  }, [filters, pagination.pageSize]);
-
-  useEffect(() => {
-    fetchData();
-  }, [fetchData]);
-
-  // Clear all filters
-  const handleClearFilters = () => {
-    setFilters(DEFAULT_FILTERS);
-  };
 
   // Load alocações for detail view
   const loadAlocacoes = async (coordenadorId: number) => {
@@ -278,7 +252,7 @@ export default function CoordenadoresPage(): JSX.Element {
       }
       setModalVisible(false);
       form.resetFields();
-      fetchData(pagination.current);
+      void refresh();
     } catch (error) {
       message.error(`Erro: ${(error as Error).message}`);
     }
@@ -304,23 +278,23 @@ export default function CoordenadoresPage(): JSX.Element {
         try {
           await deleteCoordenadorDAT(record.id);
           message.success('Coordenador excluído com sucesso');
-          fetchData(pagination.current);
+          void refresh();
         } catch (error) {
           message.error(`Erro ao excluir: ${(error as Error).message}`);
         }
       },
     });
-  }, [fetchData, pagination.current]);
+  }, [refresh]);
 
   const handleToggleAtivo = useCallback(async (record: CoordenadorRecord) => {
     try {
       await updateCoordenadorDAT(record.id, { ativo: !record.ativo });
       message.success(`Coordenador ${record.ativo ? 'desativado' : 'ativado'}`);
-      fetchData(pagination.current);
+      void refresh();
     } catch (error) {
       message.error(`Erro: ${(error as Error).message}`);
     }
-  }, [fetchData, pagination.current]);
+  }, [refresh]);
 
   // Issue #303: Helper functions extracted to ./Coordenadores/helpers.js
   // Group coordenadores by area using extracted helper - memoized (§2 Epic #459)
@@ -669,10 +643,7 @@ export default function CoordenadoresPage(): JSX.Element {
               ...pagination,
               showSizeChanger: true,
               showTotal: (total, range) => `Mostrando ${range[0]} a ${range[1]} de ${total} coordenadores`,
-              onChange: (page, pageSize) => {
-                setPagination((prev) => ({ ...prev, current: page, pageSize }));
-                fetchData(page);
-              },
+              onChange: handleTableChange,
             }}
             size="middle"
           />

--- a/v2/frontend/src/pages/DATModule/DATRegistrosPage.tsx
+++ b/v2/frontend/src/pages/DATModule/DATRegistrosPage.tsx
@@ -7,7 +7,9 @@
  * tabela com cabeçalhos agrupados e legenda de status.
  */
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect } from 'react';
+import { useTableFilters, type TableFilterParams } from '../../hooks/useTableFilters';
+import type { PaginatedResponse } from '../../types';
 import {
   Table,
   Button,
@@ -84,12 +86,6 @@ interface DATRegistroFormValues {
   [key: string]: any;
 }
 
-interface PaginationState {
-  current: number;
-  pageSize: number;
-  total: number;
-}
-
 interface ProjetoGeralOption {
   id: number;
   nome: string;
@@ -113,14 +109,15 @@ interface UFOption {
 }
 
 
+const buildRegistrosParams = (f: DATRegistrosFilters): TableFilterParams => ({
+  ...(f.uf && { uf: f.uf }),
+  ...(f.municipio !== undefined && { municipio: f.municipio }),
+  ...(f.projeto_geral !== undefined && { projeto_geral: f.projeto_geral }),
+  ...(f.usa_avaliar !== undefined && { usa_avaliar: f.usa_avaliar }),
+  ...(f.status_formar && { status_formar: f.status_formar }),
+});
+
 export default function DATRegistrosPage(): JSX.Element {
-  const [registros, setRegistros] = useState<DATRegistroRecord[]>([]);
-  const [loading, setLoading] = useState<boolean>(false);
-  const [pagination, setPagination] = useState<PaginationState>({ current: 1, pageSize: 15, total: 0 });
-
-  // Filter states - using DEFAULT_FILTERS from constants
-  const [filters, setFilters] = useState<DATRegistrosFilters>(DEFAULT_FILTERS as unknown as DATRegistrosFilters);
-
   // Options for dropdowns
   const [projetosGerais, setProjetosGerais] = useState<ProjetoGeralOption[]>([]);
   const [municipios, setMunicipios] = useState<MunicipioOption[]>([]);
@@ -132,6 +129,24 @@ export default function DATRegistrosPage(): JSX.Element {
   const [editingRegistro, setEditingRegistro] = useState<DATRegistroRecord | null>(null);
 
   const [form] = Form.useForm<DATRegistroFormValues>();
+
+  const {
+    data: registros,
+    loading,
+    filters,
+    setFilters,
+    pagination,
+    fetchData,
+    handleClearFilters: clearFilterState,
+    handleTableChange,
+    refresh,
+  } = useTableFilters<DATRegistrosFilters, DATRegistroRecord>({
+    defaultFilters: DEFAULT_FILTERS as unknown as DATRegistrosFilters,
+    listFn: listDATRegistros as unknown as (params: TableFilterParams) => Promise<PaginatedResponse<DATRegistroRecord>>,
+    buildParams: buildRegistrosParams,
+    defaultOrdering: '-created_at',
+    entityName: 'registros',
+  });
 
   // Load options on mount
   useEffect(() => {
@@ -152,41 +167,6 @@ export default function DATRegistrosPage(): JSX.Element {
     loadOptions();
   }, []);
 
-  // Fetch data with filters
-  const fetchData = useCallback(async (page = 1) => {
-    setLoading(true);
-    try {
-      const params: Record<string, string | number> = {
-        page,
-        page_size: pagination.pageSize,
-        ordering: '-created_at',
-      };
-
-      // Apply filters
-      if (filters.uf) params.uf = filters.uf;
-      if (filters.municipio) params.municipio = filters.municipio;
-      if (filters.projeto_geral) params.projeto_geral = filters.projeto_geral;
-      if (filters.usa_avaliar !== undefined) params.usa_avaliar = filters.usa_avaliar;
-      if (filters.status_formar) params.status_formar = filters.status_formar;
-
-      const data = await listDATRegistros(params);
-      setRegistros((data as any).results || data || []);
-      setPagination((prev) => ({
-        ...prev,
-        current: page,
-        total: data.count || ((data as any).results || data || []).length,
-      }));
-    } catch (error) {
-      message.error(`Erro ao carregar dados: ${(error as Error).message}`);
-    } finally {
-      setLoading(false);
-    }
-  }, [filters, pagination.pageSize]);
-
-  useEffect(() => {
-    fetchData();
-  }, [fetchData]);
-
   // Handle region filter change
   const handleRegiaoChange = (regiao: string | undefined) => {
     setFilters((prev) => ({ ...prev, regiao, uf: undefined }));
@@ -197,9 +177,9 @@ export default function DATRegistrosPage(): JSX.Element {
     }
   };
 
-  // Clear all filters
+  // Clear all filters (also resets cascading UF list)
   const handleClearFilters = () => {
-    setFilters(DEFAULT_FILTERS as any);
+    clearFilterState();
     setFilteredUFs(UF_OPTIONS as UFOption[]);
   };
 
@@ -256,7 +236,7 @@ export default function DATRegistrosPage(): JSX.Element {
       }
       setModalVisible(false);
       form.resetFields();
-      fetchData(pagination.current);
+      void refresh();
     } catch (error) {
       message.error(`Erro: ${(error as Error).message}`);
     }
@@ -273,7 +253,7 @@ export default function DATRegistrosPage(): JSX.Element {
         try {
           await deleteDATRegistro(record.id);
           message.success('Registro excluído com sucesso');
-          fetchData(pagination.current);
+          void refresh();
         } catch (error) {
           message.error(`Erro ao excluir: ${(error as Error).message}`);
         }
@@ -477,10 +457,7 @@ export default function DATRegistrosPage(): JSX.Element {
             ...pagination,
             showSizeChanger: true,
             showTotal: (total, range) => `Mostrando ${range[0]} a ${range[1]} de ${total} registros`,
-            onChange: (page, pageSize) => {
-              setPagination((prev) => ({ ...prev, current: page, pageSize }));
-              fetchData(page);
-            },
+            onChange: handleTableChange,
           }}
           size="middle"
         />

--- a/v2/frontend/src/pages/DATModule/FormacoesPage.tsx
+++ b/v2/frontend/src/pages/DATModule/FormacoesPage.tsx
@@ -7,7 +7,9 @@
  * Agendamentos, formadores, locais e acompanhamento.
  */
 
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useMemo } from 'react';
+import { useTableFilters, type TableFilterParams } from '../../hooks/useTableFilters';
+import type { PaginatedResponse } from '../../types';
 import {
   Table,
   Button,
@@ -111,12 +113,6 @@ interface FormacoesStats {
   realizadas: number;
 }
 
-interface PaginationState {
-  current: number;
-  pageSize: number;
-  total: number;
-}
-
 interface MunicipioOption {
   id: number;
   nome: string;
@@ -144,16 +140,21 @@ interface CalendarFormacaoItem {
 }
 
 
+const buildFormacoesParams = (f: FormacoesFilters): TableFilterParams => ({
+  ...(f.search && { search: f.search }),
+  ...(f.uf && { uf: f.uf }),
+  ...(f.municipio !== undefined && { municipio_id: f.municipio }),
+  ...(f.projeto !== undefined && { projeto_id: f.projeto }),
+  ...(f.coordenador !== undefined && { coordenador_id: f.coordenador }),
+  ...(f.status && { status: f.status }),
+  ...(f.modalidade && { modalidade: f.modalidade }),
+  ...(f.data_inicio && { data_inicio: f.data_inicio.format('YYYY-MM-DD') }),
+  ...(f.data_fim && { data_fim: f.data_fim.format('YYYY-MM-DD') }),
+});
+
 export default function FormacoesPage(): JSX.Element {
-  const [formacoes, setFormacoes] = useState<FormacaoRecord[]>([]);
-  const [loading, setLoading] = useState<boolean>(false);
-  const [pagination, setPagination] = useState<PaginationState>({ current: 1, pageSize: 15, total: 0 });
-  const [stats, setStats] = useState<FormacoesStats | null>(null);
   const [viewMode, setViewMode] = useState<string>(VIEW_MODES.TABLE);
   const [calendarData, setCalendarData] = useState<CalendarFormacaoItem[]>([]);
-
-  // Filter states - using DEFAULT_FILTERS from constants
-  const [filters, setFilters] = useState<FormacoesFilters>(DEFAULT_FILTERS as FormacoesFilters);
 
   // Options for dropdowns
   const [municipios, setMunicipios] = useState<MunicipioOption[]>([]);
@@ -165,6 +166,38 @@ export default function FormacoesPage(): JSX.Element {
   const [editingFormacao, setEditingFormacao] = useState<FormacaoRecord | null>(null);
 
   const [form] = Form.useForm<FormacaoFormValues>();
+
+  const {
+    data: formacoes,
+    stats,
+    loading,
+    filters,
+    setFilters,
+    pagination,
+    fetchData,
+    handleClearFilters,
+    handleTableChange,
+    refresh,
+  } = useTableFilters<FormacoesFilters, FormacaoRecord, FormacoesStats>({
+    defaultFilters: DEFAULT_FILTERS as FormacoesFilters,
+    listFn: listFormacoes as unknown as (params: TableFilterParams) => Promise<PaginatedResponse<FormacaoRecord>>,
+    statsFn: getFormacoesStats as unknown as (params: TableFilterParams) => Promise<FormacoesStats>,
+    buildParams: buildFormacoesParams,
+    defaultOrdering: 'data_formacao',
+    entityName: 'formações',
+  });
+
+  // Load calendar data when in calendar view (mirrors original inline fetch).
+  useEffect(() => {
+    if (viewMode !== VIEW_MODES.CALENDAR) return;
+    const params: TableFilterParams = {
+      ...(buildFormacoesParams(filters) as TableFilterParams),
+      ordering: 'data_formacao',
+    };
+    getFormacoesCalendario(params)
+      .then((calData) => setCalendarData((calData as any).results || calData || []))
+      .catch((error) => message.error(`Erro ao carregar calendário: ${(error as Error).message}`));
+  }, [viewMode, filters]);
 
   // Load options on mount
   useEffect(() => {
@@ -184,61 +217,6 @@ export default function FormacoesPage(): JSX.Element {
     };
     loadOptions();
   }, []);
-
-  // Fetch data with filters
-  const fetchData = useCallback(async (page = 1) => {
-    setLoading(true);
-    try {
-      const params: Record<string, string | number> = {
-        page,
-        page_size: pagination.pageSize,
-        ordering: 'data_formacao',
-      };
-
-      // Apply filters
-      if (filters.search) params.search = filters.search;
-      if (filters.uf) params.uf = filters.uf;
-      if (filters.municipio) params.municipio_id = filters.municipio;
-      if (filters.projeto) params.projeto_id = filters.projeto;
-      if (filters.coordenador) params.coordenador_id = filters.coordenador;
-      if (filters.status) params.status = filters.status;
-      if (filters.modalidade) params.modalidade = filters.modalidade;
-      if (filters.data_inicio) params.data_inicio = filters.data_inicio.format('YYYY-MM-DD');
-      if (filters.data_fim) params.data_fim = filters.data_fim.format('YYYY-MM-DD');
-
-      const [data, statsData] = await Promise.all([
-        listFormacoes(params),
-        getFormacoesStats(params),
-      ]);
-
-      setFormacoes((data as any).results || data || []);
-      setPagination((prev) => ({
-        ...prev,
-        current: page,
-        total: data.count || ((data as any).results || data || []).length,
-      }));
-      setStats(statsData as unknown as FormacoesStats);
-
-      // Load calendar data if in calendar view
-      if (viewMode === VIEW_MODES.CALENDAR) {
-        const calData = await getFormacoesCalendario(params);
-        setCalendarData((calData as any).results || calData || []);
-      }
-    } catch (error) {
-      message.error(`Erro ao carregar dados: ${(error as Error).message}`);
-    } finally {
-      setLoading(false);
-    }
-  }, [filters, pagination.pageSize, viewMode]);
-
-  useEffect(() => {
-    fetchData();
-  }, [fetchData]);
-
-  // Clear all filters
-  const handleClearFilters = () => {
-    setFilters(DEFAULT_FILTERS);
-  };
 
   // CRUD handlers
   const handleCreate = () => {
@@ -276,7 +254,7 @@ export default function FormacoesPage(): JSX.Element {
       }
       setModalVisible(false);
       form.resetFields();
-      fetchData(pagination.current);
+      void refresh();
     } catch (error) {
       message.error(`Erro: ${(error as Error).message}`);
     }
@@ -293,7 +271,7 @@ export default function FormacoesPage(): JSX.Element {
         try {
           await deleteFormacao(record.id);
           message.success('Formação excluída com sucesso');
-          fetchData(pagination.current);
+          void refresh();
         } catch (error) {
           message.error(`Erro ao excluir: ${(error as Error).message}`);
         }
@@ -573,10 +551,7 @@ export default function FormacoesPage(): JSX.Element {
               ...pagination,
               showSizeChanger: true,
               showTotal: (total, range) => `Mostrando ${range[0]} a ${range[1]} de ${total} formações`,
-              onChange: (page, pageSize) => {
-                setPagination((prev) => ({ ...prev, current: page, pageSize }));
-                fetchData(page);
-              },
+              onChange: handleTableChange,
             }}
             size="middle"
           />

--- a/v2/frontend/src/pages/DATModule/PlanoFormacoesPage.tsx
+++ b/v2/frontend/src/pages/DATModule/PlanoFormacoesPage.tsx
@@ -12,7 +12,9 @@
  * Ref: prompt-pagina-formacoes.md
  */
 
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useMemo } from 'react';
+import { useTableFilters, type TableFilterParams } from '../../hooks/useTableFilters';
+import type { PaginatedResponse } from '../../types';
 import {
   Table,
   Card,
@@ -179,29 +181,46 @@ const MODALIDADE_OPTIONS = [
 // COMPONENT
 // ============================================================
 
-export default function PlanoFormacoesPage(): JSX.Element {
-  // Data state
-  const [planos, setPlanos] = useState<PlanoFormacaoRecord[]>([]);
-  const [loading, setLoading] = useState<boolean>(false);
-  const [pagination, setPagination] = useState({
-    current: 1,
-    pageSize: 15,
-    total: 0,
-  });
-  const [stats, setStats] = useState<PlanoFormacoesStats | null>(null);
+const DEFAULT_PLANO_FILTERS: PlanoFilters = {
+  search: '',
+  uf: undefined,
+  municipio: undefined,
+  projeto: undefined,
+  coordenador: undefined,
+};
 
+const buildPlanoParams = (f: PlanoFilters): TableFilterParams => ({
+  ...(f.search && { search: f.search }),
+  ...(f.uf && { uf: f.uf }),
+  ...(f.municipio !== undefined && { municipio: f.municipio }),
+  ...(f.projeto !== undefined && { projeto: f.projeto }),
+  ...(f.coordenador !== undefined && { coordenador: f.coordenador }),
+});
+
+export default function PlanoFormacoesPage(): JSX.Element {
   // Options state
   const [municipios, setMunicipios] = useState<MunicipioOption[]>([]);
   const [projetos, setProjetos] = useState<ProjetoOption[]>([]);
   const [coordenadores, setCoordenadores] = useState<CoordenadorOption[]>([]);
 
-  // Filter state
-  const [filters, setFilters] = useState<PlanoFilters>({
-    search: '',
-    uf: undefined,
-    municipio: undefined,
-    projeto: undefined,
-    coordenador: undefined,
+  const {
+    data: planos,
+    stats,
+    loading,
+    filters,
+    setFilters,
+    pagination,
+    fetchData,
+    handleClearFilters,
+    handleTableChange,
+    refresh,
+  } = useTableFilters<PlanoFilters, PlanoFormacaoRecord, PlanoFormacoesStats>({
+    defaultFilters: DEFAULT_PLANO_FILTERS,
+    listFn: listPlanoFormacoes as unknown as (params: TableFilterParams) => Promise<PaginatedResponse<PlanoFormacaoRecord>>,
+    statsFn: getPlanoFormacoesStats as unknown as (params: TableFilterParams) => Promise<PlanoFormacoesStats>,
+    buildParams: buildPlanoParams,
+    defaultOrdering: 'municipio__nome,projeto__nome',
+    entityName: 'planos',
   });
 
   // View mode
@@ -244,58 +263,9 @@ export default function PlanoFormacoesPage(): JSX.Element {
     loadOptions();
   }, []);
 
-  // Fetch data
-  const fetchData = useCallback(async (page = 1) => {
-    setLoading(true);
-    try {
-      const params: Record<string, string | number> = {
-        page,
-        page_size: pagination.pageSize,
-        ordering: 'municipio__nome,projeto__nome',
-      };
-
-      if (filters.search) params.search = filters.search;
-      if (filters.uf) params.uf = filters.uf;
-      if (filters.municipio) params.municipio = filters.municipio;
-      if (filters.projeto) params.projeto = filters.projeto;
-      if (filters.coordenador) params.coordenador = filters.coordenador;
-
-      const [data, statsData] = await Promise.all([
-        listPlanoFormacoes(params),
-        getPlanoFormacoesStats(params),
-      ]);
-
-      setPlanos((data as any).results || data || []);
-      setPagination((prev) => ({
-        ...prev,
-        current: page,
-        total: data.count || ((data as any).results || data || []).length,
-      }));
-      setStats(statsData as unknown as PlanoFormacoesStats);
-    } catch (error) {
-      message.error(`Erro ao carregar dados: ${(error as Error).message}`);
-    } finally {
-      setLoading(false);
-    }
-  }, [filters, pagination.pageSize]);
-
-  useEffect(() => {
-    fetchData();
-  }, [fetchData]);
-
   // ============================================================
   // HANDLERS
   // ============================================================
-
-  const handleClearFilters = () => {
-    setFilters({
-      search: '',
-      uf: undefined,
-      municipio: undefined,
-      projeto: undefined,
-      coordenador: undefined,
-    });
-  };
 
   const handleCreate = () => {
     setEditingPlano(null);
@@ -326,7 +296,7 @@ export default function PlanoFormacoesPage(): JSX.Element {
         try {
           await deletePlanoFormacoes(record.id);
           message.success('Plano excluido com sucesso');
-          fetchData(pagination.current);
+          void refresh();
         } catch (error) {
           message.error(`Erro ao excluir: ${(error as Error).message}`);
         }
@@ -345,7 +315,7 @@ export default function PlanoFormacoesPage(): JSX.Element {
       }
       setModalVisible(false);
       form.resetFields();
-      fetchData(pagination.current);
+      void refresh();
     } catch (error) {
       message.error(`Erro: ${(error as Error).message}`);
     }
@@ -378,7 +348,7 @@ export default function PlanoFormacoesPage(): JSX.Element {
       await updateFormacaoInline(editingFormacao.plano.id, editingFormacao.formacao.numero, payload);
       message.success('Formacao atualizada');
       setFormacaoModalVisible(false);
-      fetchData(pagination.current);
+      void refresh();
     } catch (error) {
       message.error(`Erro: ${(error as Error).message}`);
     }
@@ -758,10 +728,7 @@ export default function PlanoFormacoesPage(): JSX.Element {
               ...pagination,
               showSizeChanger: true,
               showTotal: (total, range) => `Mostrando ${range[0]} a ${range[1]} de ${total}`,
-              onChange: (page, pageSize) => {
-                setPagination((prev) => ({ ...prev, current: page, pageSize }));
-                fetchData(page);
-              },
+              onChange: handleTableChange,
             }}
             size="small"
           />


### PR DESCRIPTION
## Summary
Closes #1116. Part of epic #1112 (FE-QUALITY).

Extracts a generic `useTableFilters<F, T, S>` hook that encapsulates the filters + pagination + fetch pattern that was duplicated across the 7 DATModule list pages.

## Changes

**New**
- `v2/frontend/src/hooks/useTableFilters.ts` — typed, generic hook (~190 LoC)
- `v2/frontend/src/hooks/__tests__/useTableFilters.test.ts` — 14 unit tests

**Migrated (all 7 DATModule pages)**
- `AcoesPage` (pilot)
- `CadastrosPage` (includes `activeTab` refetch via extra `useEffect`)
- `ComprasPage` (moved off `useCrudOperations` — CRUD inlined for consistency with the other 6 pages)
- `CoordenadoresPage` (client-side stats via `useMemo` since there is no stats endpoint)
- `DATRegistrosPage` (custom `handleClearFilters` wraps hook's reset to also clear cascading UF list)
- `FormacoesPage` (shared `buildParams` helper reused by calendar fetch)
- `PlanoFormacoesPage`

## Hook design
```ts
useTableFilters<F, T, S>({
  defaultFilters,          // clearable target
  listFn,                  // paginated list endpoint
  statsFn?,                // optional stats endpoint (same params as listFn)
  buildParams?,            // filters → API query params (default strips empty)
  defaultOrdering?,        // injected into every request
  pageSize?,               // default 15
  entityName?,             // used in error messages
  autoFetch?,              // default true
})
// returns { data, stats, loading, filters, setFilters, pagination,
//           setPagination, fetchData, refresh, handleTableChange, handleClearFilters }
```

Auto-fetch fires on mount and on filter changes. Page/pageSize changes go through `handleTableChange` to avoid cascading re-fetches via closure identity.

## Stats
- **Net change in page code**: −184 lines (325 added / 509 removed)
- **Hook + tests**: +493 lines
- Zero behavior changes intended; each page's data/CRUD flow mirrors pre-refactor behavior.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` succeeds (no bundle regressions)
- [x] `npx vitest run src/hooks` → 72/72 passed (14 new for the hook)
- [x] `npm run lint` clean
- [x] `npx size-limit` — all budgets green (Total Initial Load 400.71 KB / 500 KB limit)
- [ ] Manual smoke test each DATModule page in the browser (filter, clear, paginate, create/edit/delete)

## Staging Gate
- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

```
ALL 8 CHECKS PASSED
```