### PR TITLE
chore(ci): unify backend coverage threshold at 85% (#850)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -467,13 +467,13 @@ jobs:
         cp "$INGEST_COV" .coverage.ingest_devtools
 
         coverage combine .coverage.core .coverage.ingest_devtools
-        coverage report --fail-under=80
+        coverage report --fail-under=85
         coverage xml -o coverage.xml
 
         {
           echo "### Backend Coverage Combine"
           echo "- Source artifacts: core + ingest/devtools"
-          echo "- Threshold enforced: 80%"
+          echo "- Threshold enforced: 85%"
           echo "- Output XML: v2/backend/coverage.xml"
         } >> "${GITHUB_STEP_SUMMARY}"
 

--- a/v2/backend/pytest.ini
+++ b/v2/backend/pytest.ini
@@ -17,24 +17,9 @@ markers =
     performance: marks tests as performance tests (deselect with '-m "not performance"')
 
 # =============================================================================
-# Coverage Configuration (Issue #268)
-# Phase 1: 85% threshold (current)
-# Phase 2: 90% threshold (after stabilization)
-#
-# Modules with coverage < 85% (baseline 2025-12-29):
-# - dat_ingest/management/commands/seed_*.py (0%) - seed scripts, rarely run
-# - dat_ingest/services/parse_fluir.py (23%) - legacy parser
-# - dat_ingest/services/resolvers.py (59%) - needs more edge case tests
-# - dat_ingest/services/loaders.py (77%) - ETL loaders
-# - dat_ingest/services/parse_bloqueios.py (77%) - block parser
-# - dat_ingest/services/processors.py (80%) - ETL processors
-# - dat_ingest/views.py (81%) - API views
-# - dat_ingest/services/parse_deslocamentos.py (84%) - travel parser
-#
-# Priority for Phase 2 (90%):
-# 1. resolvers.py - core business logic
-# 2. loaders.py - data integrity
-# 3. processors.py - ETL pipeline
+# Coverage Configuration (Issues #268, #850)
+# Official threshold: 85% — applied consistently across pytest.ini, CI combine
+# step, and policy doc at v2/docs/analysis/COVERAGE_POLICY.md.
 # =============================================================================
 [coverage:run]
 source = apps

--- a/v2/docs/analysis/COVERAGE_POLICY.md
+++ b/v2/docs/analysis/COVERAGE_POLICY.md
@@ -1,0 +1,51 @@
+# Coverage Policy
+
+Backend coverage gate is unified at **85%** across every enforcement point.
+
+## Thresholds
+
+| Location | Setting | Value |
+|----------|---------|-------|
+| `v2/backend/pytest.ini` | `[coverage:report] fail_under` | 85 |
+| `.github/workflows/ci.yaml` (combine step) | `coverage report --fail-under=85` | 85 |
+
+No other places enforce a backend coverage threshold. Historical plans that
+reference `80` are kept for auditability; they do not govern current runs.
+
+## Baseline
+
+Observed on the last backend-touching main run before this policy unification
+(run `24585072952`, PR #1148):
+
+| Slice | Coverage |
+|-------|---------:|
+| `apps/core` (core suite alone) | 87% |
+| `apps/dev_tools` (ingest/devtools suite alone) | 9% (low because the suite
+exercises a narrow slice of `apps/` — combine step is the authoritative number) |
+| **Combined (core + ingest/devtools)** | **90%** |
+
+The 85% gate leaves a 5-point headroom above the current combined baseline.
+
+## Regression policy
+
+- A PR is considered in regression if the combined report drops below 85%.
+- CI fails the `Combine backend coverage` step when the threshold is breached;
+  no further manual review required.
+- Raising the threshold is done via a dedicated PR that updates this doc,
+  `pytest.ini`, and `ci.yaml` in the same change so the three never drift.
+
+## Roadmap
+
+1. **Now**: 85% combined — enforced.
+2. **Next** (#850 phase 2): publish a per-run quality scorecard (pass rate,
+   p50/p95 duration per suite, flake rate from `#677` canary) as a CI summary
+   artifact. Scorecard is informative until thresholds are agreed.
+3. **Later**: raise combined coverage target toward 90% once the scorecard
+   stabilizes and flake rate is below the agreed ceiling.
+
+## Related issues
+
+- Epic [#845](https://github.com/matheusnorjosa/aprender_sistema/issues/845) — Testing Maturity
+- [#850](https://github.com/matheusnorjosa/aprender_sistema/issues/850) — Unify coverage policy + scorecard
+- [#677](https://github.com/matheusnorjosa/aprender_sistema/issues/677) — xdist canary (flake rate input)
+- [#268](https://github.com/matheusnorjosa/aprender_sistema/issues/268) — Original coverage bar


### PR DESCRIPTION
## Summary
Closes #850 (phase 1). Part of epic #845 (Testing Maturity).

Resolves the 80%/85% split between `pytest.ini` (85%) and the CI combine step (80%) — there is now a single source of truth.

## Baseline (safety check)
Combined backend coverage on the last backend-touching main run (`24585072952`, PR #1148) was **90%**. The new 85% gate leaves a 5-point headroom, so the bump from 80% → 85% does not put any historical run at risk.

## Changes
- `.github/workflows/ci.yaml`: `coverage report --fail-under=80` → `--fail-under=85`; summary text updated.
- `v2/backend/pytest.ini`: dropped stale `dat_ingest` baseline comments (module removed in #1146); point the comment at the new policy doc.
- `v2/docs/analysis/COVERAGE_POLICY.md` (new): single source of truth for threshold, baseline, regression behavior, and roadmap.

## Out of scope
Phase 2 of #850 (continuous quality scorecard — pass rate, p50/p95 duration, flake rate as CI summary artifact) is a larger, separate change and is called out in the new policy doc.

## Test plan
- [x] `pytest.ini` and `ci.yaml` agree on `85`
- [x] Doc grep returns no other backend coverage threshold enforcement
- [ ] CI run on this PR passes the combine step at 85%
- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

```
ALL 8 CHECKS PASSED
```

## Staging Gate
- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR