### PR TITLE
feat(frontend): adopt MSW for API-boundary tests — phase 1 (#849)

### DIFF
--- a/v2/docs/TESTING_MSW.md
+++ b/v2/docs/TESTING_MSW.md
@@ -1,0 +1,140 @@
+# Frontend Test Strategy: MSW vs `vi.mock`
+
+Adopted in issue [#849](https://github.com/matheusnorjosa/aprender_sistema/issues/849) (part of epic [#845](https://github.com/matheusnorjosa/aprender_sistema/issues/845)).
+
+## TL;DR — which to reach for
+
+| Use MSW when… | Use `vi.mock` / `vi.fn()` when… |
+|---|---|
+| You test a **component/hook/page** that calls `fetchAPI`. | You test a pure helper that does not hit the network. |
+| You test an **API client module** (`src/api/*.ts`) end-to-end. | You test a hook that accepts a function callback as prop (pass `vi.fn()`). |
+| You want to assert on **response handling** (error paths, pagination shapes). | You want to assert on **wrapper invocation** (how many times, with what URL). |
+| The test crosses multiple API calls and cares about ordering. | The test exercises a single seam with a simple double. |
+
+Default to MSW for any new test that touches the API boundary. Fall back to
+`vi.mock` for unit tests where the HTTP layer is not interesting.
+
+## Infrastructure
+
+- **Handlers**: `v2/frontend/src/test/mocks/handlers.ts` — default handlers
+  (e.g. `/api/csrf/`). Keep this minimal. Scenario-specific handlers live in
+  tests via `server.use(...)`.
+- **Server**: `v2/frontend/src/test/mocks/server.ts` — `setupServer` instance.
+- **Lifecycle**: wired in `v2/frontend/src/test/setup.js`.
+  - `beforeAll`: `server.listen({ onUnhandledRequest: 'bypass' })`
+  - `afterEach`: `server.resetHandlers()`
+  - `afterAll`: `server.close()`
+
+### Why `onUnhandledRequest: 'bypass'` (for now)
+
+During rollout many existing tests still use `vi.mock('../config')` to
+replace `fetchAPI`. Those never hit the MSW layer, so `'error'` would be
+noisy. Once a majority of tests have migrated, flip this to `'error'` so
+that forgetting a handler fails loudly.
+
+### `apiUrl(path)` helper
+
+`src/test/mocks/handlers.ts` exports `apiUrl('/me/') === '/api/me/'`. Always
+use it when registering handlers — it keeps the base URL in one place.
+
+## Pattern — migrating an API client test
+
+### Before (`vi.mock`, asserts on `fetchAPI` calls)
+
+```ts
+const { fetchAPIMock } = vi.hoisted(() => ({ fetchAPIMock: vi.fn() }));
+vi.mock('../config', () => ({ fetchAPI: fetchAPIMock, buildUrl: (p: string) => p }));
+import { getMe } from '../availability';
+
+test('getMe returns data', async () => {
+  fetchAPIMock.mockResolvedValue({ id: 1, /* ... */ });
+  const user = await getMe();
+  expect(fetchAPIMock).toHaveBeenCalledWith('/me/');
+  expect(user).toEqual(/* ... */);
+});
+```
+
+### After (MSW, asserts on behavior)
+
+```ts
+import { http, HttpResponse } from 'msw';
+import { server } from '../../test/mocks/server';
+import { apiUrl } from '../../test/mocks/handlers';
+import { getMe } from '../availability';
+
+test('getMe returns data', async () => {
+  server.use(
+    http.get(apiUrl('/me/'), () => HttpResponse.json({ id: 1, /* ... */ })),
+  );
+  const user = await getMe();
+  expect(user).toEqual(/* ... */);
+});
+```
+
+The assertion shifts from "was `fetchAPI` called with this URL" to "given
+this HTTP response, does the client return the right shape". The URL check
+is implicit — if nobody matched the handler, MSW would return a 404 (with
+`onUnhandledRequest: 'error'`, it would throw).
+
+## Pattern — migrating a component/page test
+
+When a component test currently does `vi.mock('../../../api/solicitacoes')`,
+prefer MSW so the real API client runs and exercises validation, header
+handling, and error mapping. Example sketch:
+
+```ts
+server.use(
+  http.post(apiUrl('/solicitacoes/'), async ({ request }) => {
+    const body = await request.json();
+    // optional: assert on body shape here
+    return HttpResponse.json({ id: 42, ...body }, { status: 201 });
+  }),
+);
+
+render(<NewSolicitacaoWizard />);
+await userEvent.click(screen.getByRole('button', { name: /criar/i }));
+expect(await screen.findByText(/#42/)).toBeInTheDocument();
+```
+
+Mock React Router, Antd modals, and other *browser* concerns with
+`vi.mock` as before — those are not HTTP concerns.
+
+## Pattern — staying with `vi.fn()` for dependency-injected callbacks
+
+Hooks like `useTableFilters({ listFn, statsFn })` accept functions as
+props. Those are not HTTP — they are plain JS contracts. Keep using
+`vi.fn()` + `mockResolvedValue(...)` there; MSW offers no advantage.
+
+## CSRF & credentials
+
+- The default handler for `GET /api/csrf/` returns `{ csrfToken: 'msw-test-csrf-token' }`.
+- `fetchAPI` includes `credentials: 'include'`; MSW honors this.
+- If a mutation test cares about the CSRF header, assert on the request
+  headers inside the handler:
+
+  ```ts
+  server.use(
+    http.post(apiUrl('/x/'), ({ request }) => {
+      const token = request.headers.get('x-csrftoken');
+      expect(token).toBeTruthy();
+      return HttpResponse.json({}, { status: 200 });
+    }),
+  );
+  ```
+
+## Roadmap
+
+1. ✅ **Phase 1** — Infrastructure + one pilot migration (`availability.test.ts`).
+2. **Phase 2** — Migrate the Tier-1 API client tests (`adminDAT`, `datModule`,
+   `gcal`, `lookup`, `systemConfig`). Each can be its own PR.
+3. **Phase 3** — Migrate component/page tests that mock API modules
+   (`NewSolicitacaoWizard`, etc.). These produce the biggest fidelity gain.
+4. **Phase 4** — Flip `onUnhandledRequest` from `'bypass'` to `'error'` once
+   the long tail is covered, and remove the remaining `vi.mock('../config')`
+   callsites.
+
+## Related
+
+- Epic: [#845 — Testing Maturity](https://github.com/matheusnorjosa/aprender_sistema/issues/845)
+- Issue: [#849 — Adopt MSW for frontend integration tests](https://github.com/matheusnorjosa/aprender_sistema/issues/849)
+- Coverage policy: [`v2/docs/analysis/COVERAGE_POLICY.md`](analysis/COVERAGE_POLICY.md)

--- a/v2/frontend/package-lock.json
+++ b/v2/frontend/package-lock.json
@@ -43,6 +43,7 @@
         "globals": "^16.4.0",
         "jsdom": "^27.1.0",
         "lighthouse": "^12.6.1",
+        "msw": "^2.13.4",
         "postcss": "^8.5.6",
         "react-doctor": "0.0.30",
         "rollup-plugin-visualizer": "^5.14.0",
@@ -1413,6 +1414,93 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@inquirer/ansi": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.5.tgz",
+      "integrity": "sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.0.12.tgz",
+      "integrity": "sha512-h9FgGun3QwVYNj5TWIZZ+slii73bMoBFjPfVIGtnFuL4t8gBiNDV9PcSfIzkuxvgquJKt9nr1QzszpBzTbH8Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.9",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "11.1.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.1.9.tgz",
+      "integrity": "sha512-BDE4fG22uYh1bGSifcj7JSx119TVYNViMhMu85usp4Fswrzh6M0DV3yld64jA98uOAa2GSQ4Bg4bZRm2d2cwSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/figures": "^2.0.5",
+        "@inquirer/type": "^4.0.5",
+        "cli-width": "^4.1.0",
+        "fast-wrap-ansi": "^0.2.0",
+        "mute-stream": "^3.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.5.tgz",
+      "integrity": "sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.5.tgz",
+      "integrity": "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -1481,6 +1569,31 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.41.4",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.4.tgz",
+      "integrity": "sha512-3B9EinUkrdOUGYzHRzRWSXunQ4YFGboJnyLNRwEJWEde+j8fNhPUHvrN1E3g1DU/iS/s8JQrMNVe+S7AHHVs0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@mswjs/interceptors/node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
@@ -1535,6 +1648,31 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-3.0.0.tgz",
+      "integrity": "sha512-XW375UK8/9SqUVNVa6M0yEy8+iTi4QN5VZ7aZuRFQmy76LRwI9wy5F4YIBU6T+eTe2/DNDo8tqu8RHlwLHM6RA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.0",
@@ -3866,10 +4004,27 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/set-cookie-parser": {
+      "version": "2.4.10",
+      "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.10.tgz",
+      "integrity": "sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/shimmer": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
       "integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/statuses": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
+      "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
       "dev": true,
       "license": "MIT"
     },
@@ -4851,6 +5006,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -5006,6 +5171,19 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/copy-to-clipboard": {
       "version": "3.3.3",
@@ -5886,6 +6064,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+      "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+      "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.0.tgz",
+      "integrity": "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -6250,6 +6455,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/graphql": {
+      "version": "16.13.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
+      "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -6272,6 +6487,24 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/headers-polyfill": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-5.0.1.tgz",
+      "integrity": "sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/set-cookie-parser": "^2.4.10",
+        "set-cookie-parser": "^3.0.1"
+      }
+    },
+    "node_modules/headers-polyfill/node_modules/set-cookie-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
+      "integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
@@ -6583,6 +6816,13 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-mobile/-/is-mobile-5.0.0.tgz",
       "integrity": "sha512-Tz/yndySvLAEXh+Uk8liFCxOwVH6YutuR74utvOcu7I9Di+DwM0mtdPVZNaVvvBUM2OXxne/NhOs1zAO7riusQ==",
+      "license": "MIT"
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-number": {
@@ -7367,6 +7607,77 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/msw": {
+      "version": "2.13.4",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.13.4.tgz",
+      "integrity": "sha512-fPlKBeFe+8rpcyR3umUmmHuNwu6gc6T3STvkgEa9WDX/HEgal9wDeflpCUAIRtmvaLZM2igfI5y1bZ9G5J26KA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/confirm": "^6.0.11",
+        "@mswjs/interceptors": "^0.41.3",
+        "@open-draft/deferred-promise": "^3.0.0",
+        "@types/statuses": "^2.0.6",
+        "cookie": "^1.1.1",
+        "graphql": "^16.13.2",
+        "headers-polyfill": "^5.0.1",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "path-to-regexp": "^6.3.0",
+        "picocolors": "^1.1.1",
+        "rettime": "^0.11.7",
+        "statuses": "^2.0.2",
+        "strict-event-emitter": "^0.5.1",
+        "tough-cookie": "^6.0.1",
+        "type-fest": "^5.5.0",
+        "until-async": "^3.0.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "msw": "cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.8.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/msw/node_modules/type-fest": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
+      "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mute-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+      "integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/mz": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
@@ -7586,6 +7897,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/oxc-resolver": {
       "version": "11.19.1",
@@ -7819,6 +8137,13 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -9115,19 +9440,6 @@
         "react-dom": ">=18"
       }
     },
-    "node_modules/react-router/node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -9276,6 +9588,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/rettime": {
+      "version": "0.11.8",
+      "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.11.8.tgz",
+      "integrity": "sha512-0fERGXktJTyJ+h8fBEiPxHPEFOu0h15JY7JtwrOVqR5K+vb99ho6IyOo7ekLS3h4sJCzIDy4VWKIbZUfe9njmg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/reusify": {
       "version": "1.1.0",
@@ -9701,6 +10020,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/std-env": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
@@ -9732,6 +10061,13 @@
         "fast-fifo": "^1.3.2",
         "text-decoder": "^1.1.0"
       }
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-convert": {
       "version": "0.2.1",
@@ -9957,6 +10293,19 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/tailwindcss": {
       "version": "3.4.18",
@@ -10238,9 +10587,9 @@
       "license": "MIT"
     },
     "node_modules/tough-cookie": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
-      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -10371,6 +10720,16 @@
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/until-async": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/until-async/-/until-async-3.0.2.tgz",
+      "integrity": "sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/kettanaito"
+      }
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.4",

--- a/v2/frontend/package.json
+++ b/v2/frontend/package.json
@@ -64,6 +64,7 @@
     "globals": "^16.4.0",
     "jsdom": "^27.1.0",
     "lighthouse": "^12.6.1",
+    "msw": "^2.13.4",
     "postcss": "^8.5.6",
     "react-doctor": "0.0.30",
     "rollup-plugin-visualizer": "^5.14.0",

--- a/v2/frontend/src/api/__tests__/availability.test.ts
+++ b/v2/frontend/src/api/__tests__/availability.test.ts
@@ -1,16 +1,18 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest'
-
-const { fetchAPIMock, buildUrlMock } = vi.hoisted(() => ({
-  fetchAPIMock: vi.fn(),
-  buildUrlMock: vi.fn(),
-}))
-
-vi.mock('../config', () => ({
-  fetchAPI: fetchAPIMock,
-  buildUrl: buildUrlMock,
-}))
-
-import { getMe } from '../availability'
+/**
+ * Pilot for MSW-based API tests (#849).
+ *
+ * Instead of mocking `fetchAPI`/`buildUrl` at module level, we let the real
+ * `fetchAPI` run and intercept the HTTP call with MSW. The test then asserts
+ * on observable behavior (request URL hit, response shape honored) rather
+ * than on implementation details (how many times `fetchAPI` was called).
+ *
+ * See v2/docs/TESTING_MSW.md for the rollout guidance.
+ */
+import { beforeEach, describe, expect, test } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../test/mocks/server';
+import { apiUrl } from '../../test/mocks/handlers';
+import { getMe } from '../availability';
 
 const validCurrentUserPayload = {
   id: 1,
@@ -26,31 +28,35 @@ const validCurrentUserPayload = {
   is_superintendencia: false,
   can_approve_super: true,
   permissions: ['pode_operar_dat'],
-}
+};
 
-describe('availability API - current user contract', () => {
+describe('availability API — getMe (MSW)', () => {
   beforeEach(() => {
-    fetchAPIMock.mockReset()
-    buildUrlMock.mockReset()
-    buildUrlMock.mockImplementation((path: string) => path)
-  })
+    // Each test registers its own /me/ handler, so resetHandlers() between
+    // tests (wired in setup.js) keeps scenarios isolated.
+  });
 
-  test('getMe returns data when /api/me payload matches contract', async () => {
-    fetchAPIMock.mockResolvedValue(validCurrentUserPayload)
+  test('returns parsed user when /api/me/ payload matches contract', async () => {
+    server.use(
+      http.get(apiUrl('/me/'), () => HttpResponse.json(validCurrentUserPayload)),
+    );
 
-    const user = await getMe()
+    const user = await getMe();
 
-    expect(fetchAPIMock).toHaveBeenCalledWith('/me/')
-    expect(user).toEqual(validCurrentUserPayload)
-  })
+    expect(user).toEqual(validCurrentUserPayload);
+  });
 
-  test('getMe throws when /api/me payload drifts from expected shape', async () => {
-    fetchAPIMock.mockResolvedValue({
-      id: 1,
-      username: 'admin',
-      // missing mandatory contract fields
-    })
+  test('throws when /api/me/ payload drifts from expected shape', async () => {
+    server.use(
+      http.get(apiUrl('/me/'), () =>
+        HttpResponse.json({
+          id: 1,
+          username: 'admin',
+          // missing mandatory contract fields
+        }),
+      ),
+    );
 
-    await expect(getMe()).rejects.toThrow('Invalid /api/me payload shape')
-  })
-})
+    await expect(getMe()).rejects.toThrow('Invalid /api/me payload shape');
+  });
+});

--- a/v2/frontend/src/test/mocks/handlers.ts
+++ b/v2/frontend/src/test/mocks/handlers.ts
@@ -1,0 +1,35 @@
+/**
+ * MSW default handlers.
+ *
+ * These cover endpoints that most integration tests need available by default
+ * (CSRF, current user). Individual tests override or add handlers via
+ * `server.use(...)` for behavior specific to their scenario.
+ *
+ * See v2/docs/TESTING_MSW.md for usage guidance.
+ */
+import { http, HttpResponse } from 'msw';
+
+/**
+ * Base URL used by the API client. Must match `API_BASE` resolved at runtime
+ * (see src/api/config.ts). Tests run in jsdom without Vite env, so VITE_API_URL
+ * is unset and `/api` is used.
+ */
+export const API_BASE = '/api';
+
+/**
+ * Convenience to prefix a backend path with the API base.
+ *   apiUrl('/me/') === '/api/me/'
+ */
+export const apiUrl = (path: string): string =>
+  `${API_BASE}${path.startsWith('/') ? path : `/${path}`}`;
+
+/**
+ * Default request handlers. Keep this list minimal and broadly useful. If a
+ * scenario needs specific payloads, override inline with `server.use(...)`.
+ */
+export const handlers = [
+  // CSRF token issuance — many mutation paths call this first.
+  http.get(apiUrl('/csrf/'), () =>
+    HttpResponse.json({ csrfToken: 'msw-test-csrf-token' }),
+  ),
+];

--- a/v2/frontend/src/test/mocks/server.ts
+++ b/v2/frontend/src/test/mocks/server.ts
@@ -1,0 +1,21 @@
+/**
+ * MSW server for Vitest (Node/jsdom environment).
+ *
+ * Lifecycle is wired from src/test/setup.js:
+ *   - beforeAll  → server.listen({ onUnhandledRequest: 'error' })
+ *   - afterEach  → server.resetHandlers()
+ *   - afterAll   → server.close()
+ *
+ * Tests add scenario-specific handlers via `server.use(...)`:
+ *
+ *   import { server } from '@/test/mocks/server';
+ *   import { http, HttpResponse } from 'msw';
+ *
+ *   server.use(
+ *     http.get('/api/me/', () => HttpResponse.json({ id: 1, ... })),
+ *   );
+ */
+import { setupServer } from 'msw/node';
+import { handlers } from './handlers';
+
+export const server = setupServer(...handlers);

--- a/v2/frontend/src/test/setup.js
+++ b/v2/frontend/src/test/setup.js
@@ -4,9 +4,20 @@
  * Configures testing environment with:
  * - jest-dom matchers for DOM assertions
  * - Global mocks for browser APIs not available in jsdom
+ * - MSW server for intercepting HTTP traffic (see src/test/mocks/)
  */
 import '@testing-library/jest-dom'
-import { vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, vi } from 'vitest'
+import { server } from './mocks/server'
+
+// --- MSW lifecycle --------------------------------------------------------
+// `onUnhandledRequest: 'bypass'` during rollout so tests that still rely on
+// module-level mocks (vi.mock('../config'), injected callbacks) keep working
+// without forcing every file to declare a handler. Flip to 'error' once
+// coverage is broad enough. See v2/docs/TESTING_MSW.md.
+beforeAll(() => server.listen({ onUnhandledRequest: 'bypass' }))
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
 
 // Mock matchMedia for Ant Design components
 // This must be defined before any Ant Design components are imported


### PR DESCRIPTION
## Summary
Phase 1 of issue #849 (epic #845 — Testing Maturity). Lands the MSW infrastructure, a pilot migration, and the docs so follow-up PRs can migrate the remaining suites incrementally.

## What this PR does

**Infrastructure**
- Add `msw ^2.13.4` as devDependency.
- `src/test/mocks/handlers.ts` — default handlers (CSRF) plus `apiUrl()` helper that encapsulates the `/api` base prefix.
- `src/test/mocks/server.ts` — `setupServer()` instance, exported so individual tests register scenario-specific handlers via `server.use(...)`.
- `src/test/setup.js` — wires the lifecycle (`beforeAll`/`afterEach`/`afterAll`) into Vitest.

**Pilot migration**
- `src/api/__tests__/availability.test.ts` (`getMe`) no longer mocks the `fetchAPI` module. It lets the real client run and intercepts the HTTP call with MSW. Assertions shift from "was `fetchAPI` called with this URL" to "given this HTTP response, does the client behave correctly".

**Docs**
- `v2/docs/TESTING_MSW.md` — pattern guide: when to pick MSW vs `vi.mock`, before/after migration snippets, CSRF notes, and the rollout roadmap.

## Rollout note: `onUnhandledRequest: 'bypass'`
Many existing tests still use `vi.mock('../config')` to replace `fetchAPI`. Those never hit the MSW layer, so `'error'` would produce noise. The doc flags the plan to flip this to `'error'` once the long tail has migrated. Until then, only *migrated* tests actually route through MSW; legacy tests keep working unchanged.

## Out of scope (future PRs)
- **Tier 1**: `adminDAT`, `datModule`, `gcal`, `lookup`, `systemConfig` — API client tests.
- **Tier 2**: `NewSolicitacaoWizard` et al — component/page tests that currently do `vi.mock('../../../api/...')`.
- **Tier 3**: Flip `onUnhandledRequest` to `'error'` and remove remaining `vi.mock('../config')` callsites.

## Test plan
- [x] `npx vitest run` — 25/25 files, 192/192 tests pass (full suite unchanged by MSW boot since legacy tests are bypassed).
- [x] `src/api/__tests__/availability.test.ts` — 2/2 pass against real `fetchAPI` + MSW handlers.
- [x] `npx tsc --noEmit` — clean.
- [x] `npm run lint` — clean.
- [x] `npm run build` — clean.
- [x] `npx size-limit` — all budgets green (msw is dev-only; bundle unchanged).
- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

```
ALL 8 CHECKS PASSED
```

## Staging Gate
- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR