### PR TITLE
test(frontend): migrate Tier-1 API tests to MSW — closes #849

### DIFF
--- a/v2/frontend/src/api/__tests__/adminDAT.test.ts
+++ b/v2/frontend/src/api/__tests__/adminDAT.test.ts
@@ -1,18 +1,16 @@
+/**
+ * adminDAT API client — exercised against MSW handlers (issue #849, phase 2).
+ *
+ * Each test registers a scoped handler via `server.use(...)` and asserts on
+ * observable behavior: the request lands on the expected URL/method, the
+ * response shape is honored, and error-mapping wraps upstream HTTP statuses
+ * into domain-friendly messages.
+ */
 import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { http, HttpResponse, type HttpHandler } from 'msw';
+import { server } from '../../test/mocks/server';
+import { apiUrl } from '../../test/mocks/handlers';
 
-const fetchAPIMock = vi.hoisted(() => vi.fn());
-const fetchWithErrorMappingMock = vi.hoisted(() => vi.fn());
-
-vi.mock('../config', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../config')>();
-  return {
-    ...actual,
-    fetchAPI: fetchAPIMock,
-    fetchWithErrorMapping: fetchWithErrorMappingMock,
-  };
-});
-
-// Mock syncChannel to avoid BroadcastChannel in test env
 vi.mock('../../services/syncChannel', () => ({
   syncChannel: { publish: vi.fn(), subscribe: vi.fn(() => () => {}) },
 }));
@@ -29,22 +27,58 @@ import {
   updateGroup,
 } from '../adminDAT';
 
-describe('adminDAT API wrappers', () => {
+type HandlerCall = { url: string; method: string; body?: unknown };
+
+/**
+ * Registers a handler that records every matching request into `calls` and
+ * returns the provided response. Gives us a single place to make URL/method/
+ * body assertions without rebuilding the `http.verb(...)` scaffolding in
+ * every test.
+ */
+function spyHandler(
+  factory: (url: string, resolver: Parameters<typeof http.get>[1]) => HttpHandler,
+  url: string,
+  response: { json?: unknown; status?: number; text?: string },
+  calls: HandlerCall[],
+): HttpHandler {
+  return factory(url, async ({ request }) => {
+    let body: unknown;
+    if (request.method !== 'GET' && request.method !== 'DELETE') {
+      const clone = request.clone();
+      try {
+        body = await clone.json();
+      } catch {
+        body = undefined;
+      }
+    }
+    calls.push({ url: request.url, method: request.method, body });
+    if (response.text !== undefined) {
+      return new HttpResponse(response.text, { status: response.status ?? 200 });
+    }
+    return HttpResponse.json(response.json, { status: response.status ?? 200 });
+  });
+}
+
+describe('adminDAT API wrappers (MSW)', () => {
+  let calls: HandlerCall[];
+
   beforeEach(() => {
-    fetchAPIMock.mockReset();
-    fetchWithErrorMappingMock.mockReset();
+    calls = [];
   });
 
   test('listUsers calls /usuarios-admin/ with params', async () => {
-    fetchWithErrorMappingMock.mockResolvedValue({ count: 0, results: [] });
+    server.use(
+      spyHandler(http.get, apiUrl('/usuarios-admin/'), { json: { count: 0, results: [] } }, calls),
+    );
 
     await listUsers({ search: 'ana', is_active: true });
 
-    expect(fetchWithErrorMappingMock).toHaveBeenCalledWith(
-      expect.stringContaining('/usuarios-admin/'),
-      {},
-      expect.any(Object),
-    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0].method).toBe('GET');
+    const u = new URL(calls[0].url);
+    expect(u.pathname).toBe('/api/usuarios-admin/');
+    expect(u.searchParams.get('search')).toBe('ana');
+    expect(u.searchParams.get('is_active')).toBe('true');
   });
 
   test('createUser sends POST with payload', async () => {
@@ -54,91 +88,113 @@ describe('adminDAT API wrappers', () => {
       telefone: '85999990000',
       cargo: 'Coordenador',
     };
-    fetchWithErrorMappingMock.mockResolvedValue({ id: 1, ...payload });
+    server.use(
+      spyHandler(http.post, apiUrl('/usuarios-admin/'), { json: { id: 1, ...payload }, status: 201 }, calls),
+    );
 
     await createUser(payload);
 
-    expect(fetchWithErrorMappingMock).toHaveBeenCalledWith(
-      '/usuarios-admin/',
-      expect.objectContaining({ method: 'POST' }),
-      expect.any(Object),
-    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0].method).toBe('POST');
+    expect(calls[0].body).toMatchObject(payload);
   });
 
   test('assignGroups uses /usuarios-admin/{id}/assign_groups/', async () => {
-    fetchWithErrorMappingMock.mockResolvedValue({ id: 10 });
+    server.use(
+      spyHandler(http.post, apiUrl('/usuarios-admin/10/assign_groups/'), { json: { id: 10 } }, calls),
+    );
 
     await assignGroups(10, { group_ids: [1, 2, 3] });
 
-    expect(fetchWithErrorMappingMock).toHaveBeenCalledWith(
-      '/usuarios-admin/10/assign_groups/',
-      expect.objectContaining({ method: 'POST' }),
-      expect.any(Object),
-    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0].body).toEqual({ group_ids: [1, 2, 3] });
   });
 
   test('createGroup accepts group_type_input payload', async () => {
-    fetchWithErrorMappingMock.mockResolvedValue({ id: 21, name: 'Analista de Campo' });
+    server.use(
+      spyHandler(
+        http.post,
+        apiUrl('/grupos/'),
+        { json: { id: 21, name: 'Analista de Campo' }, status: 201 },
+        calls,
+      ),
+    );
 
     await createGroup({ name: 'Analista de Campo', group_type_input: 'funcao' });
 
-    expect(fetchWithErrorMappingMock).toHaveBeenCalledWith(
-      '/grupos/',
-      expect.objectContaining({ method: 'POST' }),
-      expect.any(Object),
-    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0].body).toMatchObject({ name: 'Analista de Campo', group_type_input: 'funcao' });
   });
 
   test('syncGroupMembers uses /grupos/{id}/sync-members/', async () => {
-    fetchWithErrorMappingMock.mockResolvedValue({ group_id: 5, members_count: 2 });
+    server.use(
+      spyHandler(
+        http.post,
+        apiUrl('/grupos/5/sync-members/'),
+        { json: { group_id: 5, members_count: 2, member_ids: [11, 12], added: 2, removed: 0 } },
+        calls,
+      ),
+    );
 
     await syncGroupMembers(5, { user_ids: [11, 12] });
 
-    expect(fetchWithErrorMappingMock).toHaveBeenCalledWith(
-      '/grupos/5/sync-members/',
-      expect.objectContaining({ method: 'POST' }),
-      expect.any(Object),
-    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0].body).toEqual({ user_ids: [11, 12] });
   });
 
   test('updateGroup adds confirm_reserved query param when requested', async () => {
-    fetchWithErrorMappingMock.mockResolvedValue({ id: 2, name: 'Grupo X' });
+    server.use(
+      spyHandler(http.patch, apiUrl('/grupos/2/'), { json: { id: 2, name: 'Grupo X' } }, calls),
+    );
 
     await updateGroup(2, { name: 'Grupo X' }, { confirmReserved: true });
 
-    expect(fetchWithErrorMappingMock).toHaveBeenCalledWith(
-      '/grupos/2/?confirm_reserved=true',
-      expect.objectContaining({ method: 'PATCH' }),
-      expect.any(Object),
-    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0].method).toBe('PATCH');
+    expect(new URL(calls[0].url).searchParams.get('confirm_reserved')).toBe('true');
   });
 
   test('deleteGroup adds confirm_reserved query param when requested', async () => {
-    fetchWithErrorMappingMock.mockResolvedValue(undefined);
+    // NOTE: fetchAPI always tries response.json() even on 204, so return {} with 200.
+    // Prod backends that return 204 empty would surface a JSON parse error — that is
+    // a gap worth fixing separately (out of scope for #849).
+    server.use(
+      spyHandler(http.delete, apiUrl('/grupos/2/'), { json: {} }, calls),
+    );
 
     await deleteGroup(2, { confirmReserved: true });
 
-    expect(fetchWithErrorMappingMock).toHaveBeenCalledWith(
-      '/grupos/2/?confirm_reserved=true',
-      expect.objectContaining({ method: 'DELETE' }),
-      expect.any(Object),
-    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0].method).toBe('DELETE');
+    expect(new URL(calls[0].url).searchParams.get('confirm_reserved')).toBe('true');
   });
 
   test('getRBACMeta calls /rbac/meta/', async () => {
-    fetchAPIMock.mockResolvedValue({ setor_groups: ['DAT'], funcao_groups: ['Coordenador'] });
+    server.use(
+      spyHandler(
+        http.get,
+        apiUrl('/rbac/meta/'),
+        { json: { setor_groups: ['DAT'], funcao_groups: ['Coordenador'] } },
+        calls,
+      ),
+    );
 
     await getRBACMeta();
 
-    expect(fetchAPIMock).toHaveBeenCalledWith('/rbac/meta/');
+    expect(calls).toHaveLength(1);
+    expect(new URL(calls[0].url).pathname).toBe('/api/rbac/meta/');
   });
 
   test('autocompleteMunicipiosAdmin returns results list', async () => {
-    fetchAPIMock.mockResolvedValue({
-      results: [
-        { nome: 'Fortaleza', uf: 'CE', ibge_code: '2304400', source: 'referencia', confidence: 'high' },
-      ],
-    });
+    server.use(
+      http.get(apiUrl('/municipios/autocomplete/'), () =>
+        HttpResponse.json({
+          results: [
+            { nome: 'Fortaleza', uf: 'CE', ibge_code: '2304400', source: 'referencia', confidence: 'high' },
+          ],
+        }),
+      ),
+    );
 
     const result = await autocompleteMunicipiosAdmin({ q: 'Fort', uf: 'CE' });
 
@@ -148,7 +204,9 @@ describe('adminDAT API wrappers', () => {
   });
 
   test('autocompleteMunicipiosAdmin returns empty list when no results', async () => {
-    fetchAPIMock.mockResolvedValue({});
+    server.use(
+      http.get(apiUrl('/municipios/autocomplete/'), () => HttpResponse.json({})),
+    );
 
     const result = await autocompleteMunicipiosAdmin({ q: 'X', uf: 'CE' });
 
@@ -156,22 +214,31 @@ describe('adminDAT API wrappers', () => {
   });
 
   test('fetchWithErrorMapping maps 403 to friendly error', async () => {
-    fetchWithErrorMappingMock.mockRejectedValue(new Error('Você não tem permissão para realizar esta ação.'));
+    server.use(
+      http.get(apiUrl('/usuarios-admin/'), () =>
+        HttpResponse.json({ detail: 'Forbidden' }, { status: 403 }),
+      ),
+    );
 
     await expect(listUsers()).rejects.toThrow('Você não tem permissão para realizar esta ação.');
   });
 
   test('fetchWithErrorMapping maps 404 to friendly error', async () => {
-    fetchWithErrorMappingMock.mockRejectedValue(new Error('Recurso não encontrado.'));
+    server.use(
+      http.get(apiUrl('/usuarios-admin/'), () =>
+        HttpResponse.json({ detail: 'Not found' }, { status: 404 }),
+      ),
+    );
 
     await expect(listUsers()).rejects.toThrow('Recurso não encontrado.');
   });
 
-  // Note: field-level error extraction (errors.cpf) was removed in the axios→fetch migration.
-  // fetchWithErrorMapping now uses a simple status→message map (ADMIN_ERROR_MAP).
-  // Backend detail messages are preserved via fetchAPI's default error handler.
-  test('errors propagate through fetchWithErrorMapping', async () => {
-    fetchWithErrorMappingMock.mockRejectedValue(new Error('Email já existe'));
+  test('backend detail errors propagate when status is not in the map', async () => {
+    server.use(
+      http.post(apiUrl('/usuarios-admin/'), () =>
+        HttpResponse.json({ detail: 'Email já existe' }, { status: 400 }),
+      ),
+    );
 
     await expect(createUser({ username: 'dup' })).rejects.toThrow('Email já existe');
   });

--- a/v2/frontend/src/api/__tests__/datModule.test.ts
+++ b/v2/frontend/src/api/__tests__/datModule.test.ts
@@ -1,16 +1,14 @@
+/**
+ * datModule API client — exercised against MSW handlers (issue #849, phase 2).
+ */
 import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../test/mocks/server';
+import { apiUrl } from '../../test/mocks/handlers';
 
-const fetchAPIMock = vi.hoisted(() => vi.fn());
-const fetchWithErrorMappingMock = vi.hoisted(() => vi.fn());
-
-vi.mock('../config', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('../config')>();
-  return {
-    ...actual,
-    fetchAPI: fetchAPIMock,
-    fetchWithErrorMapping: fetchWithErrorMappingMock,
-  };
-});
+vi.mock('../../services/syncChannel', () => ({
+  syncChannel: { publish: vi.fn(), subscribe: vi.fn(() => () => {}) },
+}));
 
 import {
   createProdutoDAT,
@@ -21,33 +19,56 @@ import {
   updateProdutoDAT,
 } from '../datModule';
 
-describe('datModule API', () => {
+type RequestLog = { url: string; method: string; body?: unknown };
+
+describe('datModule API (MSW)', () => {
+  let requests: RequestLog[];
+
   beforeEach(() => {
-    fetchAPIMock.mockReset();
-    fetchWithErrorMappingMock.mockReset();
+    requests = [];
   });
 
   test('updateCadastroEtapa uses POST on /dat/cadastros/{id}/etapa/', async () => {
     const payload = { id: 7, etapa: 'chaves', status: 'concluido' };
-    fetchWithErrorMappingMock.mockResolvedValue(payload);
+    server.use(
+      http.post(apiUrl('/dat/cadastros/7/etapa/'), async ({ request }) => {
+        requests.push({ url: request.url, method: request.method, body: await request.json() });
+        return HttpResponse.json(payload);
+      }),
+    );
 
     const response = await updateCadastroEtapa(7, 'chaves', 'concluido');
 
-    expect(fetchWithErrorMappingMock).toHaveBeenCalledWith(
-      '/dat/cadastros/7/etapa/',
-      expect.objectContaining({ method: 'POST' }),
-      expect.any(Object),
-    );
     expect(response).toEqual(payload);
+    expect(requests).toHaveLength(1);
+    expect(requests[0].body).toEqual({ etapa: 'chaves', status: 'concluido' });
   });
 
-  test('produto endpoints use /produtos/ base path', async () => {
-    fetchAPIMock
-      .mockResolvedValueOnce({ count: 0, results: [] })
-      .mockResolvedValueOnce({ id: 5, nome: 'Produto X' })
-      .mockResolvedValueOnce({ id: 6, nome: 'Produto Novo' })
-      .mockResolvedValueOnce({ id: 5, nome: 'Produto Atualizado' })
-      .mockResolvedValueOnce(undefined);
+  test('produto endpoints use /produtos/ base path with expected methods', async () => {
+    server.use(
+      http.get(apiUrl('/produtos/'), ({ request }) => {
+        requests.push({ url: request.url, method: 'GET' });
+        return HttpResponse.json({ count: 0, results: [] });
+      }),
+      http.get(apiUrl('/produtos/5/'), ({ request }) => {
+        requests.push({ url: request.url, method: 'GET' });
+        return HttpResponse.json({ id: 5, nome: 'Produto X' });
+      }),
+      http.post(apiUrl('/produtos/'), async ({ request }) => {
+        requests.push({ url: request.url, method: 'POST', body: await request.json() });
+        return HttpResponse.json({ id: 6, nome: 'Produto Novo' }, { status: 201 });
+      }),
+      http.patch(apiUrl('/produtos/5/'), async ({ request }) => {
+        requests.push({ url: request.url, method: 'PATCH', body: await request.json() });
+        return HttpResponse.json({ id: 5, nome: 'Produto Atualizado' });
+      }),
+      http.delete(apiUrl('/produtos/5/'), ({ request }) => {
+        requests.push({ url: request.url, method: 'DELETE' });
+        // NOTE: see adminDAT.test.ts — fetchAPI doesn't handle 204 empty body,
+        // so return {} with 200 for now.
+        return HttpResponse.json({});
+      }),
+    );
 
     await listProdutosDAT({ search: 'abc' });
     await getProdutoDAT(5);
@@ -55,10 +76,10 @@ describe('datModule API', () => {
     await updateProdutoDAT(5, { nome: 'Produto Atualizado' });
     await deleteProdutoDAT(5);
 
-    expect(fetchAPIMock).toHaveBeenNthCalledWith(1, expect.stringContaining('/produtos/'));
-    expect(fetchAPIMock).toHaveBeenNthCalledWith(2, '/produtos/5/');
-    expect(fetchAPIMock).toHaveBeenNthCalledWith(3, '/produtos/', expect.objectContaining({ method: 'POST' }));
-    expect(fetchAPIMock).toHaveBeenNthCalledWith(4, '/produtos/5/', expect.objectContaining({ method: 'PATCH' }));
-    expect(fetchAPIMock).toHaveBeenNthCalledWith(5, '/produtos/5/', expect.objectContaining({ method: 'DELETE' }));
+    expect(requests).toHaveLength(5);
+    expect(requests.map((r) => r.method)).toEqual(['GET', 'GET', 'POST', 'PATCH', 'DELETE']);
+    expect(new URL(requests[0].url).searchParams.get('search')).toBe('abc');
+    expect(requests[2].body).toEqual({ nome: 'Produto Novo' });
+    expect(requests[3].body).toEqual({ nome: 'Produto Atualizado' });
   });
 });

--- a/v2/frontend/src/api/__tests__/gcal.test.ts
+++ b/v2/frontend/src/api/__tests__/gcal.test.ts
@@ -1,15 +1,10 @@
-﻿import { beforeEach, describe, expect, test, vi } from 'vitest';
-
-const { fetchAPIMock, buildUrlMock } = vi.hoisted(() => ({
-  fetchAPIMock: vi.fn(),
-  buildUrlMock: vi.fn(),
-}));
-
-vi.mock('../config', () => ({
-  fetchAPI: fetchAPIMock,
-  buildUrl: buildUrlMock,
-  API_BASE: '/api',
-}));
+/**
+ * gcal API client — exercised against MSW handlers (issue #849, phase 2).
+ */
+import { beforeEach, describe, expect, test } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../test/mocks/server';
+import { apiUrl } from '../../test/mocks/handlers';
 
 import {
   buildDashboardEventsExportUrl,
@@ -26,133 +21,177 @@ import {
   resyncBatch,
 } from '../gcal';
 
-describe('gcal API endpoints', () => {
+type RequestLog = { url: string; method: string; body?: unknown };
+
+function captureGet(path: string, payload: unknown, log: RequestLog[]) {
+  return http.get(apiUrl(path), ({ request }) => {
+    log.push({ url: request.url, method: 'GET' });
+    return HttpResponse.json(payload);
+  });
+}
+
+function capturePost(path: string, payload: unknown, log: RequestLog[]) {
+  return http.post(apiUrl(path), async ({ request }) => {
+    log.push({ url: request.url, method: 'POST', body: await request.json() });
+    return HttpResponse.json(payload);
+  });
+}
+
+describe('gcal API endpoints (MSW)', () => {
+  let requests: RequestLog[];
+
   beforeEach(() => {
-    fetchAPIMock.mockReset();
-    buildUrlMock.mockReset();
-    buildUrlMock.mockImplementation((path: string) => path);
+    requests = [];
   });
 
   test('getStatusSummary uses /gcal/status-summary/', async () => {
-    fetchAPIMock.mockResolvedValue({ counts: {}, total: 0 });
+    server.use(captureGet('/gcal/status-summary/', { counts: {}, total: 0 }, requests));
 
     await getStatusSummary({ status: 'approved' });
 
-    expect(buildUrlMock).toHaveBeenCalledWith('/gcal/status-summary/', { status: 'approved' });
-    expect(fetchAPIMock).toHaveBeenCalledWith('/gcal/status-summary/');
+    expect(requests).toHaveLength(1);
+    const u = new URL(requests[0].url);
+    expect(u.pathname).toBe('/api/gcal/status-summary/');
+    expect(u.searchParams.get('status')).toBe('approved');
   });
 
-  test('listApprovedWithGCalStatus uses /gcal/list/ (implemented backend endpoint)', async () => {
-    fetchAPIMock.mockResolvedValue({ count: 0, next: null, previous: null, results: [] });
+  test('listApprovedWithGCalStatus uses /gcal/list/', async () => {
+    server.use(
+      captureGet('/gcal/list/', { count: 0, next: null, previous: null, results: [] }, requests),
+    );
 
     await listApprovedWithGCalStatus({ q: 'teste' });
 
-    expect(buildUrlMock).toHaveBeenCalledWith('/gcal/list/', { q: 'teste' });
-    expect(fetchAPIMock).toHaveBeenCalledWith('/gcal/list/');
+    expect(requests).toHaveLength(1);
+    const u = new URL(requests[0].url);
+    expect(u.pathname).toBe('/api/gcal/list/');
+    expect(u.searchParams.get('q')).toBe('teste');
   });
 
   test('publishBatch posts to /gcal/publish-batch/', async () => {
-    fetchAPIMock.mockResolvedValue({ queued: 1, errors: [] });
+    server.use(capturePost('/gcal/publish-batch/', { queued: 1, errors: [] }, requests));
 
     await publishBatch({ solicitacao_ids: [1], dry_run: true, apply_blocked: true });
 
-    expect(fetchAPIMock).toHaveBeenCalledWith('/gcal/publish-batch/', {
-      method: 'POST',
-      body: JSON.stringify({ solicitacao_ids: [1], dry_run: true, apply_blocked: true }),
+    expect(requests).toHaveLength(1);
+    expect(requests[0].body).toEqual({
+      solicitacao_ids: [1],
+      dry_run: true,
+      apply_blocked: true,
     });
   });
 
   test('reapplyBatch posts to /gcal/dashboard/batch/reapply/', async () => {
-    fetchAPIMock.mockResolvedValue({ queued: 1, errors: [] });
+    server.use(capturePost('/gcal/dashboard/batch/reapply/', { queued: 1, errors: [] }, requests));
 
     await reapplyBatch({ ids: [10], dry_run: false, apply_blocked: true });
 
-    expect(fetchAPIMock).toHaveBeenCalledWith('/gcal/dashboard/batch/reapply/', {
-      method: 'POST',
-      body: JSON.stringify({ ids: [10], dry_run: false, apply_blocked: true }),
-    });
+    expect(requests).toHaveLength(1);
+    expect(requests[0].body).toEqual({ ids: [10], dry_run: false, apply_blocked: true });
   });
 
   test('resyncBatch posts to /gcal/dashboard/batch/resync/', async () => {
-    fetchAPIMock.mockResolvedValue({ queued: 1, errors: [] });
+    server.use(capturePost('/gcal/dashboard/batch/resync/', { queued: 1, errors: [] }, requests));
 
     await resyncBatch({ ids: [20], dry_run: true, apply_blocked: false });
 
-    expect(fetchAPIMock).toHaveBeenCalledWith('/gcal/dashboard/batch/resync/', {
-      method: 'POST',
-      body: JSON.stringify({ ids: [20], dry_run: true, apply_blocked: false }),
-    });
+    expect(requests).toHaveLength(1);
+    expect(requests[0].body).toEqual({ ids: [20], dry_run: true, apply_blocked: false });
   });
 
   test('getDashboardMetrics uses /gcal/dashboard/metrics/', async () => {
-    fetchAPIMock.mockResolvedValue({ counts: {}, recent_errors: [] });
+    server.use(
+      captureGet('/gcal/dashboard/metrics/', { counts: {}, recent_errors: [] }, requests),
+    );
 
     await getDashboardMetrics({ start: '2026-01-01', end: '2026-01-31' });
 
-    expect(buildUrlMock).toHaveBeenCalledWith('/gcal/dashboard/metrics/', {
-      start: '2026-01-01',
-      end: '2026-01-31',
-    });
-    expect(fetchAPIMock).toHaveBeenCalledWith('/gcal/dashboard/metrics/');
+    expect(requests).toHaveLength(1);
+    const u = new URL(requests[0].url);
+    expect(u.pathname).toBe('/api/gcal/dashboard/metrics/');
+    expect(u.searchParams.get('start')).toBe('2026-01-01');
+    expect(u.searchParams.get('end')).toBe('2026-01-31');
   });
 
   test('listDashboardEvents uses /gcal/dashboard/events/', async () => {
-    fetchAPIMock.mockResolvedValue({ count: 0, next: null, previous: null, results: [] });
+    server.use(
+      captureGet(
+        '/gcal/dashboard/events/',
+        { count: 0, next: null, previous: null, results: [] },
+        requests,
+      ),
+    );
 
     await listDashboardEvents({ page: 2, page_size: 50, status: 'ERROR' });
 
-    expect(buildUrlMock).toHaveBeenCalledWith('/gcal/dashboard/events/', {
-      page: 2,
-      page_size: 50,
-      status: 'ERROR',
-    });
-    expect(fetchAPIMock).toHaveBeenCalledWith('/gcal/dashboard/events/');
+    expect(requests).toHaveLength(1);
+    const u = new URL(requests[0].url);
+    expect(u.pathname).toBe('/api/gcal/dashboard/events/');
+    expect(u.searchParams.get('page')).toBe('2');
+    expect(u.searchParams.get('page_size')).toBe('50');
+    expect(u.searchParams.get('status')).toBe('ERROR');
   });
 
   test('getDashboardSuccessRate uses /gcal/dashboard/insights/success-rate/', async () => {
-    fetchAPIMock.mockResolvedValue({ rate: 0, published: 0, error: 0, pending: 0, none: 0 });
+    server.use(
+      captureGet(
+        '/gcal/dashboard/insights/success-rate/',
+        { rate: 0, published: 0, error: 0, pending: 0, none: 0 },
+        requests,
+      ),
+    );
 
     await getDashboardSuccessRate({ start: '2026-02-01', end: '2026-02-28' });
 
-    expect(buildUrlMock).toHaveBeenCalledWith('/gcal/dashboard/insights/success-rate/', {
-      start: '2026-02-01',
-      end: '2026-02-28',
-    });
-    expect(fetchAPIMock).toHaveBeenCalledWith('/gcal/dashboard/insights/success-rate/');
+    expect(requests).toHaveLength(1);
+    const u = new URL(requests[0].url);
+    expect(u.pathname).toBe('/api/gcal/dashboard/insights/success-rate/');
   });
 
   test('getDashboardTopInsights uses /gcal/dashboard/insights/top/', async () => {
-    fetchAPIMock.mockResolvedValue({ items: [], metric: 'municipios', limit: 5 });
+    server.use(
+      captureGet(
+        '/gcal/dashboard/insights/top/',
+        { items: [], metric: 'municipios', limit: 5 },
+        requests,
+      ),
+    );
 
     await getDashboardTopInsights({ metric: 'municipios', limit: 5, start: '2026-02-01' });
 
-    expect(buildUrlMock).toHaveBeenCalledWith('/gcal/dashboard/insights/top/', {
-      metric: 'municipios',
-      limit: 5,
-      start: '2026-02-01',
-    });
-    expect(fetchAPIMock).toHaveBeenCalledWith('/gcal/dashboard/insights/top/');
+    expect(requests).toHaveLength(1);
+    const u = new URL(requests[0].url);
+    expect(u.pathname).toBe('/api/gcal/dashboard/insights/top/');
+    expect(u.searchParams.get('metric')).toBe('municipios');
+    expect(u.searchParams.get('limit')).toBe('5');
   });
 
   test('getDashboardEventDetail uses event detail endpoint', async () => {
-    fetchAPIMock.mockResolvedValue({ id: 123 });
+    server.use(captureGet('/gcal/dashboard/events/123/detail/', { id: 123 }, requests));
 
     await getDashboardEventDetail(123);
 
-    expect(fetchAPIMock).toHaveBeenCalledWith('/gcal/dashboard/events/123/detail/');
+    expect(requests).toHaveLength(1);
+    expect(new URL(requests[0].url).pathname).toBe('/api/gcal/dashboard/events/123/detail/');
   });
 
   test('getAlertsSummary uses alerts summary endpoint', async () => {
-    fetchAPIMock.mockResolvedValue({ errors: 0, pending: 0, published: 0, none: 0 });
+    server.use(
+      captureGet(
+        '/gcal/dashboard/alerts/summary/',
+        { errors: 0, pending: 0, published: 0, none: 0 },
+        requests,
+      ),
+    );
 
     await getAlertsSummary();
 
-    expect(fetchAPIMock).toHaveBeenCalledWith('/gcal/dashboard/alerts/summary/');
+    expect(requests).toHaveLength(1);
+    expect(new URL(requests[0].url).pathname).toBe('/api/gcal/dashboard/alerts/summary/');
   });
 
   test('buildDashboardEventsExportUrl builds API_BASE absolute url', () => {
-    buildUrlMock.mockReturnValue('/gcal/dashboard/events/export/?export_format=csv');
-
+    // Pure helper — no HTTP involved, stays as a unit test.
     const url = buildDashboardEventsExportUrl({
       export_format: 'csv',
       start: '2026-03-01',
@@ -160,12 +199,11 @@ describe('gcal API endpoints', () => {
       status: 'ERROR',
     });
 
-    expect(buildUrlMock).toHaveBeenCalledWith('/gcal/dashboard/events/export/', {
-      export_format: 'csv',
-      start: '2026-03-01',
-      end: '2026-03-02',
-      status: 'ERROR',
-    });
-    expect(url).toBe('/api/gcal/dashboard/events/export/?export_format=csv');
+    const parsed = new URL(url, 'http://localhost');
+    expect(parsed.pathname).toBe('/api/gcal/dashboard/events/export/');
+    expect(parsed.searchParams.get('export_format')).toBe('csv');
+    expect(parsed.searchParams.get('start')).toBe('2026-03-01');
+    expect(parsed.searchParams.get('end')).toBe('2026-03-02');
+    expect(parsed.searchParams.get('status')).toBe('ERROR');
   });
 });

--- a/v2/frontend/src/api/__tests__/lookup.test.ts
+++ b/v2/frontend/src/api/__tests__/lookup.test.ts
@@ -1,14 +1,10 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest';
-
-const { fetchAPIMock, buildUrlMock } = vi.hoisted(() => ({
-  fetchAPIMock: vi.fn(),
-  buildUrlMock: vi.fn(),
-}));
-
-vi.mock('../config', () => ({
-  fetchAPI: fetchAPIMock,
-  buildUrl: buildUrlMock,
-}));
+/**
+ * lookup API client — exercised against MSW handlers (issue #849, phase 2).
+ */
+import { beforeEach, describe, expect, test } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../test/mocks/server';
+import { apiUrl } from '../../test/mocks/handlers';
 
 import {
   lookupMunicipios,
@@ -17,47 +13,59 @@ import {
   lookupProjetosWithFilters,
 } from '../lookup';
 
-describe('lookup API filters', () => {
+type RequestLog = { pathname: string; params: URLSearchParams };
+
+describe('lookup API filters (MSW)', () => {
+  let requests: RequestLog[];
+
   beforeEach(() => {
-    fetchAPIMock.mockReset();
-    buildUrlMock.mockReset();
-    buildUrlMock.mockImplementation((path: string) => path);
-    fetchAPIMock.mockResolvedValue([]);
+    requests = [];
+    server.use(
+      http.get(apiUrl('/lookup/municipios/'), ({ request }) => {
+        const u = new URL(request.url);
+        requests.push({ pathname: u.pathname, params: u.searchParams });
+        return HttpResponse.json([]);
+      }),
+      http.get(apiUrl('/lookup/projetos/'), ({ request }) => {
+        const u = new URL(request.url);
+        requests.push({ pathname: u.pathname, params: u.searchParams });
+        return HttpResponse.json([]);
+      }),
+    );
   });
 
   test('lookupMunicipios mantém contrato atual (q simples)', async () => {
     await lookupMunicipios('Fort');
 
-    expect(buildUrlMock).toHaveBeenCalledWith('/lookup/municipios/', { q: 'Fort' });
-    expect(fetchAPIMock).toHaveBeenCalledWith('/lookup/municipios/');
+    expect(requests).toHaveLength(1);
+    expect(requests[0].pathname).toBe('/api/lookup/municipios/');
+    expect(requests[0].params.get('q')).toBe('Fort');
   });
 
   test('lookupMunicipiosWithFilters envia com_compra + projeto_id', async () => {
     await lookupMunicipiosWithFilters({ q: '', com_compra: true, projeto_id: 123 });
 
-    expect(buildUrlMock).toHaveBeenCalledWith('/lookup/municipios/', {
-      q: '',
-      com_compra: true,
-      projeto_id: 123,
-    });
-    expect(fetchAPIMock).toHaveBeenCalledWith('/lookup/municipios/');
+    expect(requests).toHaveLength(1);
+    expect(requests[0].pathname).toBe('/api/lookup/municipios/');
+    expect(requests[0].params.get('com_compra')).toBe('true');
+    expect(requests[0].params.get('projeto_id')).toBe('123');
   });
 
   test('lookupProjetos mantém contrato atual (q simples)', async () => {
     await lookupProjetos('Ace');
 
-    expect(buildUrlMock).toHaveBeenCalledWith('/lookup/projetos/', { q: 'Ace' });
-    expect(fetchAPIMock).toHaveBeenCalledWith('/lookup/projetos/');
+    expect(requests).toHaveLength(1);
+    expect(requests[0].pathname).toBe('/api/lookup/projetos/');
+    expect(requests[0].params.get('q')).toBe('Ace');
   });
 
   test('lookupProjetosWithFilters envia municipio_id + com_compra', async () => {
     await lookupProjetosWithFilters({ q: 'A', com_compra: true, municipio_id: 77 });
 
-    expect(buildUrlMock).toHaveBeenCalledWith('/lookup/projetos/', {
-      q: 'A',
-      com_compra: true,
-      municipio_id: 77,
-    });
-    expect(fetchAPIMock).toHaveBeenCalledWith('/lookup/projetos/');
+    expect(requests).toHaveLength(1);
+    expect(requests[0].pathname).toBe('/api/lookup/projetos/');
+    expect(requests[0].params.get('q')).toBe('A');
+    expect(requests[0].params.get('com_compra')).toBe('true');
+    expect(requests[0].params.get('municipio_id')).toBe('77');
   });
 });

--- a/v2/frontend/src/api/__tests__/systemConfig.test.ts
+++ b/v2/frontend/src/api/__tests__/systemConfig.test.ts
@@ -1,39 +1,50 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest'
+/**
+ * systemConfig API client — exercised against MSW handlers (issue #849, phase 2).
+ */
+import { beforeEach, describe, expect, test } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../test/mocks/server';
+import { apiUrl } from '../../test/mocks/handlers';
+import { getSystemConfig, updateSystemConfig } from '../systemConfig';
 
-const { fetchAPIMock } = vi.hoisted(() => ({
-  fetchAPIMock: vi.fn(),
-}))
+type RequestLog = { method: string; body?: unknown };
 
-vi.mock('../config', () => ({
-  fetchAPI: fetchAPIMock,
-}))
+describe('systemConfig API wrappers (MSW)', () => {
+  let requests: RequestLog[];
 
-import { getSystemConfig, updateSystemConfig } from '../systemConfig'
-
-describe('systemConfig API wrappers', () => {
   beforeEach(() => {
-    fetchAPIMock.mockReset()
-  })
+    requests = [];
+  });
 
   test('getSystemConfig calls /config/', async () => {
-    fetchAPIMock.mockResolvedValue({ TRAVEL_BUFFER_MINUTES: 120 })
+    server.use(
+      http.get(apiUrl('/config/'), ({ request }) => {
+        requests.push({ method: request.method });
+        return HttpResponse.json({ TRAVEL_BUFFER_MINUTES: 120 });
+      }),
+    );
 
-    const result = await getSystemConfig()
+    const result = await getSystemConfig();
 
-    expect(fetchAPIMock).toHaveBeenCalledWith('/config/')
-    expect(result).toEqual({ TRAVEL_BUFFER_MINUTES: 120 })
-  })
+    expect(result).toEqual({ TRAVEL_BUFFER_MINUTES: 120 });
+    expect(requests).toHaveLength(1);
+    expect(requests[0].method).toBe('GET');
+  });
 
   test('updateSystemConfig sends PUT /config/ with JSON body', async () => {
-    const payload = { TRAVEL_BUFFER_MINUTES: 90 }
-    fetchAPIMock.mockResolvedValue(payload)
+    const payload = { TRAVEL_BUFFER_MINUTES: 90 };
+    server.use(
+      http.put(apiUrl('/config/'), async ({ request }) => {
+        requests.push({ method: request.method, body: await request.json() });
+        return HttpResponse.json(payload);
+      }),
+    );
 
-    const result = await updateSystemConfig(payload)
+    const result = await updateSystemConfig(payload);
 
-    expect(fetchAPIMock).toHaveBeenCalledWith('/config/', {
-      method: 'PUT',
-      body: JSON.stringify(payload),
-    })
-    expect(result).toEqual(payload)
-  })
-})
+    expect(result).toEqual(payload);
+    expect(requests).toHaveLength(1);
+    expect(requests[0].method).toBe('PUT');
+    expect(requests[0].body).toEqual(payload);
+  });
+});


### PR DESCRIPTION
## Summary
Closes #849. Part of epic #845 (Testing Maturity).

Phase 2 of the MSW adoption — migrates the five Tier-1 API client test suites from module-level `vi.mock('../config')` to MSW handlers, fulfilling the last acceptance criterion of #849 (*"main integration tests migrated"*).

## Migrated suites

| File | Tests | Endpoints covered |
|------|------:|-------------------|
| `adminDAT.test.ts` | 13 | `/usuarios-admin/`, `/grupos/{id}/`, `/grupos/{id}/sync-members/`, `/rbac/meta/`, `/municipios/autocomplete/`, 403/404/400 error-map paths |
| `datModule.test.ts` | 2 | `/dat/cadastros/{id}/etapa/`, `/produtos/` (full GET/POST/PATCH/DELETE chain) |
| `gcal.test.ts` | 12 | `/gcal/status-summary/`, `/gcal/list/`, `/gcal/publish-batch/`, `/gcal/dashboard/*` (metrics, events, batch reapply/resync, insights, event detail, alerts) |
| `lookup.test.ts` | 4 | `/lookup/municipios/`, `/lookup/projetos/` (with filters) |
| `systemConfig.test.ts` | 2 | `/config/` (GET + PUT) |

Assertion style shifts from *"was `fetchAPI` called with this URL"* to *"the observed request had this pathname/method/body and the response was honored"*. The URL-building layer (`buildUrl`) and header handling are now exercised as a free side-effect.

## Gap surfaced

`fetchAPI` calls `response.json()` unconditionally, so a 204 No Content response throws a `SyntaxError`. The legacy tests hid this by mocking `fetchWithErrorMapping` directly. These tests return `200 {}` for `DELETE` paths as a workaround and document the gap with a `NOTE:` comment. A follow-up will teach `fetchAPI` to skip the JSON parse for empty / 204 bodies.

## Test plan
- [x] `npx vitest run` — 25/25 files, 192/192 tests pass
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] Individual suites pass: adminDAT (13), datModule (2), gcal (12), lookup (4), systemConfig (2)
- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

```
ALL 8 CHECKS PASSED
```

## What's next (future PRs)

Phase 3 — component/page tests that currently do `vi.mock('../../../api/...')` (e.g., `NewSolicitacaoWizard.test.tsx`). Those give the biggest fidelity gain since they now exercise the real client end-to-end.

Phase 4 — flip `onUnhandledRequest` from `'bypass'` to `'error'` in `src/test/setup.js` once the remaining `vi.mock('../config')` sites are gone.

Both are out of scope here and do not block closing #849.

## Staging Gate
- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR