### PR TITLE
fix(frontend): fetchAPI returns undefined for 204 / empty-body responses

### DIFF
--- a/v2/frontend/src/api/__tests__/adminDAT.test.ts
+++ b/v2/frontend/src/api/__tests__/adminDAT.test.ts
@@ -155,11 +155,8 @@ describe('adminDAT API wrappers (MSW)', () => {
   });
 
   test('deleteGroup adds confirm_reserved query param when requested', async () => {
-    // NOTE: fetchAPI always tries response.json() even on 204, so return {} with 200.
-    // Prod backends that return 204 empty would surface a JSON parse error — that is
-    // a gap worth fixing separately (out of scope for #849).
     server.use(
-      spyHandler(http.delete, apiUrl('/grupos/2/'), { json: {} }, calls),
+      spyHandler(http.delete, apiUrl('/grupos/2/'), { status: 204, text: '' }, calls),
     );
 
     await deleteGroup(2, { confirmReserved: true });

--- a/v2/frontend/src/api/__tests__/config.test.ts
+++ b/v2/frontend/src/api/__tests__/config.test.ts
@@ -8,7 +8,10 @@
  */
 
 import { describe, test, expect, vi, beforeEach } from 'vitest'
-import { getCsrfToken, clearCsrfCache, buildUrl } from '../config'
+import { http, HttpResponse } from 'msw'
+import { server } from '../../test/mocks/server'
+import { apiUrl } from '../../test/mocks/handlers'
+import { fetchAPI, getCsrfToken, clearCsrfCache, buildUrl } from '../config'
 
 // Helper para limpar cookies
 function clearAllCookies() {
@@ -119,6 +122,45 @@ describe('API Config', () => {
       const result = buildUrl('/items/', { page: 1, limit: 10 })
       expect(result).toContain('page=1')
       expect(result).toContain('limit=10')
+    })
+  })
+
+  // ============================================================================
+  // TESTES DE fetchAPI (regression: 204 / empty body handling)
+  // ============================================================================
+
+  describe('fetchAPI — empty body responses', () => {
+    test('returns undefined for 204 No Content without parsing body', async () => {
+      server.use(
+        http.get(apiUrl('/noop/'), () => new HttpResponse(null, { status: 204 })),
+      )
+
+      const result = await fetchAPI('/noop/')
+
+      expect(result).toBeUndefined()
+    })
+
+    test('returns undefined when content-length is 0', async () => {
+      server.use(
+        http.get(
+          apiUrl('/empty/'),
+          () => new HttpResponse(null, { status: 200, headers: { 'content-length': '0' } }),
+        ),
+      )
+
+      const result = await fetchAPI('/empty/')
+
+      expect(result).toBeUndefined()
+    })
+
+    test('parses JSON body for 200 with content', async () => {
+      server.use(
+        http.get(apiUrl('/ok/'), () => HttpResponse.json({ ok: true })),
+      )
+
+      const result = await fetchAPI('/ok/')
+
+      expect(result).toEqual({ ok: true })
     })
   })
 })

--- a/v2/frontend/src/api/__tests__/datModule.test.ts
+++ b/v2/frontend/src/api/__tests__/datModule.test.ts
@@ -64,9 +64,7 @@ describe('datModule API (MSW)', () => {
       }),
       http.delete(apiUrl('/produtos/5/'), ({ request }) => {
         requests.push({ url: request.url, method: 'DELETE' });
-        // NOTE: see adminDAT.test.ts — fetchAPI doesn't handle 204 empty body,
-        // so return {} with 200 for now.
-        return HttpResponse.json({});
+        return new HttpResponse(null, { status: 204 });
       }),
     );
 

--- a/v2/frontend/src/api/config.ts
+++ b/v2/frontend/src/api/config.ts
@@ -227,6 +227,12 @@ export async function fetchAPI<T = unknown>(url: string, options: FetchOptions =
     throw err;
   }
 
+  // 204 No Content responses have no body. Calling response.json() on them
+  // throws SyntaxError on modern fetch implementations (undici, browsers).
+  // Callers for DELETE endpoints expect undefined, so honor that contract.
+  if (response.status === 204 || response.headers.get('content-length') === '0') {
+    return undefined as T;
+  }
   return response.json();
 }
 


### PR DESCRIPTION
## Summary
Closes a gap surfaced during MSW Phase 2 (#1153). `fetchAPI` used to call `response.json()` unconditionally, so a **204 No Content** response — which DRF `DestroyAPIView` emits by default — would throw a `SyntaxError` ("Unexpected end of JSON input").

The bug was invisible until now because legacy tests mocked `fetchWithErrorMapping` one level above `fetchAPI`, so the problematic code path was never exercised. Production DELETE endpoints that actually return 204 empty body would have failed silently.

## Fix
`fetchAPI` short-circuits body parsing when either:
- `response.status === 204`, or
- `response.headers.get('content-length') === '0'`.

In those cases it returns `undefined` (typed as `T`), keeping the existing contract for DELETE callers (`Promise<void>`).

## Cleanup
The two workarounds left behind by #1153 are removed:
- `adminDAT.test.ts` — `deleteGroup` handler now returns real `204` (was `200 {}` with a `NOTE:` comment).
- `datModule.test.ts` — `/produtos/5/` DELETE handler now returns real `204`.

## New tests
`config.test.ts` gains a regression block covering:
- `204 No Content` → `undefined` (no parse attempt)
- `200` with `content-length: 0` → `undefined`
- `200` with body → parsed as JSON

## Test plan
- [x] `npx vitest run` — 25/25 files, 195/195 tests (was 192; +3 for 204 handling)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] Affected suites pass in isolation: `config`, `adminDAT`, `datModule`
- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

```
ALL 8 CHECKS PASSED
```

## Staging Gate
- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR