### PR TITLE
feat(services): deadlock-retry helper + ACID policy doc (phase 1 of #866)

### DIFF
--- a/v2/backend/apps/core/services/db_retry.py
+++ b/v2/backend/apps/core/services/db_retry.py
@@ -1,0 +1,187 @@
+"""
+AS v2 — Database Retry Helper (ASQ-016, issue #866)
+
+Centralized policy for surviving transient PostgreSQL errors — primarily
+serialization failures and deadlocks — in wrapped transactional sections.
+
+Usage (decorator on a function that itself opens a transaction):
+
+    from apps.core.services.db_retry import retry_on_deadlock
+
+    @retry_on_deadlock()
+    def approve_solicitacao(solicitacao, user, request, justificativa=""):
+        with transaction.atomic():
+            ...
+
+The retry loop is safe *only* when the decorated callable opens its own
+`transaction.atomic()` block on every call. That way the rolled-back state
+from a failed attempt is cleanly discarded before the next attempt runs.
+
+Covered PostgreSQL error classes:
+- `40001` serialization_failure
+- `40P01` deadlock_detected
+
+Anything else (IntegrityError, ProgrammingError, etc.) propagates immediately.
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+import time
+from collections.abc import Callable
+from functools import wraps
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+from django.db import OperationalError
+
+try:
+    from django_prometheus.exports import Counter  # type: ignore[import-untyped]
+except Exception:  # pragma: no cover - prometheus is optional in tests
+    Counter = None  # type: ignore[assignment,misc]
+
+if TYPE_CHECKING:
+    from typing import ParamSpec
+
+    P = ParamSpec("P")
+
+T = TypeVar("T")
+
+logger = logging.getLogger(__name__)
+
+# PostgreSQL SQLSTATE codes we retry on. See
+# https://www.postgresql.org/docs/current/errcodes-appendix.html
+_RETRYABLE_PGCODES = frozenset(
+    {
+        "40001",  # serialization_failure
+        "40P01",  # deadlock_detected
+    }
+)
+
+_retry_counter: Any
+if Counter is not None:  # pragma: no branch
+    _retry_counter = Counter(
+        "as_db_transaction_retries_total",
+        "Number of transactional retries triggered by deadlock/serialization errors.",
+        ["operation", "pgcode", "attempt"],
+    )
+else:  # pragma: no cover
+    _retry_counter = None
+
+
+def _extract_pgcode(exc: OperationalError) -> str | None:
+    """Best-effort extraction of the 5-char SQLSTATE from a django OperationalError.
+
+    Different psycopg versions expose this through slightly different paths,
+    so we try each one and fall back to string matching for the deadlock
+    keyword (psycopg sometimes wraps the code into `__cause__`).
+    """
+    cause = exc.__cause__ or exc
+    # psycopg3: cause.sqlstate, cause.diag.sqlstate
+    code = getattr(cause, "sqlstate", None)
+    if code:
+        return str(code)
+    diag = getattr(cause, "diag", None)
+    if diag is not None:
+        code = getattr(diag, "sqlstate", None)
+        if code:
+            return str(code)
+    # psycopg2: cause.pgcode
+    code = getattr(cause, "pgcode", None)
+    if code:
+        return str(code)
+    return None
+
+
+def _is_retryable(exc: OperationalError) -> tuple[bool, str]:
+    """Return (retryable, pgcode_or_label) for an OperationalError."""
+    code = _extract_pgcode(exc)
+    if code in _RETRYABLE_PGCODES:
+        return True, code
+    # Fallback: some configs swallow the SQLSTATE but leave the message intact.
+    msg = str(exc).lower()
+    if "deadlock detected" in msg:
+        return True, "40P01"
+    if "could not serialize" in msg:
+        return True, "40001"
+    return False, code or "unknown"
+
+
+def retry_on_deadlock(
+    *,
+    max_attempts: int = 3,
+    base_delay: float = 0.1,
+    max_delay: float = 1.0,
+    operation: str | None = None,
+) -> Callable[[Callable[..., T]], Callable[..., T]]:
+    """
+    Wrap a function that opens its own transaction so that it is retried
+    up to `max_attempts` times on transient PostgreSQL concurrency errors.
+
+    - `base_delay` and `max_delay` are in seconds; jittered exponential
+      backoff of the form `rand(0, min(max_delay, base_delay * 2**n))`
+      is used between attempts.
+    - `operation` names the retry counter label; defaults to the wrapped
+      function's qualified name.
+
+    IMPORTANT: The decorated callable MUST own its transaction boundary.
+    Retrying inside an already-open transaction is a bug — the outer
+    transaction is still marked broken by the first failure.
+    """
+    if max_attempts < 1:
+        raise ValueError("max_attempts must be >= 1")
+
+    def decorator(func: Callable[..., T]) -> Callable[..., T]:
+        op_label = operation or f"{func.__module__}.{func.__qualname__}"
+
+        @wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> T:
+            last_exc: OperationalError | None = None
+            for attempt in range(1, max_attempts + 1):
+                try:
+                    return func(*args, **kwargs)
+                except OperationalError as exc:
+                    retryable, code = _is_retryable(exc)
+                    if not retryable:
+                        raise
+                    last_exc = exc
+                    if _retry_counter is not None:
+                        try:
+                            _retry_counter.labels(
+                                operation=op_label,
+                                pgcode=code,
+                                attempt=str(attempt),
+                            ).inc()
+                        except Exception:  # pragma: no cover - never kill a retry on telemetry
+                            pass
+                    if attempt >= max_attempts:
+                        logger.warning(
+                            "db_retry exhausted",
+                            extra={
+                                "event": "db_retry_exhausted",
+                                "operation": op_label,
+                                "pgcode": code,
+                                "attempt": attempt,
+                                "max_attempts": max_attempts,
+                            },
+                        )
+                        raise
+                    delay = random.uniform(0.0, min(max_delay, base_delay * (2 ** (attempt - 1))))
+                    logger.info(
+                        "db_retry scheduled",
+                        extra={
+                            "event": "db_retry_scheduled",
+                            "operation": op_label,
+                            "pgcode": code,
+                            "attempt": attempt,
+                            "next_delay_seconds": round(delay, 3),
+                        },
+                    )
+                    time.sleep(delay)
+            # Defensive; the loop either returns or raises above.
+            assert last_exc is not None  # pragma: no cover
+            raise last_exc  # pragma: no cover
+
+        return cast(Callable[..., T], wrapper)
+
+    return decorator

--- a/v2/backend/apps/core/services/oauth/token_manager.py
+++ b/v2/backend/apps/core/services/oauth/token_manager.py
@@ -28,6 +28,7 @@ import requests
 from cryptography.fernet import Fernet, InvalidToken
 
 from apps.core.models import AuditLog, GoogleOAuthCredential, Usuario
+from apps.core.services.db_retry import retry_on_deadlock
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -116,6 +117,7 @@ _decrypt_token = decrypt_token
 # ============================================================================
 
 
+@retry_on_deadlock(operation="oauth.refresh_access_token")
 def refresh_access_token_safe(credential: GoogleOAuthCredential) -> GoogleOAuthCredential:
     """
     Atualiza access_token usando refresh_token (thread-safe).

--- a/v2/backend/apps/core/services/solicitacao_approval.py
+++ b/v2/backend/apps/core/services/solicitacao_approval.py
@@ -18,6 +18,7 @@ from django.utils import timezone
 
 from apps.core.exceptions import ValidationAPIError
 from apps.core.models import AuditLog, Solicitacao, Usuario
+from apps.core.services.db_retry import retry_on_deadlock
 
 logger = logging.getLogger(__name__)
 
@@ -98,6 +99,7 @@ def _build_batch_status_errors(ids: list[int], found_ids: set[int]) -> list[dict
     return errors
 
 
+@retry_on_deadlock(operation="solicitacao.approve")
 def approve_solicitacao(
     solicitacao: Solicitacao,
     user: Usuario,
@@ -168,6 +170,7 @@ def approve_solicitacao(
     )
 
 
+@retry_on_deadlock(operation="solicitacao.reject")
 def reject_solicitacao(
     solicitacao: Solicitacao,
     user: Usuario,
@@ -238,6 +241,7 @@ def reject_solicitacao(
     )
 
 
+@retry_on_deadlock(operation="solicitacao.batch_approve")
 def batch_approve_solicitacoes(
     ids: list[int],
     user: Usuario,
@@ -325,6 +329,7 @@ def batch_approve_solicitacoes(
     )
 
 
+@retry_on_deadlock(operation="solicitacao.batch_reject")
 def batch_reject_solicitacoes(
     ids: list[int],
     user: Usuario,

--- a/v2/backend/apps/core/tests/test_db_retry.py
+++ b/v2/backend/apps/core/tests/test_db_retry.py
@@ -1,0 +1,167 @@
+"""
+Unit tests for the deadlock-retry helper (ASQ-016, #866).
+
+Verifies that `retry_on_deadlock`:
+- retries on SQLSTATE 40001 / 40P01 and on messages containing the
+  deadlock/serialization keywords
+- surfaces non-retryable OperationalErrors unchanged
+- respects max_attempts and re-raises the last exception
+- does not introduce retries for non-OperationalError exceptions
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportMissingTypeArgument=false, reportCallIssue=false, reportIndexIssue=false, reportOperatorIssue=false, reportUnknownLambdaType=false
+
+from __future__ import annotations
+
+from django.db import OperationalError
+
+import pytest
+
+from apps.core.services.db_retry import retry_on_deadlock
+
+
+class _FakePgError(Exception):
+    """Stand-in for psycopg's DatabaseError — exposes `sqlstate`."""
+
+    def __init__(self, sqlstate: str, message: str = "db error") -> None:
+        super().__init__(message)
+        self.sqlstate = sqlstate
+
+
+def _opex_with_sqlstate(code: str, message: str = "db error") -> OperationalError:
+    """Build an OperationalError whose __cause__ mimics a psycopg error."""
+    cause = _FakePgError(code, message)
+    exc = OperationalError(message)
+    exc.__cause__ = cause
+    return exc
+
+
+class TestRetryOnDeadlock:
+    def test_returns_immediately_on_success(self):
+        calls = {"n": 0}
+
+        @retry_on_deadlock(max_attempts=3, base_delay=0, max_delay=0)
+        def fn():
+            calls["n"] += 1
+            return "ok"
+
+        assert fn() == "ok"
+        assert calls["n"] == 1
+
+    def test_retries_on_deadlock_sqlstate(self):
+        calls = {"n": 0}
+
+        @retry_on_deadlock(max_attempts=3, base_delay=0, max_delay=0)
+        def fn():
+            calls["n"] += 1
+            if calls["n"] < 2:
+                raise _opex_with_sqlstate("40P01", "deadlock detected")
+            return "recovered"
+
+        assert fn() == "recovered"
+        assert calls["n"] == 2
+
+    def test_retries_on_serialization_sqlstate(self):
+        calls = {"n": 0}
+
+        @retry_on_deadlock(max_attempts=3, base_delay=0, max_delay=0)
+        def fn():
+            calls["n"] += 1
+            if calls["n"] < 3:
+                raise _opex_with_sqlstate("40001", "could not serialize")
+            return "ok"
+
+        assert fn() == "ok"
+        assert calls["n"] == 3
+
+    def test_retries_on_deadlock_message_without_sqlstate(self):
+        # Some psycopg setups don't expose sqlstate; the helper falls back to
+        # scanning the message body for the deadlock keyword.
+        calls = {"n": 0}
+
+        @retry_on_deadlock(max_attempts=2, base_delay=0, max_delay=0)
+        def fn():
+            calls["n"] += 1
+            if calls["n"] < 2:
+                raise OperationalError("ERROR: deadlock detected on relation ...")
+            return "ok"
+
+        assert fn() == "ok"
+        assert calls["n"] == 2
+
+    def test_reraises_after_max_attempts(self):
+        @retry_on_deadlock(max_attempts=3, base_delay=0, max_delay=0)
+        def fn():
+            raise _opex_with_sqlstate("40P01")
+
+        with pytest.raises(OperationalError):
+            fn()
+
+    def test_does_not_retry_on_unknown_sqlstate(self):
+        calls = {"n": 0}
+
+        @retry_on_deadlock(max_attempts=3, base_delay=0, max_delay=0)
+        def fn():
+            calls["n"] += 1
+            raise _opex_with_sqlstate("23505", "unique_violation")  # IntegrityError-ish
+
+        with pytest.raises(OperationalError):
+            fn()
+        assert calls["n"] == 1  # no retries
+
+    def test_does_not_retry_on_non_operational_error(self):
+        calls = {"n": 0}
+
+        @retry_on_deadlock(max_attempts=3, base_delay=0, max_delay=0)
+        def fn():
+            calls["n"] += 1
+            raise ValueError("nope")
+
+        with pytest.raises(ValueError):
+            fn()
+        assert calls["n"] == 1
+
+    def test_passes_through_args_and_kwargs(self):
+        @retry_on_deadlock(max_attempts=2, base_delay=0, max_delay=0)
+        def fn(a, b, *, c):
+            return a + b + c
+
+        assert fn(1, 2, c=3) == 6
+
+    def test_max_attempts_must_be_positive(self):
+        with pytest.raises(ValueError):
+            retry_on_deadlock(max_attempts=0)
+
+    def test_exhaustion_logs_warning(self):
+        # Attach a capturing handler directly to the module logger; Django's
+        # LOGGING config may set propagate=False on child loggers, so caplog
+        # (which listens on the root) doesn't always see our events.
+        import logging
+
+        from apps.core.services import db_retry as db_retry_module
+
+        captured: list[logging.LogRecord] = []
+
+        class _Capture(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                captured.append(record)
+
+        handler = _Capture(level=logging.WARNING)
+        db_retry_module.logger.addHandler(handler)
+        try:
+
+            @retry_on_deadlock(max_attempts=2, base_delay=0, max_delay=0)
+            def fn():
+                raise _opex_with_sqlstate("40P01")
+
+            with pytest.raises(OperationalError):
+                fn()
+        finally:
+            db_retry_module.logger.removeHandler(handler)
+
+        exhausted = [r for r in captured if getattr(r, "event", None) == "db_retry_exhausted"]
+        assert exhausted, f"expected a db_retry_exhausted warning; got {[r.message for r in captured]}"
+        rec = exhausted[0]
+        assert rec.operation.endswith("fn")
+        assert rec.pgcode == "40P01"
+        assert rec.max_attempts == 2

--- a/v2/docs/ACID_POLICY.md
+++ b/v2/docs/ACID_POLICY.md
@@ -1,0 +1,83 @@
+# ACID Policy — Aprender Sistema v2
+
+Formal transactional policy for the critical flows. Tracks issue [#866](https://github.com/matheusnorjosa/aprender_sistema/issues/866) (ASQ-016, part of epic [#845](https://github.com/matheusnorjosa/aprender_sistema/issues/845)).
+
+## Goals
+
+- Every critical flow has an explicit, documented transaction boundary.
+- Lock acquisition order is consistent across services, so two concurrent callers cannot deadlock over the same resources in different orders.
+- Transient PostgreSQL concurrency errors (serialization failure, deadlock detected) are retried automatically inside the service layer — callers see the operation succeed, not an opaque 500.
+- Concurrency behavior is covered by regression tests in CI.
+
+## Database configuration (recap)
+
+| Setting | Value | Note |
+|---------|------:|------|
+| `ATOMIC_REQUESTS` | *unset* | Services own transaction boundaries; DO NOT set this globally. |
+| `CONN_MAX_AGE` | 60 | Persistent connections, health-checked. |
+| `statement_timeout` | 30s (prod) | Kills runaway queries before they block others. |
+| Isolation level | `READ COMMITTED` (PostgreSQL default) | Row locks via `SELECT ... FOR UPDATE` give serializability where it matters. |
+
+## ACID matrix — critical flows
+
+| Flow | Entry point | TX boundary | Lock strategy | Idempotency | Retry on deadlock |
+|------|------|------|---|---|---|
+| **Approve (single)** | `services/solicitacao_approval.py :: approve_solicitacao` | Function body (`transaction.atomic`) | `Solicitacao.objects.select_for_update().get(pk=...)`, re-fetched inside tx | Status check (`status == 'pendente'`) after lock | ✅ `@retry_on_deadlock("solicitacao.approve")` |
+| **Reject (single)** | `services/solicitacao_approval.py :: reject_solicitacao` | Same | Same, rejected instead of approved | Same | ✅ `@retry_on_deadlock("solicitacao.reject")` |
+| **Approve (batch)** | `services/solicitacao_approval.py :: batch_approve_solicitacoes` | Function body | `select_for_update(skip_locked=True).order_by('id')` so concurrent batches never deadlock | `skip_locked` drops already-locked rows; concurrent duplicate batches approve 0 | ✅ `@retry_on_deadlock("solicitacao.batch_approve")` |
+| **Reject (batch)** | `services/solicitacao_approval.py :: batch_reject_solicitacoes` | Same | Same | Same | ✅ `@retry_on_deadlock("solicitacao.batch_reject")` |
+| **OAuth refresh** | `services/oauth/token_manager.py :: refresh_access_token_safe` | Function body | `GoogleOAuthCredential.objects.select_for_update().get(id=...)` + double-check `token_expiry` after lock | Second caller short-circuits if token is still valid | ✅ `@retry_on_deadlock("oauth.refresh_access_token")` |
+| **GCal upsert (service)** | `services/gcal/sync.py :: upsert_one` | *Caller responsibility* (currently the Celery task / management command) | Command-level Redis lock + per-row `select_for_update` in chunked mode | Deterministic event id + payload hash on `Solicitacao` | ❌ Not yet — the hot path is wrapped by `_retry_with_circuit_breaker` (#779); deadlock retry here is a next step |
+| **Import/ETL** (11 services) | `services/*_import.py` | One `transaction.atomic` per import call with `set_rollback(dry_run)` | No explicit row locks — idempotency via unique constraints + `external_hash` | Duplicate rows handled by `IntegrityError`; dry-run discards writes | ❌ Not yet — imports run offline; deadlock retry is a follow-up |
+
+## Lock ordering convention
+
+When a flow needs to lock more than one row across tables, acquire locks in this order:
+
+1. `Usuario`
+2. `Solicitacao`
+3. `AvailabilityBlock`
+4. `GoogleOAuthCredential`
+5. `AuditLog` (always INSERT-only, last)
+
+All multi-row locks in a single transaction must use `ORDER BY id ASC` to prevent the "lock rows in different orders" class of deadlock — this is already how the batch approval paths work.
+
+## Deadlock retry contract
+
+The helper lives at `apps/core/services/db_retry.py`:
+
+```python
+from apps.core.services.db_retry import retry_on_deadlock
+
+@retry_on_deadlock(operation="solicitacao.approve")
+def approve_solicitacao(...):
+    with transaction.atomic():
+        ...
+```
+
+- **Retryable PostgreSQL SQLSTATEs**: `40001` (serialization failure), `40P01` (deadlock detected). Everything else (IntegrityError, ProgrammingError, DataError) propagates immediately — those are programmer bugs, not transient.
+- **Max attempts**: 3 (default). On exhaustion the last exception is raised and a warning is logged with `event=db_retry_exhausted`.
+- **Backoff**: jittered exponential, `rand(0, min(1.0s, 100ms * 2^(attempt-1)))`. Small by design — serialization failures are resolved on retry in < 100 ms most of the time.
+- **Non-negotiable**: the decorated callable must open its own `transaction.atomic()`. Retrying inside an already-open outer transaction does nothing useful — the outer tx is still poisoned.
+
+## Observability
+
+Prometheus counter `as_db_transaction_retries_total{operation, pgcode, attempt}` is incremented on every retry attempt (not just on final failure). A sustained non-zero rate on any `operation` is the signal to investigate lock contention; a burst followed by a `db_retry_exhausted` log line is the signal that a caller surfaced the failure to the user.
+
+Structured log events:
+- `db_retry_scheduled` — one per retry attempt, includes `operation`, `pgcode`, `attempt`, `next_delay_seconds`.
+- `db_retry_exhausted` — logged at WARNING when retries are exhausted, with the same fields plus `max_attempts`.
+
+## Gaps tracked for follow-up PRs
+
+- **GCal sync** (`upsert_one`) is not yet wrapped with its own `transaction.atomic`; the caller must provide the boundary. Adding it explicitly + applying `retry_on_deadlock` is planned alongside the "count only transient errors" filter for the circuit breaker (see #779 notes).
+- **Import/ETL** services would benefit from per-row `transaction.atomic(savepoint=True)` so one bad row doesn't roll back 10 000 good ones.
+- **Savepoint-per-item recovery** for `apply_one_solicitacao` publishing batches is not yet in place — currently an item failure aborts the chunk.
+- **Concurrency tests** today cover only double-approval races. Follow-ups should add races for concurrent token refreshes, concurrent GCal publishes, and import collisions.
+
+## Related
+
+- Epic [#845 — Testing Maturity](https://github.com/matheusnorjosa/aprender_sistema/issues/845)
+- [#866 — ASQ-016 ACID policy](https://github.com/matheusnorjosa/aprender_sistema/issues/866)
+- [#779 — ASQ-006 GCal circuit breaker](https://github.com/matheusnorjosa/aprender_sistema/issues/779) (already wired)
+- Test reference: `apps/core/tests/test_solicitacao_approval_concurrency.py`


### PR DESCRIPTION
## Summary
Phase 1 of issue #866 (ASQ-016). Part of epic #845 (Testing Maturity).

Lands the centralized deadlock-retry primitive, wires it into the hot critical flows, and publishes the formal ACID policy document. Follow-up PRs will widen the application surface (GCal upsert, imports) and expand concurrency test coverage.

## What's in

**New retry helper — `apps/core/services/db_retry.py`**
- `@retry_on_deadlock(max_attempts=3, base_delay=0.1, max_delay=1.0, operation=...)`.
- Retries on PostgreSQL SQLSTATE **40001** (serialization failure) and **40P01** (deadlock detected). Falls back to message-body scanning when the psycopg driver hides the code.
- Jittered exponential backoff.
- Prometheus counter `as_db_transaction_retries_total{operation, pgcode, attempt}` increments on every retry (not just on final failure).
- Structured log events: `db_retry_scheduled` per attempt, `db_retry_exhausted` at WARNING once the budget is burned.
- **Contract**: the decorated callable must own its own `transaction.atomic()`. Retrying inside an already-poisoned outer transaction accomplishes nothing.

**Wired into the hot paths from the ACID matrix**
- `services/solicitacao_approval.py` — `approve_solicitacao`, `reject_solicitacao`, `batch_approve_solicitacoes`, `batch_reject_solicitacoes`.
- `services/oauth/token_manager.py` — `refresh_access_token_safe`.
- The existing `select_for_update` + double-check patterns remain; the decorator is the safety net when PostgreSQL detects a deadlock cycle despite our lock ordering.

**New doc — `v2/docs/ACID_POLICY.md`**
Single source of truth for:
- Transaction boundary per critical flow (single approval, batch approval, OAuth refresh, GCal sync, imports).
- **Lock ordering convention**: `Usuario → Solicitacao → AvailabilityBlock → GoogleOAuthCredential → AuditLog`, with `ORDER BY id ASC` mandated on multi-row locks.
- Retry helper contract and observability model.
- Explicit **gaps tracked for follow-up** (GCal upsert TX wrapping, savepoint-per-item in imports, broader concurrency test coverage, runbook).

**New tests — `apps/core/tests/test_db_retry.py` (10)**
- Success path doesn't retry.
- Retries on 40P01 and 40001 SQLSTATEs; falls back to message matching when the driver doesn't expose the code.
- Non-retryable OperationalError surfaces on first attempt; non-`OperationalError` exceptions never retry.
- Re-raises after `max_attempts`; pass-through for args/kwargs.
- `max_attempts < 1` rejected.
- Exhaustion log event carries `operation`, `pgcode`, `max_attempts` via `extra=`.

## What's explicitly *not* in (future PRs)
- `services/gcal/sync.py :: upsert_one` TX wrapping + retry (doc flags it).
- Per-row `transaction.atomic(savepoint=True)` inside the 11 import services.
- Concurrency tests for concurrent OAuth refresh, GCal publish collisions, import collisions.
- Runbook for incident response.

## Test plan
- [x] `pytest apps/core/tests/` — **1585 passed** (+10), 22 skipped, 0 failures
- [x] `pytest apps/core/tests/test_db_retry.py` — 10/10 pass
- [x] `pytest apps/core/tests/test_solicitacao_approval_concurrency.py apps/core/tests/test_auditlog_approve_reject.py` — 4/4 pass (no regression from the decorator)
- [x] `black --check` on touched files — clean
- [x] `isort --check-only` on touched files — clean
- [x] `flake8` on touched files — clean
- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

```
ALL 8 CHECKS PASSED
```

## Staging Gate
- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR