### PR TITLE
feat(services): wire GCal retry + import savepoint pilot + race tests + runbook — closes #866

### DIFF
--- a/v2/backend/apps/core/services/bloqueios_import.py
+++ b/v2/backend/apps/core/services/bloqueios_import.py
@@ -61,11 +61,15 @@ def import_bloqueios_from_file(*, path: str, dry_run: bool = True) -> dict[str, 
     # Carregar arquivo
     rows = _load_file(path)
 
-    # Processar linhas
+    # Processar linhas.
+    # ASQ-016: each row runs inside a nested atomic (savepoint) so a single
+    # bad row only rolls back its own insert/update, not the whole file.
+    # The outer atomic still gives us an all-or-nothing dry-run.
     with transaction.atomic():
         for idx, row in enumerate(rows, start=1):
             try:
-                _process_row(row, idx, stats, pendencias)
+                with transaction.atomic():  # savepoint
+                    _process_row(row, idx, stats, pendencias)
             except Exception as e:
                 stats["skipped"]["other"] += 1
                 pendencias["outros"].append(

--- a/v2/backend/apps/core/services/gcal/sync.py
+++ b/v2/backend/apps/core/services/gcal/sync.py
@@ -15,6 +15,7 @@ from django.conf import settings
 from django.utils import timezone
 
 from apps.core.models import Solicitacao
+from apps.core.services.db_retry import retry_on_deadlock
 from apps.core.types import CalendarId, EventId, JsonDict
 
 from .client import CalendarClientAdapter
@@ -26,6 +27,7 @@ from .validation import _event_id_for
 logger = logging.getLogger(__name__)
 
 
+@retry_on_deadlock(operation="gcal.apply_one_solicitacao")
 def apply_one_solicitacao(
     s: Solicitacao,
     *,

--- a/v2/backend/apps/core/tests/test_concurrency_regressions_asq016.py
+++ b/v2/backend/apps/core/tests/test_concurrency_regressions_asq016.py
@@ -1,0 +1,273 @@
+"""
+Concurrency regression tests — ASQ-016 phase 2 (#866).
+
+Covers the three flows flagged as GAP-5 in ACID_POLICY.md:
+
+1. Concurrent OAuth token refresh — only one HTTP call reaches Google, the
+   second caller short-circuits through the double-check.
+2. Concurrent GCal publish for the same solicitacao — final DB state is
+   consistent regardless of how the two calls interleave.
+3. Savepoint-per-item in imports — a single bad row rolls back only its
+   own insert, not the entire file.
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportOptionalMemberAccess=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportMissingTypeArgument=false, reportCallIssue=false, reportIndexIssue=false, reportOperatorIssue=false, reportOptionalSubscript=false, reportUnknownLambdaType=false, reportPrivateUsage=false, reportPossiblyUnboundVariable=false
+
+from __future__ import annotations
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timedelta
+from datetime import timezone as dt_timezone
+from unittest import mock
+from uuid import uuid4
+
+from django.contrib.auth.models import Group
+from django.db import close_old_connections
+from django.utils import timezone
+
+import pytest
+
+from apps.core.models import (
+    AvailabilityBlock,
+    GoogleOAuthCredential,
+    Municipio,
+    Projeto,
+    Solicitacao,
+    TipoEvento,
+    Usuario,
+)
+from apps.core.services.bloqueios_import import import_bloqueios_from_file
+
+
+@pytest.fixture
+def usuario():
+    uid = uuid4().hex[:8]
+    return Usuario.objects.create_user(
+        username=f"asq016_{uid}",
+        password="x",
+        cpf=str(uuid4().int % 10**11).zfill(11),
+        email=f"asq016_{uid}@test.com",
+        first_name=f"First{uid}",
+        last_name=f"Last{uid}",
+    )
+
+
+# =============================================================================
+# Test 1 — Concurrent OAuth refresh: double-check prevents duplicate HTTP call
+# =============================================================================
+
+
+@pytest.mark.django_db(transaction=True)
+def test_concurrent_oauth_refresh_double_checks(monkeypatch, usuario):
+    """
+    Two threads race to refresh the same credential. The first wins the row
+    lock and performs the HTTP refresh; the second acquires the lock after
+    the first commits, sees token_expiry > now + 5min, and returns without
+    hitting Google.
+    """
+    from apps.core.services.oauth import token_manager
+
+    # Old enough to be expired.
+    past = timezone.now() - timedelta(minutes=10)
+
+    credential = GoogleOAuthCredential.objects.create(
+        user=usuario,
+        google_email="ops@example.com",
+        access_token_encrypted=b"old-access",
+        refresh_token_encrypted=b"old-refresh",
+        token_expiry=past,
+    )
+
+    call_count = {"n": 0}
+    response_lock = threading.Lock()
+
+    def fake_post(*args, **kwargs):
+        with response_lock:
+            call_count["n"] += 1
+        resp = mock.MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {
+            "access_token": f"new-access-{call_count['n']}",
+            "expires_in": 3600,
+        }
+        resp.raise_for_status = lambda: None
+        return resp
+
+    monkeypatch.setenv("GCAL_OAUTH_CLIENT_ID", "cid")
+    monkeypatch.setenv("GCAL_OAUTH_CLIENT_SECRET", "secret")
+    monkeypatch.setattr(token_manager, "decrypt_token", lambda _blob: "refresh-token-plain")
+    monkeypatch.setattr(
+        token_manager,
+        "encrypt_token",
+        lambda s: (s.encode() if isinstance(s, str) else bytes(s)),
+    )
+    monkeypatch.setattr(token_manager.requests, "post", fake_post)
+
+    start = threading.Barrier(2)
+
+    def worker() -> str:
+        close_old_connections()
+        try:
+            cred = GoogleOAuthCredential.objects.get(pk=credential.pk)
+            start.wait(timeout=5)
+            token_manager.refresh_access_token_safe(cred)
+            return "ok"
+        finally:
+            close_old_connections()
+
+    with ThreadPoolExecutor(max_workers=2) as ex:
+        results = list(ex.map(lambda _: worker(), range(2)))
+
+    assert results == ["ok", "ok"]
+    # Only the first refresher talks to Google; the second short-circuits.
+    assert call_count["n"] == 1, (
+        f"expected exactly 1 refresh HTTP call; observed {call_count['n']}. "
+        "Double-check pattern in refresh_access_token_safe regressed."
+    )
+
+    credential.refresh_from_db()
+    assert credential.token_expiry > timezone.now() + timedelta(minutes=50)
+
+
+# =============================================================================
+# Test 2 — Concurrent GCal publish: final state consistent, no duplicate inserts
+# =============================================================================
+
+
+class _RecordingCalendarClient:
+    """Minimal calendar client that records each external call so the test can
+    assert the collision behavior of two concurrent apply_one_solicitacao calls
+    against the same solicitacao."""
+
+    def __init__(self):
+        self.calls: list[tuple[str, str]] = []  # (verb, event_id)
+        self._lock = threading.Lock()
+        # Simulate "event already exists" once a create has landed.
+        self._existing: set[str] = set()
+
+    def get(self, calendar_id, event_id):  # noqa: ARG002
+        with self._lock:
+            if event_id in self._existing:
+                return {"id": event_id}
+            return None
+
+    def insert(self, calendar_id, event_id, payload):  # noqa: ARG002
+        with self._lock:
+            self.calls.append(("insert", event_id))
+            self._existing.add(event_id)
+            return {"id": event_id}
+
+    def update(self, calendar_id, event_id, payload):  # noqa: ARG002
+        with self._lock:
+            self.calls.append(("update", event_id))
+            return {"id": event_id}
+
+    def delete(self, calendar_id, event_id):  # noqa: ARG002
+        with self._lock:
+            self.calls.append(("delete", event_id))
+            self._existing.discard(event_id)
+
+
+@pytest.fixture
+def solicitacao_aprovada(usuario):
+    muni = Municipio.objects.create(nome=f"Mun_{uuid4().hex[:6]}", uf="CE", ativo=True)
+    proj = Projeto.objects.create(
+        nome=f"Proj_{uuid4().hex[:6]}",
+        codigo=f"P{uuid4().hex[:5]}",
+        fluxo="SUPER",
+        ativo=True,
+    )
+    tipo = TipoEvento.objects.get_or_create(nome="Evt_ASQ016")[0]
+    group, _ = Group.objects.get_or_create(name="Coordenador")
+    usuario.groups.add(group)
+    return Solicitacao.objects.create(
+        usuario=usuario,
+        municipio=muni,
+        projeto=proj,
+        tipo_evento=tipo,
+        inicio=timezone.now() + timedelta(days=1),
+        fim=timezone.now() + timedelta(days=1, hours=2),
+        status="aprovado",
+    )
+
+
+@pytest.mark.django_db(transaction=True)
+def test_concurrent_apply_one_solicitacao_keeps_state_consistent(monkeypatch, solicitacao_aprovada):
+    """
+    Two threads publish the same solicitacao at once. After both return, the
+    DB should reflect a single event id and gcal_status=PUBLISHED — no torn
+    state, no ERROR leakage.
+    """
+    from apps.core.services.gcal import sync as sync_mod
+
+    client = _RecordingCalendarClient()
+    monkeypatch.setattr(sync_mod, "_retry_with_circuit_breaker", lambda f, **_: f())
+
+    start = threading.Barrier(2)
+
+    def worker() -> str:
+        close_old_connections()
+        try:
+            s = Solicitacao.objects.get(pk=solicitacao_aprovada.pk)
+            start.wait(timeout=5)
+            outcome = sync_mod.apply_one_solicitacao(s, apply_blocked=True, client=client)
+            return outcome.action
+        finally:
+            close_old_connections()
+
+    with ThreadPoolExecutor(max_workers=2) as ex:
+        outcomes = list(ex.map(lambda _: worker(), range(2)))
+
+    # Both calls returned an action (not an exception). Whether both produced
+    # CREATE or one CREATE + one UPDATE/ADOPT depends on whose client.get
+    # landed first — GCal itself deduplicates via 409 on duplicate event ids,
+    # but the mock here doesn't emulate that and it's fine: the regression we
+    # care about is the DB state, not the call order.
+    assert len(outcomes) == 2
+    for action in outcomes:
+        assert action in {"CREATE", "UPDATE", "ADOPT"}
+
+    solicitacao_aprovada.refresh_from_db()
+    assert solicitacao_aprovada.gcal_status == Solicitacao.GCalStatus.PUBLISHED
+    assert solicitacao_aprovada.external_event_id is not None
+
+
+# =============================================================================
+# Test 3 — Savepoint-per-item in imports: one bad row doesn't drop valid rows
+# =============================================================================
+
+
+@pytest.mark.django_db(transaction=True)
+def test_bloqueios_import_uses_savepoint_per_row(tmp_path, usuario):
+    """
+    Three rows: row 1 valid, row 2 bad (unknown user), row 3 valid. After
+    import the bad row is counted as skipped but rows 1 and 3 are persisted.
+    """
+    csv_path = tmp_path / "bloqueios_asq016.csv"
+    # Valid datetimes (the service parses ISO/BR formats).
+    d1_start = datetime(2099, 1, 10, 9, 0, tzinfo=dt_timezone.utc).isoformat()
+    d1_end = datetime(2099, 1, 10, 18, 0, tzinfo=dt_timezone.utc).isoformat()
+    d3_start = datetime(2099, 1, 12, 9, 0, tzinfo=dt_timezone.utc).isoformat()
+    d3_end = datetime(2099, 1, 12, 18, 0, tzinfo=dt_timezone.utc).isoformat()
+
+    nome_valido = f"{usuario.first_name} {usuario.last_name}"
+    csv_path.write_text(
+        "usuario,inicio,fim,tipo,motivo\n"
+        f"{nome_valido},{d1_start},{d1_end},T,dia-1\n"
+        f"USUARIO_INEXISTENTE_ZZZ,{d1_start},{d1_end},T,row-ruim\n"
+        f"{nome_valido},{d3_start},{d3_end},T,dia-3\n",
+        encoding="utf-8",
+    )
+
+    before = AvailabilityBlock.objects.filter(usuario=usuario).count()
+    result = import_bloqueios_from_file(path=str(csv_path), dry_run=False)
+    after = AvailabilityBlock.objects.filter(usuario=usuario).count()
+
+    # The bad row was captured as a pendency; the two valid rows were persisted.
+    assert result["stats"]["created"] + result["stats"]["updated"] == 2
+    assert result["stats"]["skipped"]["usuario"] + result["stats"]["skipped"]["other"] >= 1
+    assert after - before == 2, (
+        "Expected exactly 2 blocks to be persisted. The savepoint-per-row "
+        "pattern must isolate the bad row's rollback."
+    )

--- a/v2/docs/ACID_POLICY.md
+++ b/v2/docs/ACID_POLICY.md
@@ -27,8 +27,10 @@ Formal transactional policy for the critical flows. Tracks issue [#866](https://
 | **Approve (batch)** | `services/solicitacao_approval.py :: batch_approve_solicitacoes` | Function body | `select_for_update(skip_locked=True).order_by('id')` so concurrent batches never deadlock | `skip_locked` drops already-locked rows; concurrent duplicate batches approve 0 | ✅ `@retry_on_deadlock("solicitacao.batch_approve")` |
 | **Reject (batch)** | `services/solicitacao_approval.py :: batch_reject_solicitacoes` | Same | Same | Same | ✅ `@retry_on_deadlock("solicitacao.batch_reject")` |
 | **OAuth refresh** | `services/oauth/token_manager.py :: refresh_access_token_safe` | Function body | `GoogleOAuthCredential.objects.select_for_update().get(id=...)` + double-check `token_expiry` after lock | Second caller short-circuits if token is still valid | ✅ `@retry_on_deadlock("oauth.refresh_access_token")` |
-| **GCal upsert (service)** | `services/gcal/sync.py :: upsert_one` | *Caller responsibility* (currently the Celery task / management command) | Command-level Redis lock + per-row `select_for_update` in chunked mode | Deterministic event id + payload hash on `Solicitacao` | ❌ Not yet — the hot path is wrapped by `_retry_with_circuit_breaker` (#779); deadlock retry here is a next step |
-| **Import/ETL** (11 services) | `services/*_import.py` | One `transaction.atomic` per import call with `set_rollback(dry_run)` | No explicit row locks — idempotency via unique constraints + `external_hash` | Duplicate rows handled by `IntegrityError`; dry-run discards writes | ❌ Not yet — imports run offline; deadlock retry is a follow-up |
+| **GCal publish (entry point)** | `services/gcal/sync.py :: apply_one_solicitacao` | Function body wraps DB writes via `s.mark_gcal` / `s.save`; HTTP call to Google happens outside the tx | Caller (Celery task / management command) is responsible for `select_for_update` on the batch; single-item callers use `@retry_on_deadlock` as the safety net | Deterministic event id + payload hash on `Solicitacao`; duplicate dispatches collapse via `client.get(...)` existence check | ✅ `@retry_on_deadlock("gcal.apply_one_solicitacao")` |
+| **GCal low-level upsert** | `services/gcal/sync.py :: upsert_one` | Each `s.save(update_fields=...)` is atomic on its own; HTTP call happens between saves | Caller contract: wrap in `transaction.atomic()` + `select_for_update` for batch sync | Same — event id + hash | Inherits retry via `apply_one_solicitacao`; circuit breaker at HTTP layer (#779) |
+| **Import/ETL** — `bloqueios_import` | `services/bloqueios_import.py :: import_bloqueios_from_file` | Outer `transaction.atomic` for dry-run rollback + **savepoint-per-row** via nested `transaction.atomic` | No explicit row locks — idempotency via uniqueness check before create | One bad row only aborts itself (savepoint); dry-run still discards the whole batch | ❌ Not yet — imports run offline. |
+| **Import/ETL** — *other 10 services* | `services/*_import.py` | One `transaction.atomic` per import call with `set_rollback(dry_run)` | No explicit row locks — idempotency via unique constraints + `external_hash` | Duplicate rows handled by `IntegrityError`; dry-run discards writes | ❌ Not yet — savepoint-per-row rollout planned. |
 
 ## Lock ordering convention
 
@@ -70,10 +72,18 @@ Structured log events:
 
 ## Gaps tracked for follow-up PRs
 
-- **GCal sync** (`upsert_one`) is not yet wrapped with its own `transaction.atomic`; the caller must provide the boundary. Adding it explicitly + applying `retry_on_deadlock` is planned alongside the "count only transient errors" filter for the circuit breaker (see #779 notes).
-- **Import/ETL** services would benefit from per-row `transaction.atomic(savepoint=True)` so one bad row doesn't roll back 10 000 good ones.
-- **Savepoint-per-item recovery** for `apply_one_solicitacao` publishing batches is not yet in place — currently an item failure aborts the chunk.
-- **Concurrency tests** today cover only double-approval races. Follow-ups should add races for concurrent token refreshes, concurrent GCal publishes, and import collisions.
+Phase 2 (#866) closed the following:
+
+- ✅ **GCal publish retry** — `apply_one_solicitacao` carries `@retry_on_deadlock`; the caller contract for `upsert_one` is documented.
+- ✅ **Savepoint-per-row in imports** — pilot landed in `bloqueios_import`; the other 10 import services follow the same template.
+- ✅ **Concurrency regression tests** — race coverage added for OAuth refresh, GCal publish, and import savepoint behavior in `test_concurrency_regressions_asq016.py`.
+- ✅ **Runbook** — see [`RUNBOOK_concurrency.md`](RUNBOOK_concurrency.md).
+
+Still open, deliberately out of scope:
+
+- **Savepoint rollout** to the 10 remaining import services (colecoes, eventos, dat_cadastros, deslocamentos, equipe_gerencia, produtos, municipios, usuarios, controle_acoes). Template in `bloqueios_import` is ready; propagation is mechanical.
+- **"Count only transient errors" filter** on the GCal circuit breaker (tracked in #779 notes).
+- **Distributed tracing span** for each retry attempt — today we have structured logs but no trace context.
 
 ## Related
 

--- a/v2/docs/RUNBOOK_concurrency.md
+++ b/v2/docs/RUNBOOK_concurrency.md
@@ -1,0 +1,74 @@
+# Runbook — Concurrency Incidents
+
+Companion to [`ACID_POLICY.md`](ACID_POLICY.md). Tracks how to diagnose and respond to the concurrency failure modes the policy defends against.
+
+## Signals to watch
+
+| Signal | Where | What it means |
+|---|---|---|
+| **Prometheus counter rate** `rate(as_db_transaction_retries_total[5m]) > 0` | Grafana `aprender-db-concurrency` board | A retry fired in the last 5 minutes. A low, bursty rate is normal; a sustained non-zero rate means a hotspot. |
+| **Log event** `db_retry_exhausted` | Loki / stdout | A user actually hit the ceiling on `max_attempts`. A single burst after a deploy can be noise; sustained events are a bug. |
+| **Log event** `solicitacao_batch_approved` over **10 s** | Loki | Batch approvals normally complete in < 1 s. Slowness usually means `skip_locked` is hitting contention somewhere upstream. |
+| **Circuit breaker `state=open`** | `GET /api/gcal/circuit-breaker/` | Google Calendar is rejecting us. Not strictly a concurrency issue, but related: approvals no longer publish, so the task retry task (`task_retry_gcal_sync_when_breaker_closes`) should be firing. |
+
+## Triage — "deadlock_detected in production"
+
+1. **Grab the event** from Loki:
+   ```
+   {event="db_retry_scheduled"} | operation=~"solicitacao.*" | pgcode="40P01"
+   ```
+2. **Check recent activity**: was there a bulk import or migration running? A deploy in the last 10 min?
+3. **Identify the two transactions** in Postgres logs (`log_lock_waits=on` must be enabled):
+   ```sql
+   SELECT pid, now() - xact_start AS running_for, query, wait_event_type, wait_event
+   FROM pg_stat_activity
+   WHERE state <> 'idle'
+   ORDER BY xact_start
+   LIMIT 20;
+   ```
+4. **If the same operation appears twice** (two `solicitacao.approve` at once on the same row): expected — the retry helper and `select_for_update` will resolve it. If `db_retry_exhausted` fires for the same `operation` more than once per minute, escalate.
+5. **If two different operations appear** (e.g. `solicitacao.approve` and an unrelated write): we have a lock-ordering violation. Compare the query acquisition order against the documented convention in `ACID_POLICY.md` — the newer code path is almost always the offender.
+
+## Triage — "serialization failure"
+
+Rare under `READ COMMITTED`. If you see it:
+1. Look for places where code reads data outside `select_for_update`, decides something, and then writes — that's the classic "lost update" shape.
+2. Check if anyone recently changed the isolation level for a specific call (`transaction.atomic(using=..., savepoint=...)` does **not** change isolation; `SET TRANSACTION ISOLATION LEVEL SERIALIZABLE` does).
+3. Fix: add `select_for_update` on the row being read or move the decision inside the existing lock scope.
+
+## Triage — "concurrent GCal publish left external_event_id in weird state"
+
+Symptoms: `Solicitacao.gcal_status = PUBLISHED` but `external_event_id = NULL`, or two different `last_sync_action` values flipping.
+
+1. Check for duplicate Celery task enqueues for the same `solicitacao_id`:
+   ```
+   {event="task_publish_solicitacao_to_gcal"} | solicitation_id=<ID>
+   ```
+2. If count > 1 in < 30 s, the upstream dispatcher is double-queuing — fix the dispatcher, not the task.
+3. As a safety net, `apply_one_solicitacao` is decorated with `@retry_on_deadlock`. A torn state should not be possible from a single dispatch — it requires two parallel dispatches.
+4. Recover: either wait for the circuit-breaker retry task to re-sync, or manually re-apply via the Django admin action.
+
+## Triage — "import took 30 min and then rolled everything back"
+
+This is the shape that savepoint-per-item solves, but only `bloqueios_import.py` has it enabled right now. For the other imports:
+1. Find the row that failed in the `pendencias.outros` array of the response.
+2. Fix the row or mark it to skip.
+3. Re-run with `dry_run=True` first, then `dry_run=False`.
+4. File a ticket referencing the remaining GAP in `ACID_POLICY.md` so the follow-up PR that widens savepoint coverage gets prioritized for that service.
+
+## Escalation
+
+- **Repeated `db_retry_exhausted` on the same operation** for > 5 min → page the on-call backend engineer.
+- **Circuit breaker stays open** (`GET /api/gcal/circuit-breaker/` returns `state=open` for > 10 min) → page OAuth owner to investigate Google API status.
+- **`pg_stat_activity` shows > 50 connections in `idle in transaction`** → open DB incident; kill the longest-running transactions with `SELECT pg_terminate_backend(pid)` after confirming it is a request, not a migration.
+
+## Known gaps this runbook does not yet cover
+
+- Tracing a deadlock back to the specific Python call stack (we have structured logs but not a distributed tracing span name yet — tracked in the `#845` epic).
+- Per-tenant lock metrics (we count by `operation`, not by `solicitacao_id` or `user_id` — intentional, since high-cardinality labels blow up Prometheus storage).
+
+## Related
+
+- [`ACID_POLICY.md`](ACID_POLICY.md) — policy spec, lock ordering, decorator contract.
+- [`COVERAGE_POLICY.md`](analysis/COVERAGE_POLICY.md) — test bar for the services this runbook protects.
+- Issue [#866](https://github.com/matheusnorjosa/aprender_sistema/issues/866) — ASQ-016 tracking.


### PR DESCRIPTION
## Summary
Closes #866 (ASQ-016). Part of epic #845 (Testing Maturity).

Phase 2 ships the remaining deliverables that Phase 1 (#1156) explicitly deferred: **GCal publish now rides the retry helper**, **imports get savepoint-per-row** via a pilot service, **concurrency tests cover the three previously-uncovered flows**, and a **runbook** exists for the on-call to triage deadlocks without guessing.

## What's in

### 1. GCal publish — closes GAP-2 from `ACID_POLICY.md`
- `services/gcal/sync.py :: apply_one_solicitacao` carries `@retry_on_deadlock(operation="gcal.apply_one_solicitacao")`.
- The HTTP call to Google still happens outside any DB transaction (we never hold a connection across a slow external call), so the retry fires only when the two `s.mark_gcal(...)` writes race with another worker processing the same solicitacao.
- `upsert_one` docstring remains unchanged — the caller contract is still "wrap in `transaction.atomic()` + `select_for_update` for batch sync". Single-item callers now inherit retry safety automatically via `apply_one_solicitacao`.

### 2. Savepoint-per-row in imports (pilot in `bloqueios_import`)
```python
with transaction.atomic():                 # outer: dry-run boundary
    for idx, row in enumerate(rows, start=1):
        try:
            with transaction.atomic():     # savepoint: per-row isolation
                _process_row(row, idx, stats, pendencias)
        except Exception as e:
            # pendencia registered; valid rows already persisted above
            ...
    if dry_run:
        transaction.set_rollback(True)
```
One bad row is captured as a pendency; the other rows in the file still commit. The 10 remaining import services follow the same template in a follow-up — mechanical propagation, listed explicitly in the updated `ACID_POLICY.md` gaps section.

### 3. Concurrency regression tests — 3 new, closing GAP-5
- `test_concurrent_oauth_refresh_double_checks` — two threads race to refresh the same credential; asserts exactly **one** HTTP call reaches Google (second caller short-circuits through the `token_expiry > now + 5min` check after acquiring the lock).
- `test_concurrent_apply_one_solicitacao_keeps_state_consistent` — two threads publish the same approved solicitacao; asserts the final DB state is consistent (`gcal_status=PUBLISHED`, `external_event_id` set, no ERROR).
- `test_bloqueios_import_uses_savepoint_per_row` — three-row CSV with a bad middle row; asserts the two valid rows are persisted (savepoint isolates the bad one).

### 4. `v2/docs/RUNBOOK_concurrency.md` — incident playbook
Triage trees for:
- deadlock_detected signals (Prometheus + Loki + `pg_stat_activity` query)
- serialization_failure (rarer, under READ COMMITTED)
- torn GCal state from duplicate Celery dispatches
- long imports that roll back in one shot (pre-savepoint tail)

Plus escalation thresholds and explicit "what this runbook doesn't yet cover" section so gaps stay visible.

### 5. `v2/docs/ACID_POLICY.md` — policy refresh
- Matrix row for GCal split into "entry point" (retry-covered) vs "low-level upsert" (caller contract).
- `bloqueios_import` row documents savepoint template; other imports listed separately.
- Gaps section re-partitioned: **closed by phase 2** vs **still open (deliberately)**.

## Test plan
- [x] `pytest apps/core/tests/` — **1588 passed**, 22 skipped, 0 failures (+3 from phase 2, +10 from phase 1's helper tests that landed in #1156)
- [x] `pytest apps/core/tests/test_concurrency_regressions_asq016.py apps/core/tests/test_db_retry.py apps/core/tests/test_solicitacao_approval_concurrency.py apps/core/tests/test_auditlog_approve_reject.py` — 17/17 pass
- [x] `black --check` + `isort --check-only` + `flake8` on touched files — clean
- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

```
ALL 8 CHECKS PASSED
```

## Follow-ups tracked in `ACID_POLICY.md`
- Propagate savepoint-per-row to the 10 remaining import services.
- Add "count only transient failures" filter to the GCal circuit breaker (noted in #779 conversation).
- Add distributed tracing span names to each retry attempt (today we have structured logs but no trace context).

## Staging Gate
- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR