### PR TITLE
chore(imports): propagate savepoint-per-row to the remaining 9 import services

### DIFF
--- a/v2/backend/apps/core/services/colecoes_import.py
+++ b/v2/backend/apps/core/services/colecoes_import.py
@@ -59,10 +59,13 @@ def import_colecoes_from_file(*, path: str, dry_run: bool = True) -> dict[str, A
     # Cache de projetos ja resolvidos por nome informado
     projeto_cache: dict[str, Projeto | None] = {}
 
+    # ASQ-016: savepoint-per-row. Outer atomic still owns the dry-run
+    # rollback; inner atomic isolates one bad row from the rest.
     with transaction.atomic():
         for idx, row in enumerate(rows, start=1):
             try:
-                _process_row(row, idx, stats, pendencias, projeto_cache)
+                with transaction.atomic():  # savepoint
+                    _process_row(row, idx, stats, pendencias, projeto_cache)
             except Exception as e:
                 stats["skipped"]["other"] += 1
                 pendencias["outros"].append(

--- a/v2/backend/apps/core/services/controle_acoes_import.py
+++ b/v2/backend/apps/core/services/controle_acoes_import.py
@@ -64,13 +64,16 @@ def import_acoes_controle(file_path: str, dry_run: bool = False) -> dict[str, An
     # Carregar arquivo
     rows: list[dict[str, Any]] = _load_file(file_path)
 
-    # Processar linhas
+    # Processar linhas.
+    # ASQ-016: savepoint-per-row. Outer atomic still owns the dry-run
+    # rollback; inner atomic isolates one bad row from the rest.
     with transaction.atomic():
         for idx, row in enumerate(rows, start=1):
             try:
-                result: str | None = _process_row(row, idx, stats, pendencias)
-                if result == "skip":
-                    continue
+                with transaction.atomic():  # savepoint
+                    result: str | None = _process_row(row, idx, stats, pendencias)
+                    if result == "skip":
+                        continue
             except Exception as e:
                 stats["skipped"]["other"] += 1
                 pendencias["outros"].append(

--- a/v2/backend/apps/core/services/dat_cadastros_import.py
+++ b/v2/backend/apps/core/services/dat_cadastros_import.py
@@ -102,13 +102,16 @@ def import_dat_cadastros(file_path: str, dry_run: bool = False) -> dict[str, Any
     # Carregar arquivo
     rows: list[dict[str, Any]] = _load_file(file_path)
 
-    # Processar linhas
+    # Processar linhas.
+    # ASQ-016: savepoint-per-row. Outer atomic still owns the dry-run
+    # rollback; inner atomic isolates one bad row from the rest.
     with transaction.atomic():
         for idx, row in enumerate(rows, start=1):
             try:
-                result: str | None = _process_row(row, idx, stats, pendencias)
-                if result == "skip":
-                    continue
+                with transaction.atomic():  # savepoint
+                    result: str | None = _process_row(row, idx, stats, pendencias)
+                    if result == "skip":
+                        continue
             except Exception as e:
                 stats["skipped"]["other"] += 1
                 pendencias["outros"].append(

--- a/v2/backend/apps/core/services/deslocamentos_import.py
+++ b/v2/backend/apps/core/services/deslocamentos_import.py
@@ -63,11 +63,14 @@ def import_deslocamentos_from_file(*, path: str, dry_run: bool = True) -> dict[s
     # Carregar arquivo
     rows = _load_file(path)
 
-    # Processar linhas
+    # Processar linhas.
+    # ASQ-016: savepoint-per-row. Outer atomic still owns the dry-run
+    # rollback; inner atomic isolates one bad row from the rest.
     with transaction.atomic():
         for idx, row in enumerate(rows, start=1):
             try:
-                _process_row(row, idx, stats, pendencias, dry_run)
+                with transaction.atomic():  # savepoint
+                    _process_row(row, idx, stats, pendencias, dry_run)
             except Exception as e:
                 stats["skipped"]["other"] += 1
                 pendencias["outros"].append(

--- a/v2/backend/apps/core/services/equipe_gerencia_import.py
+++ b/v2/backend/apps/core/services/equipe_gerencia_import.py
@@ -108,10 +108,13 @@ def import_equipe_gerencia_from_file(*, path: str, dry_run: bool = True) -> dict
 
     rows = _load_file(path)
 
+    # ASQ-016: savepoint-per-row. Outer atomic still owns the dry-run
+    # rollback; inner atomic isolates one bad row from the rest.
     with transaction.atomic():
         for idx, row in enumerate(rows, start=1):
             try:
-                _process_row(row, idx, stats, pendencias)
+                with transaction.atomic():  # savepoint
+                    _process_row(row, idx, stats, pendencias)
             except Exception as e:
                 stats["skipped"]["other"] += 1
                 pendencias["outros"].append(

--- a/v2/backend/apps/core/services/eventos_import.py
+++ b/v2/backend/apps/core/services/eventos_import.py
@@ -102,11 +102,14 @@ def import_eventos_from_file(*, path: str, dry_run: bool = True) -> dict[str, An
     # Carregar arquivo
     rows = _load_file(path)
 
-    # Processar linhas
+    # Processar linhas.
+    # ASQ-016: savepoint-per-row. Outer atomic still owns the dry-run
+    # rollback; inner atomic isolates one bad row from the rest.
     with transaction.atomic():
         for idx, row in enumerate(rows, start=1):
             try:
-                _process_row(row, idx, stats, pendencias, today)
+                with transaction.atomic():  # savepoint
+                    _process_row(row, idx, stats, pendencias, today)
             except Exception as e:
                 stats["skipped"]["other"] += 1
                 pendencias["outros"].append(

--- a/v2/backend/apps/core/services/municipios_import.py
+++ b/v2/backend/apps/core/services/municipios_import.py
@@ -54,10 +54,13 @@ def import_municipios_from_file(*, path: str, dry_run: bool = True) -> dict[str,
 
     rows = _load_file(path)
 
+    # ASQ-016: savepoint-per-row. Outer atomic still owns the dry-run
+    # rollback; inner atomic isolates one bad row from the rest.
     with transaction.atomic():
         for idx, row in enumerate(rows, start=1):
             try:
-                _process_row(row, idx, stats, pendencias)
+                with transaction.atomic():  # savepoint
+                    _process_row(row, idx, stats, pendencias)
             except Exception as e:
                 stats["skipped"]["other"] += 1
                 pendencias["outros"].append(

--- a/v2/backend/apps/core/services/produtos_import.py
+++ b/v2/backend/apps/core/services/produtos_import.py
@@ -61,11 +61,14 @@ def import_produtos_from_file(*, path: str, dry_run: bool = True) -> dict[str, A
     # Construir cache de projetos
     projeto_cache = _build_projeto_cache()
 
-    # Processar linhas
+    # Processar linhas.
+    # ASQ-016: savepoint-per-row. Outer atomic still owns the dry-run
+    # rollback; inner atomic isolates one bad row from the rest.
     with transaction.atomic():
         for idx, row in enumerate(rows, start=1):
             try:
-                _process_row(row, idx, stats, pendencias, projeto_cache, dry_run)
+                with transaction.atomic():  # savepoint
+                    _process_row(row, idx, stats, pendencias, projeto_cache, dry_run)
             except Exception as e:
                 stats["skipped"]["other"] += 1
                 pendencias["outros"].append(

--- a/v2/backend/apps/core/services/usuarios_import.py
+++ b/v2/backend/apps/core/services/usuarios_import.py
@@ -62,11 +62,14 @@ def import_usuarios_from_file(*, path: str, dry_run: bool = True) -> dict[str, A
     # Carregar arquivo
     rows = _load_file(path)
 
-    # Processar linhas
+    # Processar linhas.
+    # ASQ-016: savepoint-per-row. Outer atomic still owns the dry-run
+    # rollback; inner atomic isolates one bad row from the rest.
     with transaction.atomic():
         for idx, row in enumerate(rows, start=1):
             try:
-                _process_row(row, idx, stats, pendencias, dry_run)
+                with transaction.atomic():  # savepoint
+                    _process_row(row, idx, stats, pendencias, dry_run)
             except Exception as e:
                 stats["skipped"]["other"] += 1
                 pendencias["outros"].append(

--- a/v2/docs/ACID_POLICY.md
+++ b/v2/docs/ACID_POLICY.md
@@ -29,8 +29,7 @@ Formal transactional policy for the critical flows. Tracks issue [#866](https://
 | **OAuth refresh** | `services/oauth/token_manager.py :: refresh_access_token_safe` | Function body | `GoogleOAuthCredential.objects.select_for_update().get(id=...)` + double-check `token_expiry` after lock | Second caller short-circuits if token is still valid | ✅ `@retry_on_deadlock("oauth.refresh_access_token")` |
 | **GCal publish (entry point)** | `services/gcal/sync.py :: apply_one_solicitacao` | Function body wraps DB writes via `s.mark_gcal` / `s.save`; HTTP call to Google happens outside the tx | Caller (Celery task / management command) is responsible for `select_for_update` on the batch; single-item callers use `@retry_on_deadlock` as the safety net | Deterministic event id + payload hash on `Solicitacao`; duplicate dispatches collapse via `client.get(...)` existence check | ✅ `@retry_on_deadlock("gcal.apply_one_solicitacao")` |
 | **GCal low-level upsert** | `services/gcal/sync.py :: upsert_one` | Each `s.save(update_fields=...)` is atomic on its own; HTTP call happens between saves | Caller contract: wrap in `transaction.atomic()` + `select_for_update` for batch sync | Same — event id + hash | Inherits retry via `apply_one_solicitacao`; circuit breaker at HTTP layer (#779) |
-| **Import/ETL** — `bloqueios_import` | `services/bloqueios_import.py :: import_bloqueios_from_file` | Outer `transaction.atomic` for dry-run rollback + **savepoint-per-row** via nested `transaction.atomic` | No explicit row locks — idempotency via uniqueness check before create | One bad row only aborts itself (savepoint); dry-run still discards the whole batch | ❌ Not yet — imports run offline. |
-| **Import/ETL** — *other 10 services* | `services/*_import.py` | One `transaction.atomic` per import call with `set_rollback(dry_run)` | No explicit row locks — idempotency via unique constraints + `external_hash` | Duplicate rows handled by `IntegrityError`; dry-run discards writes | ❌ Not yet — savepoint-per-row rollout planned. |
+| **Import/ETL** — all 10 services | `services/*_import.py` (`bloqueios`, `colecoes`, `controle_acoes`, `dat_cadastros`, `deslocamentos`, `equipe_gerencia`, `eventos`, `municipios`, `produtos`, `usuarios`) | Outer `transaction.atomic` for dry-run rollback + **savepoint-per-row** via nested `transaction.atomic` | No explicit row locks — idempotency via unique constraints + `external_hash` | One bad row only aborts itself (savepoint); dry-run still discards the whole batch | ❌ Not yet — imports run offline. |
 
 ## Lock ordering convention
 
@@ -75,13 +74,12 @@ Structured log events:
 Phase 2 (#866) closed the following:
 
 - ✅ **GCal publish retry** — `apply_one_solicitacao` carries `@retry_on_deadlock`; the caller contract for `upsert_one` is documented.
-- ✅ **Savepoint-per-row in imports** — pilot landed in `bloqueios_import`; the other 10 import services follow the same template.
+- ✅ **Savepoint-per-row in imports** — rolled out to all 10 import services (bloqueios, colecoes, controle_acoes, dat_cadastros, deslocamentos, equipe_gerencia, eventos, municipios, produtos, usuarios).
 - ✅ **Concurrency regression tests** — race coverage added for OAuth refresh, GCal publish, and import savepoint behavior in `test_concurrency_regressions_asq016.py`.
 - ✅ **Runbook** — see [`RUNBOOK_concurrency.md`](RUNBOOK_concurrency.md).
 
 Still open, deliberately out of scope:
 
-- **Savepoint rollout** to the 10 remaining import services (colecoes, eventos, dat_cadastros, deslocamentos, equipe_gerencia, produtos, municipios, usuarios, controle_acoes). Template in `bloqueios_import` is ready; propagation is mechanical.
 - **"Count only transient errors" filter** on the GCal circuit breaker (tracked in #779 notes).
 - **Distributed tracing span** for each retry attempt — today we have structured logs but no trace context.
 

--- a/v2/docs/RUNBOOK_concurrency.md
+++ b/v2/docs/RUNBOOK_concurrency.md
@@ -48,13 +48,21 @@ Symptoms: `Solicitacao.gcal_status = PUBLISHED` but `external_event_id = NULL`, 
 3. As a safety net, `apply_one_solicitacao` is decorated with `@retry_on_deadlock`. A torn state should not be possible from a single dispatch — it requires two parallel dispatches.
 4. Recover: either wait for the circuit-breaker retry task to re-sync, or manually re-apply via the Django admin action.
 
-## Triage — "import took 30 min and then rolled everything back"
+## Triage — "import took 30 min and then only some rows were saved"
 
-This is the shape that savepoint-per-item solves, but only `bloqueios_import.py` has it enabled right now. For the other imports:
-1. Find the row that failed in the `pendencias.outros` array of the response.
-2. Fix the row or mark it to skip.
-3. Re-run with `dry_run=True` first, then `dry_run=False`.
-4. File a ticket referencing the remaining GAP in `ACID_POLICY.md` so the follow-up PR that widens savepoint coverage gets prioritized for that service.
+All 10 import services now use **savepoint-per-row**, so a single bad row
+aborts its own insert/update only — the outer `transaction.atomic()` still
+commits the valid rows (or rolls the whole file back if `dry_run=True`).
+If you see an import finish with fewer rows persisted than expected:
+1. The rejected rows are reported in `pendencias.*` sections of the response
+   (`usuarios`, `dates`, `outros`, etc.). Each entry carries `linha` and
+   `erro`.
+2. Fix the offending rows in the source file and re-run — re-importing the
+   same valid rows is idempotent (unique constraints / `external_hash`
+   dedupe).
+3. If you see an IntegrityError *inside* the savepoint that looks like a
+   constraint change (e.g. a new `NOT NULL` after a migration), that is a
+   schema regression, not a data issue — open an incident.
 
 ## Escalation
 


### PR DESCRIPTION
## Summary
Closes the savepoint rollout TODO that `ACID_POLICY.md` and `RUNBOOK_concurrency.md` flagged as the remaining gap after ASQ-016 phase 2 (#1157). The pilot in `bloqueios_import` (#1157) now has parity in the other nine import services.

## Services updated

| Service | Pattern |
|---|---|
| colecoes_import | `with transaction.atomic():` (outer) + `with transaction.atomic():  # savepoint` (per-row) |
| controle_acoes_import | same |
| dat_cadastros_import | same |
| deslocamentos_import | same |
| equipe_gerencia_import | same |
| eventos_import | same |
| municipios_import | same |
| produtos_import | same |
| usuarios_import | same |

Each `import_*_from_file` now wraps `_process_row(...)` in a nested `transaction.atomic()` (savepoint), so a single row that trips an `IntegrityError` or raises from a helper aborts its own insert/update only — the other valid rows commit. The outer atomic still owns the dry-run `set_rollback(True)` behavior.

## Behavior change (strictly an improvement)

- **Before**: one bad row → the entire import file rolled back; the operator had to find and fix the row before anything persisted.
- **After**: one bad row → reported in `pendencias`, valid rows persist; the operator fixes the bad rows and re-imports. Re-import of previously-valid rows is already idempotent (uniqueness checks / `external_hash`).

## Docs updated

- `ACID_POLICY.md`: matrix collapsed to a single row "all 10 import services"; gap list no longer mentions the savepoint rollout.
- `RUNBOOK_concurrency.md`: the "import took 30 min and rolled everything back" triage section rewritten for the post-rollout behavior.

## Test plan
- [x] `pytest apps/core/tests/` — **1588 passed**, 22 skipped (same as main)
- [x] `pytest -k 'import or bloqueio'` — 202/202 pass
- [x] `black --check` + `isort --check-only` + `flake8` on all 10 import services — clean
- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

```
ALL 8 CHECKS PASSED
```

## Staging Gate
- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR