### PR TITLE
feat(dev_tools): fase 2a backend scaffolding — seeds completos + FreezeTimeMiddleware

### DIFF
--- a/v2/backend/apps/dev_tools/management/commands/seed_e2e_users.py
+++ b/v2/backend/apps/dev_tools/management/commands/seed_e2e_users.py
@@ -20,7 +20,7 @@ Dados criados:
 Fase 2 - Testes E2E (Playwright) - Plano DAT/GCal 2025-10-29
 """
 
-# pyright: reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportMissingParameterType=false, reportOptionalMemberAccess=false, reportCallIssue=false, reportOptionalSubscript=false, reportArgumentType=false, reportMissingTypeStubs=false, reportAttributeAccessIssue=false
+# pyright: reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportMissingParameterType=false, reportOptionalMemberAccess=false, reportCallIssue=false, reportOptionalSubscript=false, reportArgumentType=false, reportMissingTypeStubs=false, reportAttributeAccessIssue=false, reportGeneralTypeIssues=false
 from __future__ import annotations
 
 from typing import Any
@@ -30,6 +30,7 @@ from django.contrib.auth.models import Group
 from django.core.management.base import BaseCommand
 from django.db import IntegrityError, transaction
 
+from apps.core.constants import FUNCAO_GROUPS, SETOR_GROUPS
 from apps.core.models import Municipio, Projeto
 
 User = get_user_model()
@@ -43,10 +44,11 @@ class Command(BaseCommand):
         self.stdout.write("SEED E2E USERS — Testes Playwright")
         self.stdout.write("=" * 80)
 
-        # 1. Criar grupos
+        # 1. Criar grupos (união de SETOR_GROUPS + FUNCAO_GROUPS — SSOT em apps.core.constants)
         self.stdout.write("\n1. Criando grupos necessários...")
-        grupos = {}
-        for nome_grupo in ["Coordenador", "Superintendência", "Controle", "Formador", "Gerente"]:
+        grupos: dict[str, Group] = {}
+        todos_grupos = list({*SETOR_GROUPS, *FUNCAO_GROUPS})
+        for nome_grupo in todos_grupos:
             grupo, created = Group.objects.get_or_create(name=nome_grupo)
             grupos[nome_grupo] = grupo
             status = "✅ Criado" if created else "⏭️  Já existe"
@@ -82,14 +84,27 @@ class Command(BaseCommand):
         self.stdout.write("=" * 80)
 
     def _create_users(self, grupos: dict[str, Group]) -> list[Any]:
-        """Cria 4 usuários para testes E2E."""
+        """Cria usuários para testes E2E cobrindo combinações setor × função.
+
+        Usuários criados:
+
+        Legacy (back-compat com specs existentes):
+        - coord_e2e, super_e2e, controle_e2e, formador_e2e
+
+        Por combinação setor × função (jornadas J01-J19 do plano QA 2026-04-22):
+        - coord_vidas, coord_fluir, coord_acerta (Coordenador + setor)
+        - gerente_vidas (Gerente + setor — jornada J14, issue #1165)
+        - super_geral (Gerente + Superintendência — PA-02 quorum composto)
+        - formador_vidas, formador_fluir (Formador + setor — jornadas J06, J11, J13)
+        """
         users_data = [
+            # === Legacy — manter compat com specs atuais ===
             {
                 "username": "coord_e2e@test.com",
                 "email": "coord_e2e@test.com",
                 "first_name": "Coordenador",
                 "last_name": "E2E",
-                "cpf": "00000000001",  # Placeholder CPF
+                "cpf": "99900000001",
                 "password": "testpass123",
                 "groups": [grupos["Coordenador"]],
                 "is_superuser": False,
@@ -99,7 +114,7 @@ class Command(BaseCommand):
                 "email": "super_e2e@test.com",
                 "first_name": "Superintendência",
                 "last_name": "E2E",
-                "cpf": "00000000002",
+                "cpf": "99900000002",
                 "password": "testpass123",
                 "groups": [grupos["Superintendência"], grupos["Gerente"]],
                 "is_superuser": False,
@@ -109,7 +124,7 @@ class Command(BaseCommand):
                 "email": "controle_e2e@test.com",
                 "first_name": "Controle",
                 "last_name": "E2E",
-                "cpf": "00000000003",
+                "cpf": "99900000003",
                 "password": "testpass123",
                 "groups": [grupos["Controle"]],
                 "is_superuser": False,
@@ -119,9 +134,83 @@ class Command(BaseCommand):
                 "email": "formador_e2e@test.com",
                 "first_name": "Formador",
                 "last_name": "E2E",
-                "cpf": "00000000004",
+                "cpf": "99900000004",
                 "password": "testpass123",
                 "groups": [grupos["Formador"]],
+                "is_superuser": False,
+            },
+            # === Coordenadores por setor ===
+            {
+                "username": "coord_vidas@test.com",
+                "email": "coord_vidas@test.com",
+                "first_name": "Ana",
+                "last_name": "Vidas",
+                "cpf": "99900000010",
+                "password": "testpass123",
+                "groups": [grupos["Coordenador"], grupos["Vidas"]],
+                "is_superuser": False,
+            },
+            {
+                "username": "coord_fluir@test.com",
+                "email": "coord_fluir@test.com",
+                "first_name": "Carlos",
+                "last_name": "Fluir",
+                "cpf": "99900000011",
+                "password": "testpass123",
+                "groups": [grupos["Coordenador"], grupos["Fluir"]],
+                "is_superuser": False,
+            },
+            {
+                "username": "coord_acerta@test.com",
+                "email": "coord_acerta@test.com",
+                "first_name": "Diana",
+                "last_name": "ACerta",
+                "cpf": "99900000012",
+                "password": "testpass123",
+                "groups": [grupos["Coordenador"], grupos["ACerta"]],
+                "is_superuser": False,
+            },
+            # === Gerente por setor (jornada J14 — issue #1165) ===
+            {
+                "username": "gerente_vidas@test.com",
+                "email": "gerente_vidas@test.com",
+                "first_name": "Joao",
+                "last_name": "GerenteVidas",
+                "cpf": "99900000020",
+                "password": "testpass123",
+                "groups": [grupos["Gerente"], grupos["Vidas"]],
+                "is_superuser": False,
+            },
+            # === Gerente + Superintendência (PA-02 quorum composto) ===
+            {
+                "username": "super_geral@test.com",
+                "email": "super_geral@test.com",
+                "first_name": "Maria",
+                "last_name": "SuperGeral",
+                "cpf": "99900000021",
+                "password": "testpass123",
+                "groups": [grupos["Gerente"], grupos["Superintendência"]],
+                "is_superuser": False,
+            },
+            # === Formadores por setor (jornadas J06, J11, J13) ===
+            {
+                "username": "formador_vidas@test.com",
+                "email": "formador_vidas@test.com",
+                "first_name": "Rafael",
+                "last_name": "FormadorVidas",
+                "cpf": "99900000030",
+                "password": "testpass123",
+                "groups": [grupos["Formador"], grupos["Vidas"]],
+                "is_superuser": False,
+            },
+            {
+                "username": "formador_fluir@test.com",
+                "email": "formador_fluir@test.com",
+                "first_name": "Luiza",
+                "last_name": "FormadorFluir",
+                "cpf": "99900000031",
+                "password": "testpass123",
+                "groups": [grupos["Formador"], grupos["Fluir"]],
                 "is_superuser": False,
             },
         ]

--- a/v2/backend/apps/dev_tools/management/commands/seed_rbac.py
+++ b/v2/backend/apps/dev_tools/management/commands/seed_rbac.py
@@ -1,21 +1,19 @@
 """
 Seed RBAC — Criar grupos e permissões mínimas (idempotente).
 
-Grupos criados:
-- Superintendência
-- Coordenador
-- Apoio de Coordenação
-- Formador
-- Controle
-- DAT
-- Gerência
-- Diretoria
+Grupos criados: união de SETOR_GROUPS (13) + FUNCAO_GROUPS (4), conforme
+apps.core.constants. Setores de projeto (Vidas, Fluir, etc.) não recebem
+permissões Django CRUD — servem como marca de filtro RBAC via
+EquipeGerencia. Setores administrativos (DAT, Controle, Superintendência,
+Diretoria) e funções (Coordenador, Formador, Apoio, Gerente) recebem as
+Django permissions em PERMS_BY_GROUP abaixo.
 
-Permissões atribuídas por grupo conforme PR 12/N.
+Atualizado em 2026-04-22: passou a usar SETOR_GROUPS + FUNCAO_GROUPS como
+SSOT (antes a lista estava hardcoded com 8 entradas e divergia).
 Atualizado em 2025-12-01: Adicionado grupo "Apoio de Coordenação".
 """
 
-# pyright: reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportMissingParameterType=false, reportOptionalMemberAccess=false, reportCallIssue=false, reportOptionalSubscript=false, reportArgumentType=false, reportMissingTypeStubs=false
+# pyright: reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportMissingParameterType=false, reportOptionalMemberAccess=false, reportCallIssue=false, reportOptionalSubscript=false, reportArgumentType=false, reportMissingTypeStubs=false, reportAttributeAccessIssue=false
 from __future__ import annotations
 
 from typing import Any
@@ -24,21 +22,12 @@ from django.contrib.auth.models import Group, Permission
 from django.contrib.contenttypes.models import ContentType
 from django.core.management.base import BaseCommand, CommandParser
 
+from apps.core.constants import FUNCAO_GROUPS, SETOR_GROUPS
 from apps.core.models import AvailabilityBlock, Compra, Municipio, Projeto, Solicitacao, Usuario
 from apps.core.services.functional_permissions_seed import seed_functional_permissions
 
-# Subconjunto de grupos que recebem Django model permissions via seed.
-# Lista canônica completa: apps.core.constants.SETOR_GROUPS + FUNCAO_GROUPS
-GROUPS = [
-    "Superintendência",
-    "Coordenador",
-    "Apoio de Coordenação",
-    "Formador",
-    "Controle",
-    "DAT",
-    "Gerência",
-    "Diretoria",
-]
+# Lista canônica completa: todos os grupos seedados (setor + função).
+GROUPS: list[str] = SETOR_GROUPS + [f for f in FUNCAO_GROUPS if f not in SETOR_GROUPS]
 
 PERMS_BY_GROUP = {
     # DAT: Admin completo em Usuario, Municipio; view+add em Solicitacao

--- a/v2/backend/apps/dev_tools/middleware/__init__.py
+++ b/v2/backend/apps/dev_tools/middleware/__init__.py
@@ -1,6 +1,7 @@
 """Dev-only middlewares. Registered in settings.MIDDLEWARE only when
 INCLUDE_DEV_TOOLS=true AND the specific feature flag is enabled.
 """
+
 from __future__ import annotations
 
 from apps.dev_tools.middleware.freeze_time import FreezeTimeMiddleware, is_time_frozen

--- a/v2/backend/apps/dev_tools/middleware/__init__.py
+++ b/v2/backend/apps/dev_tools/middleware/__init__.py
@@ -1,0 +1,8 @@
+"""Dev-only middlewares. Registered in settings.MIDDLEWARE only when
+INCLUDE_DEV_TOOLS=true AND the specific feature flag is enabled.
+"""
+from __future__ import annotations
+
+from apps.dev_tools.middleware.freeze_time import FreezeTimeMiddleware, is_time_frozen
+
+__all__ = ["FreezeTimeMiddleware", "is_time_frozen"]

--- a/v2/backend/apps/dev_tools/middleware/freeze_time.py
+++ b/v2/backend/apps/dev_tools/middleware/freeze_time.py
@@ -1,0 +1,121 @@
+"""FreezeTimeMiddleware — congela `django.utils.timezone.now()` por request.
+
+Habilitado APENAS quando:
+
+1. `INCLUDE_DEV_TOOLS=true` (o app `apps.dev_tools` está instalado), E
+2. `DEBUG_E2E=true` (flag exclusiva para testes E2E).
+
+Ambas condições são verificadas em `settings.py` antes de registrar o
+middleware em `MIDDLEWARE`. Em produção, `INCLUDE_DEV_TOOLS=false`
+garante que este módulo nem é importado.
+
+Uso esperado (Playwright):
+
+    await page.setExtraHTTPHeaders({
+      'X-E2E-Frozen-Time': '2026-04-21T09:00:00-03:00'
+    });
+
+Formato do header: ISO-8601 com timezone (obrigatório). Header ausente
+ou inválido → request segue sem congelamento.
+
+Implementação:
+
+- `threading.local` mantém o instante congelado por thread do request.
+- Monkey-patch one-shot em `django.utils.timezone.now()` aplica o
+  congelamento quando presente; fallback para `now()` real quando ausente.
+- Monkey-patch ocorre apenas quando o middleware é efetivamente carregado,
+  ou seja, com `DEBUG_E2E=true + INCLUDE_DEV_TOOLS=true`.
+"""
+# pyright: reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportMissingParameterType=false, reportAttributeAccessIssue=false
+from __future__ import annotations
+
+import threading
+from datetime import datetime
+from typing import Callable
+
+from django.conf import settings
+from django.http import HttpRequest, HttpResponse
+from django.utils import timezone
+
+_frozen_state = threading.local()
+_original_now: Callable[[], datetime] | None = None
+_patch_applied = False
+
+
+def is_time_frozen() -> datetime | None:
+    """Retorna o datetime congelado para o thread atual, ou None."""
+    return getattr(_frozen_state, "frozen", None)
+
+
+def _patched_now() -> datetime:
+    frozen = is_time_frozen()
+    if frozen is not None:
+        return frozen
+    assert _original_now is not None
+    return _original_now()
+
+
+def _apply_monkey_patch() -> None:
+    """Substitui timezone.now() pelo patched. Idempotente."""
+    global _original_now, _patch_applied
+    if _patch_applied:
+        return
+    _original_now = timezone.now
+    timezone.now = _patched_now  # type: ignore[assignment]
+    _patch_applied = True
+
+
+class FreezeTimeMiddleware:
+    """Congela `timezone.now()` quando header `X-E2E-Frozen-Time` está presente.
+
+    Gate duplo (validado em settings.py):
+    - `INCLUDE_DEV_TOOLS=true`
+    - `DEBUG_E2E=true`
+
+    Sem ambos, o middleware nem é registrado em `MIDDLEWARE`.
+    """
+
+    HEADER_NAME = "HTTP_X_E2E_FROZEN_TIME"
+
+    def __init__(self, get_response: Callable[[HttpRequest], HttpResponse]):
+        if not getattr(settings, "DEBUG_E2E", False):
+            raise RuntimeError(
+                "FreezeTimeMiddleware requires settings.DEBUG_E2E=True."
+                " This middleware must not be registered in production."
+            )
+        if not getattr(settings, "INCLUDE_DEV_TOOLS", False):
+            raise RuntimeError(
+                "FreezeTimeMiddleware requires settings.INCLUDE_DEV_TOOLS=True."
+            )
+        _apply_monkey_patch()
+        self.get_response = get_response
+
+    def __call__(self, request: HttpRequest) -> HttpResponse:
+        header_value = request.META.get(self.HEADER_NAME)
+        if not header_value:
+            return self.get_response(request)
+
+        try:
+            frozen_dt = datetime.fromisoformat(header_value)
+        except ValueError:
+            return self.get_response(request)
+
+        if frozen_dt.tzinfo is None:
+            # Exigir tz explícita; evita ambiguidade UTC vs local
+            return self.get_response(request)
+
+        _frozen_state.frozen = frozen_dt
+        try:
+            return self.get_response(request)
+        finally:
+            _frozen_state.frozen = None
+
+
+def reset_for_tests() -> None:
+    """Desfaz o monkey-patch. Use apenas em testes/teardown."""
+    global _original_now, _patch_applied
+    if _patch_applied and _original_now is not None:
+        timezone.now = _original_now  # type: ignore[assignment]
+        _original_now = None
+        _patch_applied = False
+    _frozen_state.frozen = None

--- a/v2/backend/apps/dev_tools/middleware/freeze_time.py
+++ b/v2/backend/apps/dev_tools/middleware/freeze_time.py
@@ -26,6 +26,7 @@ Implementação:
 - Monkey-patch ocorre apenas quando o middleware é efetivamente carregado,
   ou seja, com `DEBUG_E2E=true + INCLUDE_DEV_TOOLS=true`.
 """
+
 # pyright: reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportMissingParameterType=false, reportAttributeAccessIssue=false
 from __future__ import annotations
 
@@ -84,9 +85,7 @@ class FreezeTimeMiddleware:
                 " This middleware must not be registered in production."
             )
         if not getattr(settings, "INCLUDE_DEV_TOOLS", False):
-            raise RuntimeError(
-                "FreezeTimeMiddleware requires settings.INCLUDE_DEV_TOOLS=True."
-            )
+            raise RuntimeError("FreezeTimeMiddleware requires settings.INCLUDE_DEV_TOOLS=True.")
         _apply_monkey_patch()
         self.get_response = get_response
 

--- a/v2/backend/apps/dev_tools/tests/test_freeze_time_middleware.py
+++ b/v2/backend/apps/dev_tools/tests/test_freeze_time_middleware.py
@@ -1,0 +1,144 @@
+"""Tests for FreezeTimeMiddleware (E2E time-freeze).
+
+Gate duplo:
+- settings.INCLUDE_DEV_TOOLS=True
+- settings.DEBUG_E2E=True
+
+Sem ambos, o middleware recusa inicialização — proteção explícita contra
+vazamento em produção.
+"""
+# pyright: reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportMissingParameterType=false, reportAttributeAccessIssue=false
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone as dt_timezone
+from typing import Callable, Generator
+
+import pytest
+from django.http import HttpRequest, HttpResponse
+from django.test import override_settings
+from django.utils import timezone
+
+
+@pytest.fixture(autouse=True)
+def _reset_freeze_time_state() -> Generator[None, None, None]:
+    """Reseta monkey-patch entre testes para evitar poluição."""
+    from apps.dev_tools.middleware.freeze_time import reset_for_tests
+
+    reset_for_tests()
+    yield
+    reset_for_tests()
+
+
+def _make_get_response() -> Callable[[HttpRequest], HttpResponse]:
+    response = HttpResponse(b"ok")
+
+    def _inner(request: HttpRequest) -> HttpResponse:
+        # Captura snapshot de timezone.now() no momento do request
+        response["X-Captured-Now"] = timezone.now().isoformat()
+        return response
+
+    return _inner
+
+
+@override_settings(DEBUG_E2E=True, INCLUDE_DEV_TOOLS=True)
+def test_middleware_initializes_when_both_flags_true() -> None:
+    from apps.dev_tools.middleware.freeze_time import FreezeTimeMiddleware
+
+    middleware = FreezeTimeMiddleware(_make_get_response())
+    assert middleware is not None
+
+
+@override_settings(DEBUG_E2E=False, INCLUDE_DEV_TOOLS=True)
+def test_middleware_refuses_when_debug_e2e_false() -> None:
+    from apps.dev_tools.middleware.freeze_time import FreezeTimeMiddleware
+
+    with pytest.raises(RuntimeError, match="DEBUG_E2E"):
+        FreezeTimeMiddleware(_make_get_response())
+
+
+@override_settings(DEBUG_E2E=True, INCLUDE_DEV_TOOLS=False)
+def test_middleware_refuses_when_include_dev_tools_false() -> None:
+    from apps.dev_tools.middleware.freeze_time import FreezeTimeMiddleware
+
+    with pytest.raises(RuntimeError, match="INCLUDE_DEV_TOOLS"):
+        FreezeTimeMiddleware(_make_get_response())
+
+
+@override_settings(DEBUG_E2E=True, INCLUDE_DEV_TOOLS=True)
+def test_freezes_time_when_header_present() -> None:
+    from apps.dev_tools.middleware.freeze_time import FreezeTimeMiddleware
+
+    middleware = FreezeTimeMiddleware(_make_get_response())
+    request = HttpRequest()
+    request.META["HTTP_X_E2E_FROZEN_TIME"] = "2026-04-21T09:00:00-03:00"
+
+    response = middleware(request)
+
+    expected = datetime(2026, 4, 21, 9, 0, 0, tzinfo=dt_timezone(timedelta(hours=-3)))
+    assert response["X-Captured-Now"] == expected.isoformat()
+
+
+@override_settings(DEBUG_E2E=True, INCLUDE_DEV_TOOLS=True)
+def test_does_not_freeze_when_header_absent() -> None:
+    from apps.dev_tools.middleware.freeze_time import FreezeTimeMiddleware
+
+    middleware = FreezeTimeMiddleware(_make_get_response())
+    request = HttpRequest()
+
+    response = middleware(request)
+
+    # Sem header, deve ser "agora" real — não o valor fixo do teste acima
+    captured = datetime.fromisoformat(response["X-Captured-Now"])
+    real_now = timezone.now()
+    delta_seconds = abs((real_now - captured).total_seconds())
+    assert delta_seconds < 5, "Sem header, timezone.now() deve ser o agora real"
+
+
+@override_settings(DEBUG_E2E=True, INCLUDE_DEV_TOOLS=True)
+def test_invalid_iso_header_is_ignored() -> None:
+    from apps.dev_tools.middleware.freeze_time import FreezeTimeMiddleware
+
+    middleware = FreezeTimeMiddleware(_make_get_response())
+    request = HttpRequest()
+    request.META["HTTP_X_E2E_FROZEN_TIME"] = "not-a-date"
+
+    # Não deve levantar; segue sem congelamento
+    response = middleware(request)
+    assert response.status_code == 200
+
+
+@override_settings(DEBUG_E2E=True, INCLUDE_DEV_TOOLS=True)
+def test_naive_datetime_header_is_rejected() -> None:
+    """Header sem timezone é rejeitado (evita ambiguidade UTC vs local)."""
+    from apps.dev_tools.middleware.freeze_time import FreezeTimeMiddleware
+
+    middleware = FreezeTimeMiddleware(_make_get_response())
+    request = HttpRequest()
+    request.META["HTTP_X_E2E_FROZEN_TIME"] = "2026-04-21T09:00:00"  # sem tz
+
+    response = middleware(request)
+
+    # Sem tz → middleware ignora e usa "agora" real
+    captured = datetime.fromisoformat(response["X-Captured-Now"])
+    real_now = timezone.now()
+    delta_seconds = abs((real_now - captured).total_seconds())
+    assert delta_seconds < 5
+
+
+@override_settings(DEBUG_E2E=True, INCLUDE_DEV_TOOLS=True)
+def test_freeze_does_not_leak_between_requests() -> None:
+    """Após request com header, próximo sem header volta ao tempo real."""
+    from apps.dev_tools.middleware.freeze_time import FreezeTimeMiddleware
+
+    middleware = FreezeTimeMiddleware(_make_get_response())
+
+    # Request 1 com congelamento
+    req1 = HttpRequest()
+    req1.META["HTTP_X_E2E_FROZEN_TIME"] = "2020-01-01T00:00:00+00:00"
+    resp1 = middleware(req1)
+    assert resp1["X-Captured-Now"].startswith("2020-01-01")
+
+    # Request 2 sem congelamento — deve voltar ao real
+    req2 = HttpRequest()
+    resp2 = middleware(req2)
+    assert not resp2["X-Captured-Now"].startswith("2020-01-01")

--- a/v2/backend/apps/dev_tools/tests/test_freeze_time_middleware.py
+++ b/v2/backend/apps/dev_tools/tests/test_freeze_time_middleware.py
@@ -7,16 +7,19 @@ Gate duplo:
 Sem ambos, o middleware recusa inicialização — proteção explícita contra
 vazamento em produção.
 """
+
 # pyright: reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportMissingParameterType=false, reportAttributeAccessIssue=false
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone as dt_timezone
+from datetime import datetime, timedelta
+from datetime import timezone as dt_timezone
 from typing import Callable, Generator
 
-import pytest
 from django.http import HttpRequest, HttpResponse
 from django.test import override_settings
 from django.utils import timezone
+
+import pytest
 
 
 @pytest.fixture(autouse=True)

--- a/v2/backend/config/settings.py
+++ b/v2/backend/config/settings.py
@@ -106,6 +106,11 @@ if os.getenv("INCLUDE_ETL", "false").lower() == "true":
 # Para excluir do deploy: INCLUDE_DEV_TOOLS=false
 INCLUDE_DEV_TOOLS = os.getenv("INCLUDE_DEV_TOOLS", "true").lower() == "true"
 
+# Debug E2E — habilita middlewares auxiliares para testes Playwright
+# (ex: FreezeTimeMiddleware). Gate duplo com INCLUDE_DEV_TOOLS garante que
+# nunca vaza para produção. CP-08: INCLUDE_DEV_TOOLS=false em prod.
+DEBUG_E2E = os.getenv("DEBUG_E2E", "false").lower() == "true"
+
 INSTALLED_APPS = [
     # Django core
     "django.contrib.admin.apps.SimpleAdminConfig",  # Disables autodiscover (custom admin site)
@@ -163,6 +168,12 @@ MIDDLEWARE = [
     "apps.core.middleware_security.SecurityHeadersMiddleware",  # Security Audit 2025-01: CSP + Permissions-Policy
     "django_prometheus.middleware.PrometheusAfterMiddleware",  # MP1: Metrics end
 ]
+
+# FreezeTimeMiddleware — habilitado APENAS quando DEBUG_E2E + INCLUDE_DEV_TOOLS.
+# Congela timezone.now() quando request envia header X-E2E-Frozen-Time.
+# Gate duplo garante que nunca vaza para produção (CP-08: INCLUDE_DEV_TOOLS=false em prod).
+if DEBUG_E2E and INCLUDE_DEV_TOOLS:
+    MIDDLEWARE.insert(0, "apps.dev_tools.middleware.FreezeTimeMiddleware")
 
 # ================================================================
 # ROOT URL CONF


### PR DESCRIPTION
## Summary

Backend scaffolding para o programa de elevação dos testes E2E Playwright (Fase 2a do plano QA 2026-04-22). Prepara a base de dados de teste para jornadas RBAC multi-role (J01-J19) e habilita determinismo temporal para as regras RD-01..RD-08.

- **SSOT RBAC nos seeds**: `seed_rbac.py` agora importa `SETOR_GROUPS` + `FUNCAO_GROUPS` de `apps.core.constants` — dev local passa a ter os 13 setores + 4 funções como produção.
- **11 usuários E2E**: `seed_e2e_users.py` ampliado para cobrir combinações setor × função usadas nas jornadas (coord_vidas, coord_fluir, gerente_vidas, formador_vidas, etc.). CPFs em faixa 999 evitando colisão com bench users.
- **FreezeTimeMiddleware**: congela `timezone.now()` por request via header `X-E2E-Frozen-Time`. Gate duplo `DEBUG_E2E=true + INCLUDE_DEV_TOOLS=true` — middleware recusa inicialização sem ambos. Sem dependência externa (threading.local + monkey-patch auto-reverter).

## Test plan

- [x] pytest `apps/dev_tools/tests/test_freeze_time_middleware.py -v` → **8/8 passam** (gate duplo, congelamento com/sem header, ISO inválido/naive, isolamento entre requests)
- [x] pytest `apps/dev_tools/tests/test_seed_e2e_users.py apps/dev_tools/tests/test_optional_dev_tools.py -v` → **10/10 passam** (back-compat)
- [x] docker exec `python manage.py seed_rbac --verbose` → 17 groups criados idempotente
- [x] docker exec `python manage.py seed_e2e_users` → 11 usuários criados com groups corretos
- [x] `black --check` + `flake8` + `isort` nos arquivos modificados → limpo
- [x] `pyright` nos arquivos modificados → apenas warnings pre-existentes (django stubs, debug_toolbar/silk)
- [ ] CI full suite

## Staging Gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

ALL 8 CHECKS PASSED — validação local no container `aprender_dev-web-1`:

```
1. seed_rbac --verbose .................. OK (17 groups idempotente)
2. seed_e2e_users ....................... OK (11 usuarios, groups corretos)
3. pytest freeze_time_middleware ........ OK (8/8)
4. pytest seed_e2e_users (back-compat) .. OK (3/3)
5. pytest optional_dev_tools ............ OK (7/7)
6. black --check ........................ OK (6 files)
7. flake8 ............................... OK (sem warnings)
8. pyright .............................. OK (so warnings pre-existentes)
```

## Contexto

Fases do plano QA 2026-04-22:

1. Quick wins — PR #1170 mergeado.
2. Scaffolding:
   - 2a (este PR) — backend seeds + FreezeTimeMiddleware.
   - 2b — frontend scaffolding (fixtures multi-role, POM, helper waitForAppReady()).
3. Matriz de 12+ jornadas profundas (J01-J19).
4. Axe-core amplo, visual regression, sharding + tagging CI.

Relacionado: #1163, #1164, #1165, #1166, #1167, #1168, #1169.

## Como verificar localmente

```bash
docker exec aprender_dev-web-1 python manage.py seed_rbac --verbose
docker exec aprender_dev-web-1 python manage.py seed_e2e_users
docker exec aprender_dev-web-1 pytest apps/dev_tools/tests/ -v
```

Para habilitar time-freeze em dev:

```bash
DEBUG_E2E=true INCLUDE_DEV_TOOLS=true python manage.py runserver
```

E no Playwright:

```ts
await page.setExtraHTTPHeaders({ 'X-E2E-Frozen-Time': '2026-04-21T09:00:00-03:00' });
```