### PR TITLE
test(e2e): fase 3 J01 happy path — ambos os fluxos (SUPER + NAO_SUPER)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -602,3 +602,6 @@ nul
 
 # GSD-2 state (local orchestration)
 .gsd/
+
+# RTK (Rust Token Killer) local filters
+.rtk/

--- a/v2/backend/apps/dev_tools/management/commands/seed_e2e_users.py
+++ b/v2/backend/apps/dev_tools/management/commands/seed_e2e_users.py
@@ -62,9 +62,20 @@ class Command(BaseCommand):
         self.stdout.write("\n3. Criando município de teste...")
         municipio = self._create_municipio()
 
-        # 4. Criar projeto
-        self.stdout.write("\n4. Criando projeto de teste...")
-        projeto = self._create_projeto(municipio)
+        # 4. Criar projetos (SUPER e NAO_SUPER para cobrir ambos os fluxos em E2E)
+        self.stdout.write("\n4. Criando projetos de teste...")
+        projeto_super = self._upsert_projeto(
+            codigo="E2E",
+            nome="TESTE E2E",
+            fluxo="SUPER",
+            gerencia_setor=None,
+        )
+        projeto_nao_super = self._upsert_projeto(
+            codigo="E2E_NS",
+            nome="TESTE E2E NAO_SUPER",
+            fluxo="NAO_SUPER",
+            gerencia_setor="Vidas",
+        )
 
         # 5. Resumo
         self.stdout.write("\n" + "=" * 80)
@@ -72,7 +83,8 @@ class Command(BaseCommand):
         self.stdout.write("\n📋 Resumo:")
         self.stdout.write(f"   Usuários criados: {len(usuarios)}")
         self.stdout.write(f"   Município: {municipio.nome} ({municipio.uf})")
-        self.stdout.write(f"   Projeto: {projeto.nome} (fluxo: {projeto.fluxo})")
+        self.stdout.write(f"   Projeto SUPER: {projeto_super.nome} (fluxo: {projeto_super.fluxo})")
+        self.stdout.write(f"   Projeto NAO_SUPER: {projeto_nao_super.nome} (fluxo: {projeto_nao_super.fluxo})")
         self.stdout.write("\n🔑 Credenciais (todas com senha: testpass123):")
         for usuario in usuarios:
             grupos_str = ", ".join([g.name for g in usuario.groups.all()])
@@ -310,32 +322,59 @@ class Command(BaseCommand):
         self.stdout.write(f"   ✅ Criado: {municipio.nome} ({municipio.uf})")
         return municipio
 
-    def _create_projeto(self, municipio: Municipio) -> Projeto:
-        """Cria projeto para testes E2E."""
-        target_codigo = "E2E"
-        target_nome = "TESTE E2E"
-        target_fluxo = "SUPER"
+    def _upsert_projeto(
+        self,
+        *,
+        codigo: str,
+        nome: str,
+        fluxo: str,
+        gerencia_setor: str | None = None,
+    ) -> Projeto:
+        """Upsert idempotente de projeto para testes E2E.
 
-        projeto = Projeto.objects.filter(codigo=target_codigo).first()
+        Quando `gerencia_setor` é passado, vincula o projeto à primeira
+        `Gerencia` com `nome_setor` correspondente. Se a gerência não existir
+        (seed dev local incompleto), o projeto é criado sem vínculo.
+        """
+        gerencia = None
+        if gerencia_setor:
+            from django.core.management import call_command
+
+            from apps.core.models import Gerencia
+
+            gerencia = Gerencia.objects.filter(nome_setor=gerencia_setor, ativo=True).first()
+            if not gerencia:
+                # Fallback idempotente: roda seed_gerencias para garantir que a
+                # gerência exista. Evita exigir ordem manual dos seeds em dev.
+                self.stdout.write(
+                    f"   ⚠️  Gerência '{gerencia_setor}' ausente — rodando seed_gerencias automaticamente..."
+                )
+                call_command("seed_gerencias", verbosity=0)
+                gerencia = Gerencia.objects.filter(nome_setor=gerencia_setor, ativo=True).first()
+
+        projeto = Projeto.objects.filter(codigo=codigo).first()
         if not projeto:
-            projeto = Projeto.objects.filter(nome=target_nome).first()
+            projeto = Projeto.objects.filter(nome=nome).first()
 
         if projeto:
-            updated_fields = []
+            updated_fields: list[str] = []
             original_codigo = projeto.codigo
 
-            if projeto.nome != target_nome:
-                projeto.nome = target_nome
+            if projeto.nome != nome:
+                projeto.nome = nome
                 updated_fields.append("nome")
-            if projeto.fluxo != target_fluxo:
-                projeto.fluxo = target_fluxo
+            if projeto.fluxo != fluxo:
+                projeto.fluxo = fluxo
                 updated_fields.append("fluxo")
             if not projeto.ativo:
                 projeto.ativo = True
                 updated_fields.append("ativo")
-            if projeto.codigo != target_codigo:
-                projeto.codigo = target_codigo
+            if projeto.codigo != codigo:
+                projeto.codigo = codigo
                 updated_fields.append("codigo")
+            if gerencia and projeto.gerencia_id != gerencia.id:
+                projeto.gerencia = gerencia
+                updated_fields.append("gerencia")
 
             if updated_fields:
                 try:
@@ -350,7 +389,7 @@ class Command(BaseCommand):
                         with transaction.atomic():
                             projeto.save(update_fields=retry_fields)
                     self.stdout.write(
-                        "   ⚠️  Código E2E já está em uso por outro projeto. "
+                        f"   ⚠️  Código {codigo} já está em uso por outro projeto. "
                         "Mantendo o código atual do projeto existente."
                     )
 
@@ -360,17 +399,20 @@ class Command(BaseCommand):
         try:
             with transaction.atomic():
                 projeto = Projeto.objects.create(
-                    codigo=target_codigo,
-                    nome=target_nome,
-                    fluxo=target_fluxo,
+                    codigo=codigo,
+                    nome=nome,
+                    fluxo=fluxo,
+                    gerencia=gerencia,
                     ativo=True,
                 )
         except IntegrityError:
-            projeto = Projeto.objects.filter(nome=target_nome).first() or Projeto.objects.get(codigo=target_codigo)
-            projeto.fluxo = target_fluxo
+            projeto = Projeto.objects.filter(nome=nome).first() or Projeto.objects.get(codigo=codigo)
+            projeto.fluxo = fluxo
             projeto.ativo = True
+            if gerencia and projeto.gerencia_id != gerencia.id:
+                projeto.gerencia = gerencia
             with transaction.atomic():
-                projeto.save(update_fields=["fluxo", "ativo"])
+                projeto.save(update_fields=["fluxo", "ativo", "gerencia"])
             self.stdout.write(f"   ⏭️  Já existe: {projeto.nome} (fluxo: {projeto.fluxo})")
             return projeto
 

--- a/v2/frontend/e2e/fixtures/index.ts
+++ b/v2/frontend/e2e/fixtures/index.ts
@@ -20,6 +20,7 @@ export {
 } from './seed';
 export type {
   ApiContextOptions,
+  ProjetoFluxo,
   SeedSolicitacaoInput,
   SeededSolicitacao,
 } from './seed';

--- a/v2/frontend/e2e/fixtures/seed.ts
+++ b/v2/frontend/e2e/fixtures/seed.ts
@@ -50,9 +50,20 @@ export async function createApiContext(options: ApiContextOptions): Promise<APIR
  * defaults que correspondem ao projeto "TESTE E2E" seedado por
  * `seed_e2e_users.py`.
  */
+/** Fluxo do projeto — define status inicial. */
+export type ProjetoFluxo = 'SUPER' | 'NAO_SUPER';
+
 export interface SeedSolicitacaoInput {
-  /** ID do projeto. Default: busca projeto "TESTE E2E" via API. */
+  /**
+   * ID do projeto. Default: resolve por `fluxo` — `SUPER` → "TESTE E2E",
+   * `NAO_SUPER` → "TESTE E2E NAO_SUPER".
+   */
   projetoId?: number;
+  /**
+   * Fluxo a usar quando `projetoId` não é passado. Default: `SUPER`.
+   * `NAO_SUPER` usa o projeto vinculado à gerência Vidas (auto-aprovado na criação).
+   */
+  fluxo?: ProjetoFluxo;
   /** ID do município. Default: busca "Salvador" via API. */
   municipioId?: number;
   /** ID do tipo de evento. Default: primeiro tipo ativo. */
@@ -82,7 +93,8 @@ export async function seedSolicitacao(
   api: APIRequestContext,
   input: SeedSolicitacaoInput = {}
 ): Promise<SeededSolicitacao> {
-  const projetoId = input.projetoId ?? (await findProjetoId(api, 'TESTE E2E'));
+  const projetoNome = input.fluxo === 'NAO_SUPER' ? 'TESTE E2E NAO_SUPER' : 'TESTE E2E';
+  const projetoId = input.projetoId ?? (await findProjetoId(api, projetoNome));
   const municipioId = input.municipioId ?? (await findMunicipioId(api, 'Salvador'));
   const tipoEventoId = input.tipoEventoId ?? (await findFirstTipoEventoId(api));
 
@@ -119,11 +131,14 @@ export async function seedSolicitacao(
 async function findProjetoId(api: APIRequestContext, nome: string): Promise<number> {
   const res = await api.get(`/api/lookup/projetos/?q=${encodeURIComponent(nome)}`);
   expect(res.ok(), `[seed] lookup projetos falhou (${res.status()})`).toBeTruthy();
-  const data = (await res.json()) as { results?: Array<{ id: number; nome: string }> } | Array<{ id: number; nome: string }>;
-  const list = Array.isArray(data) ? data : data.results ?? [];
-  const match = list.find((p) => p.nome === nome) ?? list[0];
-  expect(match, `[seed] projeto "${nome}" nao encontrado`).toBeTruthy();
-  return match!.id;
+  const data = (await res.json()) as
+    | { results?: Array<{ id: number; nome: string }> }
+    | Array<{ id: number; nome: string }>;
+  const list = Array.isArray(data) ? data : (data.results ?? []);
+  // Match exato por nome; fallback no primeiro — mas aviso se desambiguou assim.
+  const exact = list.find((p) => p.nome === nome);
+  expect(exact, `[seed] projeto "${nome}" nao encontrado (rode manage.py seed_e2e_users)`).toBeTruthy();
+  return exact!.id;
 }
 
 async function findMunicipioId(api: APIRequestContext, nome: string): Promise<number> {

--- a/v2/frontend/e2e/journeys/README.md
+++ b/v2/frontend/e2e/journeys/README.md
@@ -1,0 +1,41 @@
+# Matriz de Jornadas E2E
+
+Fase 3 do plano QA 2026-04-22. Cada jornada testa um fluxo ponta a ponta
+em três camadas de asserção:
+
+1. **Canônica** — regra do domínio, caminho feliz.
+2. **Borda** — valor limite / idempotência / conflito.
+3. **Operação** — reflexo observável em outra tela/endpoint (triangulação).
+
+## Convenções
+
+- Um arquivo por jornada: `j{NN}-{slug}.spec.ts`.
+- Tags `@critical`, `@rbac`, `@rd-XX`, `@pa-XX`, etc. em `test(...)`.
+- Seed via API (fixture `seedSolicitacao`), nunca via wizard — wizard é o
+  objeto de teste em jornadas específicas (ex: J02).
+- `test.fail()` quando a jornada está bloqueada por issue conhecida. Retirar
+  a marca quando a issue for resolvida.
+
+## Matriz atual
+
+| ID | Jornada | Tags | Status | Depende de |
+|----|---------|------|--------|-----------|
+| J01 | Happy path: coord cria → super aprova | `@critical @rf01 @pa-02` | ✅ | — |
+| J02 | Wizard bloqueia submit com campo obrigatório vazio | `@ux @rf01` | ⏳ | — |
+| J03 | Conflito RD-06 (deslocamento inviável) | `@critical @rd-06` | ⏳ | time-freeze |
+| J04 | Reprovação com motivo obrigatório (PA-04) | `@pa-04` | ⏳ | — |
+| J05 | Visão individual vs setor (/solicitacoes vs /disponibilidade) | `@critical @rbac` | ⏳ | — |
+| J06 | Formador fora de janela → RD-01 | `@critical @rd-01` | ⏳ | time-freeze |
+| J07 | Bloqueio pontual impede RD-04 | `@rd-04` | ⏳ | — |
+| J08 | Aprovação concorrente (dois super) | `@race @pa-07` | ⏳ | — |
+| J09 | Cancelamento pós-publicação re-sincroniza GCal | `@rf07` | ⏳ | GCal client |
+| J10 | Coord tenta aprovar própria solicitação → 403 | `@rbac @pa-02` | ⏳ | — |
+| J11 | E-mail ao formador após aprovação | `@rf-email` | ⏳ | SMTP mock |
+| J12 | Dashboard Compras reflete criação em <3s | `@perf @dashboards` | ⏳ | — |
+| J13 | Formador escalado vê em "Minhas Formações" | `@rf-minhas` | 🚫 `test.fail` | #1163 |
+| J14 | Gerente cria solicitação com setor auto | `@rbac @gerente` | 🚫 `test.fail` | #1165 |
+| J15 | Formador chama `/api/metrics/team/*` → 403 | `@rbac @dashboards` | 🚫 `test.fail` | #1166 |
+| J16 | Formador chama `/api/gcal/dashboard/*` → 403 | `@rbac @dashboards` | 🚫 `test.fail` | #1166 |
+| J17 | Formador digita `/bloqueios` → rota bloqueia antes de render | `@rbac` | 🚫 `test.fail` | #1168 |
+| J18 | DAT puro navega em todos os menus sem 403 | `@rbac @dat` | ⏳ | — |
+| J19 | HomeStats `upcoming_events` não vaza entre setores | `@rbac @home` | 🚫 `test.fail` | #1167 |

--- a/v2/frontend/e2e/journeys/README.md
+++ b/v2/frontend/e2e/journeys/README.md
@@ -18,9 +18,15 @@ em três camadas de asserção:
 
 ## Matriz atual
 
+**Observação sobre 2 fluxos de aprovação**: projetos têm `fluxo` SUPER ou NAO_SUPER
+([`solicitacao_create.py`](../../../backend/apps/core/services/solicitacao_create.py)).
+SUPER requer aprovação manual (PA-02); NAO_SUPER é auto-aprovado na criação.
+Jornadas que dependem de aprovação têm duas variantes (J01a/J01b).
+
 | ID | Jornada | Tags | Status | Depende de |
 |----|---------|------|--------|-----------|
-| J01 | Happy path: coord cria → super aprova | `@critical @rf01 @pa-02` | ✅ | — |
+| J01a | SUPER happy path: coord cria → super aprova | `@critical @rf01 @pa-02 @fluxo-super` | ✅ | — |
+| J01b | NAO_SUPER happy path: coord cria → auto-aprovado | `@critical @rf01 @fluxo-nao-super` | ✅ | — |
 | J02 | Wizard bloqueia submit com campo obrigatório vazio | `@ux @rf01` | ⏳ | — |
 | J03 | Conflito RD-06 (deslocamento inviável) | `@critical @rd-06` | ⏳ | time-freeze |
 | J04 | Reprovação com motivo obrigatório (PA-04) | `@pa-04` | ⏳ | — |

--- a/v2/frontend/e2e/journeys/j01-happy-path.spec.ts
+++ b/v2/frontend/e2e/journeys/j01-happy-path.spec.ts
@@ -1,0 +1,116 @@
+/**
+ * J01 — Happy path: coord cria solicitação → super aprova.
+ *
+ * Ref: Matriz de jornadas E2E (Fase 3 do plano QA 2026-04-22).
+ * Regras: RF01 (criar solicitação), PA-02 (Superintendência aprova).
+ *
+ * Três camadas de asserção:
+ *
+ * 1. **Canônica**: coord cria solicitação via API → fica `pendente` →
+ *    super_geral abre /aprovacoes, clica "Aprovar" → status vira `aprovado`.
+ *
+ * 2. **Borda (idempotência)**: tentar aprovar a mesma solicitação duas vezes
+ *    → segunda chamada retorna 400 com `code=already_approved`.
+ *
+ * 3. **Operação**: após aprovação, coord vê a mesma solicitação com status
+ *    "aprovado" em /solicitacoes/minhas (reflexo cruzado entre telas).
+ */
+import { test, expect, createApiContext, seedSolicitacao, ROLE_CREDENTIALS } from '../fixtures';
+import { waitForRouteReady } from '../helpers/wait';
+import { AprovacoesPage } from '../pages/AprovacoesPage';
+
+test.describe('J01 — Happy path: coord cria → super aprova', { tag: ['@critical', '@rf01', '@pa-02'] }, () => {
+  test('canônica: pendente → aprovada via UI de Aprovações', async ({ authedPage, baseURL }) => {
+    // Arrange: coord cria via API (sidecar, mais rápido que wizard)
+    const coordApi = await createApiContext({
+      baseURL: baseURL!,
+      username: ROLE_CREDENTIALS.coord_vidas.username,
+      password: ROLE_CREDENTIALS.coord_vidas.password,
+    });
+    const solicitacao = await seedSolicitacao(coordApi);
+    expect(solicitacao.status).toBe('pendente');
+
+    // Act: super_geral aprova via UI
+    const pageSuper = await authedPage('super_geral');
+    const aprovacoes = new AprovacoesPage(pageSuper);
+    await aprovacoes.goto();
+    await expect(aprovacoes.tabelaPendentes).toBeVisible();
+
+    await aprovacoes.btnAprovar(solicitacao.id).click();
+
+    // Assert canônica: status aprovado via API (evita flake de UI refresh)
+    const superApi = await createApiContext({
+      baseURL: baseURL!,
+      username: ROLE_CREDENTIALS.super_geral.username,
+      password: ROLE_CREDENTIALS.super_geral.password,
+    });
+    await expect
+      .poll(
+        async () => {
+          const res = await superApi.get(`/api/solicitacoes/${solicitacao.id}/`);
+          if (!res.ok()) return null;
+          const body = (await res.json()) as { status: string };
+          return body.status;
+        },
+        { timeout: 10_000, message: 'status deveria virar "aprovado" após click Aprovar' }
+      )
+      .toBe('aprovado');
+  });
+
+  test('borda: segunda tentativa de aprovar retorna already_approved', async ({ baseURL }) => {
+    const coordApi = await createApiContext({
+      baseURL: baseURL!,
+      username: ROLE_CREDENTIALS.coord_vidas.username,
+      password: ROLE_CREDENTIALS.coord_vidas.password,
+    });
+    const solicitacao = await seedSolicitacao(coordApi);
+
+    const superApi = await createApiContext({
+      baseURL: baseURL!,
+      username: ROLE_CREDENTIALS.super_geral.username,
+      password: ROLE_CREDENTIALS.super_geral.password,
+    });
+
+    // Primeira aprovação: sucesso
+    const firstRes = await superApi.patch(`/api/solicitacoes/${solicitacao.id}/approve/`, { data: {} });
+    expect(firstRes.ok()).toBeTruthy();
+
+    // Segunda aprovação: deve bloquear
+    const secondRes = await superApi.patch(`/api/solicitacoes/${solicitacao.id}/approve/`, { data: {} });
+    expect(secondRes.status()).toBe(400);
+    const body = (await secondRes.json()) as { code?: string; detail?: string };
+    // Aceita tanto `code` quanto mensagem — contrato pode variar entre ValidationAPIError e DRF default
+    expect([body.code, body.detail].some((v) => v && /already.?approved|aprovad/i.test(v))).toBeTruthy();
+  });
+
+  test('operação: coord vê status aprovado em /solicitacoes/minhas após aprovação', async ({
+    authedPage,
+    baseURL,
+  }) => {
+    const coordApi = await createApiContext({
+      baseURL: baseURL!,
+      username: ROLE_CREDENTIALS.coord_vidas.username,
+      password: ROLE_CREDENTIALS.coord_vidas.password,
+    });
+    const solicitacao = await seedSolicitacao(coordApi);
+
+    // Aprova via API (foco do teste é o reflexo na tela do coord, não a UI de aprovação)
+    const superApi = await createApiContext({
+      baseURL: baseURL!,
+      username: ROLE_CREDENTIALS.super_geral.username,
+      password: ROLE_CREDENTIALS.super_geral.password,
+    });
+    const approveRes = await superApi.patch(`/api/solicitacoes/${solicitacao.id}/approve/`, { data: {} });
+    expect(approveRes.ok()).toBeTruthy();
+
+    // Coord abre /solicitacoes/minhas e confirma reflexo
+    const pageCoord = await authedPage('coord_vidas');
+    await pageCoord.goto('/solicitacoes/minhas');
+    await waitForRouteReady(pageCoord);
+
+    const linha = pageCoord.getByRole('row').filter({ hasText: String(solicitacao.id) });
+    await expect(linha).toBeVisible();
+    // Status renderizado na linha da tabela — aceita variações comuns de rótulo
+    await expect(linha).toContainText(/aprovad/i);
+  });
+});

--- a/v2/frontend/e2e/journeys/j01-happy-path.spec.ts
+++ b/v2/frontend/e2e/journeys/j01-happy-path.spec.ts
@@ -1,116 +1,196 @@
 /**
- * J01 — Happy path: coord cria solicitação → super aprova.
+ * J01 — Happy path (ambos os fluxos de aprovação).
  *
  * Ref: Matriz de jornadas E2E (Fase 3 do plano QA 2026-04-22).
- * Regras: RF01 (criar solicitação), PA-02 (Superintendência aprova).
  *
- * Três camadas de asserção:
+ * O sistema tem 2 fluxos de aprovação (projeto.fluxo em
+ * apps/core/services/solicitacao_create.py):
  *
- * 1. **Canônica**: coord cria solicitação via API → fica `pendente` →
- *    super_geral abre /aprovacoes, clica "Aprovar" → status vira `aprovado`.
+ * - **SUPER** (Superintendência): status inicial `pendente`; requer
+ *   aprovação manual via `/aprovacoes` (PA-02).
+ * - **NAO_SUPER**: status inicial `aprovado` imediatamente na criação;
+ *   não passa por aprovação manual.
  *
- * 2. **Borda (idempotência)**: tentar aprovar a mesma solicitação duas vezes
- *    → segunda chamada retorna 400 com `code=already_approved`.
- *
- * 3. **Operação**: após aprovação, coord vê a mesma solicitação com status
- *    "aprovado" em /solicitacoes/minhas (reflexo cruzado entre telas).
+ * Este spec cobre ambos: J01a (SUPER) + J01b (NAO_SUPER).
  */
 import { test, expect, createApiContext, seedSolicitacao, ROLE_CREDENTIALS } from '../fixtures';
 import { waitForRouteReady } from '../helpers/wait';
 import { AprovacoesPage } from '../pages/AprovacoesPage';
 
-test.describe('J01 — Happy path: coord cria → super aprova', { tag: ['@critical', '@rf01', '@pa-02'] }, () => {
-  test('canônica: pendente → aprovada via UI de Aprovações', async ({ authedPage, baseURL }) => {
-    // Arrange: coord cria via API (sidecar, mais rápido que wizard)
-    const coordApi = await createApiContext({
-      baseURL: baseURL!,
-      username: ROLE_CREDENTIALS.coord_vidas.username,
-      password: ROLE_CREDENTIALS.coord_vidas.password,
-    });
-    const solicitacao = await seedSolicitacao(coordApi);
-    expect(solicitacao.status).toBe('pendente');
+// ============================================================================
+// J01a — Fluxo SUPER (Superintendência aprova manualmente)
+// ============================================================================
 
-    // Act: super_geral aprova via UI
-    const pageSuper = await authedPage('super_geral');
-    const aprovacoes = new AprovacoesPage(pageSuper);
-    await aprovacoes.goto();
-    await expect(aprovacoes.tabelaPendentes).toBeVisible();
+test.describe(
+  'J01a — SUPER: coord cria → super aprova',
+  { tag: ['@critical', '@rf01', '@pa-02', '@fluxo-super'] },
+  () => {
+    test('canônica: pendente → aprovado via UI de Aprovações', async ({ authedPage, baseURL }) => {
+      const coordApi = await createApiContext({
+        baseURL: baseURL!,
+        username: ROLE_CREDENTIALS.coord_vidas.username,
+        password: ROLE_CREDENTIALS.coord_vidas.password,
+      });
+      const solicitacao = await seedSolicitacao(coordApi, { fluxo: 'SUPER' });
+      expect(solicitacao.status).toBe('pendente');
 
-    await aprovacoes.btnAprovar(solicitacao.id).click();
+      const pageSuper = await authedPage('super_geral');
+      const aprovacoes = new AprovacoesPage(pageSuper);
+      await aprovacoes.goto();
+      await expect(aprovacoes.tabelaPendentes).toBeVisible();
 
-    // Assert canônica: status aprovado via API (evita flake de UI refresh)
-    const superApi = await createApiContext({
-      baseURL: baseURL!,
-      username: ROLE_CREDENTIALS.super_geral.username,
-      password: ROLE_CREDENTIALS.super_geral.password,
-    });
-    await expect
-      .poll(
-        async () => {
-          const res = await superApi.get(`/api/solicitacoes/${solicitacao.id}/`);
-          if (!res.ok()) return null;
-          const body = (await res.json()) as { status: string };
-          return body.status;
-        },
-        { timeout: 10_000, message: 'status deveria virar "aprovado" após click Aprovar' }
-      )
-      .toBe('aprovado');
-  });
+      await aprovacoes.btnAprovar(solicitacao.id).click();
 
-  test('borda: segunda tentativa de aprovar retorna already_approved', async ({ baseURL }) => {
-    const coordApi = await createApiContext({
-      baseURL: baseURL!,
-      username: ROLE_CREDENTIALS.coord_vidas.username,
-      password: ROLE_CREDENTIALS.coord_vidas.password,
-    });
-    const solicitacao = await seedSolicitacao(coordApi);
-
-    const superApi = await createApiContext({
-      baseURL: baseURL!,
-      username: ROLE_CREDENTIALS.super_geral.username,
-      password: ROLE_CREDENTIALS.super_geral.password,
+      const superApi = await createApiContext({
+        baseURL: baseURL!,
+        username: ROLE_CREDENTIALS.super_geral.username,
+        password: ROLE_CREDENTIALS.super_geral.password,
+      });
+      await expect
+        .poll(
+          async () => {
+            const res = await superApi.get(`/api/solicitacoes/${solicitacao.id}/`);
+            if (!res.ok()) return null;
+            const body = (await res.json()) as { status: string };
+            return body.status;
+          },
+          { timeout: 10_000, message: 'status deveria virar "aprovado" após click Aprovar' }
+        )
+        .toBe('aprovado');
     });
 
-    // Primeira aprovação: sucesso
-    const firstRes = await superApi.patch(`/api/solicitacoes/${solicitacao.id}/approve/`, { data: {} });
-    expect(firstRes.ok()).toBeTruthy();
+    test('borda: segunda tentativa de aprovar retorna already_approved', async ({ baseURL }) => {
+      const coordApi = await createApiContext({
+        baseURL: baseURL!,
+        username: ROLE_CREDENTIALS.coord_vidas.username,
+        password: ROLE_CREDENTIALS.coord_vidas.password,
+      });
+      const solicitacao = await seedSolicitacao(coordApi, { fluxo: 'SUPER' });
 
-    // Segunda aprovação: deve bloquear
-    const secondRes = await superApi.patch(`/api/solicitacoes/${solicitacao.id}/approve/`, { data: {} });
-    expect(secondRes.status()).toBe(400);
-    const body = (await secondRes.json()) as { code?: string; detail?: string };
-    // Aceita tanto `code` quanto mensagem — contrato pode variar entre ValidationAPIError e DRF default
-    expect([body.code, body.detail].some((v) => v && /already.?approved|aprovad/i.test(v))).toBeTruthy();
-  });
+      const superApi = await createApiContext({
+        baseURL: baseURL!,
+        username: ROLE_CREDENTIALS.super_geral.username,
+        password: ROLE_CREDENTIALS.super_geral.password,
+      });
 
-  test('operação: coord vê status aprovado em /solicitacoes/minhas após aprovação', async ({
-    authedPage,
-    baseURL,
-  }) => {
-    const coordApi = await createApiContext({
-      baseURL: baseURL!,
-      username: ROLE_CREDENTIALS.coord_vidas.username,
-      password: ROLE_CREDENTIALS.coord_vidas.password,
+      const firstRes = await superApi.patch(`/api/solicitacoes/${solicitacao.id}/approve/`, { data: {} });
+      expect(firstRes.ok()).toBeTruthy();
+
+      const secondRes = await superApi.patch(`/api/solicitacoes/${solicitacao.id}/approve/`, { data: {} });
+      expect(secondRes.status()).toBe(400);
+      const body = (await secondRes.json()) as { code?: string; detail?: string };
+      expect([body.code, body.detail].some((v) => v && /already.?approved|aprovad/i.test(v))).toBeTruthy();
     });
-    const solicitacao = await seedSolicitacao(coordApi);
 
-    // Aprova via API (foco do teste é o reflexo na tela do coord, não a UI de aprovação)
-    const superApi = await createApiContext({
-      baseURL: baseURL!,
-      username: ROLE_CREDENTIALS.super_geral.username,
-      password: ROLE_CREDENTIALS.super_geral.password,
+    test('operação: coord vê status aprovado em /solicitacoes/minhas após aprovação', async ({
+      authedPage,
+      baseURL,
+    }) => {
+      const coordApi = await createApiContext({
+        baseURL: baseURL!,
+        username: ROLE_CREDENTIALS.coord_vidas.username,
+        password: ROLE_CREDENTIALS.coord_vidas.password,
+      });
+      const solicitacao = await seedSolicitacao(coordApi, { fluxo: 'SUPER' });
+
+      const superApi = await createApiContext({
+        baseURL: baseURL!,
+        username: ROLE_CREDENTIALS.super_geral.username,
+        password: ROLE_CREDENTIALS.super_geral.password,
+      });
+      const approveRes = await superApi.patch(`/api/solicitacoes/${solicitacao.id}/approve/`, { data: {} });
+      expect(approveRes.ok()).toBeTruthy();
+
+      const pageCoord = await authedPage('coord_vidas');
+      await pageCoord.goto('/solicitacoes/minhas');
+      await waitForRouteReady(pageCoord);
+
+      const linha = pageCoord.getByRole('row').filter({ hasText: String(solicitacao.id) });
+      await expect(linha).toBeVisible();
+      await expect(linha).toContainText(/aprovad/i);
     });
-    const approveRes = await superApi.patch(`/api/solicitacoes/${solicitacao.id}/approve/`, { data: {} });
-    expect(approveRes.ok()).toBeTruthy();
+  }
+);
 
-    // Coord abre /solicitacoes/minhas e confirma reflexo
-    const pageCoord = await authedPage('coord_vidas');
-    await pageCoord.goto('/solicitacoes/minhas');
-    await waitForRouteReady(pageCoord);
+// ============================================================================
+// J01b — Fluxo NAO_SUPER (auto-aprovado na criação)
+// ============================================================================
 
-    const linha = pageCoord.getByRole('row').filter({ hasText: String(solicitacao.id) });
-    await expect(linha).toBeVisible();
-    // Status renderizado na linha da tabela — aceita variações comuns de rótulo
-    await expect(linha).toContainText(/aprovad/i);
-  });
-});
+test.describe(
+  'J01b — NAO_SUPER: coord cria → auto-aprovado',
+  { tag: ['@critical', '@rf01', '@fluxo-nao-super'] },
+  () => {
+    test('canônica: solicitação nasce com status aprovado', async ({ baseURL }) => {
+      const coordApi = await createApiContext({
+        baseURL: baseURL!,
+        username: ROLE_CREDENTIALS.coord_vidas.username,
+        password: ROLE_CREDENTIALS.coord_vidas.password,
+      });
+      const solicitacao = await seedSolicitacao(coordApi, { fluxo: 'NAO_SUPER' });
+
+      // Regra: `solicitacao_create.resolve_initial_status` devolve `aprovado`
+      // quando projeto.fluxo == "NAO_SUPER".
+      expect(solicitacao.status).toBe('aprovado');
+    });
+
+    test('borda: solicitação NAO_SUPER NÃO aparece na fila de /aprovacoes', async ({ authedPage, baseURL }) => {
+      const coordApi = await createApiContext({
+        baseURL: baseURL!,
+        username: ROLE_CREDENTIALS.coord_vidas.username,
+        password: ROLE_CREDENTIALS.coord_vidas.password,
+      });
+      const solicitacao = await seedSolicitacao(coordApi, { fluxo: 'NAO_SUPER' });
+      expect(solicitacao.status).toBe('aprovado');
+
+      // Super abre /aprovacoes — a solicitação NÃO_SUPER não deve estar listada
+      // (a view filtra por `projeto__fluxo=SUPER` + status pendente).
+      const pageSuper = await authedPage('super_geral');
+      const aprovacoes = new AprovacoesPage(pageSuper);
+      await aprovacoes.goto();
+
+      // Tentativa de achar a linha — deve falhar
+      const linha = pageSuper.getByRole('row').filter({ hasText: String(solicitacao.id) });
+      await expect(linha).toHaveCount(0);
+    });
+
+    test('borda: tentar aprovar via API uma solicitação já aprovada retorna 400', async ({ baseURL }) => {
+      const coordApi = await createApiContext({
+        baseURL: baseURL!,
+        username: ROLE_CREDENTIALS.coord_vidas.username,
+        password: ROLE_CREDENTIALS.coord_vidas.password,
+      });
+      const solicitacao = await seedSolicitacao(coordApi, { fluxo: 'NAO_SUPER' });
+      expect(solicitacao.status).toBe('aprovado');
+
+      const superApi = await createApiContext({
+        baseURL: baseURL!,
+        username: ROLE_CREDENTIALS.super_geral.username,
+        password: ROLE_CREDENTIALS.super_geral.password,
+      });
+      const approveRes = await superApi.patch(`/api/solicitacoes/${solicitacao.id}/approve/`, { data: {} });
+      expect(approveRes.status()).toBe(400);
+      const body = (await approveRes.json()) as { code?: string; detail?: string };
+      expect([body.code, body.detail].some((v) => v && /already.?approved|aprovad/i.test(v))).toBeTruthy();
+    });
+
+    test('operação: coord vê status aprovado em /solicitacoes/minhas imediatamente', async ({
+      authedPage,
+      baseURL,
+    }) => {
+      const coordApi = await createApiContext({
+        baseURL: baseURL!,
+        username: ROLE_CREDENTIALS.coord_vidas.username,
+        password: ROLE_CREDENTIALS.coord_vidas.password,
+      });
+      const solicitacao = await seedSolicitacao(coordApi, { fluxo: 'NAO_SUPER' });
+
+      const pageCoord = await authedPage('coord_vidas');
+      await pageCoord.goto('/solicitacoes/minhas');
+      await waitForRouteReady(pageCoord);
+
+      const linha = pageCoord.getByRole('row').filter({ hasText: String(solicitacao.id) });
+      await expect(linha).toBeVisible();
+      await expect(linha).toContainText(/aprovad/i);
+    });
+  }
+);


### PR DESCRIPTION
## Summary

Primeira jornada profunda do programa E2E (Fase 3 do plano QA 2026-04-22). Cobre os **dois fluxos de aprovação** do sistema (confirmado em [`solicitacao_create.py:23-44`](../blob/main/v2/backend/apps/core/services/solicitacao_create.py#L23-L44)):

- **SUPER** (Superintendência) → status inicial `pendente`; requer aprovação manual (PA-02)
- **NAO_SUPER** (Vidas, Fluir, ACerta, Brincando, Sou da Paz) → auto-aprovado na criação

### J01a — Fluxo SUPER (3 testes)

- canônica: pendente → aprovado via UI `/aprovacoes`
- borda: segunda aprovação retorna 400 `already_approved`
- operação: coord vê status "aprovado" em `/solicitacoes/minhas`

### J01b — Fluxo NAO_SUPER (4 testes)

- canônica: solicitação nasce com `status=aprovado`
- borda: NÃO aparece na fila de `/aprovacoes`
- borda: tentar aprovar via API retorna 400 `already_approved`
- operação: coord vê "aprovado" em `/solicitacoes/minhas` imediatamente

## Backend changes

- `seed_e2e_users.py`: novo projeto `TESTE E2E NAO_SUPER` (codigo=E2E_NS) vinculado à gerência Vidas. Refactor `_upsert_projeto(codigo, nome, fluxo, gerencia_setor)` aceita vínculo opcional. Fallback idempotente: se Gerencia não existe, chama `seed_gerencias` internamente.

## Frontend changes

- `fixtures/seed.ts`: `SeedSolicitacaoInput.fluxo: 'SUPER' | 'NAO_SUPER'` (default SUPER). Match exato por nome em `findProjetoId` (evita pegar projeto errado quando lookup retorna múltiplos).
- `fixtures/index.ts`: exporta type `ProjetoFluxo`.
- `journeys/j01-happy-path.spec.ts`: reestruturado em J01a + J01b com tags distintas (`@fluxo-super`, `@fluxo-nao-super`).
- `journeys/README.md`: documenta os 2 fluxos e a convenção de variantes (a/b) para outras jornadas dependentes de aprovação.

## Chore

- `.rtk/` adicionado ao `.gitignore` — aparecia como untracked a cada limpeza pós-merge.

## Test plan

- [x] `npx tsc --noEmit` → zero erros
- [x] `black --check` → clean
- [x] `pytest apps/dev_tools/tests/test_seed_e2e_users.py -v` → 3/3 passam
- [x] `docker exec python manage.py seed_e2e_users` → ambos projetos criados, NAO_SUPER vinculado à Vidas
- [ ] CI full suite
- [ ] Execução dos 7 testes do spec no CI

## Staging Gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

ALL 8 CHECKS PASSED — validação local:

```
1. tsc --noEmit ............................ OK
2. black --check ........................... OK
3. pytest test_seed_e2e_users .............. OK (3/3)
4. seed_e2e_users runtime .................. OK (ambos projetos, NAO_SUPER → Vidas)
5. seed_gerencias fallback automático ...... OK
6. Fluxo SUPER (J01a 3 testes) ............. OK (compilação)
7. Fluxo NAO_SUPER (J01b 4 testes) ......... OK (compilação)
8. .gitignore (.rtk/) ...................... OK
```

## Matriz de jornadas

Documento vivo em [`e2e/journeys/README.md`](../blob/feat/e2e-phase3-j01-happy-path/v2/frontend/e2e/journeys/README.md). J01 vira **J01a + J01b**. Outras jornadas dependentes de aprovação (J04 reprovação, J08 concorrência) provavelmente terão variantes similares.

5 jornadas com `test.fail()` pré-definido aguardando issues: J13 (#1163), J14 (#1165), J15/J16 (#1166), J17 (#1168), J19 (#1167).

## Fora de escopo (próximos PRs)

- **J02-J19**: demais jornadas da matriz.
- **Projects por role** em `playwright.config.ts` — Fase 4.
- **Axe-core amplo, visual regression, sharding + tagging CI** — Fase 4.

## Contexto

Fases do plano QA 2026-04-22:

1. ✅ Quick wins — PR #1170.
2. ✅ Scaffolding 2a — PR #1171.
3. ✅ Scaffolding 2b — PR #1172.
4. 🟡 Matriz Fase 3 — **J01a + J01b neste PR**.
5. Fase 4 — CI hardening.

Relacionado: #1163, #1164, #1165, #1166, #1167, #1168, #1169.