### PR TITLE
test(e2e): fase 3 lote RBAC — J05 + J10 + J18

### DIFF
--- a/v2/backend/apps/dev_tools/management/commands/seed_e2e_users.py
+++ b/v2/backend/apps/dev_tools/management/commands/seed_e2e_users.py
@@ -193,6 +193,17 @@ class Command(BaseCommand):
                 "groups": [grupos["Gerente"], grupos["Vidas"]],
                 "is_superuser": False,
             },
+            # === DAT puro (jornada J18 — regra PO: DAT acesso total no frontend) ===
+            {
+                "username": "dat_e2e@test.com",
+                "email": "dat_e2e@test.com",
+                "first_name": "Daniel",
+                "last_name": "DATPuro",
+                "cpf": "99900000040",
+                "password": "testpass123",
+                "groups": [grupos["DAT"]],
+                "is_superuser": False,
+            },
             # === Gerente + Superintendência (PA-02 quorum composto) ===
             {
                 "username": "super_geral@test.com",

--- a/v2/frontend/e2e/fixtures/roles.ts
+++ b/v2/frontend/e2e/fixtures/roles.ts
@@ -38,6 +38,7 @@ export const E2E_ROLES = [
   'super_geral',
   'formador_vidas',
   'formador_fluir',
+  'dat_e2e', // DAT puro — jornada J18
 ] as const;
 
 export type E2eRole = (typeof E2E_ROLES)[number];
@@ -54,6 +55,7 @@ export const ROLE_CREDENTIALS: Record<E2eRole, { username: string; password: str
   super_geral: { username: 'super_geral@test.com', password: 'testpass123' },
   formador_vidas: { username: 'formador_vidas@test.com', password: 'testpass123' },
   formador_fluir: { username: 'formador_fluir@test.com', password: 'testpass123' },
+  dat_e2e: { username: 'dat_e2e@test.com', password: 'testpass123' },
 };
 
 /**

--- a/v2/frontend/e2e/journeys/README.md
+++ b/v2/frontend/e2e/journeys/README.md
@@ -30,12 +30,12 @@ Jornadas que dependem de aprovação têm duas variantes (J01a/J01b).
 | J02 | Wizard bloqueia submit com campo obrigatório vazio | `@ux @rf01` | ⏳ | — |
 | J03 | Conflito RD-06 (deslocamento inviável) | `@critical @rd-06` | ⏳ | time-freeze |
 | J04 | Reprovação com motivo obrigatório (PA-04) | `@pa-04` | ⏳ | — |
-| J05 | Visão individual vs setor (/solicitacoes vs /disponibilidade) | `@critical @rbac` | ⏳ | — |
+| J05 | Visão individual vs setor (/solicitacoes vs /disponibilidade) | `@critical @rbac` | ✅ | — |
 | J06 | Formador fora de janela → RD-01 | `@critical @rd-01` | ⏳ | time-freeze |
 | J07 | Bloqueio pontual impede RD-04 | `@rd-04` | ⏳ | — |
 | J08 | Aprovação concorrente (dois super) | `@race @pa-07` | ⏳ | — |
 | J09 | Cancelamento pós-publicação re-sincroniza GCal | `@rf07` | ⏳ | GCal client |
-| J10 | Coord tenta aprovar própria solicitação → 403 | `@rbac @pa-02` | ⏳ | — |
+| J10 | Coord tenta aprovar própria solicitação → 403 | `@critical @rbac @pa-02` | ✅ | — |
 | J11 | E-mail ao formador após aprovação | `@rf-email` | ⏳ | SMTP mock |
 | J12 | Dashboard Compras reflete criação em <3s | `@perf @dashboards` | ⏳ | — |
 | J13 | Formador escalado vê em "Minhas Formações" | `@rf-minhas` | 🚫 `test.fail` | #1163 |
@@ -43,5 +43,5 @@ Jornadas que dependem de aprovação têm duas variantes (J01a/J01b).
 | J15 | Formador chama `/api/metrics/team/*` → 403 | `@rbac @dashboards` | 🚫 `test.fail` | #1166 |
 | J16 | Formador chama `/api/gcal/dashboard/*` → 403 | `@rbac @dashboards` | 🚫 `test.fail` | #1166 |
 | J17 | Formador digita `/bloqueios` → rota bloqueia antes de render | `@rbac` | 🚫 `test.fail` | #1168 |
-| J18 | DAT puro navega em todos os menus sem 403 | `@rbac @dat` | ⏳ | — |
+| J18 | DAT puro navega em todos os menus sem 403 | `@critical @rbac @dat` | ✅ | — |
 | J19 | HomeStats `upcoming_events` não vaza entre setores | `@rbac @home` | 🚫 `test.fail` | #1167 |

--- a/v2/frontend/e2e/journeys/j05-rbac-individual-vs-setor.spec.ts
+++ b/v2/frontend/e2e/journeys/j05-rbac-individual-vs-setor.spec.ts
@@ -1,0 +1,116 @@
+/**
+ * J05 — RBAC: visão individual vs visão de setor.
+ *
+ * Ref: Design discutido na auditoria RBAC (2026-04-22), issue #1159 fechada
+ * como by-design. O sistema tem dois endpoints complementares:
+ *
+ * - `/api/solicitacoes/` (listagem) — **individual**: coord vê APENAS as que
+ *   ele mesmo criou (filtra por `usuario=request.user`).
+ * - `/api/availability/monthly` (grade mensal) — **setor**: coord vê tudo
+ *   do próprio setor via `HasSectorAccess` + `EquipeGerencia`.
+ *
+ * Esta jornada valida que ambos funcionam conforme o design e que os
+ * escopos não vazam entre setores diferentes.
+ *
+ * Três camadas de asserção:
+ *
+ * 1. **Canônica**: coord_vidas vê apenas as próprias em `/api/solicitacoes/`.
+ * 2. **Borda**: coord_fluir **não** vê as de coord_vidas em `/api/solicitacoes/`
+ *    (escopo individual preserva privacidade entre setores).
+ * 3. **Operação**: coord_fluir tenta acessar grade mensal do setor Vidas
+ *    (`gerencia_id=<Vidas>`) → recebe 403 (HasSectorAccess bloqueia).
+ */
+import { test, expect, createApiContext, seedSolicitacao, ROLE_CREDENTIALS } from '../fixtures';
+import type { APIRequestContext } from '@playwright/test';
+
+async function findGerenciaIdByNomeSetor(api: APIRequestContext, nomeSetor: string): Promise<number> {
+  const res = await api.get('/api/gerencias/');
+  expect(res.ok(), `[j05] /api/gerencias/ falhou (${res.status()})`).toBeTruthy();
+  const data = (await res.json()) as
+    | { results?: Array<{ id: number; nome_setor: string }> }
+    | Array<{ id: number; nome_setor: string }>;
+  const list = Array.isArray(data) ? data : (data.results ?? []);
+  const match = list.find((g) => g.nome_setor === nomeSetor);
+  expect(match, `[j05] gerencia com nome_setor "${nomeSetor}" nao encontrada`).toBeTruthy();
+  return match!.id;
+}
+
+test.describe(
+  'J05 — RBAC: visão individual vs setor',
+  { tag: ['@critical', '@rbac'] },
+  () => {
+    test('canônica: coord_vidas vê apenas suas solicitações em /api/solicitacoes/?mine=true', async ({
+      baseURL,
+    }) => {
+      const coordVidasApi = await createApiContext({
+        baseURL: baseURL!,
+        username: ROLE_CREDENTIALS.coord_vidas.username,
+        password: ROLE_CREDENTIALS.coord_vidas.password,
+      });
+      const solicitacao = await seedSolicitacao(coordVidasApi, { fluxo: 'SUPER' });
+
+      const res = await coordVidasApi.get('/api/solicitacoes/?mine=true');
+      expect(res.ok()).toBeTruthy();
+      const data = (await res.json()) as
+        | { results?: Array<{ id: number }> }
+        | Array<{ id: number }>;
+      const list = Array.isArray(data) ? data : (data.results ?? []);
+      const ids = list.map((s) => s.id);
+      expect(ids).toContain(solicitacao.id);
+    });
+
+    test('borda: coord_fluir NÃO vê solicitação criada por coord_vidas', async ({ baseURL }) => {
+      // Ana (coord_vidas) cria solicitação
+      const coordVidasApi = await createApiContext({
+        baseURL: baseURL!,
+        username: ROLE_CREDENTIALS.coord_vidas.username,
+        password: ROLE_CREDENTIALS.coord_vidas.password,
+      });
+      const solicitacao = await seedSolicitacao(coordVidasApi, { fluxo: 'SUPER' });
+
+      // Carlos (coord_fluir) consulta sua listagem — não deve ver a de Ana
+      const coordFluirApi = await createApiContext({
+        baseURL: baseURL!,
+        username: ROLE_CREDENTIALS.coord_fluir.username,
+        password: ROLE_CREDENTIALS.coord_fluir.password,
+      });
+      const res = await coordFluirApi.get('/api/solicitacoes/?mine=true');
+      expect(res.ok()).toBeTruthy();
+      const data = (await res.json()) as
+        | { results?: Array<{ id: number }> }
+        | Array<{ id: number }>;
+      const list = Array.isArray(data) ? data : (data.results ?? []);
+      const ids = list.map((s) => s.id);
+      expect(ids).not.toContain(solicitacao.id);
+    });
+
+    test('operação: coord_fluir recebe 403 ao tentar grade mensal do setor Vidas', async ({
+      baseURL,
+    }) => {
+      // Descobre ID da gerência Vidas via API (como qualquer autenticado)
+      const anyApi = await createApiContext({
+        baseURL: baseURL!,
+        username: ROLE_CREDENTIALS.coord_vidas.username,
+        password: ROLE_CREDENTIALS.coord_vidas.password,
+      });
+      const vidasId = await findGerenciaIdByNomeSetor(anyApi, 'Vidas');
+
+      // coord_vidas acessa a grade do próprio setor → 200
+      const resVidas = await anyApi.get(
+        `/api/availability/monthly?year=2026&month=4&role=FORMADOR&gerencia_id=${vidasId}`
+      );
+      expect(resVidas.status(), 'coord_vidas deve acessar grade de Vidas').toBeLessThan(400);
+
+      // coord_fluir tenta acessar grade do setor Vidas → deve ser bloqueado
+      const coordFluirApi = await createApiContext({
+        baseURL: baseURL!,
+        username: ROLE_CREDENTIALS.coord_fluir.username,
+        password: ROLE_CREDENTIALS.coord_fluir.password,
+      });
+      const resFluir = await coordFluirApi.get(
+        `/api/availability/monthly?year=2026&month=4&role=FORMADOR&gerencia_id=${vidasId}`
+      );
+      expect(resFluir.status(), 'coord_fluir não deve acessar grade de Vidas').toBe(403);
+    });
+  }
+);

--- a/v2/frontend/e2e/journeys/j10-self-approval-blocked.spec.ts
+++ b/v2/frontend/e2e/journeys/j10-self-approval-blocked.spec.ts
@@ -1,0 +1,94 @@
+/**
+ * J10 — Coord não aprova própria solicitação.
+ *
+ * Ref: PA-02 adaptada (Superintendência, DAT ou superuser aprovam).
+ *
+ * O criador não pode aprovar a própria solicitação — mesmo que seja
+ * superintendente ou tenha permissão de aprovação. Esta regra impede
+ * conflito de interesse e é garantida pela permission class
+ * `IsSuperintendencia` combinada com o check de ownership.
+ *
+ * Na prática atual, `IsSuperintendencia` aceita `Superintendência | DAT |
+ * superuser`. Coord (sem essas funções) bate direto na permission class e
+ * recebe 403, independente de ser dono ou não.
+ *
+ * Três camadas:
+ *
+ * 1. **Canônica**: coord_vidas cria → tenta aprovar → 403 (permission).
+ * 2. **Borda**: outro coord (fluir, setor diferente) também recebe 403.
+ * 3. **Operação**: após tentativa bloqueada, status permanece pendente.
+ *    Super_geral então aprova com sucesso.
+ */
+import { test, expect, createApiContext, seedSolicitacao, ROLE_CREDENTIALS } from '../fixtures';
+
+test.describe(
+  'J10 — Coord não aprova própria solicitação',
+  { tag: ['@critical', '@rbac', '@pa-02'] },
+  () => {
+    test('canônica: coord_vidas tenta aprovar a própria solicitação → 403', async ({ baseURL }) => {
+      const coordApi = await createApiContext({
+        baseURL: baseURL!,
+        username: ROLE_CREDENTIALS.coord_vidas.username,
+        password: ROLE_CREDENTIALS.coord_vidas.password,
+      });
+      const solicitacao = await seedSolicitacao(coordApi, { fluxo: 'SUPER' });
+      expect(solicitacao.status).toBe('pendente');
+
+      const approveRes = await coordApi.patch(`/api/solicitacoes/${solicitacao.id}/approve/`, { data: {} });
+      expect(approveRes.status()).toBe(403);
+    });
+
+    test('borda: coord de outro setor também recebe 403', async ({ baseURL }) => {
+      const coordVidasApi = await createApiContext({
+        baseURL: baseURL!,
+        username: ROLE_CREDENTIALS.coord_vidas.username,
+        password: ROLE_CREDENTIALS.coord_vidas.password,
+      });
+      const solicitacao = await seedSolicitacao(coordVidasApi, { fluxo: 'SUPER' });
+
+      const coordFluirApi = await createApiContext({
+        baseURL: baseURL!,
+        username: ROLE_CREDENTIALS.coord_fluir.username,
+        password: ROLE_CREDENTIALS.coord_fluir.password,
+      });
+      const approveRes = await coordFluirApi.patch(
+        `/api/solicitacoes/${solicitacao.id}/approve/`,
+        { data: {} }
+      );
+      expect(approveRes.status()).toBe(403);
+    });
+
+    test('operação: status permanece pendente após 403; super_geral aprova com sucesso', async ({
+      baseURL,
+    }) => {
+      const coordApi = await createApiContext({
+        baseURL: baseURL!,
+        username: ROLE_CREDENTIALS.coord_vidas.username,
+        password: ROLE_CREDENTIALS.coord_vidas.password,
+      });
+      const solicitacao = await seedSolicitacao(coordApi, { fluxo: 'SUPER' });
+
+      // Coord tenta aprovar → 403
+      const failRes = await coordApi.patch(`/api/solicitacoes/${solicitacao.id}/approve/`, { data: {} });
+      expect(failRes.status()).toBe(403);
+
+      // Status continua pendente
+      const check1 = await coordApi.get(`/api/solicitacoes/${solicitacao.id}/`);
+      const body1 = (await check1.json()) as { status: string };
+      expect(body1.status).toBe('pendente');
+
+      // super_geral aprova → 200 e status vira aprovado
+      const superApi = await createApiContext({
+        baseURL: baseURL!,
+        username: ROLE_CREDENTIALS.super_geral.username,
+        password: ROLE_CREDENTIALS.super_geral.password,
+      });
+      const okRes = await superApi.patch(`/api/solicitacoes/${solicitacao.id}/approve/`, { data: {} });
+      expect(okRes.ok()).toBeTruthy();
+
+      const check2 = await superApi.get(`/api/solicitacoes/${solicitacao.id}/`);
+      const body2 = (await check2.json()) as { status: string };
+      expect(body2.status).toBe('aprovado');
+    });
+  }
+);

--- a/v2/frontend/e2e/journeys/j18-dat-full-access.spec.ts
+++ b/v2/frontend/e2e/journeys/j18-dat-full-access.spec.ts
@@ -1,0 +1,103 @@
+/**
+ * J18 — DAT tem acesso total ao frontend.
+ *
+ * Ref: Regra PO confirmada em 2026-04-22, memória
+ * `project_rbac_invariants`: DAT é o grupo de manutenção da plataforma;
+ * deve navegar em todas as telas sem receber 403/404 no frontend, embora
+ * não receba autonomia de decisão de negócio (ex: aprovar solicitações —
+ * isso já é permitido pela `IsSuperintendencia` que aceita DAT também).
+ *
+ * Esta jornada valida que um usuário com **apenas** o group `DAT` (sem
+ * `Superuser`, sem função adicional) consegue carregar todas as rotas
+ * principais do sistema.
+ *
+ * Três camadas:
+ *
+ * 1. **Canônica**: DAT abre rotas autenticadas comuns → todas carregam
+ *    o shell (`<main>`) sem redirecionar para `/login` ou mostrar
+ *    `<Forbidden />`.
+ * 2. **Borda**: DAT tem flags de menu correspondentes via `/api/me/`
+ *    (permissões funcionais retornadas pelo endpoint incluem as de DAT).
+ * 3. **Operação**: DAT consegue chamar endpoints de manutenção — ex:
+ *    `/api/dat/compras-materiais/dashboard/` retorna 200 (canDashboardCompras).
+ *
+ * **Nota**: issue #1166 (normalizar dashboards para Diretoria+DAT+superuser)
+ * está aberta — quando resolvida, expandir este spec para validar acesso a
+ * todos os 5 dashboards. Por ora valida apenas Compras (que já funciona).
+ */
+import { test, expect, createApiContext, ROLE_CREDENTIALS } from '../fixtures';
+import { waitForRouteReady } from '../helpers/wait';
+
+/**
+ * Rotas que um usuário DAT puro deve conseguir abrir sem 403.
+ * Excluídos: rotas legacy, rotas que redirecionam para outro lugar, rotas
+ * que exigem dado seedado específico.
+ */
+const DAT_ACCESSIBLE_ROUTES = [
+  '/home',
+  '/solicitacoes/minhas',
+  '/solicitacoes/nova',
+  '/aprovacoes', // DAT aprova (IsSuperintendencia inclui DAT)
+  '/pre-agenda', // IsControleOrDAT
+  '/deslocamentos', // IsControleOrDAT
+  '/dat/admin',
+  '/dat/cadastros',
+  '/dat/importacao',
+  '/dat/registros',
+  '/dashboards/compras', // canDashboardCompras (atual já permite DAT)
+];
+
+test.describe(
+  'J18 — DAT tem acesso total ao frontend',
+  { tag: ['@critical', '@rbac', '@dat'] },
+  () => {
+    for (const route of DAT_ACCESSIBLE_ROUTES) {
+      test(`canônica: DAT abre ${route} sem receber Forbidden`, async ({ authedPage }) => {
+        const page = await authedPage('dat_e2e');
+        await page.goto(route);
+        await waitForRouteReady(page);
+
+        // Shell autenticado carregado (role="main" presente no AppShell)
+        await expect(page.getByRole('main')).toBeVisible();
+
+        // Não deve ter chegado em <Forbidden /> (rota de 403 do frontend)
+        await expect(page.getByText(/403|forbidden|acesso negado/i)).toHaveCount(0);
+
+        // Não deve ter redirecionado para /login
+        expect(page.url()).not.toContain('/login');
+      });
+    }
+
+    test('borda: /api/me/ retorna grupos com DAT e flag canDAT=true derivável', async ({ baseURL }) => {
+      const datApi = await createApiContext({
+        baseURL: baseURL!,
+        username: ROLE_CREDENTIALS.dat_e2e.username,
+        password: ROLE_CREDENTIALS.dat_e2e.password,
+      });
+      const res = await datApi.get('/api/me/');
+      expect(res.ok()).toBeTruthy();
+      const me = (await res.json()) as { username: string; groups?: string[]; setores?: string[] };
+
+      expect(me.username).toBe('dat_e2e@test.com');
+      // O backend expõe groups OU setores/funcoes (dependendo da versão do /me/).
+      // Ambos os caminhos devem incluir DAT.
+      const hasDatViaGroups = !!me.groups?.some((g) => g === 'DAT');
+      const hasDatViaSetores = !!me.setores?.some((s) => s === 'DAT');
+      expect(hasDatViaGroups || hasDatViaSetores).toBeTruthy();
+    });
+
+    test('operação: DAT consegue chamar endpoint de manutenção do dashboard Compras', async ({
+      baseURL,
+    }) => {
+      const datApi = await createApiContext({
+        baseURL: baseURL!,
+        username: ROLE_CREDENTIALS.dat_e2e.username,
+        password: ROLE_CREDENTIALS.dat_e2e.password,
+      });
+      // Endpoint conhecido que DAT acessa hoje (pode_acessar_dashboard_compras
+      // inclui DAT + Diretoria no functional_permissions_seed).
+      const res = await datApi.get('/api/dat/compras-materiais/dashboard/');
+      expect(res.status(), `DAT deveria acessar dashboard Compras`).toBeLessThan(400);
+    });
+  }
+);


### PR DESCRIPTION
## Summary

Três jornadas RBAC do plano QA 2026-04-22. Todas validam **comportamento proposital** (sem depender de issues abertas), totalizando 5/19 jornadas concluídas na matriz.

### J05 — Visão individual vs setor (3 testes)

Valida o design que motivou fechar #1159 como `wontfix/by-design`:

- `/api/solicitacoes/` = **individual** (coord só vê as próprias)
- `/api/availability/monthly` = **setor** (via `HasSectorAccess` + `EquipeGerencia`)
- Escopos não vazam entre setores diferentes

### J10 — Coord não aprova própria solicitação (3 testes)

Valida PA-02: apenas Superintendência/DAT/superuser aprovam. Coord (mesmo sendo dono) recebe 403 ao tentar aprovar.

### J18 — DAT tem acesso total ao frontend (13 testes)

Valida regra do PO (memória `project_rbac_invariants`): DAT é suporte técnico e navega em todas as telas. Inclui novo usuário seedado `dat_e2e@test.com` com group `DAT` puro. Cobre 11 rotas principais + 2 testes de borda/operação.

## Backend changes

- `seed_e2e_users.py`: novo usuário `dat_e2e@test.com` (CPF 99900000040, group `DAT` puro) para jornada J18. Total de usuários E2E: 12.

## Frontend changes

- `fixtures/roles.ts`: `'dat_e2e'` adicionado a `E2E_ROLES` e `ROLE_CREDENTIALS`.
- `journeys/j05-rbac-individual-vs-setor.spec.ts`: 3 testes (canônica, borda, operação).
- `journeys/j10-self-approval-blocked.spec.ts`: 3 testes (canônica, borda, operação).
- `journeys/j18-dat-full-access.spec.ts`: 13 testes (11 rotas + 2 borda/operação).
- `journeys/README.md`: J05, J10, J18 marcados como ✅. Matriz atualizada.

## Test plan

- [x] `npx tsc --noEmit` → zero erros
- [x] `black --check` → clean
- [x] `docker exec python manage.py seed_e2e_users` → 12 usuários criados, dat_e2e com group DAT puro
- [ ] CI full suite
- [ ] Execução dos 19 testes dos 3 specs no CI

## Staging Gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

ALL 8 CHECKS PASSED — validação local:

```
1. tsc --noEmit ............................ OK (zero erros)
2. black --check ........................... OK
3. seed_e2e_users com dat_e2e .............. OK (12 usuarios total)
4. J05 canonica + borda + operacao ......... OK (compilacao)
5. J10 canonica + borda + operacao ......... OK (compilacao)
6. J18 11 rotas + borda + operacao ......... OK (compilacao)
7. Matriz README com 5/19 concluidas ....... OK
8. Fixtures multi-role reutilizadas ........ OK (coord_vidas, coord_fluir, dat_e2e, super_geral)
```

## Observações

- **J18 e #1166**: o J18 testa apenas dashboard **Compras** (que DAT já acessa hoje). Os outros 4 dashboards (Overview, Equipe, GCal, Mapa) ficam fora até #1166 normalizar para Diretoria+DAT+superuser. Comentário explicativo no corpo do spec.
- **J10 e PA-02**: A regra `IsSuperintendencia` aceita `Superintendência | DAT | superuser`. Coord nunca aprova — nem mesmo a própria. Spec documenta isso no preâmbulo.

## Fora de escopo (próximos PRs)

- **J02 (wizard validation)**, **J03 (RD-06 com time-freeze)**, **J04 (reprovação PA-04)**, **J06 (RD-01)**, **J07 (RD-04)**, **J08 (concorrência)** — próximas jornadas.
- Axe-core amplo, visual regression, sharding + tagging CI — Fase 4.

## Contexto

Fases do plano QA 2026-04-22:

1. ✅ Quick wins — PR #1170.
2. ✅ Scaffolding 2a — PR #1171.
3. ✅ Scaffolding 2b — PR #1172.
4. ✅ J01 (SUPER + NAO_SUPER) — PR #1173.
5. 🟡 Lote RBAC — **este PR** (J05 + J10 + J18).
6. Fase 4 — CI hardening.

Relacionado: #1163, #1164, #1165, #1166, #1167, #1168, #1169.