### PR TITLE
fix(e2e): J03 canônica — gap de 30 min força RD-04 D (era 2h, igual ao buffer)

### DIFF
--- a/v2/frontend/e2e/journeys/j03-rd04-deslocamento.spec.ts
+++ b/v2/frontend/e2e/journeys/j03-rd04-deslocamento.spec.ts
@@ -44,15 +44,6 @@ test.describe(
     test('canônica: check em Fortaleza no mesmo dia de evento em Salvador → conflito D', async ({
       baseURL,
     }) => {
-      // Flaky em CI: /api/availability/check/ às vezes retorna conflicts=[]
-      // em vez de incluir 'D'. Participation FORMADOR via
-      // extra_participants.formador_ids parece não persistir de forma
-      // consistente. Usar test.fixme() (não test.fail) porque o teste passa
-      // em alguns runs — investigação backend pendente.
-      test.fixme(
-        true,
-        'Flaky: extra_participants.formador_ids não gera Participation consistentemente — investigação backend'
-      );
       const DAY = uniqueFutureDay();
       const superApi = await createApiContext({
         baseURL: baseURL!,
@@ -88,12 +79,15 @@ test.describe(
       // Usamos o `inicio` efetivo da solicitação criada (não o DAY original).
       const actualDay = solicitacaoSalvador.inicio.slice(0, 10); // "YYYY-MM-DD"
 
-      // Consulta RD-04: pedir janela em Fortaleza no mesmo dia, 2h depois
+      // Consulta RD-04: janela em Fortaleza 30 min após o fim do evento em
+      // Salvador. TRAVEL_BUFFER_MINUTES é 60 (dev) ou 120 (prod/CI), então
+      // gap de 30 min é SEMPRE < buffer → força conflito 'D'. Gaps ≥60 min
+      // fariam o teste passar apenas em prod (buffer maior), nunca em dev.
       const checkRes = await superApi.get(
         `/api/availability/check/` +
           `?usuario_id=${formadorId}` +
-          `&inicio=${encodeURIComponent(`${actualDay}T13:00:00-03:00`)}` +
-          `&fim=${encodeURIComponent(`${actualDay}T15:00:00-03:00`)}` +
+          `&inicio=${encodeURIComponent(`${actualDay}T11:30:00-03:00`)}` +
+          `&fim=${encodeURIComponent(`${actualDay}T13:30:00-03:00`)}` +
           `&municipio_id=${fortalezaId}`
       );
       expect(checkRes.ok()).toBeTruthy();


### PR DESCRIPTION
## Summary

- **Root cause do bug "flaky" do J03 canônica**: assertion esperava conflito `D` (RD-04) com gap de 2h entre evento em Salvador e check em Fortaleza. Mas `availability_service.check_conflicts` faz `mins < buffer_min`, e gap = buffer "passa" (comentário explícito: "Buffer exato (==) deve passar").
- Resultado: `120 < 60` (dev) e `120 < 120` (CI) = False → conflito D nunca gerado → teste nunca poderia passar.
- Fix: gap de 30 min (check 11:30-13:30 após evento 09-11). 30 < 60 < 120 → sempre gera D.

## Investigação

O teste passou em um run CI do #1202 com "Expected to fail, but passed" — interpretei como prova de flaky e usei `test.fixme`. Na verdade era anomalia do marcador `test.fail` (aceita falha de assert como passagem esperada). Reproduzi localmente em `repeat-each=5` e obtive **5/5 falhas consistentes** antes do fix, **5/5 sucessos** depois.

Backend está CORRETO — `check_conflicts` fazendo exatamente o que documenta (`mins < buffer_min`). Bug era só na expectativa do teste.

## Observação ambiental

- `TRAVEL_BUFFER_MINUTES` em dev (docker-compose): 60 min
- `TRAVEL_BUFFER_MINUTES` default em settings.py: 120 min (CI usa este)
- Gap de 30 min é seguro nos dois ambientes.

## Test plan

- [x] `rtk proxy npx playwright test j03 --workers=1 --grep "canônica" --repeat-each=5` → 5/5 passa
- [x] `rtk proxy npx playwright test journeys/j03 journeys/j06 --workers=2` → 6/6 passa (CI parity)
- [x] TS check limpo
- [ ] Aguardando CI `[info] e2e journeys` job verde
## Staging gate

ALL 8 CHECKS PASSED
- [x] Feature complete
- [x] Tests updated
- [x] TS/Lint clean
- [x] No breaking API changes
- [x] No DB migrations needed
- [x] No infra changes
- [x] Docs inline nos comments
- [x] Backward compatible (só mexe em spec E2E)