### PR TITLE
fix(e2e): J05 canônica — ?ordering=-id elimina dependência de paginação

### DIFF
--- a/v2/frontend/e2e/journeys/j05-rbac-individual-vs-setor.spec.ts
+++ b/v2/frontend/e2e/journeys/j05-rbac-individual-vs-setor.spec.ts
@@ -42,12 +42,6 @@ test.describe(
     test('canônica: coord_vidas vê apenas suas solicitações em /api/solicitacoes/?mine=true', async ({
       baseURL,
     }) => {
-      // BACKLOG: com centenas de solicitações acumuladas no banco dev, a
-      // solicitação recém-criada pode cair na página 2+ da paginação default.
-      // Em CI com DB virgem o teste pode passar. test.fixme evita
-      // falso-positivo de "Expected to fail, but passed".
-      // Fix planejado: usar `expect.poll` + filtro por `inicio` explícito.
-      test.fixme(true, 'Paginação esconde solicitação recém-criada — investigar filtro por inicio');
       const coordVidasApi = await createApiContext({
         baseURL: baseURL!,
         username: ROLE_CREDENTIALS.coord_vidas.username,
@@ -55,7 +49,11 @@ test.describe(
       });
       const solicitacao = await seedSolicitacao(coordVidasApi, { fluxo: 'SUPER' });
 
-      const res = await coordVidasApi.get('/api/solicitacoes/?mine=true');
+      // A view tem `ordering=["-inicio"]` (ordena por data do evento, não
+      // de criação). Seeds usam random 7-365 dias futuros, então a sol
+      // recém-criada cai em qualquer posição da lista paginada. Forçar
+      // `ordering=-id` garante que ela apareça na pag 1 (IDs monotônicos).
+      const res = await coordVidasApi.get('/api/solicitacoes/?mine=true&ordering=-id');
       expect(res.ok()).toBeTruthy();
       const data = (await res.json()) as
         | { results?: Array<{ id: number }> }


### PR DESCRIPTION
## Summary

- **Root cause**: `SolicitacaoViewSet` tem `ordering = ["-inicio"]` — ordena por data do evento, não por criação. Seeds usam `inicio` random 7-365 dias futuros, então a sol recém-criada cai em qualquer posição da lista paginada (662 sols no dev, page_size=100). Assert `ids.toContain(solicitacao.id)` falhava quando caía fora da pag 1.
- **Em CI com DB virgem** havia poucas sols → tudo cabia na pag 1, por isso o teste passava "às vezes" e foi marcado `test.fixme`.
- **Fix**: passar `?ordering=-id`. IDs são monotonicamente crescentes → sol recém-criada tem maior ID → sempre pag 1.

## Validação

- `rtk proxy npx playwright test j05 --workers=1 --grep "canônica" --repeat-each=5` → 5/5 passa (antes 2/3 falhavam)
- Backend não precisa mudar — `ordering_fields` já inclui `id`
- TS check limpo

## Observação de design

O teste só exercia a assertion em contextos específicos (banco virgem), o que explica por que o `test.fixme` atrasou o diagnóstico. A lição (salva em memória `feedback_e2e_respect_env_config`): asserts que dependem de ordering/paginação devem passar parâmetro explícito.

## Test plan

- [x] `rtk proxy npx playwright test j05 --workers=1 --grep "canônica" --repeat-each=5` → 5/5
- [ ] CI `[info] e2e journeys` verde
## Staging gate

ALL 8 CHECKS PASSED
- [x] Feature complete
- [x] Tests updated
- [x] TS/Lint clean
- [x] No breaking API changes
- [x] No DB migrations needed
- [x] No infra changes
- [x] Docs inline nos comments
- [x] Backward compatible (só mexe em spec E2E)