### PR TITLE
fix(e2e): z-auth logout — storage isolado + selector por role Sair

### DIFF
--- a/v2/frontend/e2e/navigation.spec.ts
+++ b/v2/frontend/e2e/navigation.spec.ts
@@ -10,11 +10,12 @@ import { waitForAppReady } from './helpers/wait';
 
 test.describe('Navegação Principal', () => {
   test('1. Página Inicial carrega corretamente', async ({ page }) => {
-    // Spec legacy pré-programa de jornadas. Flaky sob contenção de 2
-    // workers paralelos — às vezes passa, às vezes a sidebar não
-    // renderiza. Usar test.fixme (não test.fail) para não gerar falha
-    // quando passa. Backlog: migrar para POM padrão das jornadas.
-    test.fixme(true, 'Flaky legacy spec — backlog de migração');
+    // Spec legacy pré-programa de jornadas. Passa local consistentemente,
+    // mas flaky sob contenção de full suite com 2 workers em CI (sidebar
+    // às vezes não renderiza no timeout). test.fixme evita falso-positivo
+    // de "Expected to fail, but passed". Backlog: migrar para POM padrão
+    // das jornadas.
+    test.fixme(true, 'Flaky em CI sob full suite — backlog de migração');
     await page.goto('/home');
     await waitForAppReady(page);
     await expect(page.getByRole('navigation', { name: 'Navegacao principal' })).toBeVisible();

--- a/v2/frontend/e2e/z-auth.spec.ts
+++ b/v2/frontend/e2e/z-auth.spec.ts
@@ -58,25 +58,29 @@ test.describe('Fluxo de Autenticação', () => {
     });
   });
 
-  // Este teste USA a sessão autenticada do setup
+  // Logout é destrutivo (invalida sessão server-side). Não pode usar o
+  // storageState compartilhado dos setups — runs consecutivos/paralelos
+  // se contaminariam. Isola com storage vazio + login inline.
   test.describe('Logout', () => {
-    test('4. Logout funciona corretamente', async ({ page }) => {
-      // Spec legacy pré-programa de jornadas. Mesma flakiness do
-      // navigation.spec — sidebar às vezes não renderiza sob contenção
-      // de workers paralelos. test.fixme para não falhar quando passa.
-      test.fixme(true, 'Flaky legacy spec — backlog de migração');
-      // Já está logado via setup - ir para home
-      await page.goto('/home');
+    test.use({ storageState: { cookies: [], origins: [] } });
 
-      // Verificar que está logado
+    test('4. Logout funciona corretamente', async ({ page }) => {
+      // Login inline (storage vazio, sessão autocontida)
+      await page.goto('/');
+      await page.fill('input[id="login_username"]', ADMIN_USER.username);
+      await page.fill('input[id="login_password"]', ADMIN_USER.password);
+      await page.click('button[type="submit"]');
       await expect(
         page.getByRole('navigation', { name: 'Navegacao principal' })
-      ).toBeVisible({ timeout: 5000 });
+      ).toBeVisible({ timeout: 15000 });
 
-      // Clicar no botão de logout (selector explícito para evitar ambiguidades)
-      await page.click('[data-testid="app-logout-button"]');
+      // Click no botão "Sair" do AppHeader. Selector antigo
+      // `[data-testid="app-logout-button"]` não existe mais no componente
+      // (AppHeader.tsx:179-186 renderiza `<Button>Sair</Button>` sem
+      // data-testid).
+      await page.getByRole('button', { name: /sair/i }).click();
 
-      // Deve voltar para tela de login (h1, não h2)
+      // Volta para tela de login
       await expect(page.locator('h1:has-text("Login")')).toBeVisible({ timeout: 10000 });
     });
   });


### PR DESCRIPTION
## Summary

**Root cause do z-auth #4 (flaky de verdade, não do tipo "passar em CI por acidente")**:

1. `page.click('[data-testid=\"app-logout-button\"]')` — selector obsoleto. `AppHeader.tsx:179-186` renderiza `<Button>Sair</Button>` sem data-testid.
2. Logout é destrutivo (invalida sessão server-side), mas o teste usava storageState compartilhado dos setups. Runs consecutivos/paralelos se contaminavam: primeira run desloga, segunda tenta `/home` mas já não tem sessão, redireciona pra login, botão "Sair" não existe → timeout.

Local `--repeat-each=5 --workers=2` falhava 4/5 antes; agora passa 5/5.

## Fix

- `test.use({ storageState: { cookies: [], origins: [] } })` isola o teste: cada run começa sem sessão.
- Login inline (reutiliza credenciais do topo do arquivo — já definidas para os outros testes de Login).
- Selector `getByRole('button', { name: /sair/i })` — estável via AntD + texto renderizado.

## navigation.spec #1 — mantido `test.fixme`

Passa 5/5 local com 1 worker, mas flaky em CI sob full suite de ~108 testes com 2 workers. Não vale migrar agora (smoke test superficial coberto indiretamente por outras jornadas). Backlog: migrar para POM padrão das jornadas OU remover se redundante.

## Test plan

- [x] `rtk proxy npx playwright test z-auth.spec --workers=2 --grep "Logout" --repeat-each=5` → 5/5
- [x] Full suite local `--workers=2` → 104 passed + 1 skipped (navigation fixme) + 1 failed (J01a canônica, ambiente-específico de dev sujo, passa em CI)
- [ ] CI `[info] e2e journeys` verde
## Staging gate

ALL 8 CHECKS PASSED
- [x] Feature complete
- [x] Tests updated
- [x] TS/Lint clean
- [x] No breaking API changes
- [x] No DB migrations needed
- [x] No infra changes
- [x] Docs inline nos comments
- [x] Backward compatible (só mexe em spec E2E)