### PR TITLE
refactor(rbac): Epic 2 — HasPerm(codename) + deprecation das 12 classes (#1181)

### DIFF
--- a/v2/backend/apps/core/migrations/0073_rename_permission_labels.py
+++ b/v2/backend/apps/core/migrations/0073_rename_permission_labels.py
@@ -12,7 +12,7 @@ Idempotente via `update_or_create` — seguro para re-run.
 Ver master-plan §3.2, §3.4 e v2/docs/plans/rbac-refactor/epic-1-labels.md.
 """
 
-# pyright: reportUnknownMemberType=false, reportUnknownVariableType=false, reportMissingParameterType=false
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false
 
 from __future__ import annotations
 

--- a/v2/backend/apps/core/permissions.py
+++ b/v2/backend/apps/core/permissions.py
@@ -33,8 +33,6 @@ from apps.core.services.rbac_permissions import get_user_functional_permissions
 # o decorator para sinalização em static type-checkers.
 
 
-
-
 class HasPerm(permissions.BasePermission):  # type: ignore[misc]
     """
     Capability-oriented parametric permission class (DRF).

--- a/v2/backend/apps/core/permissions.py
+++ b/v2/backend/apps/core/permissions.py
@@ -1,14 +1,24 @@
 """
 DRF permissions para RBAC funcional (database-driven).
 
+Epic 2 RBAC Refactor (2026-04-23): introduz `HasPerm(codename)`
+parametrizado como padrão canônico + marca as 12 classes factory legacy
+com `warnings.warn(DeprecationWarning)` no `__init__`. Classes legacy
+continuam funcionais — remoção efetiva é Epic 5 (libcst codemod).
+PEP 702 `@typing.deprecated` será readicionado quando subirmos para Python 3.13.
+
+Ver v2/docs/RBAC_NAMING.md para convenção completa.
+
 Backwards compatible:
 - nomes das classes publicas preservados;
-- imports existentes continuam funcionando.
+- imports existentes continuam funcionando;
+- comportamento das legacy idêntico (só emite DeprecationWarning).
 """
 
-# pyright: reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportAttributeAccessIssue=false
+# pyright: reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportAttributeAccessIssue=false, reportCallIssue=false
 from __future__ import annotations
 
+import warnings
 from typing import cast
 
 from rest_framework import permissions  # type: ignore[attr-defined]
@@ -17,10 +27,89 @@ from rest_framework.views import APIView
 
 from apps.core.services.rbac_permissions import get_user_functional_permissions
 
+# PEP 702 `@typing.deprecated` exige Python 3.13+. Em 3.12 nos baseamos
+# em runtime warnings via `warnings.warn(DeprecationWarning)` no __init__
+# de cada classe legacy. Quando subirmos para 3.13, podemos readicionar
+# o decorator para sinalização em static type-checkers.
+
+
+
+
+class HasPerm(permissions.BasePermission):  # type: ignore[misc]
+    """
+    Capability-oriented parametric permission class (DRF).
+
+    Checa uma único functional permission codename via
+    `get_user_functional_permissions`. Preferido sobre subclassing para
+    endpoints novos. Emite a decisão de design do master-plan §3.3
+    (RBAC Refactor): classes DRF devem ser parametrizadas, não 1 classe
+    por capability.
+
+    Composition (DRF 3.9+):
+        HasPerm("a") | HasPerm("b")  # OR — grant se qualquer um
+        HasPerm("a") & HasPerm("b")  # AND — grant só se ambos
+        ~HasPerm("a")                # NOT — grant se não tem a perm
+
+    Usage:
+        class MyView(APIView):
+            permission_classes = [IsAuthenticated, HasPerm("pode_aprovar_superintendencia")]
+
+    Nota sobre app_label:
+        O prefixo "core." é opcional — o sistema funcional usa codename
+        bare. Aceitamos ambas as formas para familiaridade com
+        `user.has_perm()` nativo do Django.
+    """
+
+    def __init__(self, codename: str, *, message: str | None = None) -> None:
+        # Strip "app_label." prefix se presente
+        self.codename = codename.split(".", 1)[-1] if "." in codename else codename
+        if message:
+            self.message = message
+
+    def __call__(self) -> "HasPerm":
+        """DRF composition resolve para uma callable; já somos uma instance."""
+        return self
+
+    def has_permission(self, request: Request, view: APIView) -> bool:
+        user = request.user
+        if not user or not user.is_authenticated:
+            return False
+        if getattr(user, "is_superuser", False):
+            return True
+        return self.codename in get_user_functional_permissions(user)
+
+    def __repr__(self) -> str:
+        return f"HasPerm({self.codename!r})"
+
+    # Composition sobre instances (DRF OperandHolder só opera em classes).
+    # Permite o idioma canônico `HasPerm("a") | HasPerm("b")` em
+    # `permission_classes`. Delegamos para as classes `OR`/`AND`/`NOT` do
+    # próprio DRF. Retornamos Any para evitar strict-type mismatch — DRF
+    # OR/AND/NOT implementam o protocolo BasePermission mas não herdam dele.
+    def __or__(self, other):  # type: ignore[no-untyped-def]
+        return permissions.OR(self, other)
+
+    def __and__(self, other):  # type: ignore[no-untyped-def]
+        return permissions.AND(self, other)
+
+    def __invert__(self):  # type: ignore[no-untyped-def]
+        return permissions.NOT(self)
+
+    def __ror__(self, other):  # type: ignore[no-untyped-def]
+        return permissions.OR(other, self)
+
+    def __rand__(self, other):  # type: ignore[no-untyped-def]
+        return permissions.AND(other, self)
+
 
 class HasFunctionalPermission(permissions.BasePermission):  # type: ignore[misc]
     """
     Base class para checagem por codename funcional.
+
+    NOTA (Epic 2): preferir `HasPerm(codename)` inline em permission_classes
+    para endpoints novos. Esta classe continua servindo de base para as 12
+    factory classes legacy + 2 compostas (`IsGerenteSuperintendencia`,
+    `IsOwnerOrPrivileged`). Remoção das legacy é Epic 5.
     """
 
     functional_codename = ""
@@ -49,6 +138,26 @@ def funcperm_factory(
     return cast(type[HasFunctionalPermission], type(class_name, (HasFunctionalPermission,), attrs))
 
 
+def _warn_legacy(class_name: str, new_codename: str) -> None:
+    """Helper: emite DeprecationWarning padronizado apontando para HasPerm equivalente."""
+    warnings.warn(
+        f"{class_name} is deprecated; use HasPerm({new_codename!r}). "
+        "This class will be removed in Epic 5 of the RBAC refactor. "
+        "See v2/docs/RBAC_NAMING.md.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+
+
+# ============================================================================
+# Epic 2 Legacy factory classes (12) — deprecated em favor de HasPerm(codename)
+#
+# Cada uma emite DeprecationWarning no __init__ apontando para HasPerm
+# equivalente. Remoção efetiva no Epic 5 (libcst codemod). Ver master-plan
+# §3.3 e v2/docs/RBAC_NAMING.md.
+# ============================================================================
+
+
 class IsSuperintendencia(
     funcperm_factory(
         "IsSuperintendencia",
@@ -56,7 +165,9 @@ class IsSuperintendencia(
         "Apenas usuários da Superintendência, DAT ou Superusuários podem realizar esta ação.",
     )
 ):
-    pass
+    def __init__(self) -> None:
+        super().__init__()
+        _warn_legacy("IsSuperintendencia", "pode_aprovar_superintendencia")
 
 
 class IsSuperintendenciaOnly(
@@ -66,7 +177,9 @@ class IsSuperintendenciaOnly(
         "Apenas usuários da Superintendência podem realizar esta ação.",
     )
 ):
-    pass
+    def __init__(self) -> None:
+        super().__init__()
+        _warn_legacy("IsSuperintendenciaOnly", "pode_gerenciar_superintendencia_only")
 
 
 class IsCoordenadorOrDAT(
@@ -76,7 +189,9 @@ class IsCoordenadorOrDAT(
         "Apenas Coordenadores, Apoio de Coordenação ou DAT podem criar solicitações.",
     )
 ):
-    pass
+    def __init__(self) -> None:
+        super().__init__()
+        _warn_legacy("IsCoordenadorOrDAT", "pode_criar_solicitacao_coord_dat")
 
 
 class IsControleOrSuper(
@@ -86,7 +201,9 @@ class IsControleOrSuper(
         "Apenas Controle ou Superintendência podem realizar esta ação.",
     )
 ):
-    pass
+    def __init__(self) -> None:
+        super().__init__()
+        _warn_legacy("IsControleOrSuper", "pode_importar_controle_super")
 
 
 class IsDATOrSuper(
@@ -96,7 +213,9 @@ class IsDATOrSuper(
         "Apenas usuários do grupo DAT ou superusers podem realizar esta ação.",
     )
 ):
-    pass
+    def __init__(self) -> None:
+        super().__init__()
+        _warn_legacy("IsDATOrSuper", "pode_operar_dat")
 
 
 class IsComprasDashboardAccess(
@@ -106,7 +225,9 @@ class IsComprasDashboardAccess(
         "Apenas usuários dos grupos DAT ou Diretoria podem acessar o dashboard de compras.",
     )
 ):
-    pass
+    def __init__(self) -> None:
+        super().__init__()
+        _warn_legacy("IsComprasDashboardAccess", "pode_acessar_dashboard_compras")
 
 
 class IsDAT(
@@ -116,7 +237,9 @@ class IsDAT(
         "Apenas usuários do grupo DAT podem realizar esta ação.",
     )
 ):
-    pass
+    def __init__(self) -> None:
+        super().__init__()
+        _warn_legacy("IsDAT", "pode_operar_dat_exclusivo")
 
 
 class IsControleOrDAT(
@@ -126,7 +249,9 @@ class IsControleOrDAT(
         "Apenas Controle ou DAT podem realizar esta ação.",
     )
 ):
-    pass
+    def __init__(self) -> None:
+        super().__init__()
+        _warn_legacy("IsControleOrDAT", "pode_operar_controle_dat")
 
 
 class IsControle(
@@ -136,7 +261,9 @@ class IsControle(
         "Apenas usuários do grupo Controle podem realizar esta ação.",
     )
 ):
-    pass
+    def __init__(self) -> None:
+        super().__init__()
+        _warn_legacy("IsControle", "pode_operar_controle")
 
 
 class IsGerencia(
@@ -146,7 +273,9 @@ class IsGerencia(
         "Apenas usuários com permissão gerencial (Gerência, Superintendência ou Diretoria) podem realizar esta ação.",
     )
 ):
-    pass
+    def __init__(self) -> None:
+        super().__init__()
+        _warn_legacy("IsGerencia", "pode_operar_gerencia")
 
 
 class IsDashboardOverview(
@@ -156,7 +285,9 @@ class IsDashboardOverview(
         "Apenas usuários com permissão de dashboard (Superintendência, Gerência ou Diretoria) podem acessar o dashboard geral.",
     )
 ):
-    pass
+    def __init__(self) -> None:
+        super().__init__()
+        _warn_legacy("IsDashboardOverview", "pode_acessar_dashboard_overview")
 
 
 class IsMapMetrics(
@@ -166,7 +297,9 @@ class IsMapMetrics(
         "Apenas usuários autorizados podem acessar métricas do mapa.",
     )
 ):
-    pass
+    def __init__(self) -> None:
+        super().__init__()
+        _warn_legacy("IsMapMetrics", "pode_acessar_map_metrics")
 
 
 class IsGerenteSuperintendencia(HasFunctionalPermission):  # type: ignore[misc]

--- a/v2/backend/apps/core/tests/test_permissions_hasperm.py
+++ b/v2/backend/apps/core/tests/test_permissions_hasperm.py
@@ -11,7 +11,7 @@ Valida:
 Ver v2/docs/plans/rbac-refactor/epic-2-hasperm.md e master-plan §3.3.
 """
 
-# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportAttributeAccessIssue=false, reportOptionalMemberAccess=false, reportCallIssue=false
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportOptionalMemberAccess=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportMissingTypeArgument=false, reportCallIssue=false, reportIndexIssue=false, reportOperatorIssue=false, reportOptionalSubscript=false, reportUnknownLambdaType=false, reportImplicitStringConcatenation=false
 
 from __future__ import annotations
 

--- a/v2/backend/apps/core/tests/test_permissions_hasperm.py
+++ b/v2/backend/apps/core/tests/test_permissions_hasperm.py
@@ -1,0 +1,261 @@
+"""
+Epic 2 RBAC Refactor — tests for HasPerm(codename) parametric permission class.
+
+Valida:
+- HasPerm grant/deny baseado em get_user_functional_permissions
+- Bypass para is_superuser
+- Composition DRF: & (AND), | (OR), ~ (NOT)
+- Deprecation warnings nas 12 classes factory legacy
+- Integração com o cache de permissões funcionais
+
+Ver v2/docs/plans/rbac-refactor/epic-2-hasperm.md e master-plan §3.3.
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportAttributeAccessIssue=false, reportOptionalMemberAccess=false, reportCallIssue=false
+
+from __future__ import annotations
+
+import warnings
+
+from django.contrib.auth.models import AnonymousUser, Group
+from rest_framework.request import Request
+from rest_framework.test import APIRequestFactory
+
+import pytest
+
+from apps.core.models import PermissaoFuncional, Usuario
+from apps.core.permissions import (
+    HasPerm,
+    IsComprasDashboardAccess,
+    IsControle,
+    IsControleOrDAT,
+    IsControleOrSuper,
+    IsCoordenadorOrDAT,
+    IsDashboardOverview,
+    IsDAT,
+    IsDATOrSuper,
+    IsGerencia,
+    IsMapMetrics,
+    IsSuperintendencia,
+    IsSuperintendenciaOnly,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+# ============================================================================
+# FIXTURES
+# ============================================================================
+
+
+@pytest.fixture
+def seeded_permission():
+    """Cria uma PermissaoFuncional real para testes de HasPerm."""
+    perm, _ = PermissaoFuncional.objects.get_or_create(
+        codename="can_do_test_action",
+        defaults={
+            "label": "Executar ação de teste",
+            "description": "Permissão para testes de HasPerm.",
+            "category": "operacao",
+            "is_system": False,
+        },
+    )
+    return perm
+
+
+@pytest.fixture
+def group_with_permission(seeded_permission):
+    """Cria um group Django associado à permission de teste."""
+    group, _ = Group.objects.get_or_create(name="TestCapabilityGroup")
+    seeded_permission.groups.add(group)
+    return group
+
+
+@pytest.fixture
+def user_with_capability(group_with_permission):
+    """Usuário cuja associação de group lhe dá a permissão funcional."""
+    user = Usuario.objects.create_user(
+        username="cap_user",
+        email="cap@test.com",
+        password="x",
+        cpf="10000000001",
+    )
+    user.groups.add(group_with_permission)
+    return user
+
+
+@pytest.fixture
+def user_without_capability():
+    """Usuário autenticado mas sem a permissão de teste."""
+    return Usuario.objects.create_user(
+        username="no_cap_user",
+        email="nocap@test.com",
+        password="x",
+        cpf="10000000002",
+    )
+
+
+@pytest.fixture
+def superuser():
+    """Superuser — sempre passa em HasPerm (bypass)."""
+    return Usuario.objects.create_superuser(
+        username="su",
+        email="su@test.com",
+        password="x",
+        cpf="10000000003",
+    )
+
+
+@pytest.fixture
+def request_factory():
+    return APIRequestFactory()
+
+
+def _build_request(factory, user) -> Request:
+    """Constrói um request DRF autenticado com o user fornecido."""
+    django_req = factory.get("/")
+    req = Request(django_req)
+    req.user = user
+    return req
+
+
+# ============================================================================
+# HasPerm — comportamento básico
+# ============================================================================
+
+
+def test_hasperm_grants_user_with_functional_permission(request_factory, user_with_capability):
+    """HasPerm('codename') deve retornar True para user com a permissão via group."""
+    perm = HasPerm("can_do_test_action")
+    req = _build_request(request_factory, user_with_capability)
+    assert perm.has_permission(req, None) is True
+
+
+def test_hasperm_denies_user_without_functional_permission(request_factory, user_without_capability):
+    """HasPerm retorna False para user autenticado sem a permissão."""
+    perm = HasPerm("can_do_test_action")
+    req = _build_request(request_factory, user_without_capability)
+    assert perm.has_permission(req, None) is False
+
+
+def test_hasperm_denies_anonymous_user(request_factory):
+    """HasPerm retorna False para user não autenticado (nunca bypass)."""
+    perm = HasPerm("can_do_test_action")
+    req = _build_request(request_factory, AnonymousUser())
+    assert perm.has_permission(req, None) is False
+
+
+def test_hasperm_grants_superuser_bypass(request_factory, superuser):
+    """HasPerm sempre retorna True para is_superuser, sem consultar funcperm."""
+    perm = HasPerm("nonexistent_codename_ever")
+    req = _build_request(request_factory, superuser)
+    assert perm.has_permission(req, None) is True
+
+
+def test_hasperm_strips_app_label_prefix(request_factory, user_with_capability):
+    """HasPerm aceita 'core.codename' e 'codename' como formas equivalentes.
+
+    Django has_perm usa prefixo app_label; o sistema funcional usa codename
+    bare. HasPerm aceita as duas formas para familiaridade com API do Django.
+    """
+    bare = HasPerm("can_do_test_action")
+    prefixed = HasPerm("core.can_do_test_action")
+    req = _build_request(request_factory, user_with_capability)
+    assert bare.has_permission(req, None) is True
+    assert prefixed.has_permission(req, None) is True
+
+
+def test_hasperm_custom_message():
+    """HasPerm aceita message customizada no kwarg."""
+    perm = HasPerm("some_codename", message="Operação restrita a auditores.")
+    assert perm.message == "Operação restrita a auditores."
+
+
+def test_hasperm_repr_includes_codename():
+    """__repr__ expõe o codename para debug/logs (sem prefixo app_label)."""
+    perm = HasPerm("core.approve_solicitation")
+    assert "approve_solicitation" in repr(perm)
+
+
+# ============================================================================
+# Composition DRF (&, |, ~)
+# ============================================================================
+
+
+def test_hasperm_composition_or_grants_if_any_match(request_factory, user_with_capability):
+    """HasPerm('A') | HasPerm('B') deve grantar se user tem A OU B."""
+    composed = HasPerm("can_do_test_action") | HasPerm("nonexistent_perm")
+    req = _build_request(request_factory, user_with_capability)
+    assert composed.has_permission(req, None) is True
+
+
+def test_hasperm_composition_and_requires_both(request_factory, user_with_capability):
+    """HasPerm('A') & HasPerm('B') deve negar se user tem só A."""
+    composed = HasPerm("can_do_test_action") & HasPerm("nonexistent_perm")
+    req = _build_request(request_factory, user_with_capability)
+    assert composed.has_permission(req, None) is False
+
+
+def test_hasperm_composition_not_inverts_grant(request_factory, user_with_capability):
+    """~HasPerm('A') deve negar user que TEM a permissão A."""
+    composed = ~HasPerm("can_do_test_action")
+    req = _build_request(request_factory, user_with_capability)
+    assert composed.has_permission(req, None) is False
+
+
+# ============================================================================
+# Deprecation — 12 classes factory legacy emitem DeprecationWarning
+# ============================================================================
+
+
+LEGACY_CLASSES = [
+    IsSuperintendencia,
+    IsSuperintendenciaOnly,
+    IsCoordenadorOrDAT,
+    IsControleOrSuper,
+    IsDATOrSuper,
+    IsComprasDashboardAccess,
+    IsDAT,
+    IsControleOrDAT,
+    IsControle,
+    IsGerencia,
+    IsDashboardOverview,
+    IsMapMetrics,
+]
+
+
+@pytest.mark.parametrize("legacy_cls", LEGACY_CLASSES)
+def test_legacy_factory_class_emits_deprecation_warning(legacy_cls):
+    """Cada uma das 12 factory classes deve emitir DeprecationWarning no __init__."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        legacy_cls()
+        deprecation_warnings = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert deprecation_warnings, f"{legacy_cls.__name__} não emitiu DeprecationWarning. " "Ver master-plan §3.3."
+        msg = str(deprecation_warnings[0].message)
+        assert (
+            "HasPerm" in msg
+        ), f"Mensagem de deprecation de {legacy_cls.__name__} deve apontar para HasPerm equivalente."
+
+
+def test_legacy_classes_still_work_behaviorally(
+    request_factory, user_with_capability, seeded_permission, group_with_permission
+):
+    """
+    Deprecation é cosmética: comportamento das 12 classes legacy deve
+    permanecer idêntico para garantir backward compat até o Epic 5.
+    """
+    # Conecta a permissão "can_do_test_action" ao codename de uma legacy class
+    # para validar que a classe legacy ainda funciona.
+    # Usamos IsDAT (codename=pode_operar_dat_exclusivo) como piloto.
+    pode_operar_dat_exclusivo = PermissaoFuncional.objects.filter(codename="pode_operar_dat_exclusivo").first()
+    assert pode_operar_dat_exclusivo is not None, "Seed deve ter a permissão."
+
+    # Adiciona o group do user à permissão pode_operar_dat_exclusivo
+    pode_operar_dat_exclusivo.groups.add(group_with_permission)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        perm = IsDAT()
+    req = _build_request(request_factory, user_with_capability)
+    assert perm.has_permission(req, None) is True

--- a/v2/backend/apps/core/tests/test_rbac_service_whitelist.py
+++ b/v2/backend/apps/core/tests/test_rbac_service_whitelist.py
@@ -2,6 +2,8 @@
 Testes para whitelist dinamica de grupos atribuiveis (#832).
 """
 
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportOptionalMemberAccess=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportMissingTypeArgument=false, reportCallIssue=false, reportIndexIssue=false, reportOperatorIssue=false, reportOptionalSubscript=false, reportUnknownLambdaType=false
+
 from __future__ import annotations
 
 from typing import Any, cast

--- a/v2/docs/RBAC_NAMING.md
+++ b/v2/docs/RBAC_NAMING.md
@@ -1,0 +1,238 @@
+# RBAC Naming Convention — Aprender Sistema v2
+
+**Status:** Canônico a partir de Epic 2 do RBAC Refactor (2026-04-23).
+**Source of truth:** este documento.
+**Sources autoritativos** que embasam as regras: [Django auth customizing](https://docs.djangoproject.com/en/5.2/topics/auth/customizing/), [DRF permissions](https://www.django-rest-framework.org/api-guide/permissions/), [NIST RBAC](https://csrc.nist.gov/projects/role-based-access-control), [GitLab permissions conventions](https://docs.gitlab.com/development/permissions/conventions/), [OWASP Authorization Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Authorization_Cheat_Sheet.html).
+
+---
+
+## Princípio central
+
+**Permission é capacidade, não identidade.** Separar o que a pessoa pode fazer (permission) de quem ela é organizacionalmente (setor, função, grupo). Groups agregam permissions; permissions nomeiam ações sobre recursos. Essa é a forma canônica do NIST RBAC.
+
+Manifestação prática: se a organização reestrutura (DAT vira "Operações Administrativas"), **zero linha de código** muda. Apenas `Group.name`.
+
+---
+
+## 1. Codenames (identificador interno)
+
+Formato: `<verb>_<noun>[_<qualifier>]`, snake_case, inglês.
+
+**Verbos canônicos**:
+`create`, `read`, `update`, `delete`, `approve`, `publish`, `import`, `export`, `assign`, `reconcile`, `view`.
+
+**Verbos proibidos** (escopo ambíguo / bundle CRUD):
+`admin_`, `manage_`, `operate_`, `configure_`, `change_`, `modify_`, `edit_`, `list_`, `set_`, `write_`.
+
+**Nunca no codename**:
+- Nome de setor (`dat`, `controle`, `super`, `vidas`, ...)
+- Nome de função (`coordenador`, `formador`, ...)
+- Nome de grupo Django
+
+### Bons exemplos
+
+```text
+approve_solicitation
+publish_gcal_event
+import_spreadsheet
+view_compras_dashboard
+create_solicitation
+view_all_availability
+```
+
+### Maus exemplos
+
+```text
+pode_operar_dat                   # setor no nome
+admin_cadastros                    # verbo proibido
+change_solicitation               # ambíguo (update? aprove? cancel?)
+dat_full_access                   # setor + bundle indefinido
+```
+
+### Exceções conscientes ao "no `manage_`"
+
+Duas permissões bundle foram mantidas por decisão YAGNI (ver master-plan §9.3):
+
+- `manage_admin_registries` — CRUD de cadastros administrativos (municípios, projetos, produtos, etc.)
+- `manage_purchases_and_materials` — CRUD de compras e materiais
+
+Decompor cada uma em `create/read/update/delete` hoje produziria 8+ codenames sempre atribuídos juntos (ruído puro). Decompõe-se quando surgir primeiro papel com subset diferente (ex: auditor read-only).
+
+---
+
+## 2. Labels (texto user-visible, pt-BR)
+
+Formato: `<Verbo infinitivo> <substantivo plural>`.
+
+**Regras**:
+- Começar com verbo infinitivo: *Aprovar*, *Criar*, *Importar*, *Visualizar*, *Administrar*.
+- Evitar: gerúndio ("Aprovação de...", "Criando..."), substantivação ("Aprovações"), adjetivo puro ("Owner"), nome de módulo solto ("Dashboard").
+- **Nunca** nome de setor/função (mesma regra dos codenames).
+
+### Bons exemplos
+
+```text
+Aprovar solicitações
+Importar planilhas e dados
+Visualizar dashboard de compras
+Administrar cadastros
+Exercer supervisão gerencial
+```
+
+### Maus exemplos
+
+```text
+Operacao DAT                       # setor
+Dashboard de Compras               # substantivo, não começa com verbo
+Owner ou privilegiado              # adjetivo
+Aprovação (Superintendência)       # substantivação + setor
+```
+
+### Categorias válidas
+
+```text
+solicitacao
+importacao
+cadastros_administrativos
+dashboard
+operacao
+supervisao
+```
+
+Categorias fora desse vocabulário **quebram testes de regressão** em `apps/core/tests/test_rbac_labels_capability_oriented.py`.
+
+---
+
+## 3. Permission classes (DRF)
+
+**Preferir sempre**: `HasPerm("codename")` inline no `permission_classes`.
+
+```python
+from apps.core.permissions import HasPerm
+from rest_framework.permissions import IsAuthenticated
+
+class SolicitacaoApproveView(APIView):
+    permission_classes = [IsAuthenticated, HasPerm("approve_solicitation")]
+```
+
+### Composition
+
+```python
+# OR: qualquer um
+permission_classes = [IsAuthenticated, HasPerm("approve_solicitation") | HasPerm("manage_admin_registries")]
+
+# AND explícito (mesma semântica de listar dois):
+permission_classes = [IsAuthenticated, HasPerm("a") & HasPerm("b")]
+
+# NOT (raro):
+permission_classes = [IsAuthenticated, ~HasPerm("b")]
+```
+
+### Exceções aceitas (classes dedicadas)
+
+Só para lógica que **não** pode ser expressa por `HasPerm(codename)`:
+
+- **Object-level check**: `IsSolicitationOwner` / `IsOwnerOrPrivileged` (verifica `obj.usuario`).
+- **Dynamic scope por query param**: `HasSectorAccess` (lê `gerencia_id` do request).
+- **Composite rule fixa**: `IsGerenteSuperintendencia` (permission funcional + grupo "Gerente").
+
+Nomear como **condição** (não como identidade): `IsSolicitationOwner`, `IsWithinEditWindow`, `HasSectorAccess`. **Nunca** `Is<Role>`, `Is<Setor>`, `Is<Group>`.
+
+### Proibido
+
+```python
+# Não faça isto em endpoints novos (Epic 5 remove estas 12 classes):
+from apps.core.permissions import IsDAT, IsControle, IsSuperintendencia
+permission_classes = [IsDAT]          # ❌ DeprecationWarning
+permission_classes = [IsControleOrDAT] # ❌ mesmo motivo
+```
+
+---
+
+## 4. Checks de autorização em código
+
+**Canônico**:
+
+```python
+# 1) Via HasPerm (DRF permission class)
+permission_classes = [HasPerm("approve_solicitation")]
+
+# 2) Via has_perm() nativo do Django (fora de views DRF)
+if user.has_perm("approve_solicitation"):
+    ...
+
+# 3) Helper para múltiplas permissions (epic 3):
+from apps.core.rbac_helpers import user_has_any_perm
+if user_has_any_perm(user, "a", "b"):
+    ...
+```
+
+**Proibido** (bypass do RBAC):
+
+```python
+# ❌ NUNCA — ignorado por has_perm(), quebra com rename de Group, Epic 6 lint rejeita
+user.groups.filter(name="DAT").exists()
+user.groups.filter(name__in=["Controle", "DAT"]).exists()
+```
+
+---
+
+## 5. Adicionando uma permission nova
+
+1. Adicionar a `FUNCTIONAL_PERMISSIONS_SEED` em `apps/core/services/functional_permissions_seed.py`:
+   - `codename` seguindo §1
+   - `label` seguindo §2
+   - `category` no vocabulário canônico
+   - `group_names` com os grupos que a receberão por default
+
+2. Criar migration data-only (`RunPython` com `update_or_create`), seguindo `0073_rename_permission_labels.py` como template.
+
+3. Usar em views via `HasPerm("codename")`.
+
+4. Adicionar teste (padrão: `test_endpoint_<name>_forbidden_without_perm`).
+
+5. Atualizar `RBAC_NAMING.md` se introduzir nova categoria.
+
+---
+
+## 6. Depreciação de classe legacy
+
+Se você criar uma nova classe de permission **e** ela puder ser expressa como `HasPerm(codename)`, **não crie** — use `HasPerm` direto.
+
+Se você for remover uma legacy do código:
+- Substituir por `HasPerm("codename")` no `permission_classes`
+- Deletar o import
+- Remover a classe do `apps/core/permissions.py` **somente** quando não houver mais nenhum uso (Epic 5 faz isso via libcst).
+
+---
+
+## 7. Enforcement automático
+
+O Epic 6 (#1179) introduzirá um **lint custom** em `.github/workflows/` que falha PRs que:
+
+- **V001**: usam `user.groups.filter(name=...)` em `views/` ou `services/`
+- **V002**: definem classe `Is<Word>` fora da whitelist
+- **V003**: importam `django.contrib.auth.models.Group` para decisões de autorização
+
+Whitelist do lint: `tests/`, `migrations/`, `fixtures/`, `apps/core/rbac/constants.py`.
+
+Até o Epic 6 entrar em vigor, a revisão manual de PR faz esse papel.
+
+---
+
+## 8. Referência rápida
+
+| Tipo | Forma canônica | Forma proibida |
+|---|---|---|
+| **Codename** | `approve_solicitation` | `pode_aprovar_superintendencia` |
+| **Label** | "Aprovar solicitações" | "Aprovar/Reprovar (Superintendência)" |
+| **Category** | `solicitacao`, `operacao`, ... | `admin_dat`, `gerencia` |
+| **Permission class** | `HasPerm("approve_solicitation")` | `IsSuperintendencia` |
+| **Authz check** | `user.has_perm("approve_solicitation")` | `user.groups.filter(name="Superintendência")` |
+| **Classe dedicada** | `IsSolicitationOwner` (condição) | `IsDAT` (identidade) |
+
+---
+
+## 9. Changelog
+
+- **2026-04-23** — v1.0 criada com Epic 2 (#1181). `HasPerm` introduzido, 12 classes factory marcadas com `warnings.warn(DeprecationWarning)` + aviso para remoção no Epic 5.

--- a/v2/frontend/e2e/journeys/README.md
+++ b/v2/frontend/e2e/journeys/README.md
@@ -24,7 +24,7 @@ SUPER requer aprovação manual (PA-02); NAO_SUPER é auto-aprovado na criação
 Jornadas que dependem de aprovação têm duas variantes (J01a/J01b).
 
 | ID | Jornada | Tags | Status | Depende de |
-|----|---------|------|--------|-----------|
+| ---- | ---------- | ------ | -------- | ----------- |
 | J01a | SUPER happy path: coord cria → super aprova | `@critical @rf01 @pa-02 @fluxo-super` | ✅ | — |
 | J01b | NAO_SUPER happy path: coord cria → auto-aprovado | `@critical @rf01 @fluxo-nao-super` | ✅ | — |
 | J02 | Wizard de nova solicitação: estrutura, validação, RBAC | `@critical @ux @rf01` | ✅ | — |


### PR DESCRIPTION
## Summary

Introduz `HasPerm(codename)` parametrizado como padrão canônico DRF + marca 12 classes factory legacy com `warnings.warn(DeprecationWarning)`. Remoção efetiva das legacy é Epic 5 (libcst codemod).

**Motivação** (ver [master-plan §3.3](v2/docs/plans/rbac-refactor/master-plan.md)): DRF oficial nunca define `Is<Role>` — só estados (`IsAuthenticated`). Ter 12 classes para 12 codenames é "permission class explosion" (OWASP anti-pattern).

## Design da `HasPerm`

```python
from apps.core.permissions import HasPerm
from rest_framework.permissions import IsAuthenticated

class SolicitacaoApproveView(APIView):
    permission_classes = [IsAuthenticated, HasPerm("approve_solicitation")]

# Composition:
#   HasPerm("a") | HasPerm("b")  → OR
#   HasPerm("a") & HasPerm("b")  → AND
#   ~HasPerm("a")                → NOT
```

**Detalhes**:
- Bypass de `is_superuser` preservado (compat com classes legacy)
- Aceita `"core.codename"` ou `"codename"` (strip app_label prefix)
- Composition sobre **instances** (DRF `OperandHolder` só opera em classes; usamos `__or__`/`__and__`/`__invert__` delegando para `permissions.OR/AND/NOT`)

## Deprecation pattern

12 classes factory emitem `DeprecationWarning` no `__init__`:

```python
class IsDAT(funcperm_factory("IsDAT", "pode_operar_dat_exclusivo", "...")):
    def __init__(self) -> None:
        super().__init__()
        _warn_legacy("IsDAT", "pode_operar_dat_exclusivo")
```

**3 classes mantidas** (não são anti-pattern — exprimem lógica que `HasPerm(codename)` não cobre):
- `IsGerenteSuperintendencia` — composite rule (permission funcional + grupo "Gerente")
- `IsOwnerOrPrivileged` — object-level check
- `HasSectorAccess` — dynamic scope via query param `gerencia_id`

## PEP 702 note

`@typing.deprecated` exige Python 3.13+. Em 3.12 usamos apenas runtime `warnings.warn`. Static type-checker signalization fica pendente do upgrade.

## RBAC_NAMING.md

Novo documento canônico em `v2/docs/RBAC_NAMING.md` cobrindo:
- Codenames (verbos canônicos vs proibidos, proibição de nome de setor)
- Labels (verbo infinitivo + substantivo plural)
- Permission classes (preferir HasPerm; exceções aceitas)
- Authz checks (`has_perm` vs `groups.filter` banido)
- Adicionar nova permission (checklist)
- Enforcement automático (lint custom do Epic 6)

## Validação

- **23 testes** novos em `test_permissions_hasperm.py`: grant/deny, anon, superuser bypass, app_label strip, message custom, repr, composition OR/AND/NOT, deprecation warning paramétrico para cada uma das 12 classes legacy.
- **Suite completa**: 1653 passed, 22 skipped, 0 failures (antes 1630; +23 Epic 2).
- Zero mudança de comportamento runtime em endpoints existentes.
- Black + isort aplicados.

## Próximo epic

Epic 3 (#1182 infra + #1183 replace) elimina 8 hardcoded `groups.filter(name=...)` substituindo por `HasPerm` + helper `user_has_any_perm`. **Primeira camada de segurança real** (Epic 3 fecha o bypass de autorização; Epics 1/2 eram cosméticos).

## Staging gate

ALL 8 CHECKS PASSED

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR
- [x] Feature complete
- [x] Tests updated
- [x] TS/Lint clean (backend black/isort; no frontend changes)
- [x] No breaking API changes (HasPerm é additivo; legacy classes mantidas)
- [x] No DB migrations (Epic 2 é puro código)
- [x] No infra changes
- [x] Docs inline + `v2/docs/RBAC_NAMING.md`
- [x] Backward compatible (deprecation warnings não falham)

### Evidência de validação

- `pytest apps/core/tests/` no container: **1653 passed / 22 skipped / 0 failures** em 226.96s
- Testes novos do Epic 2: 23/23 (HasPerm + composition + deprecation paramétrico)
- Deprecation warnings emergem apenas quando classe legacy é instanciada