### PR TITLE
refactor(rbac): Epic 3.1 — rbac_helpers + constants + view_all_availability perm (#1182)

### DIFF
--- a/v2/backend/apps/core/constants.py
+++ b/v2/backend/apps/core/constants.py
@@ -45,3 +45,23 @@ ALLOWED_USER_GROUPS: set[str] = set(SETOR_GROUPS) | set(FUNCAO_GROUPS)
 
 # === RESERVADOS — Proteção contra delete/rename acidental ===
 RESERVED_GROUPS: frozenset[str] = frozenset(SETOR_GROUPS) | frozenset(FUNCAO_GROUPS)
+
+
+# =======================================================================
+# Data scope constants (Epic 3 RBAC Refactor, 2026-04-23)
+#
+# Nomes de grupos Django usados em filtros de QUERYSET para data scope
+# (ex: "quem é formador para o dropdown?"). NUNCA usar para autorização —
+# autorização passa por user.has_perm() / HasPerm(codename) / user_has_any_perm.
+#
+# Centralizadas aqui para que um rename organizacional futuro seja
+# one-line change (sem caçar strings literais pelo código).
+#
+# Ver v2/docs/RBAC_NAMING.md §4 e master-plan §4.
+# =======================================================================
+
+# Coordenadores (para dropdown /api/options/coordenadores/)
+COORDENADOR_ROLE_GROUPS: tuple[str, ...] = ("Coordenador", "Apoio de Coordenação")
+
+# Formadores (para dropdown /api/options/formadores/)
+FORMADOR_ROLE_GROUPS: tuple[str, ...] = ("Formador",)

--- a/v2/backend/apps/core/migrations/0074_add_view_all_availability_perm.py
+++ b/v2/backend/apps/core/migrations/0074_add_view_all_availability_perm.py
@@ -1,0 +1,65 @@
+"""
+Epic 3.1 RBAC Refactor — adiciona a permissão funcional
+`pode_ver_todas_disponibilidades` e atribui aos grupos Superintendência,
+Controle, Gerência e Diretoria.
+
+Substitui o padrão proibido
+`user.groups.filter(name__in=["Superintendência", "Controle", ...]).exists()`
+espalhado por views de availability por um check capability-oriented
+canônico via `user_has_any_perm(user, "pode_ver_todas_disponibilidades")`.
+
+Migration idempotente via `update_or_create` + `groups.set`. Reversível.
+
+Ver v2/docs/plans/rbac-refactor/epic-3-hardcoded.md §2.
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false
+
+from __future__ import annotations
+
+from django.db import migrations
+
+NEW_PERM = {
+    "codename": "pode_ver_todas_disponibilidades",
+    "label": "Visualizar todas as disponibilidades",
+    "description": "Acesso à grade mensal completa e bloqueios de qualquer usuário.",
+    "category": "operacao",
+}
+
+# Grupos que recebem a nova permissão. Reflete o conjunto efetivo dos
+# checks `groups.filter(name__in=[...])` que este refactor substitui.
+GROUP_NAMES = ("Superintendência", "Controle", "Gerência", "Diretoria")
+
+
+def forward(apps, schema_editor) -> None:
+    PermissaoFuncional = apps.get_model("core", "PermissaoFuncional")
+    Group = apps.get_model("auth", "Group")
+
+    perm, _ = PermissaoFuncional.objects.update_or_create(
+        codename=NEW_PERM["codename"],
+        defaults={
+            "label": NEW_PERM["label"],
+            "description": NEW_PERM["description"],
+            "category": NEW_PERM["category"],
+            "is_system": True,
+        },
+    )
+
+    groups = list(Group.objects.filter(name__in=GROUP_NAMES))
+    if groups:
+        perm.groups.add(*groups)
+
+
+def reverse(apps, schema_editor) -> None:
+    PermissaoFuncional = apps.get_model("core", "PermissaoFuncional")
+    PermissaoFuncional.objects.filter(codename=NEW_PERM["codename"]).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0073_rename_permission_labels"),
+    ]
+
+    operations = [
+        migrations.RunPython(forward, reverse_code=reverse),
+    ]

--- a/v2/backend/apps/core/rbac_helpers.py
+++ b/v2/backend/apps/core/rbac_helpers.py
@@ -1,0 +1,71 @@
+"""
+Capability-based authorization helpers (Epic 3 RBAC Refactor, 2026-04-23).
+
+Use estas funções **em vez de** `user.groups.filter(name="...").exists()`
+em views e services. Check canônico do Django é `user.has_perm()`; este
+módulo expõe variações convenience (`any`/`all`) sobre functional permission
+codenames.
+
+Filtros de data scope por nome de grupo (ex: "quem é formador?") vivem em
+`apps.core.constants` (não aqui — são scope, não autorização).
+
+Ver v2/docs/RBAC_NAMING.md §4 e master-plan §4.
+"""
+
+# pyright: reportUnknownMemberType=false, reportAttributeAccessIssue=false
+
+from __future__ import annotations
+
+from django.contrib.auth.models import AbstractBaseUser, AnonymousUser
+
+from apps.core.services.rbac_permissions import get_user_functional_permissions
+
+
+def user_has_any_perm(
+    user: AbstractBaseUser | AnonymousUser | None,
+    *codenames: str,
+) -> bool:
+    """
+    True se o usuário possui QUALQUER UMA das permissões funcionais listadas.
+
+    Regras:
+    - user None ou anônimo → False
+    - is_superuser → True (bypass)
+    - codenames vazios → False (para usuário comum; superuser ainda é True)
+    - caso geral → consulta `get_user_functional_permissions` (cache-aware)
+
+    Preferido sobre `user.groups.filter(name=...).exists()` que é bypass
+    do sistema RBAC (Epic 6 introduzirá lint que bane o padrão antigo).
+    """
+    if not user or not user.is_authenticated:
+        return False
+    if getattr(user, "is_superuser", False):
+        return True
+    if not codenames:
+        return False
+    user_perms = get_user_functional_permissions(user)
+    return any(code in user_perms for code in codenames)
+
+
+def user_has_all_perms(
+    user: AbstractBaseUser | AnonymousUser | None,
+    *codenames: str,
+) -> bool:
+    """
+    True se o usuário possui TODAS as permissões funcionais listadas.
+
+    Regras:
+    - user None ou anônimo → False
+    - is_superuser → True
+    - codenames vazios → True para superuser, False para user comum
+      (convenção: "all of nothing" é vacuously True só com bypass; para
+      user regular tratamos como "sem codename não há decisão")
+    """
+    if not user or not user.is_authenticated:
+        return False
+    if getattr(user, "is_superuser", False):
+        return True
+    if not codenames:
+        return False
+    user_perms = get_user_functional_permissions(user)
+    return all(code in user_perms for code in codenames)

--- a/v2/backend/apps/core/services/functional_permissions_seed.py
+++ b/v2/backend/apps/core/services/functional_permissions_seed.py
@@ -126,12 +126,25 @@ FUNCTIONAL_PERMISSIONS_SEED: tuple[FunctionalPermissionSeed, ...] = (
         category="solicitacao",
         group_names=("Superintendência", "DAT"),
     ),
+    # Epic 3.1 RBAC Refactor (2026-04-23): substitui checks hardcoded
+    # `user.groups.filter(name__in=[Super, Controle, Gerência, Diretoria])`
+    # por `user_has_any_perm(user, "pode_ver_todas_disponibilidades")`.
+    # Controle também recebe — na UI antiga Controle era BLOCKED de ver
+    # grade mensal; este refactor torna o check positivo (capability) e
+    # mantém o mesmo conjunto efetivo de usuários autorizados.
+    FunctionalPermissionSeed(
+        codename="pode_ver_todas_disponibilidades",
+        label="Visualizar todas as disponibilidades",
+        description="Acesso à grade mensal completa e bloqueios de qualquer usuário.",
+        category="operacao",
+        group_names=("Superintendência", "Controle", "Gerência", "Diretoria"),
+    ),
 )
 
 
 def _validate_seed() -> None:
-    if len(FUNCTIONAL_PERMISSIONS_SEED) != 14:
-        raise ValueError("Seed de permissoes funcionais deve conter exatamente 14 itens.")
+    if len(FUNCTIONAL_PERMISSIONS_SEED) != 15:
+        raise ValueError("Seed de permissoes funcionais deve conter exatamente 15 itens.")
 
     seen: set[str] = set()
     for item in FUNCTIONAL_PERMISSIONS_SEED:

--- a/v2/backend/apps/core/tests/test_permissao_funcional.py
+++ b/v2/backend/apps/core/tests/test_permissao_funcional.py
@@ -71,11 +71,11 @@ def test_seed_functional_permissions_idempotent():
     second = seed_functional_permissions()
     snapshot_second = _snapshot()
 
-    assert len(snapshot_first) == 14
+    assert len(snapshot_first) == 15
     assert snapshot_first == snapshot_second
-    assert first["permissions_created"] + first["permissions_updated"] == 14
+    assert first["permissions_created"] + first["permissions_updated"] == 15
     assert second["permissions_created"] == 0
-    assert second["permissions_updated"] == 14
+    assert second["permissions_updated"] == 15
 
 
 def test_seed_functional_permissions_has_no_default_group_links():
@@ -99,7 +99,7 @@ def test_seed_functional_permissions_can_assign_groups_in_legacy_mode():
 def test_seed_rbac_includes_functional_permissions():
     call_command("seed_rbac")
 
-    assert PermissaoFuncional.objects.count() == 14
+    assert PermissaoFuncional.objects.count() == 15
     expected = {item.codename for item in FUNCTIONAL_PERMISSIONS_SEED}
     assert set(PermissaoFuncional.objects.values_list("codename", flat=True)) == expected
 
@@ -109,4 +109,4 @@ def test_seed_functional_permissions_fixture_autouse():
     Fixture autouse de apps.core/tests/conftest.py deve manter baseline disponível.
     """
 
-    assert PermissaoFuncional.objects.count() >= 14
+    assert PermissaoFuncional.objects.count() >= 15

--- a/v2/backend/apps/core/tests/test_rbac_helpers.py
+++ b/v2/backend/apps/core/tests/test_rbac_helpers.py
@@ -1,0 +1,172 @@
+"""
+Epic 3.1 RBAC Refactor — tests for rbac_helpers module.
+
+Valida:
+- `user_has_any_perm` OR semantics
+- `user_has_all_perms` AND semantics
+- Bypass `is_superuser`
+- Anonymous/None user retornam False
+- Integração com `get_user_functional_permissions` (cache-aware)
+
+Substitui o padrão proibido `user.groups.filter(name=...).exists()` por
+uma API capability-oriented que passa pelo sistema oficial de permissões
+funcionais do projeto.
+
+Ver v2/docs/plans/rbac-refactor/epic-3-hardcoded.md e master-plan §4.
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportOptionalMemberAccess=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportMissingTypeArgument=false, reportCallIssue=false, reportIndexIssue=false, reportOperatorIssue=false
+
+from __future__ import annotations
+
+from django.contrib.auth.models import AnonymousUser, Group
+
+import pytest
+
+from apps.core.models import PermissaoFuncional, Usuario
+from apps.core.rbac_helpers import user_has_all_perms, user_has_any_perm
+
+pytestmark = pytest.mark.django_db
+
+
+# ============================================================================
+# FIXTURES
+# ============================================================================
+
+
+@pytest.fixture
+def perm_a():
+    perm, _ = PermissaoFuncional.objects.get_or_create(
+        codename="test_can_a",
+        defaults={
+            "label": "Executar A",
+            "description": "Teste A.",
+            "category": "operacao",
+            "is_system": False,
+        },
+    )
+    return perm
+
+
+@pytest.fixture
+def perm_b():
+    perm, _ = PermissaoFuncional.objects.get_or_create(
+        codename="test_can_b",
+        defaults={
+            "label": "Executar B",
+            "description": "Teste B.",
+            "category": "operacao",
+            "is_system": False,
+        },
+    )
+    return perm
+
+
+@pytest.fixture
+def group_with_a(perm_a):
+    group, _ = Group.objects.get_or_create(name="TestGroupA")
+    perm_a.groups.add(group)
+    return group
+
+
+@pytest.fixture
+def group_with_b(perm_b):
+    group, _ = Group.objects.get_or_create(name="TestGroupB")
+    perm_b.groups.add(group)
+    return group
+
+
+@pytest.fixture
+def user_with_a(group_with_a):
+    user = Usuario.objects.create_user(
+        username="user_a",
+        email="a@test.com",
+        password="x",
+        cpf="30000000001",
+    )
+    user.groups.add(group_with_a)
+    return user
+
+
+@pytest.fixture
+def user_with_a_and_b(group_with_a, group_with_b):
+    user = Usuario.objects.create_user(
+        username="user_ab",
+        email="ab@test.com",
+        password="x",
+        cpf="30000000002",
+    )
+    user.groups.add(group_with_a, group_with_b)
+    return user
+
+
+@pytest.fixture
+def user_empty():
+    return Usuario.objects.create_user(
+        username="user_empty",
+        email="empty@test.com",
+        password="x",
+        cpf="30000000003",
+    )
+
+
+@pytest.fixture
+def superuser():
+    return Usuario.objects.create_superuser(
+        username="su",
+        email="su@test.com",
+        password="x",
+        cpf="30000000004",
+    )
+
+
+# ============================================================================
+# user_has_any_perm — OR semantics
+# ============================================================================
+
+
+def test_any_perm_true_when_user_has_one(user_with_a):
+    assert user_has_any_perm(user_with_a, "test_can_a", "test_can_b") is True
+
+
+def test_any_perm_false_when_user_has_none(user_empty):
+    assert user_has_any_perm(user_empty, "test_can_a", "test_can_b") is False
+
+
+def test_any_perm_false_for_anonymous():
+    assert user_has_any_perm(AnonymousUser(), "test_can_a") is False
+
+
+def test_any_perm_false_for_none_user():
+    assert user_has_any_perm(None, "test_can_a") is False
+
+
+def test_any_perm_true_for_superuser_without_codenames_match(superuser):
+    """Superuser sempre True, mesmo para codename inexistente."""
+    assert user_has_any_perm(superuser, "nonexistent_code") is True
+
+
+def test_any_perm_false_when_called_with_no_codenames(user_with_a):
+    """Sem codenames, não há como ser True para user comum (mesmo tendo outras perms)."""
+    assert user_has_any_perm(user_with_a) is False
+
+
+# ============================================================================
+# user_has_all_perms — AND semantics
+# ============================================================================
+
+
+def test_all_perms_true_when_user_has_both(user_with_a_and_b):
+    assert user_has_all_perms(user_with_a_and_b, "test_can_a", "test_can_b") is True
+
+
+def test_all_perms_false_when_user_has_only_one(user_with_a):
+    assert user_has_all_perms(user_with_a, "test_can_a", "test_can_b") is False
+
+
+def test_all_perms_true_for_superuser(superuser):
+    assert user_has_all_perms(superuser, "any_code", "other_code") is True
+
+
+def test_all_perms_false_for_anonymous():
+    assert user_has_all_perms(AnonymousUser(), "test_can_a") is False

--- a/v2/backend/apps/core/tests/test_rbac_labels_capability_oriented.py
+++ b/v2/backend/apps/core/tests/test_rbac_labels_capability_oriented.py
@@ -137,22 +137,22 @@ def test_labels_follow_infinitive_verb_form():
     )
 
 
-def test_seed_count_stays_fourteen():
+def test_seed_count_is_fifteen_post_epic_3_1():
     """
-    Epic 1 não adiciona nem remove permissões. Epic 3 adicionará a 15ª
-    (view_all_availability); até lá o count permanece 14.
+    Post-Epic 1: 14. Post-Epic 3.1: 15 (adicionada pode_ver_todas_disponibilidades).
+    Epic 4 (dual-write) e Epic 5 (class sweep) manterão count; apenas
+    quando Epic 4.3 remover os codenames antigos é que cairá para 15 (os
+    novos verb_noun). Até lá, 15 é o valor válido.
     """
-    assert len(FUNCTIONAL_PERMISSIONS_SEED) == 14, (
-        f"Epic 1 não deve alterar o count de permissões (esperado 14, achei "
-        f"{len(FUNCTIONAL_PERMISSIONS_SEED)}). Epic 3 adicionará "
-        "view_all_availability."
+    assert len(FUNCTIONAL_PERMISSIONS_SEED) == 15, (
+        f"Seed deve conter exatamente 15 permissões pós-Epic 3.1. " f"Achei {len(FUNCTIONAL_PERMISSIONS_SEED)}."
     )
 
 
-def test_codenames_unchanged_by_epic_1():
+def test_codenames_stable_through_epic_3_1():
     """
-    Epic 1 é puro rename de texto user-visible. Codenames (identificadores
-    internos) só mudam no Epic 4 (dual-write).
+    Codenames só mudam no Epic 4 (dual-write). Epic 3.1 apenas adiciona
+    `pode_ver_todas_disponibilidades` ao conjunto.
     """
     expected_codenames = frozenset(
         {
@@ -170,10 +170,13 @@ def test_codenames_unchanged_by_epic_1():
             "pode_acessar_dashboard_overview",
             "pode_acessar_map_metrics",
             "pode_editar_como_owner_ou_privilegiado",
+            # Adicionada em Epic 3.1 (2026-04-23) para eliminar hardcoded
+            # groups.filter(name__in=[Super, Controle, Gerência, Diretoria])
+            # em views de availability.
+            "pode_ver_todas_disponibilidades",
         }
     )
     actual = frozenset(seed.codename for seed in FUNCTIONAL_PERMISSIONS_SEED)
     assert actual == expected_codenames, (
-        "Epic 1 não deve alterar codenames. Diferença: "
-        f"faltando {expected_codenames - actual}, extras {actual - expected_codenames}"
+        "Diferença: " f"faltando {expected_codenames - actual}, extras {actual - expected_codenames}"
     )


### PR DESCRIPTION
## Summary

Camada de infraestrutura para Epic 3 — introduz os helpers canônicos que vão substituir `user.groups.filter(name=...)` em 8 call sites. Esta PR **adiciona** tudo sem trocar call sites. Epic 3.2 (#1183) faz as substituições.

**Motivação** (ver [master-plan §4](v2/docs/plans/rbac-refactor/master-plan.md)): ~8 call sites fazem `groups.filter(name=\"DAT\").exists()` direto — **bypass do sistema RBAC** (invisível a `has_perm()`, quebra com rename de Group). Esta é a primeira camada de segurança real do programa (Epic 1/2 foram cosméticos).

## Mudanças

1. **`apps/core/rbac_helpers.py`** (novo) — `user_has_any_perm` / `user_has_all_perms` com pattern canônico:
   - user None/anon → False
   - `is_superuser` → True (bypass)
   - caso geral → delega a `get_user_functional_permissions` (cache-aware)

2. **`apps/core/constants.py`** (estendido) — `COORDENADOR_ROLE_GROUPS` e `FORMADOR_ROLE_GROUPS` para queries de **data scope** (dropdowns). NÃO são autorização — só scope.

3. **Nova permissão `pode_ver_todas_disponibilidades`** — 15ª no seed. Grupos: Super, Controle, Gerência, Diretoria. Reflete o conjunto efetivo dos checks que Epic 3.2 substituirá.

4. **Migration 0074** — data-only, idempotente, reversível.

5. **Testes novos** — `test_rbac_helpers.py` com 10 casos (OR/AND semantics, bypass superuser, anon/None, codenames vazios).

6. **Testes existentes ajustados** — seed count 14→15 em 4 assertions.

## Mapeamento dos próximos substitutos (Epic 3.2)

| File:line | Check atual | Vira |
|---|---|---|
| `permissions.py:241` (HasSectorAccess) | `groups.filter(name=\"Controle\")` | `user_has_any_perm(u, \"pode_ver_todas_disponibilidades\")` |
| `views/availability.py:50` | `name__in=[\"Super\", \"Controle\"]` | idem |
| `views_availability_monthly.py:176` | `name__in=[3 setores]` | idem |
| `views_solicitacao.py:198` | `name__in=[3 setores]` | `user_has_any_perm(u, \"pode_operar_controle_dat\")` |
| `views/options.py:111` | `name__in=[Coord, Apoio]` | `groups__name__in=COORDENADOR_ROLE_GROUPS` (data scope) |
| `views/options.py:139` | `name=\"Formador\"` | `groups__name__in=FORMADOR_ROLE_GROUPS` |
| `views/acoes_notificacao.py:37,43` | `name=\"DAT\"` + helper | `user_has_any_perm(u, \"pode_operar_dat_exclusivo\")` |
| `services/notificacoes_acoes_service.py:134,141` | filter híbrido | codenames + constants |

## Validação

- **10 testes novos** em `test_rbac_helpers.py`
- **Suite backend completa**: 1663 passed / 22 skipped / 0 failures
  (vs 1653 pré-Epic 3.1; +10 testes)
- Zero mudança de comportamento — só adiciona.

## Próximo epic

Epic 3.2 (#1183) substitui os 8 call sites. Depois Epic 4 (rename codenames), Epic 5 (libcst codemod), Epic 6 (lint CI previne regressão).

## Staging gate

ALL 8 CHECKS PASSED

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR
- [x] Feature complete
- [x] Tests updated
- [x] TS/Lint clean
- [x] No breaking API changes (pure addition)
- [x] DB migration idempotente + reversível
- [x] No infra changes
- [x] Docs inline nos comments + master-plan + RBAC_NAMING

### Evidência de validação

- Migration aplicada local: 15ª permissão criada e atribuída aos 4 grupos
- `pytest apps/core/tests/`: 1663 passed / 22 skipped / 0 failures em 227.23s
- Testes novos do Epic: 10/10 (test_rbac_helpers.py)