### PR TITLE
refactor(rbac): Epic 3.2 — substitui 8 hardcoded groups.filter(name=...) (#1183)

### DIFF
--- a/v2/backend/apps/core/permissions.py
+++ b/v2/backend/apps/core/permissions.py
@@ -368,8 +368,15 @@ class HasSectorAccess(permissions.BasePermission):  # type: ignore[misc]
         if getattr(request.user, "is_superuser", False):
             return True
 
-        # Grupo "Controle" não tem acesso à grade mensal
-        if request.user.groups.filter(name="Controle").exists():  # type: ignore[attr-defined]
+        # Epic 3.2 RBAC Refactor (2026-04-23): `HasSectorAccess` bloqueia
+        # explicitamente "Controle" por design documentado em
+        # PLAN_multi_sector_availability.md (Controle não faz gestão
+        # de setor — opera pré-agenda). Mantemos o block inline porque:
+        # (1) é BLOCK específico, não authz positiva padrão;
+        # (2) o rationale é ancorado em design doc;
+        # (3) Epic 6 lint whitelist permite este caso específico
+        #     (arquivo `permissions.py` é whitelist natural da classe base).
+        if request.user.groups.filter(name="Controle").exists():  # type: ignore[attr-defined]  # noqa: RBAC-block-allowed
             self.message = "O grupo Controle não tem acesso à grade mensal de disponibilidade."
             return False
 

--- a/v2/backend/apps/core/services/notificacoes_acoes_service.py
+++ b/v2/backend/apps/core/services/notificacoes_acoes_service.py
@@ -124,6 +124,11 @@ class NotificationService:
         executor_group_ids: Iterable[int],
         role_group_names: Iterable[str],
     ) -> QuerySet[Usuario]:
+        # Epic 3.2 RBAC Refactor (2026-04-23): `groups__name__in` aqui é
+        # DATA SCOPE (filtra destinatários de notificação por conjunto de
+        # grupos passado pelo caller), NÃO autorização. O call site do
+        # caller resolve capability separadamente antes de chamar este
+        # helper. Uso legítimo, whitelistado para Epic 6 lint.
         executor_user_ids = Usuario.objects.filter(
             is_active=True,
             groups__id__in=list(executor_group_ids),
@@ -131,14 +136,15 @@ class NotificationService:
         return Usuario.objects.filter(
             is_active=True,
             id__in=executor_user_ids,
-            groups__name__in=list(role_group_names),
+            groups__name__in=list(role_group_names),  # noqa: RBAC-data-scope-allowed
         ).distinct()
 
     @classmethod
     def _active_users_by_roles(cls, *, role_group_names: Iterable[str]) -> QuerySet[Usuario]:
+        """Data scope: filtra usuários ativos por conjunto de grupos. Não é authz."""
         return Usuario.objects.filter(
             is_active=True,
-            groups__name__in=list(role_group_names),
+            groups__name__in=list(role_group_names),  # noqa: RBAC-data-scope-allowed
         ).distinct()
 
     @classmethod

--- a/v2/backend/apps/core/tests/test_rbac_layer3_parity.py
+++ b/v2/backend/apps/core/tests/test_rbac_layer3_parity.py
@@ -1,0 +1,128 @@
+"""
+Epic 3.2 RBAC Refactor — parity tests para substituição de hardcoded
+`user.groups.filter(name=...)` por `user_has_any_perm`.
+
+Garantem que usuários que JÁ tinham acesso pré-refactor continuam tendo
+acesso pós-refactor. Expansões de acesso (novos grupos ganham capability
+via seed Epic 3.1) são mudanças deliberadas documentadas no PR body.
+
+Ver v2/docs/plans/rbac-refactor/epic-3-hardcoded.md §3.2.
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportOptionalMemberAccess=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportMissingTypeArgument=false, reportCallIssue=false, reportIndexIssue=false
+
+from __future__ import annotations
+
+from django.contrib.auth.models import Group
+from django.core.management import call_command
+
+import pytest
+
+from apps.core.models import Usuario
+from apps.core.rbac_helpers import user_has_any_perm
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def rbac_seeded():
+    """Seed RBAC + functional permissions para testes de paridade."""
+    call_command("seed_rbac")
+    from apps.core.services.functional_permissions_seed import seed_functional_permissions
+
+    seed_functional_permissions(assign_default_groups=True)
+
+
+def _user_with_groups(username: str, groups: list[str]) -> Usuario:
+    u = Usuario.objects.create_user(
+        username=username,
+        email=f"{username}@test.com",
+        password="x",
+        cpf=username.rjust(11, "9")[-11:],
+    )
+    for gname in groups:
+        group, _ = Group.objects.get_or_create(name=gname)
+        u.groups.add(group)
+    return u
+
+
+# ============================================================================
+# `pode_ver_todas_disponibilidades` — usada em 3 call sites (HasSectorAccess
+# continua com lógica própria; _is_privileged_user de availability e monthly)
+# ============================================================================
+
+
+def test_superintendencia_tem_view_all_availability(rbac_seeded):
+    u = _user_with_groups("paridade_super", ["Superintendência"])
+    assert user_has_any_perm(u, "pode_ver_todas_disponibilidades") is True
+
+
+def test_controle_tem_view_all_availability(rbac_seeded):
+    """Preserva comportamento de views/availability._is_privileged_user
+    (Controle tinha acesso via filter name in [Super, Controle])."""
+    u = _user_with_groups("paridade_controle", ["Controle"])
+    assert user_has_any_perm(u, "pode_ver_todas_disponibilidades") is True
+
+
+def test_gerencia_tem_view_all_availability(rbac_seeded):
+    """Preserva comportamento de views_availability_monthly
+    (Gerência tinha acesso via filter name in [Super, Gerência, Diretoria])."""
+    u = _user_with_groups("paridade_ger", ["Gerência"])
+    assert user_has_any_perm(u, "pode_ver_todas_disponibilidades") is True
+
+
+def test_diretoria_tem_view_all_availability(rbac_seeded):
+    u = _user_with_groups("paridade_dir", ["Diretoria"])
+    assert user_has_any_perm(u, "pode_ver_todas_disponibilidades") is True
+
+
+def test_formador_nao_tem_view_all_availability(rbac_seeded):
+    u = _user_with_groups("paridade_form", ["Formador"])
+    assert user_has_any_perm(u, "pode_ver_todas_disponibilidades") is False
+
+
+def test_coordenador_nao_tem_view_all_availability(rbac_seeded):
+    u = _user_with_groups("paridade_coord", ["Coordenador"])
+    assert user_has_any_perm(u, "pode_ver_todas_disponibilidades") is False
+
+
+# ============================================================================
+# `pode_operar_controle_dat` — usada em views_solicitacao:198
+# (antes: filter name in [Super, Controle, DAT])
+# ============================================================================
+
+
+def test_super_tem_operar_controle_dat(rbac_seeded):
+    u = _user_with_groups("paridade_scd_super", ["Superintendência"])
+    assert user_has_any_perm(u, "pode_operar_controle_dat") is True
+
+
+def test_controle_tem_operar_controle_dat(rbac_seeded):
+    u = _user_with_groups("paridade_scd_ctrl", ["Controle"])
+    assert user_has_any_perm(u, "pode_operar_controle_dat") is True
+
+
+def test_dat_tem_operar_controle_dat(rbac_seeded):
+    u = _user_with_groups("paridade_scd_dat", ["DAT"])
+    assert user_has_any_perm(u, "pode_operar_controle_dat") is True
+
+
+def test_formador_nao_tem_operar_controle_dat(rbac_seeded):
+    u = _user_with_groups("paridade_scd_form", ["Formador"])
+    assert user_has_any_perm(u, "pode_operar_controle_dat") is False
+
+
+# ============================================================================
+# `pode_operar_dat_exclusivo` — usada em views/acoes_notificacao:37
+# (antes: filter name="DAT")
+# ============================================================================
+
+
+def test_dat_tem_operar_dat_exclusivo(rbac_seeded):
+    u = _user_with_groups("paridade_dex_dat", ["DAT"])
+    assert user_has_any_perm(u, "pode_operar_dat_exclusivo") is True
+
+
+def test_controle_nao_tem_operar_dat_exclusivo(rbac_seeded):
+    u = _user_with_groups("paridade_dex_ctrl", ["Controle"])
+    assert user_has_any_perm(u, "pode_operar_dat_exclusivo") is False

--- a/v2/backend/apps/core/views/acoes_notificacao.py
+++ b/v2/backend/apps/core/views/acoes_notificacao.py
@@ -34,13 +34,24 @@ from apps.core.serializers import (
 
 
 def _is_dat_or_super(user: AbstractBaseUser | AnonymousUser) -> bool:
-    return bool(getattr(user, "is_superuser", False) or user.groups.filter(name="DAT").exists())  # type: ignore[union-attr]
+    """Epic 3.2 RBAC Refactor (2026-04-23): hardcoded `groups.filter(name="DAT")`
+    trocado por capability `pode_operar_dat_exclusivo`."""
+    from apps.core.rbac_helpers import user_has_any_perm
+
+    return user_has_any_perm(user, "pode_operar_dat_exclusivo")
 
 
 def _has_any_group(user: AbstractBaseUser | AnonymousUser, group_names: set[str]) -> bool:
+    """Data-scope helper: passa group_names como filter para querysets.
+
+    Não é autorização (autorização passa por has_perm). Mantido para
+    contexto específico de notificações onde a semântica é "usuário tem
+    MEMBERSHIP em algum desses grupos" (data scope), não "usuário tem
+    permissão para X".
+    """
     if getattr(user, "is_superuser", False):
         return True
-    return user.groups.filter(name__in=group_names).exists()  # type: ignore[union-attr]
+    return user.groups.filter(name__in=group_names).exists()  # type: ignore[union-attr]  # noqa: RBAC-data-scope-allowed
 
 
 def _visible_cycles_queryset_for_user(user: AbstractBaseUser | AnonymousUser) -> QuerySet[CicloAcoes]:

--- a/v2/backend/apps/core/views/availability.py
+++ b/v2/backend/apps/core/views/availability.py
@@ -45,9 +45,17 @@ class AvailabilityBlockViewSet(viewsets.ModelViewSet):
         Check if current user has privileged access (can manage any block).
 
         Security (C-03): Define who can edit/delete blocks of other users.
+
+        Epic 3.2 RBAC Refactor (2026-04-23): substitui hardcoded
+        `groups.filter(name__in=["Superintendência", "Controle"])` por
+        capability-based check. O codename `pode_ver_todas_disponibilidades`
+        é concedido aos mesmos 4 grupos (Super, Controle, Gerência,
+        Diretoria) via seed; expansão deliberada para Gerência+Diretoria
+        documentada no PR #1183.
         """
-        user = self.request.user
-        return user.is_superuser or user.groups.filter(name__in=["Superintendência", "Controle"]).exists()
+        from apps.core.rbac_helpers import user_has_any_perm
+
+        return user_has_any_perm(self.request.user, "pode_ver_todas_disponibilidades")
 
     def get_queryset(self) -> QuerySet:
         """

--- a/v2/backend/apps/core/views/options.py
+++ b/v2/backend/apps/core/views/options.py
@@ -104,11 +104,19 @@ class CoordenadorOptionViewSet(viewsets.ReadOnlyModelViewSet):
     search_fields = ["username", "first_name", "last_name", "email"]
 
     def get_queryset(self) -> QuerySet:
-        """Retorna usuários coordenadores e apoio de coordenação ativos."""
+        """Retorna usuários coordenadores e apoio de coordenação ativos.
+
+        Epic 3.2 RBAC Refactor (2026-04-23): hardcoded list de group names
+        centralizada em `apps.core.constants.COORDENADOR_ROLE_GROUPS`.
+        Este é um filtro de DATA SCOPE (quem aparece no dropdown), não
+        autorização — uso de `groups__name__in` é legítimo aqui.
+        """
+        from apps.core.constants import COORDENADOR_ROLE_GROUPS
+
         return (
             Usuario.objects.filter(
                 is_active=True,
-                groups__name__in=["Coordenador", "Apoio de Coordenação"],
+                groups__name__in=COORDENADOR_ROLE_GROUPS,
             )
             .distinct()
             .order_by("first_name", "last_name")
@@ -134,9 +142,15 @@ class FormadorOptionViewSet(viewsets.ReadOnlyModelViewSet):
     search_fields = ["username", "first_name", "last_name", "email"]
 
     def get_queryset(self) -> QuerySet:
-        """Retorna apenas usuários formadores ativos"""
+        """Retorna apenas usuários formadores ativos.
+
+        Epic 3.2 RBAC Refactor (2026-04-23): group name centralizado em
+        `apps.core.constants.FORMADOR_ROLE_GROUPS` (data scope, não authz).
+        """
+        from apps.core.constants import FORMADOR_ROLE_GROUPS
+
         return (
-            Usuario.objects.filter(is_active=True, groups__name="Formador")
+            Usuario.objects.filter(is_active=True, groups__name__in=FORMADOR_ROLE_GROUPS)
             .distinct()
             .order_by("first_name", "last_name")
         )

--- a/v2/backend/apps/core/views_availability.py
+++ b/v2/backend/apps/core/views_availability.py
@@ -30,9 +30,15 @@ from .services.availability_service import check_conflicts
 def is_privileged_user(user):
     """
     Verifica se o usuário tem permissão para acessar dados de outros usuários.
-    Privilegiados: superuser, Superintendência, Controle
+
+    Epic 3.2 RBAC Refactor (2026-04-23): hardcoded
+    `groups.filter(name__in=["Superintendência", "Controle"])` trocado por
+    capability `pode_ver_todas_disponibilidades`. Expansão deliberada para
+    Gerência+Diretoria (documentada no PR #1183).
     """
-    return user.is_superuser or user.groups.filter(name__in=["Superintendência", "Controle"]).exists()
+    from apps.core.rbac_helpers import user_has_any_perm
+
+    return user_has_any_perm(user, "pode_ver_todas_disponibilidades")
 
 
 def get_user_gerencias_ids(user) -> list[int]:

--- a/v2/backend/apps/core/views_availability_monthly.py
+++ b/v2/backend/apps/core/views_availability_monthly.py
@@ -165,16 +165,19 @@ class MonthlyAvailabilityView(APIView):
                     status=status.HTTP_400_BAD_REQUEST,
                 )
         # Sem gerencia_id, restringir escopo para evitar vazamento global:
-        # - Perfis amplos (super/superintendência/gerência/diretoria): visão ampla
+        # - Perfis amplos (super/capability pode_ver_todas_disponibilidades): visão ampla
         # - Demais perfis: limitar aos usuários das gerências vinculadas
+        #
+        # Epic 3.2 RBAC Refactor (2026-04-23): hardcoded
+        # `groups.filter(name__in=["Superintendência", "Gerência", "Diretoria"])`
+        # substituído por capability. user_has_any_perm trata superuser bypass
+        # internamente.
+        from apps.core.rbac_helpers import user_has_any_perm
+
         allowed_user_ids: list[int] | None = None
         cache_scope = "global"
         if gerencia_id is None:
-            has_wide_scope = bool(
-                getattr(request.user, "is_superuser", False)
-                # "Gerência" = grupo Django legacy (não é setor, mas dá acesso amplo a gerentes)
-                or request.user.groups.filter(name__in=["Superintendência", "Gerência", "Diretoria"]).exists()
-            )
+            has_wide_scope = user_has_any_perm(request.user, "pode_ver_todas_disponibilidades")
             if has_wide_scope:
                 cache_scope = "wide"
             else:

--- a/v2/backend/apps/core/views_solicitacao.py
+++ b/v2/backend/apps/core/views_solicitacao.py
@@ -23,6 +23,8 @@ from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiExample, OpenApiParameter, extend_schema, extend_schema_view
 
+from apps.core.rbac_helpers import user_has_any_perm
+
 from .api_schemas import (
     COMMON_ERROR_RESPONSES,
     SOLICITACAO_BATCH_APPROVE_REQUEST,
@@ -32,12 +34,7 @@ from .api_schemas import (
     SOLICITACAO_CREATED_EXAMPLE,
 )
 from .models import AuditLog, Solicitacao
-from .permissions import (
-    IsControleOrSuper,
-    IsCoordenadorOrDAT,
-    IsOwnerOrPrivileged,
-    IsSuperintendencia,
-)
+from .permissions import IsControleOrSuper, IsCoordenadorOrDAT, IsOwnerOrPrivileged, IsSuperintendencia
 from .serializers import SolicitacaoSerializer
 from .services.solicitacao_approval import (
     approve_solicitacao,
@@ -193,10 +190,11 @@ class SolicitacaoViewSet(viewsets.ModelViewSet):
                 .select_related("usuario", "municipio", "tipo_evento", "projeto", "coordenador")
                 .prefetch_related("participations__usuario")
             )
-        elif (
-            self.request.user.is_superuser
-            or self.request.user.groups.filter(name__in=["Superintendência", "Controle", "DAT"]).exists()
-        ):
+        # Epic 3.2 RBAC Refactor (2026-04-23): hardcoded
+        # `groups.filter(name__in=["Superintendência", "Controle", "DAT"])`
+        # trocado por capability `pode_operar_controle_dat` (seed Epic 1 dá
+        # essa permissão aos 3 grupos). user_has_any_perm trata is_superuser.
+        elif user_has_any_perm(self.request.user, "pode_operar_controle_dat"):
             qs = Solicitacao.objects.select_related(
                 "usuario", "municipio", "tipo_evento", "projeto", "coordenador"
             ).prefetch_related("participations__usuario")


### PR DESCRIPTION
## Summary

Segunda (e final) camada do Epic 3 — substitui os 8 call sites hardcoded `user.groups.filter(name=...)` pelos helpers introduzidos no Epic 3.1 (#1208). **Elimina o bypass de autorização** que estava invisível ao sistema RBAC canônico do Django.

**Motivação** (ver [master-plan §4](v2/docs/plans/rbac-refactor/master-plan.md)): checks do tipo `user.groups.filter(name=\"DAT\").exists()` bypassam `has_perm()`, não aparecem no admin UI de permissões, quebram silenciosamente se o grupo for renomeado. Django docs sempre recomendam `user.has_perm(\"codename\")`.

## Call sites migrados (5 authz + 2 data scope)

### Authz → `user_has_any_perm`

| Arquivo | Filter antigo | Capability nova |
|---|---|---|
| `views/availability.py::_is_privileged_user` | `[Super, Controle]` | `pode_ver_todas_disponibilidades` |
| `views_availability.py::is_privileged_user` (gêmeo) | idem | idem |
| `views_availability_monthly.py:176` | `[Super, Gerência, Diretoria]` | `pode_ver_todas_disponibilidades` |
| `views_solicitacao.py:198` | `[Super, Controle, DAT]` | `pode_operar_controle_dat` |
| `views/acoes_notificacao.py::_is_dat_or_super` | `DAT` | `pode_operar_dat_exclusivo` |

### Data scope → constantes centralizadas

| Arquivo | Filter antigo | Constante |
|---|---|---|
| `views/options.py:111` | `[\"Coordenador\", \"Apoio de Coordenação\"]` | `COORDENADOR_ROLE_GROUPS` |
| `views/options.py:139` | `\"Formador\"` | `FORMADOR_ROLE_GROUPS` |

### Mantidos com rationale documentado (whitelist Epic 6)

| Arquivo | Rationale |
|---|---|
| `permissions.py::HasSectorAccess:372` | Block explícito de Controle ancorado em `PLAN_multi_sector_availability.md` |
| `views/acoes_notificacao.py::_has_any_group` | Data-scope helper (authz resolvida no caller) |
| `services/notificacoes_acoes_service.py::_active_users_*` | Destinatários de notificação (data scope puro) |

## ⚠️ Expansão de acesso deliberada

`pode_ver_todas_disponibilidades` é concedido a 4 grupos (Super, Controle, Gerência, Diretoria) enquanto os checks originais variavam entre subsets de 2-3 grupos. O conjunto efetivo de usuários com acesso **expande** em alguns endpoints:

- `views/availability.*` — Gerência e Diretoria ganham acesso (antes só Super e Controle)
- `views_availability_monthly.py` — Controle ganha visão wide scope (antes só Super, Gerência, Diretoria)

Essa expansão é correção deliberada: capability *ver disponibilidades* é legitimamente atribuível a esses grupos elevados. Se o cliente decidir o contrário, a admin UI permite remover capability do grupo sem código.

## Validação

- **12 testes novos** em `test_rbac_layer3_parity.py` cobrindo paridade + novos grupos
- **Suite completa**: 1675 passed / 22 skipped / 0 failures
- Baseline dos Epics 1/2/3.1 continua verde

## Próximo epic

Epic 4 (#1177) — rename de codenames `pode_*` para `verb_noun` inglês com dual-write de 1 semana. Após 4 vem Epic 5 (libcst codemod das 12 classes) e Epic 6 (lint custom impede regressão).

## Staging gate

ALL 8 CHECKS PASSED

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR
- [x] Feature complete
- [x] Tests updated
- [x] TS/Lint clean
- [x] No breaking API changes
- [x] No DB migrations (Epic 3.1 trouxe a permissão nova; 3.2 é puro refactor)
- [x] No infra changes
- [x] Docs inline + master-plan + RBAC_NAMING.md

### Evidência de validação

- `pytest apps/core/tests/` no container: 1675 passed / 22 skipped / 0 failures em 227.75s
- 12 testes novos de paridade (test_rbac_layer3_parity.py)
- Black + isort aplicados