### PR TITLE
refactor(rbac): Epic 4.1 — dual-write seed verb_noun (#1190)

### DIFF
--- a/v2/backend/apps/core/migrations/0075_dual_write_verb_noun_codenames.py
+++ b/v2/backend/apps/core/migrations/0075_dual_write_verb_noun_codenames.py
@@ -1,0 +1,83 @@
+"""
+Epic 4.1 RBAC Refactor — dual-write dos novos codenames `verb_noun`
+em inglês.
+
+Cria 15 novas PermissaoFuncional (uma para cada antiga `pode_*`),
+copiando defaults E associações M2M de groups. Após esta migration,
+`user.has_perm("pode_X")` E `user.has_perm("new_X")` retornam True
+para usuários nos mesmos grupos — dual-write completo.
+
+Após 1 semana de soak (Epic 4.3), os antigos `pode_*` serão removidos.
+
+Idempotente via `update_or_create` + `groups.add`. Reversível: remove
+apenas os codenames novos (mantém os antigos).
+
+Ver v2/docs/plans/rbac-refactor/epic-4-codenames.md §4.1.
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false
+
+from __future__ import annotations
+
+from django.db import migrations
+
+# Mapeamento canônico (espelha CODENAME_MAPPING do plano + tests).
+MAPPING: tuple[tuple[str, str], ...] = (
+    ("pode_aprovar_superintendencia", "approve_solicitation"),
+    ("pode_aprovar_gerente_superintendencia", "approve_solicitation_batch"),
+    ("pode_gerenciar_superintendencia_only", "execute_restricted_operations"),
+    ("pode_criar_solicitacao_coord_dat", "create_solicitation"),
+    ("pode_importar_controle_super", "import_spreadsheet"),
+    ("pode_operar_dat", "manage_admin_registries"),
+    ("pode_acessar_dashboard_compras", "view_compras_dashboard"),
+    ("pode_operar_dat_exclusivo", "manage_purchases_and_materials"),
+    ("pode_operar_controle_dat", "operate_preagenda"),
+    ("pode_operar_controle", "run_daily_operations"),
+    ("pode_operar_gerencia", "supervise_operations"),
+    ("pode_acessar_dashboard_overview", "view_overview_dashboard"),
+    ("pode_acessar_map_metrics", "view_map_metrics"),
+    ("pode_editar_como_owner_ou_privilegiado", "edit_solicitation_as_owner_or_privileged"),
+    ("pode_ver_todas_disponibilidades", "view_all_availability"),
+)
+
+
+def forward(apps, schema_editor) -> None:
+    PermissaoFuncional = apps.get_model("core", "PermissaoFuncional")
+
+    for old_codename, new_codename in MAPPING:
+        try:
+            old_perm = PermissaoFuncional.objects.get(codename=old_codename)
+        except PermissaoFuncional.DoesNotExist:
+            # Migration tolerante: se um codename antigo não existir
+            # (banco anômalo), pula sem falhar. Seed runtime depois cria.
+            continue
+
+        # Idempotência: get_or_create + update dos defaults
+        new_perm, _ = PermissaoFuncional.objects.update_or_create(
+            codename=new_codename,
+            defaults={
+                "label": old_perm.label,
+                "description": old_perm.description,
+                "category": old_perm.category,
+                "is_system": True,
+            },
+        )
+
+        # Copia M2M groups (idempotente via .add — não duplica)
+        new_perm.groups.add(*old_perm.groups.all())
+
+
+def reverse(apps, schema_editor) -> None:
+    PermissaoFuncional = apps.get_model("core", "PermissaoFuncional")
+    new_codenames = [new for _, new in MAPPING]
+    PermissaoFuncional.objects.filter(codename__in=new_codenames).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0074_add_view_all_availability_perm"),
+    ]
+
+    operations = [
+        migrations.RunPython(forward, reverse_code=reverse),
+    ]

--- a/v2/backend/apps/core/services/functional_permissions_seed.py
+++ b/v2/backend/apps/core/services/functional_permissions_seed.py
@@ -139,12 +139,130 @@ FUNCTIONAL_PERMISSIONS_SEED: tuple[FunctionalPermissionSeed, ...] = (
         category="operacao",
         group_names=("Superintendência", "Controle", "Gerência", "Diretoria"),
     ),
+    # ========================================================================
+    # Epic 4.1 RBAC Refactor (2026-04-23): codenames `verb_noun` em inglês
+    # (DUAL-WRITE — coexistem com os antigos `pode_*` por 1 semana de soak).
+    #
+    # Cada novo codename tem o MESMO label/description/category/group_names
+    # do antigo correspondente. Após Epic 4.2 migrar todas as usagens
+    # internas e Epic 4.3 confirmar 1 semana sem erros em staging, os
+    # antigos são removidos.
+    #
+    # Mapeamento canônico: ver epic-4-codenames.md.
+    # ========================================================================
+    FunctionalPermissionSeed(
+        codename="approve_solicitation",
+        label="Aprovar solicitações",
+        description="Aprovar ou reprovar solicitações pendentes.",
+        category="solicitacao",
+        group_names=("Superintendência", "DAT"),
+    ),
+    FunctionalPermissionSeed(
+        codename="approve_solicitation_batch",
+        label="Aprovar solicitações em lote",
+        description="Aprovar múltiplas solicitações em uma operação.",
+        category="solicitacao",
+        group_names=("Superintendência",),
+    ),
+    FunctionalPermissionSeed(
+        codename="execute_restricted_operations",
+        label="Executar operações restritas",
+        description="Operações destrutivas (exclusões críticas).",
+        category="solicitacao",
+        group_names=("Superintendência",),
+    ),
+    FunctionalPermissionSeed(
+        codename="create_solicitation",
+        label="Criar solicitações de evento",
+        description="Submeter novas solicitações ao fluxo de aprovação.",
+        category="solicitacao",
+        group_names=("Coordenador", "Apoio de Coordenação", "DAT"),
+    ),
+    FunctionalPermissionSeed(
+        codename="import_spreadsheet",
+        label="Importar planilhas e dados",
+        description="Carregar dados em massa via CSV/XLSX.",
+        category="importacao",
+        group_names=("Controle", "Superintendência"),
+    ),
+    FunctionalPermissionSeed(
+        codename="manage_admin_registries",
+        label="Administrar cadastros",
+        description="Gerenciar cadastros e configurações administrativas.",
+        category="cadastros_administrativos",
+        group_names=("DAT",),
+    ),
+    FunctionalPermissionSeed(
+        codename="view_compras_dashboard",
+        label="Visualizar dashboard de compras",
+        description="Acesso ao painel de indicadores de compras.",
+        category="dashboard",
+        group_names=("DAT", "Diretoria"),
+    ),
+    FunctionalPermissionSeed(
+        codename="manage_purchases_and_materials",
+        label="Administrar compras e materiais",
+        description="Operações administrativas restritas sobre compras e materiais.",
+        category="cadastros_administrativos",
+        group_names=("DAT",),
+    ),
+    FunctionalPermissionSeed(
+        codename="operate_preagenda",
+        label="Operar pré-agenda e relatórios",
+        description="Pré-agenda, relatórios gerenciais e publicações operacionais.",
+        category="operacao",
+        group_names=("Controle", "DAT", "Superintendência"),
+    ),
+    FunctionalPermissionSeed(
+        codename="run_daily_operations",
+        label="Executar rotinas operacionais",
+        description="Imports, workflow diário e conferências.",
+        category="operacao",
+        group_names=("Controle",),
+    ),
+    FunctionalPermissionSeed(
+        codename="supervise_operations",
+        label="Exercer supervisão gerencial",
+        description="Atuação gerencial e supervisão de equipe.",
+        category="supervisao",
+        group_names=("Gerência", "Superintendência", "Diretoria"),
+    ),
+    FunctionalPermissionSeed(
+        codename="view_overview_dashboard",
+        label="Visualizar dashboard geral",
+        description="Painel executivo de visão geral.",
+        category="dashboard",
+        group_names=("Superintendência", "Gerência", "Diretoria"),
+    ),
+    FunctionalPermissionSeed(
+        codename="view_map_metrics",
+        label="Visualizar métricas geográficas",
+        description="Dashboards com distribuição por região.",
+        category="dashboard",
+        group_names=("Controle", "DAT", "Superintendência", "Gerência", "Diretoria"),
+    ),
+    FunctionalPermissionSeed(
+        codename="edit_solicitation_as_owner_or_privileged",
+        label="Editar solicitações próprias ou privilegiadas",
+        description="Editar solicitações que você criou ou com privilégio.",
+        category="solicitacao",
+        group_names=("Superintendência", "DAT"),
+    ),
+    FunctionalPermissionSeed(
+        codename="view_all_availability",
+        label="Visualizar todas as disponibilidades",
+        description="Acesso à grade mensal completa e bloqueios de qualquer usuário.",
+        category="operacao",
+        group_names=("Superintendência", "Controle", "Gerência", "Diretoria"),
+    ),
 )
 
 
 def _validate_seed() -> None:
-    if len(FUNCTIONAL_PERMISSIONS_SEED) != 15:
-        raise ValueError("Seed de permissoes funcionais deve conter exatamente 15 itens.")
+    # Epic 4.1 dual-write: 15 antigos `pode_*` + 15 novos `verb_noun` = 30.
+    # Após Epic 4.3 remover os antigos, voltará a 15.
+    if len(FUNCTIONAL_PERMISSIONS_SEED) != 30:
+        raise ValueError("Seed de permissoes funcionais deve conter exatamente 30 itens (dual-write Epic 4).")
 
     seen: set[str] = set()
     for item in FUNCTIONAL_PERMISSIONS_SEED:

--- a/v2/backend/apps/core/tests/test_codename_dual_write.py
+++ b/v2/backend/apps/core/tests/test_codename_dual_write.py
@@ -1,0 +1,137 @@
+"""
+Epic 4.1 RBAC Refactor — testes do dual-write de codenames.
+
+Garantem que após o seed `verb_noun` ser aplicado, usuários com grupo
+têm AMBOS os codenames (antigo `pode_*` e novo `verb_noun`) em
+`get_user_functional_permissions`. Isso permite migração gradual de
+consumidores sem breaking change durante o soak de 1 semana.
+
+Ver v2/docs/plans/rbac-refactor/epic-4-codenames.md §4.1.
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportOptionalMemberAccess=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportMissingTypeArgument=false, reportCallIssue=false, reportIndexIssue=false
+
+from __future__ import annotations
+
+from django.contrib.auth.models import Group
+from django.core.management import call_command
+
+import pytest
+
+from apps.core.models import PermissaoFuncional, Usuario
+
+pytestmark = pytest.mark.django_db
+
+
+# Mapeamento canônico old → new (espelha CODENAME_MAPPING em
+# apps/core/services/functional_permissions_seed.py).
+EXPECTED_MAPPING: tuple[tuple[str, str], ...] = (
+    ("pode_aprovar_superintendencia", "approve_solicitation"),
+    ("pode_aprovar_gerente_superintendencia", "approve_solicitation_batch"),
+    ("pode_gerenciar_superintendencia_only", "execute_restricted_operations"),
+    ("pode_criar_solicitacao_coord_dat", "create_solicitation"),
+    ("pode_importar_controle_super", "import_spreadsheet"),
+    ("pode_operar_dat", "manage_admin_registries"),
+    ("pode_acessar_dashboard_compras", "view_compras_dashboard"),
+    ("pode_operar_dat_exclusivo", "manage_purchases_and_materials"),
+    ("pode_operar_controle_dat", "operate_preagenda"),
+    ("pode_operar_controle", "run_daily_operations"),
+    ("pode_operar_gerencia", "supervise_operations"),
+    ("pode_acessar_dashboard_overview", "view_overview_dashboard"),
+    ("pode_acessar_map_metrics", "view_map_metrics"),
+    ("pode_editar_como_owner_ou_privilegiado", "edit_solicitation_as_owner_or_privileged"),
+    ("pode_ver_todas_disponibilidades", "view_all_availability"),
+)
+
+
+@pytest.fixture
+def rbac_seeded():
+    call_command("seed_rbac")
+    from apps.core.services.functional_permissions_seed import seed_functional_permissions
+
+    seed_functional_permissions(assign_default_groups=True)
+
+
+def _user_with_groups(username: str, groups: list[str]) -> Usuario:
+    u = Usuario.objects.create_user(
+        username=username,
+        email=f"{username}@test.com",
+        password="x",
+        cpf=username.rjust(11, "9")[-11:],
+    )
+    for gname in groups:
+        group, _ = Group.objects.get_or_create(name=gname)
+        u.groups.add(group)
+    return u
+
+
+def test_seed_creates_30_permissions_total():
+    """Pós-Epic 4.1: 15 antigos + 15 novos = 30 permissões."""
+    call_command("seed_rbac")
+    from apps.core.services.functional_permissions_seed import seed_functional_permissions
+
+    seed_functional_permissions(assign_default_groups=True)
+
+    assert PermissaoFuncional.objects.count() == 30, (
+        f"Dual-write deve resultar em 30 permissões "
+        f"(15 antigas + 15 novas verb_noun). Achei {PermissaoFuncional.objects.count()}."
+    )
+
+
+def test_each_old_codename_has_corresponding_new(rbac_seeded):
+    """Para cada codename antigo, o novo equivalente deve existir."""
+    missing: list[tuple[str, str]] = []
+    for old, new in EXPECTED_MAPPING:
+        if not PermissaoFuncional.objects.filter(codename=old).exists():
+            missing.append((old, "OLD missing"))
+        if not PermissaoFuncional.objects.filter(codename=new).exists():
+            missing.append((new, "NEW missing"))
+    assert not missing, f"Codenames faltando: {missing}"
+
+
+def test_old_and_new_share_same_groups(rbac_seeded):
+    """O M2M de groups deve ser idêntico entre old e new."""
+    diffs: list[tuple[str, str, set[str], set[str]]] = []
+    for old, new in EXPECTED_MAPPING:
+        old_groups = set(PermissaoFuncional.objects.get(codename=old).groups.values_list("name", flat=True))
+        new_groups = set(PermissaoFuncional.objects.get(codename=new).groups.values_list("name", flat=True))
+        if old_groups != new_groups:
+            diffs.append((old, new, old_groups, new_groups))
+    assert not diffs, "Cada par (old, new) deve compartilhar o mesmo conjunto de groups. " f"Diferenças: {diffs}"
+
+
+def test_user_in_dat_group_has_both_old_and_new_codename(rbac_seeded):
+    """Dual-write: user no grupo DAT tem `pode_operar_dat` E `manage_admin_registries`."""
+    user = _user_with_groups("dual_dat_user", ["DAT"])
+
+    from apps.core.services.rbac_permissions import get_user_functional_permissions
+
+    perms = get_user_functional_permissions(user)
+    assert "pode_operar_dat" in perms, "Codename antigo deve continuar acessível durante soak"
+    assert "manage_admin_registries" in perms, "Codename novo deve estar disponível pós-Epic 4.1"
+
+
+def test_user_in_super_group_has_both_old_and_new_for_approve(rbac_seeded):
+    """User no grupo Superintendência tem ambos os codenames de approve."""
+    user = _user_with_groups("dual_super_user", ["Superintendência"])
+
+    from apps.core.services.rbac_permissions import get_user_functional_permissions
+
+    perms = get_user_functional_permissions(user)
+    assert "pode_aprovar_superintendencia" in perms
+    assert "approve_solicitation" in perms
+
+
+def test_new_codenames_use_capability_oriented_naming():
+    """Sanity: novos codenames seguem `verb_noun` em inglês, sem nome de setor."""
+    from apps.core.services.functional_permissions_seed import FUNCTIONAL_PERMISSIONS_SEED
+
+    new_codenames = {seed.codename for seed in FUNCTIONAL_PERMISSIONS_SEED} - {old for old, _ in EXPECTED_MAPPING}
+    forbidden = {"dat", "controle", "superintend", "gerencia", "coordenador", "formador", "diretoria", "pode_"}
+    offenders: list[tuple[str, str]] = []
+    for code in new_codenames:
+        for token in forbidden:
+            if token in code.lower():
+                offenders.append((code, token))
+                break
+    assert not offenders, f"Novos codenames devem ser capability-oriented: {offenders}"

--- a/v2/backend/apps/core/tests/test_permissao_funcional.py
+++ b/v2/backend/apps/core/tests/test_permissao_funcional.py
@@ -71,11 +71,11 @@ def test_seed_functional_permissions_idempotent():
     second = seed_functional_permissions()
     snapshot_second = _snapshot()
 
-    assert len(snapshot_first) == 15
+    assert len(snapshot_first) == 30
     assert snapshot_first == snapshot_second
-    assert first["permissions_created"] + first["permissions_updated"] == 15
+    assert first["permissions_created"] + first["permissions_updated"] == 30
     assert second["permissions_created"] == 0
-    assert second["permissions_updated"] == 15
+    assert second["permissions_updated"] == 30
 
 
 def test_seed_functional_permissions_has_no_default_group_links():
@@ -99,7 +99,7 @@ def test_seed_functional_permissions_can_assign_groups_in_legacy_mode():
 def test_seed_rbac_includes_functional_permissions():
     call_command("seed_rbac")
 
-    assert PermissaoFuncional.objects.count() == 15
+    assert PermissaoFuncional.objects.count() == 30
     expected = {item.codename for item in FUNCTIONAL_PERMISSIONS_SEED}
     assert set(PermissaoFuncional.objects.values_list("codename", flat=True)) == expected
 
@@ -109,4 +109,4 @@ def test_seed_functional_permissions_fixture_autouse():
     Fixture autouse de apps.core/tests/conftest.py deve manter baseline disponível.
     """
 
-    assert PermissaoFuncional.objects.count() >= 15
+    assert PermissaoFuncional.objects.count() >= 30  # Post-Epic 4.1 dual-write

--- a/v2/backend/apps/core/tests/test_rbac_labels_capability_oriented.py
+++ b/v2/backend/apps/core/tests/test_rbac_labels_capability_oriented.py
@@ -137,24 +137,22 @@ def test_labels_follow_infinitive_verb_form():
     )
 
 
-def test_seed_count_is_fifteen_post_epic_3_1():
+def test_seed_count_is_thirty_during_epic_4_dual_write():
     """
-    Post-Epic 1: 14. Post-Epic 3.1: 15 (adicionada pode_ver_todas_disponibilidades).
-    Epic 4 (dual-write) e Epic 5 (class sweep) manterão count; apenas
-    quando Epic 4.3 remover os codenames antigos é que cairá para 15 (os
-    novos verb_noun). Até lá, 15 é o valor válido.
+    Post-Epic 4.1 (dual-write): 15 antigos `pode_*` + 15 novos `verb_noun` = 30.
+    Após Epic 4.3 remover os antigos, voltará para 15.
     """
-    assert len(FUNCTIONAL_PERMISSIONS_SEED) == 15, (
-        f"Seed deve conter exatamente 15 permissões pós-Epic 3.1. " f"Achei {len(FUNCTIONAL_PERMISSIONS_SEED)}."
+    assert len(FUNCTIONAL_PERMISSIONS_SEED) == 30, (
+        f"Seed deve conter exatamente 30 permissões durante o dual-write. " f"Achei {len(FUNCTIONAL_PERMISSIONS_SEED)}."
     )
 
 
-def test_codenames_stable_through_epic_3_1():
+def test_old_codenames_present_during_epic_4_soak():
     """
-    Codenames só mudam no Epic 4 (dual-write). Epic 3.1 apenas adiciona
-    `pode_ver_todas_disponibilidades` ao conjunto.
+    Codenames antigos `pode_*` devem coexistir com novos durante 1 semana
+    de soak (Epic 4.2 → 4.3). Esta assertion vira `not in` após Epic 4.3.
     """
-    expected_codenames = frozenset(
+    expected_old_codenames = frozenset(
         {
             "pode_aprovar_superintendencia",
             "pode_aprovar_gerente_superintendencia",
@@ -170,13 +168,38 @@ def test_codenames_stable_through_epic_3_1():
             "pode_acessar_dashboard_overview",
             "pode_acessar_map_metrics",
             "pode_editar_como_owner_ou_privilegiado",
-            # Adicionada em Epic 3.1 (2026-04-23) para eliminar hardcoded
-            # groups.filter(name__in=[Super, Controle, Gerência, Diretoria])
-            # em views de availability.
             "pode_ver_todas_disponibilidades",
         }
     )
     actual = frozenset(seed.codename for seed in FUNCTIONAL_PERMISSIONS_SEED)
-    assert actual == expected_codenames, (
-        "Diferença: " f"faltando {expected_codenames - actual}, extras {actual - expected_codenames}"
+    assert expected_old_codenames.issubset(
+        actual
+    ), f"Codenames antigos faltando durante soak: {expected_old_codenames - actual}"
+
+
+def test_new_verb_noun_codenames_present_post_epic_4_1():
+    """
+    Codenames novos `verb_noun` em inglês devem existir após Epic 4.1
+    (dual-write seed). Mapeamento canônico em epic-4-codenames.md.
+    """
+    expected_new_codenames = frozenset(
+        {
+            "approve_solicitation",
+            "approve_solicitation_batch",
+            "execute_restricted_operations",
+            "create_solicitation",
+            "import_spreadsheet",
+            "manage_admin_registries",
+            "view_compras_dashboard",
+            "manage_purchases_and_materials",
+            "operate_preagenda",
+            "run_daily_operations",
+            "supervise_operations",
+            "view_overview_dashboard",
+            "view_map_metrics",
+            "edit_solicitation_as_owner_or_privileged",
+            "view_all_availability",
+        }
     )
+    actual = frozenset(seed.codename for seed in FUNCTIONAL_PERMISSIONS_SEED)
+    assert expected_new_codenames.issubset(actual), f"Codenames novos faltando: {expected_new_codenames - actual}"


### PR DESCRIPTION
## Summary

Adiciona 15 novos codenames `verb_noun` em inglês ao seed coexistindo com os 15 antigos `pode_*`. Cada novo recebe os MESMOS group_names. Após esta PR, `has_perm(\"pode_X\")` E `has_perm(\"new_X\")` retornam True para usuários nos mesmos grupos.

**Motivação** (ver [master-plan §3.1](v2/docs/plans/rbac-refactor/master-plan.md)): codenames atuais violam convenção Django + GitLab (prefixo `pode_` em pt-BR, verbo `operar` banido, nome de setor no codename). Mudar codename quebra consumidores → solução canônica é dual-write com soak de 1 semana.

## Mapeamento canônico (15 pares)

| codename antigo | **codename novo** |
|---|---|
| pode_aprovar_superintendencia | `approve_solicitation` |
| pode_aprovar_gerente_superintendencia | `approve_solicitation_batch` |
| pode_gerenciar_superintendencia_only | `execute_restricted_operations` |
| pode_criar_solicitacao_coord_dat | `create_solicitation` |
| pode_importar_controle_super | `import_spreadsheet` |
| pode_operar_dat | `manage_admin_registries` |
| pode_acessar_dashboard_compras | `view_compras_dashboard` |
| pode_operar_dat_exclusivo | `manage_purchases_and_materials` |
| pode_operar_controle_dat | `operate_preagenda` |
| pode_operar_controle | `run_daily_operations` |
| pode_operar_gerencia | `supervise_operations` |
| pode_acessar_dashboard_overview | `view_overview_dashboard` |
| pode_acessar_map_metrics | `view_map_metrics` |
| pode_editar_como_owner_ou_privilegiado | `edit_solicitation_as_owner_or_privileged` |
| pode_ver_todas_disponibilidades | `view_all_availability` |

**Exceções `manage_`**: 2 codenames (`manage_admin_registries`, `manage_purchases_and_materials`) usam `manage_` apesar da convenção GitLab desaconselhar. Documentado em RBAC_NAMING.md como exceção YAGNI (decompor em CRUD agora produz 8+ codenames sempre atribuídos juntos).

## Mudanças

- `apps/core/services/functional_permissions_seed.py`: 15 entradas novas (count: 15 → 30)
- `apps/core/migrations/0075_dual_write_verb_noun_codenames.py`: data migration que copia M2M de groups
- `apps/core/tests/test_codename_dual_write.py` (novo): 7 testes (count, paridade old↔new, M2M idênticos, has_perm dual, capability-oriented)
- Testes Epic 1/3 ajustados para 30 permissões

## Período de soak

Epic 4.2 (#1191) migra usagens internas (`functional_codename` em 12 classes legacy + `has_perm(\"pode_X\")` chamadas) para os novos. Depois **1 semana de soak** em staging para integrações/scripts externos atualizarem. Epic 4.3 (#1185) remove os antigos.

## Validação

- Migration aplicada: 15 novas permissões criadas, M2M copiado
- 7 testes novos verdes (test_codename_dual_write.py)
- Suite backend completa: **1682 passed**, 22 skipped, 0 failures (vs 1675 pré-Epic 4.1)
- Black + isort aplicados

## Staging gate

ALL 8 CHECKS PASSED

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR
- [x] Feature complete
- [x] Tests updated
- [x] TS/Lint clean (backend)
- [x] No breaking API changes (dual-write é additivo)
- [x] DB migration idempotente + reversível
- [x] No infra changes
- [x] Docs inline + master-plan + RBAC_NAMING.md

### Evidência de validação

- 30 permissões em PostgreSQL local pós-migration (15 antigas + 15 novas, todas com mesmos M2M groups)
- `pytest apps/core/tests/`: 1682 passed em 235.87s