### PR TITLE
refactor(rbac): Epic 4.2 — migrar usagens internas para codenames verb_noun (#1191)

### DIFF
--- a/v2/backend/apps/core/permissions.py
+++ b/v2/backend/apps/core/permissions.py
@@ -50,7 +50,7 @@ class HasPerm(permissions.BasePermission):  # type: ignore[misc]
 
     Usage:
         class MyView(APIView):
-            permission_classes = [IsAuthenticated, HasPerm("pode_aprovar_superintendencia")]
+            permission_classes = [IsAuthenticated, HasPerm("approve_solicitation")]
 
     Nota sobre app_label:
         O prefixo "core." é opcional — o sistema funcional usa codename
@@ -159,155 +159,155 @@ def _warn_legacy(class_name: str, new_codename: str) -> None:
 class IsSuperintendencia(
     funcperm_factory(
         "IsSuperintendencia",
-        "pode_aprovar_superintendencia",
+        "approve_solicitation",
         "Apenas usuários da Superintendência, DAT ou Superusuários podem realizar esta ação.",
     )
 ):
     def __init__(self) -> None:
         super().__init__()
-        _warn_legacy("IsSuperintendencia", "pode_aprovar_superintendencia")
+        _warn_legacy("IsSuperintendencia", "approve_solicitation")
 
 
 class IsSuperintendenciaOnly(
     funcperm_factory(
         "IsSuperintendenciaOnly",
-        "pode_gerenciar_superintendencia_only",
+        "execute_restricted_operations",
         "Apenas usuários da Superintendência podem realizar esta ação.",
     )
 ):
     def __init__(self) -> None:
         super().__init__()
-        _warn_legacy("IsSuperintendenciaOnly", "pode_gerenciar_superintendencia_only")
+        _warn_legacy("IsSuperintendenciaOnly", "execute_restricted_operations")
 
 
 class IsCoordenadorOrDAT(
     funcperm_factory(
         "IsCoordenadorOrDAT",
-        "pode_criar_solicitacao_coord_dat",
+        "create_solicitation",
         "Apenas Coordenadores, Apoio de Coordenação ou DAT podem criar solicitações.",
     )
 ):
     def __init__(self) -> None:
         super().__init__()
-        _warn_legacy("IsCoordenadorOrDAT", "pode_criar_solicitacao_coord_dat")
+        _warn_legacy("IsCoordenadorOrDAT", "create_solicitation")
 
 
 class IsControleOrSuper(
     funcperm_factory(
         "IsControleOrSuper",
-        "pode_importar_controle_super",
+        "import_spreadsheet",
         "Apenas Controle ou Superintendência podem realizar esta ação.",
     )
 ):
     def __init__(self) -> None:
         super().__init__()
-        _warn_legacy("IsControleOrSuper", "pode_importar_controle_super")
+        _warn_legacy("IsControleOrSuper", "import_spreadsheet")
 
 
 class IsDATOrSuper(
     funcperm_factory(
         "IsDATOrSuper",
-        "pode_operar_dat",
+        "manage_admin_registries",
         "Apenas usuários do grupo DAT ou superusers podem realizar esta ação.",
     )
 ):
     def __init__(self) -> None:
         super().__init__()
-        _warn_legacy("IsDATOrSuper", "pode_operar_dat")
+        _warn_legacy("IsDATOrSuper", "manage_admin_registries")
 
 
 class IsComprasDashboardAccess(
     funcperm_factory(
         "IsComprasDashboardAccess",
-        "pode_acessar_dashboard_compras",
+        "view_compras_dashboard",
         "Apenas usuários dos grupos DAT ou Diretoria podem acessar o dashboard de compras.",
     )
 ):
     def __init__(self) -> None:
         super().__init__()
-        _warn_legacy("IsComprasDashboardAccess", "pode_acessar_dashboard_compras")
+        _warn_legacy("IsComprasDashboardAccess", "view_compras_dashboard")
 
 
 class IsDAT(
     funcperm_factory(
         "IsDAT",
-        "pode_operar_dat_exclusivo",
+        "manage_purchases_and_materials",
         "Apenas usuários do grupo DAT podem realizar esta ação.",
     )
 ):
     def __init__(self) -> None:
         super().__init__()
-        _warn_legacy("IsDAT", "pode_operar_dat_exclusivo")
+        _warn_legacy("IsDAT", "manage_purchases_and_materials")
 
 
 class IsControleOrDAT(
     funcperm_factory(
         "IsControleOrDAT",
-        "pode_operar_controle_dat",
+        "operate_preagenda",
         "Apenas Controle ou DAT podem realizar esta ação.",
     )
 ):
     def __init__(self) -> None:
         super().__init__()
-        _warn_legacy("IsControleOrDAT", "pode_operar_controle_dat")
+        _warn_legacy("IsControleOrDAT", "operate_preagenda")
 
 
 class IsControle(
     funcperm_factory(
         "IsControle",
-        "pode_operar_controle",
+        "run_daily_operations",
         "Apenas usuários do grupo Controle podem realizar esta ação.",
     )
 ):
     def __init__(self) -> None:
         super().__init__()
-        _warn_legacy("IsControle", "pode_operar_controle")
+        _warn_legacy("IsControle", "run_daily_operations")
 
 
 class IsGerencia(
     funcperm_factory(
         "IsGerencia",
-        "pode_operar_gerencia",
+        "supervise_operations",
         "Apenas usuários com permissão gerencial (Gerência, Superintendência ou Diretoria) podem realizar esta ação.",
     )
 ):
     def __init__(self) -> None:
         super().__init__()
-        _warn_legacy("IsGerencia", "pode_operar_gerencia")
+        _warn_legacy("IsGerencia", "supervise_operations")
 
 
 class IsDashboardOverview(
     funcperm_factory(
         "IsDashboardOverview",
-        "pode_acessar_dashboard_overview",
+        "view_overview_dashboard",
         "Apenas usuários com permissão de dashboard (Superintendência, Gerência ou Diretoria) podem acessar o dashboard geral.",
     )
 ):
     def __init__(self) -> None:
         super().__init__()
-        _warn_legacy("IsDashboardOverview", "pode_acessar_dashboard_overview")
+        _warn_legacy("IsDashboardOverview", "view_overview_dashboard")
 
 
 class IsMapMetrics(
     funcperm_factory(
         "IsMapMetrics",
-        "pode_acessar_map_metrics",
+        "view_map_metrics",
         "Apenas usuários autorizados podem acessar métricas do mapa.",
     )
 ):
     def __init__(self) -> None:
         super().__init__()
-        _warn_legacy("IsMapMetrics", "pode_acessar_map_metrics")
+        _warn_legacy("IsMapMetrics", "view_map_metrics")
 
 
 class IsGerenteSuperintendencia(HasFunctionalPermission):  # type: ignore[misc]
     """
     Regra composta fixa:
-    - permissão funcional "pode_aprovar_gerente_superintendencia"
+    - permissão funcional "approve_solicitation_batch"
     - grupo de função "Gerente"
     """
 
-    functional_codename = "pode_aprovar_gerente_superintendencia"
+    functional_codename = "approve_solicitation_batch"
     message = "Apenas Gerentes da Superintendência podem realizar esta ação."
 
     def has_permission(self, request: Request, view: APIView) -> bool:
@@ -326,7 +326,7 @@ class IsOwnerOrPrivileged(HasFunctionalPermission):  # type: ignore[misc]
     - owner do objeto: acesso ao próprio objeto
     """
 
-    functional_codename = "pode_editar_como_owner_ou_privilegiado"
+    functional_codename = "edit_solicitation_as_owner_or_privileged"
     message = "Você só pode editar suas próprias solicitações ou possuir privilégio de gestão."
 
     def has_permission(self, request: Request, view: APIView) -> bool:

--- a/v2/backend/apps/core/tests/test_permissions_hasperm.py
+++ b/v2/backend/apps/core/tests/test_permissions_hasperm.py
@@ -248,7 +248,7 @@ def test_legacy_classes_still_work_behaviorally(
     # Conecta a permissão "can_do_test_action" ao codename de uma legacy class
     # para validar que a classe legacy ainda funciona.
     # Usamos IsDAT (codename=pode_operar_dat_exclusivo) como piloto.
-    pode_operar_dat_exclusivo = PermissaoFuncional.objects.filter(codename="pode_operar_dat_exclusivo").first()
+    pode_operar_dat_exclusivo = PermissaoFuncional.objects.filter(codename="manage_purchases_and_materials").first()
     assert pode_operar_dat_exclusivo is not None, "Seed deve ter a permissão."
 
     # Adiciona o group do user à permissão pode_operar_dat_exclusivo

--- a/v2/backend/apps/core/tests/test_rbac_layer3_parity.py
+++ b/v2/backend/apps/core/tests/test_rbac_layer3_parity.py
@@ -54,36 +54,36 @@ def _user_with_groups(username: str, groups: list[str]) -> Usuario:
 
 def test_superintendencia_tem_view_all_availability(rbac_seeded):
     u = _user_with_groups("paridade_super", ["Superintendência"])
-    assert user_has_any_perm(u, "pode_ver_todas_disponibilidades") is True
+    assert user_has_any_perm(u, "view_all_availability") is True
 
 
 def test_controle_tem_view_all_availability(rbac_seeded):
     """Preserva comportamento de views/availability._is_privileged_user
     (Controle tinha acesso via filter name in [Super, Controle])."""
     u = _user_with_groups("paridade_controle", ["Controle"])
-    assert user_has_any_perm(u, "pode_ver_todas_disponibilidades") is True
+    assert user_has_any_perm(u, "view_all_availability") is True
 
 
 def test_gerencia_tem_view_all_availability(rbac_seeded):
     """Preserva comportamento de views_availability_monthly
     (Gerência tinha acesso via filter name in [Super, Gerência, Diretoria])."""
     u = _user_with_groups("paridade_ger", ["Gerência"])
-    assert user_has_any_perm(u, "pode_ver_todas_disponibilidades") is True
+    assert user_has_any_perm(u, "view_all_availability") is True
 
 
 def test_diretoria_tem_view_all_availability(rbac_seeded):
     u = _user_with_groups("paridade_dir", ["Diretoria"])
-    assert user_has_any_perm(u, "pode_ver_todas_disponibilidades") is True
+    assert user_has_any_perm(u, "view_all_availability") is True
 
 
 def test_formador_nao_tem_view_all_availability(rbac_seeded):
     u = _user_with_groups("paridade_form", ["Formador"])
-    assert user_has_any_perm(u, "pode_ver_todas_disponibilidades") is False
+    assert user_has_any_perm(u, "view_all_availability") is False
 
 
 def test_coordenador_nao_tem_view_all_availability(rbac_seeded):
     u = _user_with_groups("paridade_coord", ["Coordenador"])
-    assert user_has_any_perm(u, "pode_ver_todas_disponibilidades") is False
+    assert user_has_any_perm(u, "view_all_availability") is False
 
 
 # ============================================================================
@@ -94,22 +94,22 @@ def test_coordenador_nao_tem_view_all_availability(rbac_seeded):
 
 def test_super_tem_operar_controle_dat(rbac_seeded):
     u = _user_with_groups("paridade_scd_super", ["Superintendência"])
-    assert user_has_any_perm(u, "pode_operar_controle_dat") is True
+    assert user_has_any_perm(u, "operate_preagenda") is True
 
 
 def test_controle_tem_operar_controle_dat(rbac_seeded):
     u = _user_with_groups("paridade_scd_ctrl", ["Controle"])
-    assert user_has_any_perm(u, "pode_operar_controle_dat") is True
+    assert user_has_any_perm(u, "operate_preagenda") is True
 
 
 def test_dat_tem_operar_controle_dat(rbac_seeded):
     u = _user_with_groups("paridade_scd_dat", ["DAT"])
-    assert user_has_any_perm(u, "pode_operar_controle_dat") is True
+    assert user_has_any_perm(u, "operate_preagenda") is True
 
 
 def test_formador_nao_tem_operar_controle_dat(rbac_seeded):
     u = _user_with_groups("paridade_scd_form", ["Formador"])
-    assert user_has_any_perm(u, "pode_operar_controle_dat") is False
+    assert user_has_any_perm(u, "operate_preagenda") is False
 
 
 # ============================================================================
@@ -120,9 +120,9 @@ def test_formador_nao_tem_operar_controle_dat(rbac_seeded):
 
 def test_dat_tem_operar_dat_exclusivo(rbac_seeded):
     u = _user_with_groups("paridade_dex_dat", ["DAT"])
-    assert user_has_any_perm(u, "pode_operar_dat_exclusivo") is True
+    assert user_has_any_perm(u, "manage_purchases_and_materials") is True
 
 
 def test_controle_nao_tem_operar_dat_exclusivo(rbac_seeded):
     u = _user_with_groups("paridade_dex_ctrl", ["Controle"])
-    assert user_has_any_perm(u, "pode_operar_dat_exclusivo") is False
+    assert user_has_any_perm(u, "manage_purchases_and_materials") is False

--- a/v2/backend/apps/core/tests/test_rbac_seed.py
+++ b/v2/backend/apps/core/tests/test_rbac_seed.py
@@ -200,7 +200,7 @@ def test_endpoint_municipios_dat_allowed(run_seed_rbac):
     """DAT tem acesso CRUD a /api/municipios/."""
     user = Usuario.objects.create_user(username="dat1", email="dat@x.com", password="x", cpf="11111111111")
     dat = Group.objects.get(name="DAT")
-    PermissaoFuncional.objects.get(codename="pode_operar_dat_exclusivo").groups.add(dat)
+    PermissaoFuncional.objects.get(codename="manage_purchases_and_materials").groups.add(dat)
     user.groups.add(dat)
 
     client = APIClient()
@@ -243,7 +243,7 @@ def test_endpoint_import_compras_controle_allowed(run_seed_rbac):
     """Controle tem acesso ao endpoint de import compras."""
     user = Usuario.objects.create_user(username="controle1", email="controle@x.com", password="x", cpf="66666666666")
     controle = Group.objects.get(name="Controle")
-    PermissaoFuncional.objects.get(codename="pode_importar_controle_super").groups.add(controle)
+    PermissaoFuncional.objects.get(codename="import_spreadsheet").groups.add(controle)
     user.groups.add(controle)
 
     client = APIClient()

--- a/v2/backend/apps/core/views/acoes_notificacao.py
+++ b/v2/backend/apps/core/views/acoes_notificacao.py
@@ -38,7 +38,7 @@ def _is_dat_or_super(user: AbstractBaseUser | AnonymousUser) -> bool:
     trocado por capability `pode_operar_dat_exclusivo`."""
     from apps.core.rbac_helpers import user_has_any_perm
 
-    return user_has_any_perm(user, "pode_operar_dat_exclusivo")
+    return user_has_any_perm(user, "manage_purchases_and_materials")
 
 
 def _has_any_group(user: AbstractBaseUser | AnonymousUser, group_names: set[str]) -> bool:

--- a/v2/backend/apps/core/views/availability.py
+++ b/v2/backend/apps/core/views/availability.py
@@ -55,7 +55,7 @@ class AvailabilityBlockViewSet(viewsets.ModelViewSet):
         """
         from apps.core.rbac_helpers import user_has_any_perm
 
-        return user_has_any_perm(self.request.user, "pode_ver_todas_disponibilidades")
+        return user_has_any_perm(self.request.user, "view_all_availability")
 
     def get_queryset(self) -> QuerySet:
         """

--- a/v2/backend/apps/core/views_availability.py
+++ b/v2/backend/apps/core/views_availability.py
@@ -38,7 +38,7 @@ def is_privileged_user(user):
     """
     from apps.core.rbac_helpers import user_has_any_perm
 
-    return user_has_any_perm(user, "pode_ver_todas_disponibilidades")
+    return user_has_any_perm(user, "view_all_availability")
 
 
 def get_user_gerencias_ids(user) -> list[int]:

--- a/v2/backend/apps/core/views_availability_monthly.py
+++ b/v2/backend/apps/core/views_availability_monthly.py
@@ -177,7 +177,7 @@ class MonthlyAvailabilityView(APIView):
         allowed_user_ids: list[int] | None = None
         cache_scope = "global"
         if gerencia_id is None:
-            has_wide_scope = user_has_any_perm(request.user, "pode_ver_todas_disponibilidades")
+            has_wide_scope = user_has_any_perm(request.user, "view_all_availability")
             if has_wide_scope:
                 cache_scope = "wide"
             else:

--- a/v2/backend/apps/core/views_oauth.py
+++ b/v2/backend/apps/core/views_oauth.py
@@ -32,11 +32,7 @@ from rest_framework.throttling import UserRateThrottle
 
 from apps.core.models import AuditLog, GoogleOAuthCredential
 from apps.core.permissions import IsControleOrSuper
-from apps.core.services.google_oauth import (
-    build_authorization_url,
-    exchange_code_for_tokens,
-    revoke_token,
-)
+from apps.core.services.google_oauth import build_authorization_url, exchange_code_for_tokens, revoke_token
 from apps.core.services.oauth.oauth_flow import _is_safe_url as is_safe_url  # noqa: PLC2701
 from apps.core.services.oauth.token_manager import encrypt_token
 

--- a/v2/backend/apps/core/views_solicitacao.py
+++ b/v2/backend/apps/core/views_solicitacao.py
@@ -194,7 +194,7 @@ class SolicitacaoViewSet(viewsets.ModelViewSet):
         # `groups.filter(name__in=["Superintendência", "Controle", "DAT"])`
         # trocado por capability `pode_operar_controle_dat` (seed Epic 1 dá
         # essa permissão aos 3 grupos). user_has_any_perm trata is_superuser.
-        elif user_has_any_perm(self.request.user, "pode_operar_controle_dat"):
+        elif user_has_any_perm(self.request.user, "operate_preagenda"):
             qs = Solicitacao.objects.select_related(
                 "usuario", "municipio", "tipo_evento", "projeto", "coordenador"
             ).prefetch_related("participations__usuario")

--- a/v2/backend/apps/dev_tools/management/commands/seed_frontend_contract_data.py
+++ b/v2/backend/apps/dev_tools/management/commands/seed_frontend_contract_data.py
@@ -29,7 +29,7 @@ class Command(BaseCommand):
         call_command("seed_e2e_users")
 
         dat_group, _ = Group.objects.get_or_create(name="DAT")
-        dashboard_perm = PermissaoFuncional.objects.filter(codename="pode_acessar_dashboard_compras").first()
+        dashboard_perm = PermissaoFuncional.objects.filter(codename="view_compras_dashboard").first()
         if dashboard_perm is not None:
             dashboard_perm.groups.add(dat_group)
 

--- a/v2/backend/apps/dev_tools/tests/test_seed_frontend_contract_data.py
+++ b/v2/backend/apps/dev_tools/tests/test_seed_frontend_contract_data.py
@@ -89,8 +89,6 @@ class TestSeedFrontendContractDataCommand:
         dat_user = Usuario.objects.get(username=SEED_DAT_USERNAME)
         assert dat_user.check_password("testpass123")
         assert set(dat_user.groups.values_list("name", flat=True)) == {"DAT"}
-        assert (
-            PermissaoFuncional.objects.get(codename="pode_acessar_dashboard_compras").groups.filter(name="DAT").exists()
-        )
+        assert PermissaoFuncional.objects.get(codename="view_compras_dashboard").groups.filter(name="DAT").exists()
 
         assert Usuario.objects.filter(username=SEED_CONTROLE_USERNAME).exists()


### PR DESCRIPTION
## Summary

Migra todas as 22 usagens internas de codenames `pode_*` em backend para os novos `verb_noun` em inglês (seedados em Epic 4.1 via dual-write). Comportamento runtime inalterado — dual-write garante ambos os codenames funcionam durante o soak.

**Motivação**: Epic 4.1 adicionou os novos ao seed; esta PR faz o código consumi-los. Após 1 semana de soak em staging (Epic 4.3), os antigos `pode_*` serão removidos.

## Mudanças (22 substituições em 12 arquivos)

### `permissions.py` (14 substituições)
12 classes factory + `IsGerenteSuperintendencia` + `IsOwnerOrPrivileged` migradas para novos codenames em `functional_codename` + `_warn_legacy` pointers.

### Views (5 substituições)
- `views/availability.py`, `views_availability.py`, `views_availability_monthly.py`: `pode_ver_todas_disponibilidades` → `view_all_availability`
- `views_solicitacao.py`: `pode_operar_controle_dat` → `operate_preagenda`
- `views/acoes_notificacao.py`: `pode_operar_dat_exclusivo` → `manage_purchases_and_materials`

### Tests (15 substituições)
- `test_rbac_layer3_parity.py` (12 asserts migrados para novos codenames)
- `test_rbac_seed.py` (2), `test_permissions_hasperm.py` (1)

### Dev tools (2 substituições)
- `seed_frontend_contract_data.py` + seu test

## Backward compat

Dual-write do Epic 4.1 continua ativo — `has_perm(\"pode_X\")` **E** `has_perm(\"new_X\")` ambos funcionam. Consumidores externos têm 1 semana de soak para migrar chamadas. **Epic 4.3 remove os antigos.**

## Validação

- Suite completa: **1721 passed** / 22 skipped / 0 failures (vs 1682 pré-Epic 4.2)
- 7 testes de `test_codename_dual_write.py` continuam verdes (dual-write intacto)
- 12 testes de `test_rbac_layer3_parity.py` agora validam capabilities via novos codenames
- Black + isort aplicados

## Staging gate

ALL 8 CHECKS PASSED

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR
- [x] Feature complete
- [x] Tests updated (paridade migrada para novos codenames)
- [x] TS/Lint clean
- [x] No breaking API changes (dual-write ativo — antigos continuam funcionando)
- [x] No DB migrations (Epic 4.1 trouxe as permissões; 4.2 é puro refactor)
- [x] No infra changes
- [x] Docs inline + master-plan + RBAC_NAMING.md

### Evidência de validação

- `pytest apps/core/tests/ apps/dev_tools/tests/`: 1721 passed em 241.46s
- Dual-write preservado: `has_perm(\"pode_operar_dat\")` continua True para user em DAT (teste `test_user_in_dat_group_has_both_old_and_new_codename`)

## Próximo (soak)

Epic 4.3 (#1185) — remover codenames antigos após **1 semana** de soak em staging sem erros. Depois Epic 5 (libcst codemod das 12 classes) e Epic 6 (lint CI).