### PR TITLE
refactor(rbac): Epic 5.3 — deletar 12 classes factory legacy (#1188)

### DIFF
--- a/v2/backend/apps/core/permissions.py
+++ b/v2/backend/apps/core/permissions.py
@@ -18,9 +18,6 @@ Backwards compatible:
 # pyright: reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportAttributeAccessIssue=false, reportCallIssue=false
 from __future__ import annotations
 
-import warnings
-from typing import cast
-
 from rest_framework import permissions  # type: ignore[attr-defined]
 from rest_framework.request import Request
 from rest_framework.views import APIView
@@ -133,180 +130,20 @@ class HasFunctionalPermission(permissions.BasePermission):  # type: ignore[misc]
         return self.functional_codename in get_user_functional_permissions(user)
 
 
-def funcperm_factory(
-    class_name: str,
-    functional_codename: str,
-    message: str,
-) -> type[HasFunctionalPermission]:
-    attrs = {
-        "functional_codename": functional_codename,
-        "message": message,
-    }
-    return cast(type[HasFunctionalPermission], type(class_name, (HasFunctionalPermission,), attrs))
-
-
-def _warn_legacy(class_name: str, new_codename: str) -> None:
-    """Helper: emite DeprecationWarning padronizado apontando para HasPerm equivalente."""
-    warnings.warn(
-        f"{class_name} is deprecated; use HasPerm({new_codename!r}). "
-        "This class will be removed in Epic 5 of the RBAC refactor. "
-        "See v2/docs/RBAC_NAMING.md.",
-        DeprecationWarning,
-        stacklevel=3,
-    )
-
-
 # ============================================================================
-# Epic 2 Legacy factory classes (12) — deprecated em favor de HasPerm(codename)
+# Epic 5.3 RBAC Refactor (2026-04-24): as 12 classes factory legacy
+# (`IsSuperintendencia`, `IsDAT`, `IsControleOrDAT`, ...) foram removidas.
+# Callers agora usam `HasPerm("codename")` diretamente via codemod do
+# Epic 5.2. `funcperm_factory` e `_warn_legacy` helper também removidos
+# — não há mais consumidores desses utilitários.
 #
-# Cada uma emite DeprecationWarning no __init__ apontando para HasPerm
-# equivalente. Remoção efetiva no Epic 5 (libcst codemod). Ver master-plan
-# §3.3 e v2/docs/RBAC_NAMING.md.
+# As 3 classes mantidas abaixo (`IsGerenteSuperintendencia`,
+# `IsOwnerOrPrivileged`, `HasSectorAccess`) permanecem porque exprimem
+# lógica que `HasPerm(codename)` não cobre:
+# - Composite rule (funcperm + grupo Django)
+# - Object-level check (obj.usuario)
+# - Dynamic scope via query param
 # ============================================================================
-
-
-class IsSuperintendencia(
-    funcperm_factory(
-        "IsSuperintendencia",
-        "approve_solicitation",
-        "Apenas usuários da Superintendência, DAT ou Superusuários podem realizar esta ação.",
-    )
-):
-    def __init__(self) -> None:
-        super().__init__()
-        _warn_legacy("IsSuperintendencia", "approve_solicitation")
-
-
-class IsSuperintendenciaOnly(
-    funcperm_factory(
-        "IsSuperintendenciaOnly",
-        "execute_restricted_operations",
-        "Apenas usuários da Superintendência podem realizar esta ação.",
-    )
-):
-    def __init__(self) -> None:
-        super().__init__()
-        _warn_legacy("IsSuperintendenciaOnly", "execute_restricted_operations")
-
-
-class IsCoordenadorOrDAT(
-    funcperm_factory(
-        "IsCoordenadorOrDAT",
-        "create_solicitation",
-        "Apenas Coordenadores, Apoio de Coordenação ou DAT podem criar solicitações.",
-    )
-):
-    def __init__(self) -> None:
-        super().__init__()
-        _warn_legacy("IsCoordenadorOrDAT", "create_solicitation")
-
-
-class IsControleOrSuper(
-    funcperm_factory(
-        "IsControleOrSuper",
-        "import_spreadsheet",
-        "Apenas Controle ou Superintendência podem realizar esta ação.",
-    )
-):
-    def __init__(self) -> None:
-        super().__init__()
-        _warn_legacy("IsControleOrSuper", "import_spreadsheet")
-
-
-class IsDATOrSuper(
-    funcperm_factory(
-        "IsDATOrSuper",
-        "manage_admin_registries",
-        "Apenas usuários do grupo DAT ou superusers podem realizar esta ação.",
-    )
-):
-    def __init__(self) -> None:
-        super().__init__()
-        _warn_legacy("IsDATOrSuper", "manage_admin_registries")
-
-
-class IsComprasDashboardAccess(
-    funcperm_factory(
-        "IsComprasDashboardAccess",
-        "view_compras_dashboard",
-        "Apenas usuários dos grupos DAT ou Diretoria podem acessar o dashboard de compras.",
-    )
-):
-    def __init__(self) -> None:
-        super().__init__()
-        _warn_legacy("IsComprasDashboardAccess", "view_compras_dashboard")
-
-
-class IsDAT(
-    funcperm_factory(
-        "IsDAT",
-        "manage_purchases_and_materials",
-        "Apenas usuários do grupo DAT podem realizar esta ação.",
-    )
-):
-    def __init__(self) -> None:
-        super().__init__()
-        _warn_legacy("IsDAT", "manage_purchases_and_materials")
-
-
-class IsControleOrDAT(
-    funcperm_factory(
-        "IsControleOrDAT",
-        "operate_preagenda",
-        "Apenas Controle ou DAT podem realizar esta ação.",
-    )
-):
-    def __init__(self) -> None:
-        super().__init__()
-        _warn_legacy("IsControleOrDAT", "operate_preagenda")
-
-
-class IsControle(
-    funcperm_factory(
-        "IsControle",
-        "run_daily_operations",
-        "Apenas usuários do grupo Controle podem realizar esta ação.",
-    )
-):
-    def __init__(self) -> None:
-        super().__init__()
-        _warn_legacy("IsControle", "run_daily_operations")
-
-
-class IsGerencia(
-    funcperm_factory(
-        "IsGerencia",
-        "supervise_operations",
-        "Apenas usuários com permissão gerencial (Gerência, Superintendência ou Diretoria) podem realizar esta ação.",
-    )
-):
-    def __init__(self) -> None:
-        super().__init__()
-        _warn_legacy("IsGerencia", "supervise_operations")
-
-
-class IsDashboardOverview(
-    funcperm_factory(
-        "IsDashboardOverview",
-        "view_overview_dashboard",
-        "Apenas usuários com permissão de dashboard (Superintendência, Gerência ou Diretoria) podem acessar o dashboard geral.",
-    )
-):
-    def __init__(self) -> None:
-        super().__init__()
-        _warn_legacy("IsDashboardOverview", "view_overview_dashboard")
-
-
-class IsMapMetrics(
-    funcperm_factory(
-        "IsMapMetrics",
-        "view_map_metrics",
-        "Apenas usuários autorizados podem acessar métricas do mapa.",
-    )
-):
-    def __init__(self) -> None:
-        super().__init__()
-        _warn_legacy("IsMapMetrics", "view_map_metrics")
 
 
 class IsGerenteSuperintendencia(HasFunctionalPermission):  # type: ignore[misc]

--- a/v2/backend/apps/core/tests/test_permissions_hasperm.py
+++ b/v2/backend/apps/core/tests/test_permissions_hasperm.py
@@ -15,8 +15,6 @@ Ver v2/docs/plans/rbac-refactor/epic-2-hasperm.md e master-plan §3.3.
 
 from __future__ import annotations
 
-import warnings
-
 from django.contrib.auth.models import AnonymousUser, Group
 from rest_framework.request import Request
 from rest_framework.test import APIRequestFactory
@@ -24,21 +22,7 @@ from rest_framework.test import APIRequestFactory
 import pytest
 
 from apps.core.models import PermissaoFuncional, Usuario
-from apps.core.permissions import (
-    HasPerm,
-    IsComprasDashboardAccess,
-    IsControle,
-    IsControleOrDAT,
-    IsControleOrSuper,
-    IsCoordenadorOrDAT,
-    IsDashboardOverview,
-    IsDAT,
-    IsDATOrSuper,
-    IsGerencia,
-    IsMapMetrics,
-    IsSuperintendencia,
-    IsSuperintendenciaOnly,
-)
+from apps.core.permissions import HasPerm
 
 pytestmark = pytest.mark.django_db
 
@@ -204,58 +188,47 @@ def test_hasperm_composition_not_inverts_grant(request_factory, user_with_capabi
 
 
 # ============================================================================
-# Deprecation — 12 classes factory legacy emitem DeprecationWarning
+# Epic 5.3 (2026-04-24): as 12 classes factory legacy foram REMOVIDAS.
+# Os testes parametrizados de DeprecationWarning que viviam aqui não têm
+# mais alvo. Callers agora usam `HasPerm("codename")` diretamente via
+# codemod do Epic 5.2 (#1213).
 # ============================================================================
 
 
-LEGACY_CLASSES = [
-    IsSuperintendencia,
-    IsSuperintendenciaOnly,
-    IsCoordenadorOrDAT,
-    IsControleOrSuper,
-    IsDATOrSuper,
-    IsComprasDashboardAccess,
-    IsDAT,
-    IsControleOrDAT,
-    IsControle,
-    IsGerencia,
-    IsDashboardOverview,
-    IsMapMetrics,
-]
+def test_legacy_factory_classes_removed():
+    """Sanity test: Epic 5.3 garante que as 12 classes factory foram removidas."""
+    import apps.core.permissions as perms_module
+
+    removed = (
+        "IsSuperintendencia",
+        "IsSuperintendenciaOnly",
+        "IsCoordenadorOrDAT",
+        "IsControleOrSuper",
+        "IsDATOrSuper",
+        "IsComprasDashboardAccess",
+        "IsDAT",
+        "IsControleOrDAT",
+        "IsControle",
+        "IsGerencia",
+        "IsDashboardOverview",
+        "IsMapMetrics",
+    )
+    still_present = [name for name in removed if hasattr(perms_module, name)]
+    assert not still_present, f"Classes removidas no Epic 5.3 ainda existem: {still_present}"
 
 
-@pytest.mark.parametrize("legacy_cls", LEGACY_CLASSES)
-def test_legacy_factory_class_emits_deprecation_warning(legacy_cls):
-    """Cada uma das 12 factory classes deve emitir DeprecationWarning no __init__."""
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
-        legacy_cls()
-        deprecation_warnings = [w for w in caught if issubclass(w.category, DeprecationWarning)]
-        assert deprecation_warnings, f"{legacy_cls.__name__} não emitiu DeprecationWarning. " "Ver master-plan §3.3."
-        msg = str(deprecation_warnings[0].message)
-        assert (
-            "HasPerm" in msg
-        ), f"Mensagem de deprecation de {legacy_cls.__name__} deve apontar para HasPerm equivalente."
+def test_funcperm_factory_removed():
+    """Epic 5.3: `funcperm_factory` e `_warn_legacy` foram removidos."""
+    import apps.core.permissions as perms_module
+
+    assert not hasattr(perms_module, "funcperm_factory"), "funcperm_factory deveria ter sido removido no Epic 5.3"
+    assert not hasattr(perms_module, "_warn_legacy"), "_warn_legacy deveria ter sido removido no Epic 5.3"
 
 
-def test_legacy_classes_still_work_behaviorally(
-    request_factory, user_with_capability, seeded_permission, group_with_permission
-):
-    """
-    Deprecation é cosmética: comportamento das 12 classes legacy deve
-    permanecer idêntico para garantir backward compat até o Epic 5.
-    """
-    # Conecta a permissão "can_do_test_action" ao codename de uma legacy class
-    # para validar que a classe legacy ainda funciona.
-    # Usamos IsDAT (codename=pode_operar_dat_exclusivo) como piloto.
-    pode_operar_dat_exclusivo = PermissaoFuncional.objects.filter(codename="manage_purchases_and_materials").first()
-    assert pode_operar_dat_exclusivo is not None, "Seed deve ter a permissão."
+def test_kept_classes_still_exported():
+    """As 3 classes mantidas (composite/object-level/dynamic) continuam acessíveis."""
+    from apps.core.permissions import HasSectorAccess, IsGerenteSuperintendencia, IsOwnerOrPrivileged
 
-    # Adiciona o group do user à permissão pode_operar_dat_exclusivo
-    pode_operar_dat_exclusivo.groups.add(group_with_permission)
-
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", DeprecationWarning)
-        perm = IsDAT()
-    req = _build_request(request_factory, user_with_capability)
-    assert perm.has_permission(req, None) is True
+    assert IsGerenteSuperintendencia is not None
+    assert IsOwnerOrPrivileged is not None
+    assert HasSectorAccess is not None

--- a/v2/backend/apps/core/tests/test_rbac_functional_permissions.py
+++ b/v2/backend/apps/core/tests/test_rbac_functional_permissions.py
@@ -13,7 +13,7 @@ from rest_framework.test import APIRequestFactory
 import pytest
 
 from apps.core.models import PermissaoFuncional, Usuario
-from apps.core.permissions import HasPerm, IsGerenteSuperintendencia, funcperm_factory
+from apps.core.permissions import HasPerm, IsGerenteSuperintendencia
 
 pytestmark = pytest.mark.django_db
 
@@ -117,12 +117,8 @@ def test_cache_invalidated_when_permission_m2m_changes():
     )
     custom_perm.groups.set([dat_group])
 
-    CustomPermission = funcperm_factory(
-        "CustomPermissionM2M",
-        "perm_temp_m2m",
-        "Permissão temporária",
-    )
-    permission = CustomPermission()
+    # Epic 5.3 (2026-04-24): funcperm_factory removido. Uso direto de HasPerm.
+    permission = HasPerm("perm_temp_m2m")
     request = _request_with_user(APIRequestFactory(), user)
     assert permission.has_permission(request, _MockView()) is True
 
@@ -152,12 +148,8 @@ def test_cache_invalidated_when_permission_saved():
     )
     custom_perm.groups.set([dat_group])
 
-    CustomPermission = funcperm_factory(
-        "CustomPermissionSave",
-        "perm_temp_save",
-        "Permissão temporária",
-    )
-    permission = CustomPermission()
+    # Epic 5.3: HasPerm substitui funcperm_factory
+    permission = HasPerm("perm_temp_save")
     request = _request_with_user(APIRequestFactory(), user)
     assert permission.has_permission(request, _MockView()) is True
 
@@ -188,12 +180,8 @@ def test_cache_invalidated_when_permission_deleted():
     )
     custom_perm.groups.set([dat_group])
 
-    CustomPermission = funcperm_factory(
-        "CustomPermissionDelete",
-        "perm_temp_delete",
-        "Permissão temporária",
-    )
-    permission = CustomPermission()
+    # Epic 5.3: HasPerm substitui funcperm_factory
+    permission = HasPerm("perm_temp_delete")
     request = _request_with_user(APIRequestFactory(), user)
     assert permission.has_permission(request, _MockView()) is True
 


### PR DESCRIPTION
## Summary

Remove as 12 classes factory legacy, `funcperm_factory` e `_warn_legacy` de `permissions.py`. Após Epic 5.2 migrar todos os callers via codemod, não há mais consumidores — a deleção é puramente cosmética (remove código morto). **Success criterion S1 do programa é atingido aqui**: zero `Is<Role>` em views.

## Deletado (~180 linhas em `permissions.py`)

- `funcperm_factory()` function
- `_warn_legacy()` helper
- **12 classes factory**: `IsSuperintendencia`, `IsSuperintendenciaOnly`, `IsCoordenadorOrDAT`, `IsControleOrSuper`, `IsDATOrSuper`, `IsComprasDashboardAccess`, `IsDAT`, `IsControleOrDAT`, `IsControle`, `IsGerencia`, `IsDashboardOverview`, `IsMapMetrics`
- Imports órfãos (`warnings`, `typing.cast`)

## Mantidas (ver [RBAC_NAMING §3](v2/docs/RBAC_NAMING.md))

- `HasPerm(codename)` — parametrizada, padrão canônico
- `HasFunctionalPermission` — base usada pelas 2 abaixo
- `IsGerenteSuperintendencia` — composite rule (funcperm + Django group)
- `IsOwnerOrPrivileged` — object-level check (obj.usuario)
- `HasSectorAccess` — dynamic scope via query param

## Ajustes em testes

- `test_permissions_hasperm.py`: removidos 12 testes parametrizados de DeprecationWarning. Substituídos por 3 testes de sanidade:
  - `test_legacy_factory_classes_removed` — `hasattr` retorna False para cada uma
  - `test_funcperm_factory_removed`
  - `test_kept_classes_still_exported`
- `test_rbac_functional_permissions.py`: 3 usos de `funcperm_factory(\"CustomPermission...\", codename, msg)` substituídos por `HasPerm(codename)` direto.

## Estado final do `permissions.py`

- **~240 linhas** (era ~420 pré-Epic 5.3)
- 1 classe parametrizada + 3 especializadas + 1 base
- **Zero `Is<Role>`** fora de strings históricas em migration 0065

## Validação

- Suite backend completa: **1711 passed** / 22 skipped / 0 failures (-10 testes removidos, +3 de sanidade)
- `grep -rE \"\\bIs(DAT|Controle|Superintendencia|...)\\b\" apps/core/` retorna apenas `migrations/0065_seed_permissoes_funcionais.py` (histórica) e comentários.

## Próximo

- **Epic 4.3 (#1185)**: aguarda soak 1 semana (remover codenames antigos `pode_*` após dual-write)
- **Epic 6 (#1189)**: lint CI custom que previne regressão do padrão `groups.filter(name=...)` + proibição de `Is<Role>` inline

## Staging gate

ALL 8 CHECKS PASSED

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR
- [x] Feature complete (code morto removido)
- [x] Tests updated (testes de sanidade substituem parametrizados)
- [x] TS/Lint clean
- [x] No breaking API changes (classes não tinham consumidores após Epic 5.2)
- [x] No DB migrations
- [x] No infra changes
- [x] Docs inline + master-plan + RBAC_NAMING

### Evidência de validação

- `pytest apps/core/tests/ apps/dev_tools/tests/`: 1711 passed em 249.98s
- Success criterion S1: `grep Is<Role>` views returns zero