### PR TITLE
feat(rbac): Epic 6 — módulo apps.core.rbac + lint CI guard (closes #1189) — ÚLTIMO do programa

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -179,6 +179,31 @@ jobs:
           echo "✓ No new /api/v1/ references found outside allowlist."
 
   # ----------------------------------------------------------------
+  # Job 1b: RBAC lint — Epic 6 RBAC Refactor guard
+  # ----------------------------------------------------------------
+  # AST-based custom lint que impede regressão capability → identity.
+  # Regras:
+  #   V001 — user.groups.filter(name=...) em views/services (use HasPerm)
+  #   V002 — classes Is<Role> fora da whitelist (use HasPerm inline)
+  # Ver: v2/backend/scripts/rbac_lint.py + v2/docs/RBAC_NAMING.md
+  rbac-lint:
+    name: "[required] backend rbac-lint"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5
+        with:
+          python-version: '3.12'
+
+      - name: Run RBAC lint (AST)
+        run: |
+          cd v2/backend
+          python scripts/rbac_lint.py apps/
+
+  # ----------------------------------------------------------------
   # Job 2a: Backend tests - core suite (serial)
   # ----------------------------------------------------------------
   backend-tests-core:

--- a/v2/backend/apps/core/permissions.py
+++ b/v2/backend/apps/core/permissions.py
@@ -1,256 +1,28 @@
 """
-DRF permissions para RBAC funcional (database-driven).
+Backcompat shim para `apps.core.rbac.permissions`.
 
-Epic 2 RBAC Refactor (2026-04-23): introduz `HasPerm(codename)`
-parametrizado como padrão canônico + marca as 12 classes factory legacy
-com `warnings.warn(DeprecationWarning)` no `__init__`. Classes legacy
-continuam funcionais — remoção efetiva é Epic 5 (libcst codemod).
-PEP 702 `@typing.deprecated` será readicionado quando subirmos para Python 3.13.
+Após Epic 6 do RBAC Refactor (2026-04-24), o SSOT das DRF permission classes
+migrou para `apps.core.rbac.permissions`. Este arquivo existe apenas para
+preservar imports legacy (`from apps.core.permissions import HasPerm`).
 
-Ver v2/docs/RBAC_NAMING.md para convenção completa.
+Para novos imports, prefira:
+    from apps.core.rbac import HasPerm
 
-Backwards compatible:
-- nomes das classes publicas preservados;
-- imports existentes continuam funcionando;
-- comportamento das legacy idêntico (só emite DeprecationWarning).
+Ver: apps/core/rbac/README.md e v2/docs/RBAC_NAMING.md
 """
 
-# pyright: reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportAttributeAccessIssue=false, reportCallIssue=false
-from __future__ import annotations
+from apps.core.rbac.permissions import (  # noqa: F401
+    HasFunctionalPermission,
+    HasPerm,
+    HasSectorAccess,
+    IsGerenteSuperintendencia,
+    IsOwnerOrPrivileged,
+)
 
-from rest_framework import permissions  # type: ignore[attr-defined]
-from rest_framework.request import Request
-from rest_framework.views import APIView
-
-from apps.core.services.rbac_permissions import get_user_functional_permissions
-
-# PEP 702 `@typing.deprecated` exige Python 3.13+. Em 3.12 nos baseamos
-# em runtime warnings via `warnings.warn(DeprecationWarning)` no __init__
-# de cada classe legacy. Quando subirmos para 3.13, podemos readicionar
-# o decorator para sinalização em static type-checkers.
-
-# Epic 5 (2026-04-24): permitir composition de permission INSTANCES em
-# `permission_classes`. DRF espera callables (classes) em permission_classes
-# e faz `p()` para instanciar. Como HasPerm é parametrizada e a composition
-# retorna `permissions.OR`/`AND`/`NOT` instances, essas classes precisam de
-# `__call__` retornando self para DRF não falhar com "OR object is not callable".
-permissions.OR.__call__ = lambda self: self  # type: ignore[method-assign]
-permissions.AND.__call__ = lambda self: self  # type: ignore[method-assign]
-permissions.NOT.__call__ = lambda self: self  # type: ignore[method-assign]
-
-
-class HasPerm(permissions.BasePermission):  # type: ignore[misc]
-    """
-    Capability-oriented parametric permission class (DRF).
-
-    Checa uma único functional permission codename via
-    `get_user_functional_permissions`. Preferido sobre subclassing para
-    endpoints novos. Emite a decisão de design do master-plan §3.3
-    (RBAC Refactor): classes DRF devem ser parametrizadas, não 1 classe
-    por capability.
-
-    Composition (DRF 3.9+):
-        HasPerm("a") | HasPerm("b")  # OR — grant se qualquer um
-        HasPerm("a") & HasPerm("b")  # AND — grant só se ambos
-        ~HasPerm("a")                # NOT — grant se não tem a perm
-
-    Usage:
-        class MyView(APIView):
-            permission_classes = [IsAuthenticated, HasPerm("approve_solicitation")]
-
-    Nota sobre app_label:
-        O prefixo "core." é opcional — o sistema funcional usa codename
-        bare. Aceitamos ambas as formas para familiaridade com
-        `user.has_perm()` nativo do Django.
-    """
-
-    def __init__(self, codename: str, *, message: str | None = None) -> None:
-        # Strip "app_label." prefix se presente
-        self.codename = codename.split(".", 1)[-1] if "." in codename else codename
-        if message:
-            self.message = message
-
-    def __call__(self) -> "HasPerm":
-        """DRF composition resolve para uma callable; já somos uma instance."""
-        return self
-
-    def has_permission(self, request: Request, view: APIView) -> bool:
-        user = request.user
-        if not user or not user.is_authenticated:
-            return False
-        if getattr(user, "is_superuser", False):
-            return True
-        return self.codename in get_user_functional_permissions(user)
-
-    def __repr__(self) -> str:
-        return f"HasPerm({self.codename!r})"
-
-    # Composition sobre instances (DRF OperandHolder só opera em classes).
-    # Permite o idioma canônico `HasPerm("a") | HasPerm("b")` em
-    # `permission_classes`. Delegamos para as classes `OR`/`AND`/`NOT` do
-    # próprio DRF. Retornamos Any para evitar strict-type mismatch — DRF
-    # OR/AND/NOT implementam o protocolo BasePermission mas não herdam dele.
-    def __or__(self, other):  # type: ignore[no-untyped-def]
-        return permissions.OR(self, other)
-
-    def __and__(self, other):  # type: ignore[no-untyped-def]
-        return permissions.AND(self, other)
-
-    def __invert__(self):  # type: ignore[no-untyped-def]
-        return permissions.NOT(self)
-
-    def __ror__(self, other):  # type: ignore[no-untyped-def]
-        return permissions.OR(other, self)
-
-    def __rand__(self, other):  # type: ignore[no-untyped-def]
-        return permissions.AND(other, self)
-
-
-class HasFunctionalPermission(permissions.BasePermission):  # type: ignore[misc]
-    """
-    Base class para checagem por codename funcional.
-
-    NOTA (Epic 2): preferir `HasPerm(codename)` inline em permission_classes
-    para endpoints novos. Esta classe continua servindo de base para as 12
-    factory classes legacy + 2 compostas (`IsGerenteSuperintendencia`,
-    `IsOwnerOrPrivileged`). Remoção das legacy é Epic 5.
-    """
-
-    functional_codename = ""
-    message = "Você não tem permissão para realizar esta ação."
-
-    def has_permission(self, request: Request, view: APIView) -> bool:
-        user = request.user
-        if not user or not user.is_authenticated:
-            return False
-        if getattr(user, "is_superuser", False):
-            return True
-        if not self.functional_codename:
-            return False
-        return self.functional_codename in get_user_functional_permissions(user)
-
-
-# ============================================================================
-# Epic 5.3 RBAC Refactor (2026-04-24): as 12 classes factory legacy
-# (`IsSuperintendencia`, `IsDAT`, `IsControleOrDAT`, ...) foram removidas.
-# Callers agora usam `HasPerm("codename")` diretamente via codemod do
-# Epic 5.2. `funcperm_factory` e `_warn_legacy` helper também removidos
-# — não há mais consumidores desses utilitários.
-#
-# As 3 classes mantidas abaixo (`IsGerenteSuperintendencia`,
-# `IsOwnerOrPrivileged`, `HasSectorAccess`) permanecem porque exprimem
-# lógica que `HasPerm(codename)` não cobre:
-# - Composite rule (funcperm + grupo Django)
-# - Object-level check (obj.usuario)
-# - Dynamic scope via query param
-# ============================================================================
-
-
-class IsGerenteSuperintendencia(HasFunctionalPermission):  # type: ignore[misc]
-    """
-    Regra composta fixa:
-    - permissão funcional "approve_solicitation_batch"
-    - grupo de função "Gerente"
-    """
-
-    functional_codename = "approve_solicitation_batch"
-    message = "Apenas Gerentes da Superintendência podem realizar esta ação."
-
-    def has_permission(self, request: Request, view: APIView) -> bool:
-        if not super().has_permission(request, view):
-            return False
-        user = request.user
-        return bool(user and user.groups.filter(name="Gerente").exists())
-
-
-class IsOwnerOrPrivileged(HasFunctionalPermission):  # type: ignore[misc]
-    """
-    Permissão para edição de solicitações.
-
-    - superuser: acesso total
-    - usuário com permissão funcional privilegiada: acesso total
-    - owner do objeto: acesso ao próprio objeto
-    """
-
-    functional_codename = "edit_solicitation_as_owner_or_privileged"
-    message = "Você só pode editar suas próprias solicitações ou possuir privilégio de gestão."
-
-    def has_permission(self, request: Request, view: APIView) -> bool:
-        return bool(request.user and request.user.is_authenticated)
-
-    def has_object_permission(self, request: Request, view: APIView, obj: object) -> bool:
-        user = request.user
-        if not user or not user.is_authenticated:
-            return False
-        if getattr(user, "is_superuser", False):
-            return True
-        if self.functional_codename in get_user_functional_permissions(user):
-            return True
-
-        obj_usuario = getattr(obj, "usuario", None)
-        return obj_usuario == user
-
-
-class HasSectorAccess(permissions.BasePermission):  # type: ignore[misc]
-    """
-    Permissão para acesso à grade mensal de disponibilidade por setor.
-
-    Regras (conforme PLAN_multi_sector_availability.md):
-    - Superusers: acesso a todos os setores
-    - Grupo "Controle": BLOQUEADO (não tem acesso à grade mensal)
-    - Sem gerencia_id: permite (assume SUPER - comportamento atual)
-    - Com gerencia_id: verifica se usuário pertence à gerência via EquipeGerencia
-
-    Usado em: MonthlyAvailabilityView
-    """
-
-    message = "Você não tem acesso a este setor."
-
-    def has_permission(self, request: Request, view: APIView) -> bool:
-        if not request.user or not request.user.is_authenticated:
-            return False
-
-        # Superusers sempre podem acessar tudo
-        if getattr(request.user, "is_superuser", False):
-            return True
-
-        # Epic 3.2 RBAC Refactor (2026-04-23): `HasSectorAccess` bloqueia
-        # explicitamente "Controle" por design documentado em
-        # PLAN_multi_sector_availability.md (Controle não faz gestão
-        # de setor — opera pré-agenda). Mantemos o block inline porque:
-        # (1) é BLOCK específico, não authz positiva padrão;
-        # (2) o rationale é ancorado em design doc;
-        # (3) Epic 6 lint whitelist permite este caso específico
-        #     (arquivo `permissions.py` é whitelist natural da classe base).
-        if request.user.groups.filter(name="Controle").exists():  # type: ignore[attr-defined]  # noqa: RBAC-block-allowed
-            self.message = "O grupo Controle não tem acesso à grade mensal de disponibilidade."
-            return False
-
-        # Obter gerencia_id da URL (via kwargs) ou query params
-        gerencia_id_raw = view.kwargs.get("gerencia_id")  # type: ignore[attr-defined]
-        if gerencia_id_raw is None:
-            gerencia_id_raw = request.query_params.get("gerencia_id")
-
-        # Sem gerencia_id = comportamento SUPER (permitido para todos autenticados)
-        if gerencia_id_raw is None:
-            return True
-
-        # Hardening: evitar ValueError em query params inválidos
-        try:
-            gerencia_id = int(gerencia_id_raw)
-        except (TypeError, ValueError):
-            self.message = "gerencia_id deve ser um número inteiro."
-            return False
-
-        # Com gerencia_id = verificar se usuário pertence à gerência
-        from apps.core.models import EquipeGerencia
-
-        has_access = EquipeGerencia.objects.filter(
-            usuario=request.user,
-            gerencia_id=gerencia_id,
-        ).exists()
-
-        if not has_access:
-            self.message = "Você não tem acesso a este setor."
-
-        return has_access
+__all__ = [
+    "HasPerm",
+    "HasFunctionalPermission",
+    "HasSectorAccess",
+    "IsGerenteSuperintendencia",
+    "IsOwnerOrPrivileged",
+]

--- a/v2/backend/apps/core/rbac/README.md
+++ b/v2/backend/apps/core/rbac/README.md
@@ -1,0 +1,103 @@
+# `apps.core.rbac` — Centralized RBAC Module
+
+SSOT (Single Source of Truth) do sistema de autorização do Aprender Sistema v2.
+
+## Módulos
+
+| Arquivo | Conteúdo |
+|---|---|
+| `__init__.py` | API pública (re-exports) |
+| `permissions.py` | DRF permission classes (`HasPerm` + 3 mantidas) |
+| `helpers.py` | `user_has_any_perm`, `user_has_all_perms` |
+| `constants.py` | `COORDENADOR_ROLE_GROUPS`, `FORMADOR_ROLE_GROUPS` (data-scope) |
+
+## Como usar
+
+### Em views DRF
+
+```python
+from apps.core.rbac import HasPerm
+
+class ApproveSolicitacaoView(APIView):
+    permission_classes = [IsAuthenticated, HasPerm("approve_solicitation")]
+```
+
+### Composition OR/AND/NOT
+
+```python
+from apps.core.rbac import HasPerm
+
+class OperarView(APIView):
+    permission_classes = [
+        IsAuthenticated,
+        HasPerm("operate_preagenda") | HasPerm("supervise_operations"),
+    ]
+```
+
+### Em services/helpers (não-DRF)
+
+```python
+from apps.core.rbac import user_has_any_perm
+
+def my_service(user):
+    if not user_has_any_perm(user, "operate_preagenda", "supervise_operations"):
+        raise PermissionDenied
+    ...
+```
+
+### Filtros de data-scope
+
+```python
+from apps.core.rbac import COORDENADOR_ROLE_GROUPS
+
+queryset = Usuario.objects.filter(groups__name__in=COORDENADOR_ROLE_GROUPS)
+```
+
+## O que NÃO fazer (lint Epic 6 bane)
+
+### V001 — `groups.filter(name=...)` em views/services
+
+```python
+# ❌ Errado
+if user.groups.filter(name="DAT").exists():
+    ...
+
+# ✅ Certo
+if user_has_any_perm(user, "manage_admin_registries"):
+    ...
+```
+
+### V002 — Criar classes `Is<Role>`
+
+```python
+# ❌ Errado
+class IsDAT(BasePermission):
+    def has_permission(self, request, view):
+        return request.user.groups.filter(name="DAT").exists()
+
+# ✅ Certo — não precisa classe, usa HasPerm inline
+permission_classes = [HasPerm("manage_admin_registries")]
+```
+
+## Exceções (whitelist)
+
+Usos legítimos de `groups.filter(name=...)` devem ter marker `# noqa: RBAC-*-allowed`:
+
+- **`# noqa: RBAC-composite-allowed`** — classes compostas (funcperm + grupo)
+- **`# noqa: RBAC-block-allowed`** — bloqueio explícito de um grupo por design
+- **`# noqa: RBAC-data-scope-allowed`** — filtro de escopo de dados (não authz)
+
+## Shims de backcompat
+
+Por decisão de migração Epic 6, os arquivos antigos continuam funcionando como shim:
+
+- `apps/core/permissions.py` → re-exporta de `apps.core.rbac.permissions`
+- `apps/core/rbac_helpers.py` → re-exporta de `apps.core.rbac.helpers`
+
+Para novos imports, prefira `from apps.core.rbac import ...`. Os shims serão
+mantidos indefinidamente para não quebrar branches em flight.
+
+## Ver também
+
+- [v2/docs/RBAC_NAMING.md](../../../../docs/RBAC_NAMING.md) — Convenção canônica
+- [scripts/rbac_lint.py](../../../scripts/rbac_lint.py) — Lint AST que enforça as regras

--- a/v2/backend/apps/core/rbac/README.md
+++ b/v2/backend/apps/core/rbac/README.md
@@ -4,12 +4,12 @@ SSOT (Single Source of Truth) do sistema de autorização do Aprender Sistema v2
 
 ## Módulos
 
-| Arquivo | Conteúdo |
-|---|---|
-| `__init__.py` | API pública (re-exports) |
-| `permissions.py` | DRF permission classes (`HasPerm` + 3 mantidas) |
-| `helpers.py` | `user_has_any_perm`, `user_has_all_perms` |
-| `constants.py` | `COORDENADOR_ROLE_GROUPS`, `FORMADOR_ROLE_GROUPS` (data-scope) |
+| Arquivo          | Conteúdo                                                         |
+| ---------------- | ---------------------------------------------------------------- |
+| `__init__.py`    | API pública (re-exports)                                         |
+| `permissions.py` | DRF permission classes (`HasPerm` + 3 mantidas)                  |
+| `helpers.py`     | `user_has_any_perm`, `user_has_all_perms`                        |
+| `constants.py`   | `COORDENADOR_ROLE_GROUPS`, `FORMADOR_ROLE_GROUPS` (data-scope)   |
 
 ## Como usar
 

--- a/v2/backend/apps/core/rbac/__init__.py
+++ b/v2/backend/apps/core/rbac/__init__.py
@@ -1,0 +1,52 @@
+"""
+Centralized RBAC (Role-Based Access Control) module.
+
+SSOT público do sistema de autorização. Toda lógica de authz passa por aqui:
+permission classes DRF, helpers de consulta de capability, constantes de
+data scope.
+
+Public API:
+    HasPerm                      — Parametric DRF permission class
+    HasFunctionalPermission      — Base class para permissions por codename
+    HasSectorAccess              — Dynamic scope check via query param
+    IsGerenteSuperintendencia    — Composite: funcperm + grupo "Gerente"
+    IsOwnerOrPrivileged          — Object-level: owner ou usuário privilegiado
+    user_has_any_perm            — True se tem QUALQUER uma das codenames
+    user_has_all_perms           — True se tem TODAS as codenames
+    COORDENADOR_ROLE_GROUPS      — Data-scope filter (dropdown coordenadores)
+    FORMADOR_ROLE_GROUPS         — Data-scope filter (dropdown formadores)
+
+Idiomas canônicos:
+    permission_classes = [HasPerm("approve_solicitation")]
+    permission_classes = [HasPerm("a") | HasPerm("b")]   # OR composition
+    if user_has_any_perm(user, "operate_preagenda", "supervise_operations"): ...
+
+Nunca fazer (lint Epic 6 bane):
+    user.groups.filter(name="X")          → use HasPerm(codename) / user_has_any_perm
+    class IsDAT(BasePermission)           → use HasPerm("codename") inline
+    permission_classes = [IsControleOrDAT] → use HasPerm(...) direto
+
+Ver v2/docs/RBAC_NAMING.md para convenção completa.
+"""
+
+from apps.core.rbac.constants import COORDENADOR_ROLE_GROUPS, FORMADOR_ROLE_GROUPS
+from apps.core.rbac.helpers import user_has_all_perms, user_has_any_perm
+from apps.core.rbac.permissions import (
+    HasFunctionalPermission,
+    HasPerm,
+    HasSectorAccess,
+    IsGerenteSuperintendencia,
+    IsOwnerOrPrivileged,
+)
+
+__all__ = [
+    "HasPerm",
+    "HasFunctionalPermission",
+    "HasSectorAccess",
+    "IsGerenteSuperintendencia",
+    "IsOwnerOrPrivileged",
+    "user_has_any_perm",
+    "user_has_all_perms",
+    "COORDENADOR_ROLE_GROUPS",
+    "FORMADOR_ROLE_GROUPS",
+]

--- a/v2/backend/apps/core/rbac/constants.py
+++ b/v2/backend/apps/core/rbac/constants.py
@@ -1,0 +1,15 @@
+"""
+RBAC data-scope constants.
+
+Estes grupos são usados para **data scope** (filtrar querysets por função
+do usuário), NÃO para autorização. Autorização passa sempre por
+`user.has_perm()` / `HasPerm(codename)` / `user_has_any_perm`.
+
+Ver v2/docs/RBAC_NAMING.md §4 e master-plan §4.
+"""
+
+# Coordenadores (para dropdown /api/options/coordenadores/)
+COORDENADOR_ROLE_GROUPS: tuple[str, ...] = ("Coordenador", "Apoio de Coordenação")
+
+# Formadores (para dropdown /api/options/formadores/)
+FORMADOR_ROLE_GROUPS: tuple[str, ...] = ("Formador",)

--- a/v2/backend/apps/core/rbac/helpers.py
+++ b/v2/backend/apps/core/rbac/helpers.py
@@ -1,0 +1,71 @@
+"""
+Capability-based authorization helpers (Epic 3 RBAC Refactor, 2026-04-23).
+
+Use estas funções **em vez de** `user.groups.filter(name="...").exists()`
+em views e services. Check canônico do Django é `user.has_perm()`; este
+módulo expõe variações convenience (`any`/`all`) sobre functional permission
+codenames.
+
+Filtros de data scope por nome de grupo (ex: "quem é formador?") vivem em
+`apps.core.rbac.constants` — são scope, não autorização.
+
+Ver v2/docs/RBAC_NAMING.md §4 e master-plan §4.
+"""
+
+# pyright: reportUnknownMemberType=false, reportAttributeAccessIssue=false
+
+from __future__ import annotations
+
+from django.contrib.auth.models import AbstractBaseUser, AnonymousUser
+
+from apps.core.services.rbac_permissions import get_user_functional_permissions
+
+
+def user_has_any_perm(
+    user: AbstractBaseUser | AnonymousUser | None,
+    *codenames: str,
+) -> bool:
+    """
+    True se o usuário possui QUALQUER UMA das permissões funcionais listadas.
+
+    Regras:
+    - user None ou anônimo → False
+    - is_superuser → True (bypass)
+    - codenames vazios → False (para usuário comum; superuser ainda é True)
+    - caso geral → consulta `get_user_functional_permissions` (cache-aware)
+
+    Preferido sobre `user.groups.filter(name=...).exists()` que é bypass
+    do sistema RBAC (Epic 6 lint bane o padrão antigo).
+    """
+    if not user or not user.is_authenticated:
+        return False
+    if getattr(user, "is_superuser", False):
+        return True
+    if not codenames:
+        return False
+    user_perms = get_user_functional_permissions(user)
+    return any(code in user_perms for code in codenames)
+
+
+def user_has_all_perms(
+    user: AbstractBaseUser | AnonymousUser | None,
+    *codenames: str,
+) -> bool:
+    """
+    True se o usuário possui TODAS as permissões funcionais listadas.
+
+    Regras:
+    - user None ou anônimo → False
+    - is_superuser → True
+    - codenames vazios → False para usuário comum
+      (convenção: "all of nothing" é vacuously True só com bypass; para
+      user regular tratamos como "sem codename não há decisão")
+    """
+    if not user or not user.is_authenticated:
+        return False
+    if getattr(user, "is_superuser", False):
+        return True
+    if not codenames:
+        return False
+    user_perms = get_user_functional_permissions(user)
+    return all(code in user_perms for code in codenames)

--- a/v2/backend/apps/core/rbac/permissions.py
+++ b/v2/backend/apps/core/rbac/permissions.py
@@ -1,0 +1,246 @@
+"""
+DRF permissions para RBAC funcional (database-driven).
+
+SSOT das classes DRF do RBAC. Re-exportado por `apps.core.rbac`.
+
+Idioma canônico:
+    permission_classes = [IsAuthenticated, HasPerm("approve_solicitation")]
+
+Para composition:
+    permission_classes = [HasPerm("a") | HasPerm("b")]
+
+3 classes "não-reduzíveis" mantidas (ver RBAC_NAMING.md §3):
+- `IsGerenteSuperintendencia` (composite: funcperm + grupo Django)
+- `IsOwnerOrPrivileged` (object-level: checa obj.usuario)
+- `HasSectorAccess` (dynamic scope via gerencia_id query param)
+
+Ver v2/docs/RBAC_NAMING.md para convenção completa.
+"""
+
+# pyright: reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportAttributeAccessIssue=false, reportCallIssue=false, reportIncompatibleMethodOverride=false, reportMissingTypeStubs=false, reportArgumentType=false
+from __future__ import annotations
+
+from rest_framework import permissions  # type: ignore[attr-defined]
+from rest_framework.request import Request
+from rest_framework.views import APIView
+
+from apps.core.services.rbac_permissions import get_user_functional_permissions
+
+# Epic 5 (2026-04-24): permitir composition de permission INSTANCES em
+# `permission_classes`. DRF espera callables (classes) em permission_classes
+# e faz `p()` para instanciar. Como HasPerm é parametrizada e a composition
+# retorna `permissions.OR`/`AND`/`NOT` instances, essas classes precisam de
+# `__call__` retornando self para DRF não falhar com "OR object is not callable".
+permissions.OR.__call__ = lambda self: self  # type: ignore[method-assign]
+permissions.AND.__call__ = lambda self: self  # type: ignore[method-assign]
+permissions.NOT.__call__ = lambda self: self  # type: ignore[method-assign]
+
+
+class HasPerm(permissions.BasePermission):  # type: ignore[misc]
+    """
+    Capability-oriented parametric permission class (DRF).
+
+    Checa um único functional permission codename via
+    `get_user_functional_permissions`. Preferido sobre subclassing para
+    endpoints novos. Decisão de design: classes DRF devem ser parametrizadas,
+    não 1 classe por capability (NIST RBAC §5.3).
+
+    Composition (DRF 3.9+):
+        HasPerm("a") | HasPerm("b")  # OR — grant se qualquer um
+        HasPerm("a") & HasPerm("b")  # AND — grant só se ambos
+        ~HasPerm("a")                # NOT — grant se não tem a perm
+
+    Usage:
+        class MyView(APIView):
+            permission_classes = [IsAuthenticated, HasPerm("approve_solicitation")]
+
+    Nota sobre app_label:
+        O prefixo "core." é opcional — o sistema funcional usa codename
+        bare. Aceitamos ambas as formas para familiaridade com
+        `user.has_perm()` nativo do Django.
+    """
+
+    def __init__(self, codename: str, *, message: str | None = None) -> None:
+        # Strip "app_label." prefix se presente
+        self.codename = codename.split(".", 1)[-1] if "." in codename else codename
+        if message:
+            self.message = message
+
+    def __call__(self) -> "HasPerm":
+        """DRF composition resolve para uma callable; já somos uma instance."""
+        return self
+
+    def has_permission(self, request: Request, view: APIView) -> bool:
+        user = request.user
+        if not user or not user.is_authenticated:
+            return False
+        if getattr(user, "is_superuser", False):
+            return True
+        return self.codename in get_user_functional_permissions(user)
+
+    def __repr__(self) -> str:
+        return f"HasPerm({self.codename!r})"
+
+    # Composition sobre instances (DRF OperandHolder só opera em classes).
+    # Permite o idioma canônico `HasPerm("a") | HasPerm("b")` em
+    # `permission_classes`. Delegamos para as classes `OR`/`AND`/`NOT` do
+    # próprio DRF. Retornamos Any para evitar strict-type mismatch — DRF
+    # OR/AND/NOT implementam o protocolo BasePermission mas não herdam dele.
+    def __or__(self, other):  # type: ignore[no-untyped-def]
+        return permissions.OR(self, other)
+
+    def __and__(self, other):  # type: ignore[no-untyped-def]
+        return permissions.AND(self, other)
+
+    def __invert__(self):  # type: ignore[no-untyped-def]
+        return permissions.NOT(self)
+
+    def __ror__(self, other):  # type: ignore[no-untyped-def]
+        return permissions.OR(other, self)
+
+    def __rand__(self, other):  # type: ignore[no-untyped-def]
+        return permissions.AND(other, self)
+
+
+class HasFunctionalPermission(permissions.BasePermission):  # type: ignore[misc]
+    """
+    Base class para checagem por codename funcional.
+
+    Preferir `HasPerm(codename)` inline em `permission_classes` para endpoints
+    novos. Esta classe continua servindo de base para as 2 classes compostas
+    mantidas (`IsGerenteSuperintendencia`, `IsOwnerOrPrivileged`).
+    """
+
+    functional_codename = ""
+    message = "Você não tem permissão para realizar esta ação."
+
+    def has_permission(self, request: Request, view: APIView) -> bool:
+        user = request.user
+        if not user or not user.is_authenticated:
+            return False
+        if getattr(user, "is_superuser", False):
+            return True
+        if not self.functional_codename:
+            return False
+        return self.functional_codename in get_user_functional_permissions(user)
+
+
+# ============================================================================
+# 3 classes mantidas pós-Epic 5.3 — expressam lógica que `HasPerm(codename)`
+# não cobre:
+# - Composite rule (funcperm + grupo Django)
+# - Object-level check (obj.usuario)
+# - Dynamic scope via query param
+# ============================================================================
+
+
+class IsGerenteSuperintendencia(HasFunctionalPermission):  # type: ignore[misc]
+    """
+    Regra composta fixa:
+    - permissão funcional "approve_solicitation_batch"
+    - grupo de função "Gerente"
+    """
+
+    functional_codename = "approve_solicitation_batch"
+    message = "Apenas Gerentes da Superintendência podem realizar esta ação."
+
+    def has_permission(self, request: Request, view: APIView) -> bool:
+        if not super().has_permission(request, view):
+            return False
+        user = request.user
+        # `IsGerenteSuperintendencia` é composite (funcperm + grupo Django):
+        # valida que o usuário tem a função "Gerente" além da funcperm.
+        # Uso aqui é whitelist natural — a classe é uma das 3 mantidas por design (RBAC_NAMING §3).
+        return bool(user and user.groups.filter(name="Gerente").exists())  # noqa: RBAC-composite-allowed
+
+
+class IsOwnerOrPrivileged(HasFunctionalPermission):  # type: ignore[misc]
+    """
+    Permissão para edição de solicitações.
+
+    - superuser: acesso total
+    - usuário com permissão funcional privilegiada: acesso total
+    - owner do objeto: acesso ao próprio objeto
+    """
+
+    functional_codename = "edit_solicitation_as_owner_or_privileged"
+    message = "Você só pode editar suas próprias solicitações ou possuir privilégio de gestão."
+
+    def has_permission(self, request: Request, view: APIView) -> bool:
+        return bool(request.user and request.user.is_authenticated)
+
+    def has_object_permission(self, request: Request, view: APIView, obj: object) -> bool:
+        user = request.user
+        if not user or not user.is_authenticated:
+            return False
+        if getattr(user, "is_superuser", False):
+            return True
+        if self.functional_codename in get_user_functional_permissions(user):
+            return True
+
+        obj_usuario = getattr(obj, "usuario", None)
+        return obj_usuario == user
+
+
+class HasSectorAccess(permissions.BasePermission):  # type: ignore[misc]
+    """
+    Permissão para acesso à grade mensal de disponibilidade por setor.
+
+    Regras (conforme PLAN_multi_sector_availability.md):
+    - Superusers: acesso a todos os setores
+    - Grupo "Controle": BLOQUEADO (não tem acesso à grade mensal)
+    - Sem gerencia_id: permite (assume SUPER - comportamento atual)
+    - Com gerencia_id: verifica se usuário pertence à gerência via EquipeGerencia
+
+    Usado em: MonthlyAvailabilityView
+    """
+
+    message = "Você não tem acesso a este setor."
+
+    def has_permission(self, request: Request, view: APIView) -> bool:
+        if not request.user or not request.user.is_authenticated:
+            return False
+
+        # Superusers sempre podem acessar tudo
+        if getattr(request.user, "is_superuser", False):
+            return True
+
+        # `HasSectorAccess` bloqueia explicitamente "Controle" por design
+        # documentado em PLAN_multi_sector_availability.md (Controle não faz
+        # gestão de setor — opera pré-agenda). Mantemos o block inline porque:
+        # (1) é BLOCK específico, não authz positiva padrão;
+        # (2) o rationale é ancorado em design doc;
+        # (3) Epic 6 lint whitelist permite este caso específico
+        #     (arquivo `permissions.py` é whitelist natural da classe base).
+        if request.user.groups.filter(name="Controle").exists():  # type: ignore[attr-defined]  # noqa: RBAC-block-allowed
+            self.message = "O grupo Controle não tem acesso à grade mensal de disponibilidade."
+            return False
+
+        # Obter gerencia_id da URL (via kwargs) ou query params
+        gerencia_id_raw = view.kwargs.get("gerencia_id")  # type: ignore[attr-defined]
+        if gerencia_id_raw is None:
+            gerencia_id_raw = request.query_params.get("gerencia_id")
+
+        # Sem gerencia_id = comportamento SUPER (permitido para todos autenticados)
+        if gerencia_id_raw is None:
+            return True
+
+        # Hardening: evitar ValueError em query params inválidos
+        try:
+            gerencia_id = int(gerencia_id_raw)
+        except (TypeError, ValueError):
+            self.message = "gerencia_id deve ser um número inteiro."
+            return False
+
+        # Com gerencia_id = verificar se usuário pertence à gerência
+        from apps.core.models import EquipeGerencia
+
+        has_access = EquipeGerencia.objects.filter(
+            usuario=request.user,
+            gerencia_id=gerencia_id,
+        ).exists()
+
+        if not has_access:
+            self.message = "Você não tem acesso a este setor."
+
+        return has_access

--- a/v2/backend/apps/core/rbac_helpers.py
+++ b/v2/backend/apps/core/rbac_helpers.py
@@ -1,71 +1,16 @@
 """
-Capability-based authorization helpers (Epic 3 RBAC Refactor, 2026-04-23).
+Backcompat shim para `apps.core.rbac.helpers`.
 
-Use estas funções **em vez de** `user.groups.filter(name="...").exists()`
-em views e services. Check canônico do Django é `user.has_perm()`; este
-módulo expõe variações convenience (`any`/`all`) sobre functional permission
-codenames.
+Após Epic 6 do RBAC Refactor (2026-04-24), o SSOT dos helpers de capability
+migrou para `apps.core.rbac.helpers`. Este arquivo existe apenas para
+preservar imports legacy (`from apps.core.rbac_helpers import user_has_any_perm`).
 
-Filtros de data scope por nome de grupo (ex: "quem é formador?") vivem em
-`apps.core.constants` (não aqui — são scope, não autorização).
+Para novos imports, prefira:
+    from apps.core.rbac import user_has_any_perm, user_has_all_perms
 
-Ver v2/docs/RBAC_NAMING.md §4 e master-plan §4.
+Ver: apps/core/rbac/README.md e v2/docs/RBAC_NAMING.md
 """
 
-# pyright: reportUnknownMemberType=false, reportAttributeAccessIssue=false
+from apps.core.rbac.helpers import user_has_all_perms, user_has_any_perm  # noqa: F401
 
-from __future__ import annotations
-
-from django.contrib.auth.models import AbstractBaseUser, AnonymousUser
-
-from apps.core.services.rbac_permissions import get_user_functional_permissions
-
-
-def user_has_any_perm(
-    user: AbstractBaseUser | AnonymousUser | None,
-    *codenames: str,
-) -> bool:
-    """
-    True se o usuário possui QUALQUER UMA das permissões funcionais listadas.
-
-    Regras:
-    - user None ou anônimo → False
-    - is_superuser → True (bypass)
-    - codenames vazios → False (para usuário comum; superuser ainda é True)
-    - caso geral → consulta `get_user_functional_permissions` (cache-aware)
-
-    Preferido sobre `user.groups.filter(name=...).exists()` que é bypass
-    do sistema RBAC (Epic 6 introduzirá lint que bane o padrão antigo).
-    """
-    if not user or not user.is_authenticated:
-        return False
-    if getattr(user, "is_superuser", False):
-        return True
-    if not codenames:
-        return False
-    user_perms = get_user_functional_permissions(user)
-    return any(code in user_perms for code in codenames)
-
-
-def user_has_all_perms(
-    user: AbstractBaseUser | AnonymousUser | None,
-    *codenames: str,
-) -> bool:
-    """
-    True se o usuário possui TODAS as permissões funcionais listadas.
-
-    Regras:
-    - user None ou anônimo → False
-    - is_superuser → True
-    - codenames vazios → True para superuser, False para user comum
-      (convenção: "all of nothing" é vacuously True só com bypass; para
-      user regular tratamos como "sem codename não há decisão")
-    """
-    if not user or not user.is_authenticated:
-        return False
-    if getattr(user, "is_superuser", False):
-        return True
-    if not codenames:
-        return False
-    user_perms = get_user_functional_permissions(user)
-    return all(code in user_perms for code in codenames)
+__all__ = ["user_has_any_perm", "user_has_all_perms"]

--- a/v2/backend/apps/core/serializers/solicitacao.py
+++ b/v2/backend/apps/core/serializers/solicitacao.py
@@ -363,5 +363,6 @@ class EventDetailSerializer(serializers.ModelSerializer):
             .order_by("-created_at")[:20]
         )
 
-        # Serializar
-        return AuditLogTimelineSerializer(logs, many=True).data
+        # Serializar — `.data` em DRF retorna ReturnList | ReturnDict | Any;
+        # com many=True é sempre ReturnList (subclasse de list).
+        return cast(list[dict[str, Any]], AuditLogTimelineSerializer(logs, many=True).data)

--- a/v2/backend/apps/core/tests/test_availability_service.py
+++ b/v2/backend/apps/core/tests/test_availability_service.py
@@ -4,7 +4,7 @@ Tests: Availability Service (RD-01 a RD-08)
 Cobertura completa das regras de disponibilidade + endpoint de checagem.
 """
 
-# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportOptionalMemberAccess=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportMissingTypeArgument=false, reportCallIssue=false, reportIndexIssue=false, reportOperatorIssue=false, reportOptionalSubscript=false, reportUnknownLambdaType=false
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportOptionalMemberAccess=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportMissingTypeArgument=false, reportCallIssue=false, reportIndexIssue=false, reportOperatorIssue=false, reportOptionalSubscript=false, reportUnknownLambdaType=false, reportMissingTypeStubs=false, reportPrivateUsage=false
 
 from __future__ import annotations
 
@@ -347,7 +347,8 @@ class TestAvailabilityServiceRules:
         event_end_local = datetime.combine(test_date, time(23, 59), tzinfo=fortaleza_tz)
 
         # Criar evento aprovado às 23:30 Fortaleza
-        existing = Solicitacao.objects.create(
+        # (persistido só pelo side effect — check_conflicts vai buscar no DB)
+        Solicitacao.objects.create(
             usuario=usuario_test,
             tipo_evento=tipo_evento_test,
             municipio=municipio_a,

--- a/v2/backend/apps/core/tests/test_rbac_lint.py
+++ b/v2/backend/apps/core/tests/test_rbac_lint.py
@@ -1,0 +1,131 @@
+"""
+Self-verification do lint RBAC (Epic 6).
+
+Verifica que:
+1. O lint aceita o codebase atual (baseline limpo).
+2. O lint rejeita um arquivo sintético com violação V001.
+3. O lint rejeita um arquivo sintético com violação V002.
+4. O lint aceita um arquivo V001 com marcador noqa válido.
+5. Paths whitelisted (tests/, migrations/) são ignorados.
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportMissingTypeStubs=false
+
+from __future__ import annotations
+
+import pathlib
+import subprocess
+import sys
+
+import pytest
+
+# parents[0]=tests, [1]=core, [2]=apps, [3]=backend root (local: v2/backend, container: /app)
+BACKEND_ROOT = pathlib.Path(__file__).resolve().parents[3]
+LINT_SCRIPT = BACKEND_ROOT / "scripts" / "rbac_lint.py"
+
+
+def _run_lint(target: pathlib.Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(LINT_SCRIPT), str(target)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_lint_script_exists():
+    assert LINT_SCRIPT.exists(), f"rbac_lint.py não encontrado em {LINT_SCRIPT}"
+
+
+def test_lint_passes_on_current_apps_core():
+    """Baseline: o codebase atual passa limpo."""
+    target = BACKEND_ROOT / "apps" / "core"
+    result = _run_lint(target)
+    assert result.returncode == 0, (
+        f"Lint violações inesperadas no baseline:\n" f"STDOUT: {result.stdout}\n" f"STDERR: {result.stderr}"
+    )
+
+
+def test_lint_catches_v001_in_views(tmp_path):
+    """Feed bad view — expect V001 violation."""
+    views_dir = tmp_path / "apps" / "core" / "views_fake"
+    views_dir.mkdir(parents=True)
+    (views_dir / "bad_view.py").write_text(
+        "def handler(request):\n" "    return request.user.groups.filter(name='DAT').exists()\n"
+    )
+    result = _run_lint(views_dir)
+    assert result.returncode == 1
+    assert "V001" in result.stderr
+
+
+def test_lint_catches_v002_class_name(tmp_path):
+    """Feed Is<Word> class — expect V002 violation."""
+    mod = tmp_path / "bad_module.py"
+    mod.write_text("class IsDATManager:\n" "    pass\n")
+    result = _run_lint(mod)
+    assert result.returncode == 1
+    assert "V002" in result.stderr
+
+
+def test_lint_accepts_noqa_marker(tmp_path):
+    """V001 com `# noqa: RBAC-block-allowed` é aceito."""
+    views_dir = tmp_path / "apps" / "core" / "views_fake"
+    views_dir.mkdir(parents=True)
+    (views_dir / "allowed_view.py").write_text(
+        "def handler(request):\n"
+        "    # Block específico por design documentado.\n"
+        "    return request.user.groups.filter(name='Controle').exists()  # noqa: RBAC-block-allowed\n"
+    )
+    result = _run_lint(views_dir)
+    assert result.returncode == 0, f"Esperava passar com noqa, mas: {result.stderr}"
+
+
+def test_lint_skips_tests_path(tmp_path):
+    """Arquivos em tests/ devem ser ignorados (fixtures podem usar nomes de grupo)."""
+    tests_dir = tmp_path / "apps" / "core" / "tests"
+    tests_dir.mkdir(parents=True)
+    (tests_dir / "test_something.py").write_text(
+        "def test_user_has_group(user):\n" "    assert user.groups.filter(name='Coordenador').exists()\n"
+    )
+    result = _run_lint(tests_dir)
+    assert result.returncode == 0, f"Esperava pular tests/, mas deu erro: {result.stderr}"
+
+
+def test_lint_skips_dev_tools_path(tmp_path):
+    """Arquivos em apps/dev_tools/ devem ser ignorados (seeds manipulam grupos por design)."""
+    seeds_dir = tmp_path / "apps" / "dev_tools" / "management" / "commands"
+    seeds_dir.mkdir(parents=True)
+    (seeds_dir / "seed_fake.py").write_text(
+        "def handle(user):\n"
+        "    if not user.groups.filter(name='Gerência').exists():\n"
+        "        user.groups.add(...)\n"
+    )
+    result = _run_lint(seeds_dir)
+    assert result.returncode == 0, f"Esperava pular apps/dev_tools/, mas deu erro: {result.stderr}"
+
+
+def test_lint_whitelisted_classes_pass(tmp_path):
+    """IsGerenteSuperintendencia e IsOwnerOrPrivileged são whitelisted (V002)."""
+    mod = tmp_path / "apps" / "sample" / "permissions.py"
+    mod.parent.mkdir(parents=True)
+    mod.write_text("class IsGerenteSuperintendencia:\n" "    pass\n" "class IsOwnerOrPrivileged:\n" "    pass\n")
+    result = _run_lint(mod.parent)
+    assert result.returncode == 0, f"Esperava whitelist passar, mas: {result.stderr}"
+
+
+@pytest.mark.parametrize(
+    "bad_call",
+    [
+        "request.user.groups.filter(name='DAT').exists()",
+        "user.groups.filter(name__in=['DAT', 'Controle']).exists()",
+        "usuario.groups.exclude(name='Superintendência')",
+    ],
+)
+def test_lint_v001_variants(tmp_path, bad_call):
+    """V001 pega variantes: name=, name__in=, exclude()."""
+    views_dir = tmp_path / "apps" / "core" / "views_fake"
+    views_dir.mkdir(parents=True)
+    (views_dir / "bad.py").write_text(f"def h():\n    {bad_call}\n")
+    result = _run_lint(views_dir)
+    assert result.returncode == 1, f"Esperava V001 em '{bad_call}', mas passou."
+    assert "V001" in result.stderr

--- a/v2/backend/apps/core/views_reports.py
+++ b/v2/backend/apps/core/views_reports.py
@@ -9,7 +9,6 @@ Provides analytical reports for decision-making.
 from __future__ import annotations
 
 from datetime import datetime, timedelta
-from typing import Any
 
 from django.db.models import Count
 from django.db.models.functions import TruncWeek

--- a/v2/backend/scripts/rbac_lint.py
+++ b/v2/backend/scripts/rbac_lint.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""
+RBAC lint — enforça a convenção capability-oriented do programa Epic 6 do
+RBAC Refactor (2026-04-24). Sem este guard, em 6-12 meses alguém escreveria
+`user.groups.filter(name="DAT")` em uma view e a dívida voltaria.
+
+Regras enforçadas:
+
+- **V001** `user.groups.filter(name=...)` em `apps/core/views*/` ou
+  `apps/core/services/`. Usar `user_has_any_perm(user, "<codename>")` ou
+  `HasPerm("<codename>")`. Se o uso for legítimo (composite, block, data scope),
+  adicionar marcador `# noqa: RBAC-<tipo>-allowed` na mesma linha.
+
+- **V002** `class Is<Word>(...):` fora da whitelist de classes mantidas
+  (`IsGerenteSuperintendencia`, `IsOwnerOrPrivileged`). Usar `HasPerm(codename)`
+  inline em `permission_classes`.
+
+Whitelist de paths (não linta):
+- `tests/`, `migrations/`, `fixtures/` (test data e data migrations podem
+  referenciar nomes de grupos por design)
+- `apps/core/rbac/` (o próprio módulo RBAC)
+- `apps/core/constants.py`, `apps/core/permissions.py`, `apps/core/rbac_helpers.py`
+  (shims e data-scope constants)
+- `scripts/rbac_lint.py`, `scripts/rbac_codemod.py` (o próprio lint e histórico)
+
+Exit code:
+- 0 se limpo
+- 1 se alguma violação (CI falha)
+
+Uso:
+    python scripts/rbac_lint.py apps/core/
+    python scripts/rbac_lint.py apps/           # scan tudo
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+import sys
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+# Classes `Is<Word>` permitidas (não-reduzíveis a HasPerm — ver RBAC_NAMING §3).
+WHITELISTED_CLASS_NAMES: frozenset[str] = frozenset(
+    {
+        "IsGerenteSuperintendencia",  # composite: funcperm + grupo Django
+        "IsOwnerOrPrivileged",  # object-level: checa obj.usuario
+    }
+)
+
+# Substrings de path que isentam um arquivo do lint.
+# Usamos substring (não exact) para cobrir variações (apps/core/tests vs
+# apps/dev_tools/tests, etc).
+WHITELIST_PATH_SUBSTRINGS: tuple[str, ...] = (
+    "/tests/",
+    "\\tests\\",
+    "/migrations/",
+    "\\migrations\\",
+    "/fixtures/",
+    "\\fixtures\\",
+    "/apps/core/rbac/",
+    "\\apps\\core\\rbac\\",
+    # `apps/dev_tools/` é seed/admin tooling por design — comandos como
+    # `seed_gerentes`, `seed_rbac`, `seed_e2e_users` criam e atribuem
+    # grupos por nome, que é operação legítima de bootstrap, não authz.
+    "/apps/dev_tools/",
+    "\\apps\\dev_tools\\",
+    "/scripts/rbac_lint.py",
+    "\\scripts\\rbac_lint.py",
+    "/scripts/rbac_codemod.py",
+    "\\scripts\\rbac_codemod.py",
+)
+
+# Arquivos específicos whitelisted (shims + data-scope SSOT).
+WHITELIST_EXACT_FILES: tuple[str, ...] = (
+    "apps/core/constants.py",
+    "apps/core/permissions.py",
+    "apps/core/rbac_helpers.py",
+)
+
+# Kwargs de filter/exclude que indicam authz por nome de grupo.
+GROUP_NAME_KWARGS: frozenset[str] = frozenset({"name", "name__in", "name__exact", "name__iexact"})
+
+
+@dataclass(frozen=True)
+class Violation:
+    filepath: str
+    lineno: int
+    code: str
+    message: str
+
+
+class RBACLintVisitor(ast.NodeVisitor):
+    """Varre um AST procurando violações V001/V002."""
+
+    def __init__(self, filepath: pathlib.Path, source_lines: list[str]) -> None:
+        self.filepath: pathlib.Path = filepath
+        self.source_lines: list[str] = source_lines
+        self.violations: list[Violation] = []
+
+    # V002 — nomes de classe começando com Is<Upper>
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        name = node.name
+        if name.startswith("Is") and len(name) > 2 and name[2].isupper() and name not in WHITELISTED_CLASS_NAMES:
+            self.violations.append(
+                Violation(
+                    filepath=str(self.filepath),
+                    lineno=node.lineno,
+                    code="V002",
+                    message=(
+                        f"Classe '{name}' viola convenção RBAC: "
+                        f"prefira HasPerm('codename') inline em permission_classes "
+                        f"(whitelist mantida: {sorted(WHITELISTED_CLASS_NAMES)})"
+                    ),
+                )
+            )
+        self.generic_visit(node)
+
+    # V001 — groups.filter(name=...) ou equivalentes
+    def visit_Call(self, node: ast.Call) -> None:
+        if self._is_groups_filter_with_name_kw(node) and not self._has_noqa_marker(node.lineno):
+            self.violations.append(
+                Violation(
+                    filepath=str(self.filepath),
+                    lineno=node.lineno,
+                    code="V001",
+                    message=(
+                        "user.groups.filter(name=...) é bypass do RBAC funcional. "
+                        "Use user_has_any_perm(user, '<codename>') / HasPerm('<codename>'). "
+                        "Se o uso for legítimo, adicione '# noqa: RBAC-<tipo>-allowed' na linha."
+                    ),
+                )
+            )
+        self.generic_visit(node)
+
+    @staticmethod
+    def _is_groups_filter_with_name_kw(node: ast.Call) -> bool:
+        """True se `node` é `<expr>.groups.filter(name=...)` (ou variantes)."""
+        func = node.func
+        if not isinstance(func, ast.Attribute):
+            return False
+        if func.attr not in ("filter", "exclude"):
+            return False
+        inner = func.value
+        if not isinstance(inner, ast.Attribute):
+            return False
+        if inner.attr != "groups":
+            return False
+        return any(kw.arg in GROUP_NAME_KWARGS for kw in node.keywords if kw.arg)
+
+    def _has_noqa_marker(self, lineno: int) -> bool:
+        """True se a linha tem '# noqa: RBAC-<tipo>-allowed'."""
+        if lineno < 1 or lineno > len(self.source_lines):
+            return False
+        line = self.source_lines[lineno - 1]
+        return "# noqa: RBAC-" in line and "-allowed" in line
+
+
+def _is_path_whitelisted(path: pathlib.Path, root: pathlib.Path) -> bool:
+    """True se `path` está na whitelist (não deve ser lintado)."""
+    path_str = str(path).replace("\\", "/")
+    # Substrings (cobre dirs em qualquer nível)
+    if any(s.replace("\\", "/") in path_str for s in WHITELIST_PATH_SUBSTRINGS):
+        return True
+    # Arquivos exatos — normalizar relativo ao root
+    try:
+        rel = path.relative_to(root).as_posix()
+    except ValueError:
+        rel = path.as_posix()
+    if rel in WHITELIST_EXACT_FILES:
+        return True
+    # Casos onde o user passa o próprio arquivo — cheque por suffix
+    return any(rel.endswith("/" + f) or rel == f for f in WHITELIST_EXACT_FILES)
+
+
+def check_file(path: pathlib.Path, root: pathlib.Path) -> list[Violation]:
+    if _is_path_whitelisted(path, root):
+        return []
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError:
+        return []
+    visitor = RBACLintVisitor(path, source.splitlines())
+    visitor.visit(tree)
+    return visitor.violations
+
+
+def iter_py_files(root: pathlib.Path) -> Iterable[pathlib.Path]:
+    if root.is_file():
+        if root.suffix == ".py":
+            yield root
+        return
+    for py in root.rglob("*.py"):
+        yield py
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print("Uso: python scripts/rbac_lint.py <dir_ou_arquivo>", file=sys.stderr)
+        return 2
+    target = pathlib.Path(argv[1]).resolve()
+    if not target.exists():
+        print(f"Path não encontrado: {target}", file=sys.stderr)
+        return 2
+
+    root = target if target.is_dir() else target.parent
+    violations: list[Violation] = []
+    for py_file in iter_py_files(target):
+        violations.extend(check_file(py_file, root))
+
+    if not violations:
+        print("OK RBAC lint: 0 violacoes")
+        return 0
+
+    print(f"X RBAC lint: {len(violations)} violacao(oes):", file=sys.stderr)
+    for v in violations:
+        rel = pathlib.Path(v.filepath)
+        try:
+            rel = rel.relative_to(pathlib.Path.cwd())
+        except ValueError:
+            pass
+        print(f"  {rel}:{v.lineno} [{v.code}] {v.message}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/v2/docs/RBAC_NAMING.md
+++ b/v2/docs/RBAC_NAMING.md
@@ -25,11 +25,12 @@ Formato: `<verb>_<noun>[_<qualifier>]`, snake_case, inglês.
 `admin_`, `manage_`, `operate_`, `configure_`, `change_`, `modify_`, `edit_`, `list_`, `set_`, `write_`.
 
 **Nunca no codename**:
+
 - Nome de setor (`dat`, `controle`, `super`, `vidas`, ...)
 - Nome de função (`coordenador`, `formador`, ...)
 - Nome de grupo Django
 
-### Bons exemplos
+### Bons exemplos de codename
 
 ```text
 approve_solicitation
@@ -40,7 +41,7 @@ create_solicitation
 view_all_availability
 ```
 
-### Maus exemplos
+### Maus exemplos de codename
 
 ```text
 pode_operar_dat                   # setor no nome
@@ -65,11 +66,12 @@ Decompor cada uma em `create/read/update/delete` hoje produziria 8+ codenames se
 Formato: `<Verbo infinitivo> <substantivo plural>`.
 
 **Regras**:
+
 - Começar com verbo infinitivo: *Aprovar*, *Criar*, *Importar*, *Visualizar*, *Administrar*.
 - Evitar: gerúndio ("Aprovação de...", "Criando..."), substantivação ("Aprovações"), adjetivo puro ("Owner"), nome de módulo solto ("Dashboard").
 - **Nunca** nome de setor/função (mesma regra dos codenames).
 
-### Bons exemplos
+### Bons exemplos de label
 
 ```text
 Aprovar solicitações
@@ -79,7 +81,7 @@ Administrar cadastros
 Exercer supervisão gerencial
 ```
 
-### Maus exemplos
+### Maus exemplos de label
 
 ```text
 Operacao DAT                       # setor
@@ -200,6 +202,7 @@ user.groups.filter(name__in=["Controle", "DAT"]).exists()
 Se você criar uma nova classe de permission **e** ela puder ser expressa como `HasPerm(codename)`, **não crie** — use `HasPerm` direto.
 
 Se você for remover uma legacy do código:
+
 - Substituir por `HasPerm("codename")` no `permission_classes`
 - Deletar o import
 - Remover a classe do `apps/core/permissions.py` **somente** quando não houver mais nenhum uso (Epic 5 faz isso via libcst).
@@ -250,14 +253,14 @@ python scripts/rbac_lint.py apps/
 
 ## 8. Referência rápida
 
-| Tipo | Forma canônica | Forma proibida |
-|---|---|---|
-| **Codename** | `approve_solicitation` | `pode_aprovar_superintendencia` |
-| **Label** | "Aprovar solicitações" | "Aprovar/Reprovar (Superintendência)" |
-| **Category** | `solicitacao`, `operacao`, ... | `admin_dat`, `gerencia` |
-| **Permission class** | `HasPerm("approve_solicitation")` | `IsSuperintendencia` |
-| **Authz check** | `user.has_perm("approve_solicitation")` | `user.groups.filter(name="Superintendência")` |
-| **Classe dedicada** | `IsSolicitationOwner` (condição) | `IsDAT` (identidade) |
+| Tipo                 | Forma canônica                            | Forma proibida                                    |
+| -------------------- | ----------------------------------------- | ------------------------------------------------- |
+| **Codename**         | `approve_solicitation`                    | `pode_aprovar_superintendencia`                   |
+| **Label**            | "Aprovar solicitações"                    | "Aprovar/Reprovar (Superintendência)"             |
+| **Category**         | `solicitacao`, `operacao`, ...            | `admin_dat`, `gerencia`                           |
+| **Permission class** | `HasPerm("approve_solicitation")`         | `IsSuperintendencia`                              |
+| **Authz check**      | `user.has_perm("approve_solicitation")`   | `user.groups.filter(name="Superintendência")`     |
+| **Classe dedicada**  | `IsSolicitationOwner` (condição)          | `IsDAT` (identidade)                              |
 
 ---
 

--- a/v2/docs/RBAC_NAMING.md
+++ b/v2/docs/RBAC_NAMING.md
@@ -208,15 +208,43 @@ Se você for remover uma legacy do código:
 
 ## 7. Enforcement automático
 
-O Epic 6 (#1179) introduzirá um **lint custom** em `.github/workflows/` que falha PRs que:
+Lint AST custom em `v2/backend/scripts/rbac_lint.py` falha PRs que:
 
-- **V001**: usam `user.groups.filter(name=...)` em `views/` ou `services/`
-- **V002**: definem classe `Is<Word>` fora da whitelist
-- **V003**: importam `django.contrib.auth.models.Group` para decisões de autorização
+- **V001**: `user.groups.filter(name=...)` / `exclude(name=...)` em código de produção.
+  Exceção: linha com marcador `# noqa: RBAC-<tipo>-allowed` documentando a justificativa (composite, block, data-scope).
+- **V002**: definem classe `class Is<Word>(...)` fora da whitelist
+  `{IsGerenteSuperintendencia, IsOwnerOrPrivileged}`.
 
-Whitelist do lint: `tests/`, `migrations/`, `fixtures/`, `apps/core/rbac/constants.py`.
+**V003 (import de Group) foi descartado** — V001 já cobre o padrão observável
+na prática; V003 gerava 100+ falsos positivos (seeds, fixtures, serializers,
+admin views têm imports legítimos) com zero violações reais a ganhar.
 
-Até o Epic 6 entrar em vigor, a revisão manual de PR faz esse papel.
+**Paths whitelisted** (o lint pula):
+
+- `tests/`, `migrations/`, `fixtures/`
+- `apps/core/rbac/` (o próprio módulo RBAC)
+- `apps/dev_tools/` (seeds e admin tooling manipulam grupos por design)
+- `apps/core/constants.py`, `apps/core/permissions.py`, `apps/core/rbac_helpers.py` (shims e data-scope SSOT)
+- `scripts/rbac_lint.py`, `scripts/rbac_codemod.py`
+
+**Markers `# noqa: RBAC-*-allowed` em uso**:
+
+| Marker                      | Uso legítimo                                           |
+| --------------------------- | ------------------------------------------------------ |
+| `RBAC-composite-allowed`    | Classe composite (funcperm + grupo Django)             |
+| `RBAC-block-allowed`        | Bloqueio explícito de um grupo por design documentado  |
+| `RBAC-data-scope-allowed`   | Filtro de escopo de dados (não authz)                  |
+
+**CI job**: `[required] backend rbac-lint` em `.github/workflows/ci.yaml` — falha o PR automaticamente.
+
+**Self-test**: `apps/core/tests/test_rbac_lint.py` valida que o lint aceita o baseline atual e rejeita os padrões proibidos (10 testes).
+
+Rodar localmente:
+
+```bash
+cd v2/backend
+python scripts/rbac_lint.py apps/
+```
 
 ---
 


### PR DESCRIPTION
## Summary

**Último PR do programa RBAC Refactor** — cimenta institucionalmente o trabalho dos 9 PRs anteriores com um lint CI custom + consolidação do módulo RBAC.

Sem este guard, em 6-12 meses alguém escreveria `user.groups.filter(name=\"DAT\")` em uma view e a dívida voltaria. Agora o CI falha PRs com o padrão proibido automaticamente.

## Motivação

O programa RBAC Refactor eliminou identity coupling em 9 PRs (Epics 1-5). Este Epic 6 **fecha o programa** com:

1. **Módulo `apps.core.rbac/`** — SSOT oficial de DRF permissions + helpers + constants
2. **Lint AST** — bane os padrões que acabamos de eliminar
3. **CI gate** — PR falha automaticamente se alguém reintroduzir regressão

## Entregas

### Módulo `apps.core.rbac/` (SSOT)

- `__init__.py` — API pública (re-exports)
- `permissions.py` — HasPerm + 3 classes mantidas (IsGerenteSuperintendencia, IsOwnerOrPrivileged, HasSectorAccess)
- `helpers.py` — `user_has_any_perm`, `user_has_all_perms`
- `constants.py` — `COORDENADOR_ROLE_GROUPS`, `FORMADOR_ROLE_GROUPS`
- `README.md` — documentação interna

### Shims de backcompat (zero-risco)

- `apps/core/permissions.py` → re-exporta de `apps.core.rbac.permissions`
- `apps/core/rbac_helpers.py` → re-exporta de `apps.core.rbac.helpers`
- **Todos os 39 imports legacy continuam funcionando** sem alteração

### Lint AST (`scripts/rbac_lint.py`, ~240 linhas)

Regras:

- **V001** — `user.groups.filter(name=...)` em código de produção (exceto whitelist ou `# noqa: RBAC-*-allowed`)
- **V002** — classes `Is<Word>` fora da whitelist (`IsGerenteSuperintendencia`, `IsOwnerOrPrivileged`)

**V003 descartado durante execução**: auditoria mostrou que V001 cobre o padrão observável; V003 (import de Group) geraria 100+ falsos positivos (seeds, fixtures, serializers, admin CRUD) com zero violações reais a ganhar.

Paths whitelisted:
- `tests/`, `migrations/`, `fixtures/`
- `apps/core/rbac/` (o próprio módulo)
- `apps/dev_tools/` (seeds/admin tooling manipulam grupos por design)
- shims + data-scope SSOT

Markers `# noqa` documentados: `RBAC-composite-allowed`, `RBAC-block-allowed`, `RBAC-data-scope-allowed`.

### Self-test (`test_rbac_lint.py`, 11 tests)

Valida:
- Baseline atual passa limpo
- V001/V002 são detectados (variantes: `name=`, `name__in=`, `exclude()`)
- Whitelists funcionam (`tests/`, `dev_tools/`, classes mantidas)
- noqa markers são respeitados

### CI job

`[required] backend rbac-lint` em `.github/workflows/ci.yaml` — falha PR em <5s.

### Fix in-scope (permissions.py)

- `# noqa: RBAC-composite-allowed` em `IsGerenteSuperintendencia:163` (classe mantida por design, precisava do marcador)
- Blanket pyright expandido (`reportIncompatibleMethodOverride`, `reportMissingTypeStubs`, `reportArgumentType`) — falsos positivos de DRF sem stubs

### Drive-by type cleanup (commit separado)

Resolve 7 problems do VSCode em arquivos vizinhos:
- `views_reports.py` — remove `from typing import Any` unused
- `serializers/solicitacao.py` — `cast(list[dict[str, Any]], ...)` no retorno do serializer
- `tests/test_availability_service.py` — blanket expandido + side-effect-only create

## Success criteria (master-plan)

- **S1** ✅ `grep Is<Role> apps/core/views*/` retorna 0 (Epic 5.3 + V002 lock)
- **S2** ✅ `grep groups.filter(name= apps/core/views*/` retorna só usos com noqa (V001 lock)
- **S3** ✅ Nenhum codename `pode_*` (Epic 4.3)
- **S4** ✅ Nenhum label contém nome de setor (Epic 1)
- **S5** ✅ Categorias vocabulário canônico (Epic 1)
- **S8** ✅ Lint CI implementado (este PR)
- **S9** ✅ `RBAC_NAMING.md` publicado + atualizado com §7 (Enforcement)
- **S10** ✅ Self-test garante que regras valem para sempre

## Programa RBAC Refactor — 100% concluído

10 PRs: #1206 #1207 #1208 #1209 #1210 #1211 #1212 #1213 #1214 #1215 + este (#1189).

Codebase passou de bypass-heavy/identity-coupled → capability-oriented, com 3 classes mantidas por design + guard automático.

## Validação local

- **Lint baseline**: \`python scripts/rbac_lint.py apps/\` → 0 violações
- **Self-test**: \`pytest apps/core/tests/test_rbac_lint.py\` → 11 passed
- **RBAC suite regressão**: \`pytest apps/core/tests/test_permissions_hasperm.py test_rbac_helpers.py test_rbac_layer3_parity.py test_rbac_labels_capability_oriented.py test_permissao_funcional.py test_availability_service.py\` → 78 passed (sem regressão pós-shim)
- **Black/isort/flake8 clean** nos arquivos novos

## Staging gate

ALL 8 CHECKS PASSED

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR
- [x] Feature complete (módulo + lint + CI + self-test + docs)
- [x] Tests updated (11 novos no test_rbac_lint.py)
- [x] TS/Lint clean (black/isort/flake8 no baseline)
- [x] No breaking API changes (shims preservam todos os 39 imports legacy)
- [x] Self-test garante regras válidas no futuro (regressão detectável)
- [x] Documentação atualizada (RBAC_NAMING.md §7, CLAUDE.md, rbac/README.md)