### PR TITLE
chore(deps): bump pre-commit hooks + requirements-dev to latest (2026-04)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
 
   # Code formatting with Black
   - repo: https://github.com/psf/black
-    rev: 25.9.0
+    rev: 26.3.1
     hooks:
       - id: black
         name: 🎨 Format Python code (Black)
@@ -26,7 +26,7 @@ repos:
 
   # Import sorting with isort
   - repo: https://github.com/pycqa/isort
-    rev: 6.1.0
+    rev: 8.0.1
     hooks:
       - id: isort
         name: 📐 Sort Python imports (isort)
@@ -48,7 +48,7 @@ repos:
 
   # Security analysis with Bandit
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.8.6
+    rev: 1.9.4
     hooks:
       - id: bandit
         name: 🔒 Security scan (Bandit)
@@ -147,7 +147,7 @@ repos:
 
   # Conventional commits (optional but recommended)
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.2.0
+    rev: v4.4.0
     hooks:
       - id: conventional-pre-commit
         name: 📝 Conventional commits format

--- a/v2/backend/requirements-dev.txt
+++ b/v2/backend/requirements-dev.txt
@@ -6,12 +6,12 @@
 -r requirements-prod.txt
 
 # Code Quality & Linting
-bandit==1.7.9
+bandit==1.9.4
 black==26.3.1
-flake8==7.1.1
-isort==5.13.2
+flake8==7.3.0
+isort==8.0.1
 mypy==1.11.2
-pylint==3.2.7
+pylint==4.0.5
 
 # Testing
 factory-boy==3.3.1


### PR DESCRIPTION
## Summary

Sincroniza \`.pre-commit-config.yaml\` e \`requirements-dev.txt\` — ambos com gap de 6+ meses sem updates. Durante a investigação descobri **desync entre os dois arquivos** (ex: black já estava em 26.3.1 no requirements-dev, mas o pre-commit ainda apontava pra 25.9.0).

## Bumps

| Ferramenta | Antes (pre-commit / req-dev) | Depois |
|---|---|---|
| black | 25.9.0 / 26.3.1 (desync) | **26.3.1** |
| isort | 6.1.0 / 5.13.2 (desync) | **8.0.1** |
| flake8 | 7.3.0 / 7.1.1 (desync) | **7.3.0** |
| bandit | 1.8.6 / 1.7.9 | **1.9.4** |
| pylint | — / 3.2.7 | **4.0.5** |
| conventional-pre-commit | v4.2.0 | **v4.4.0** |

pylint subiu pra 4.0.5 por compat com isort 8 (pylint 3.x requer \`isort<6\`).

## Validação local

Todas as versões novas aceitam o codebase atual **sem reformatar**:

- \`black 26.3.1\`: 386 files would be left unchanged (**zero diff**)
- \`isort 8.0.1\`: zero reorder
- \`flake8 7.3.0\`: zero warnings
- \`bandit 1.9.4\`: \"No issues identified\" (74.5k LOC)
- **34/34 testes RBAC passam** (test_rbac_lint, test_permissions_hasperm, test_rbac_helpers)

PR é **só config** — zero risco de formatting drift no diff, nenhum arquivo \`.py\` foi tocado.

## Staging gate

Este PR só toca:
- \`.pre-commit-config.yaml\` (raiz — ferramenta local, não runtime)
- \`v2/backend/requirements-dev.txt\` (dev-only, nunca instalado em produção — requirements-prod.txt é separado)

Nenhuma mudança runtime. Staging gate **não se aplica** a este PR (não toca \`v2/backend/apps/\`).

- [x] Feature complete (bump)
- [x] Validação local (black/isort/flake8/bandit + 34 tests)
- [x] TS/Lint clean (config-only PR)
- [x] No breaking API changes (dev tooling only)
- [x] Documentação não precisa mudar (bumps de versão)