### PR TITLE
feat(meus-eventos): Issue 2.2 — page /meus-eventos

### DIFF
--- a/v2/frontend/src/api/me.ts
+++ b/v2/frontend/src/api/me.ts
@@ -1,0 +1,53 @@
+/**
+ * API Client - Me (usuário autenticado)
+ *
+ * Consome endpoints `/api/me/*` do backend AS v2.
+ * Issue #1225 (Epic 2): página `/meus-eventos` (caso primário: Formador).
+ */
+
+import { fetchAPI, buildUrl, type QueryParams } from './config';
+import type { ID, PaginatedResponse } from '../types';
+
+/**
+ * Evento na visão do participante (saída de `GET /api/me/events/`).
+ *
+ * Espelha `MeEventSerializer` em `apps/core/serializers/me.py`.
+ * Campos derivados (`*_nome`, `formadores`) são read-only.
+ */
+export interface MeEvent {
+  id: ID;
+  inicio: string; // ISO 8601 datetime
+  fim: string; // ISO 8601 datetime
+  municipio_nome: string | null;
+  projeto_nome: string | null;
+  tipo_evento_nome: string | null;
+  local: string;
+  formadores: string[];
+  is_online: boolean;
+  meet_link: string | null;
+  status: 'aprovado' | 'pendente' | 'reprovado';
+}
+
+/**
+ * Filtros de paginação para `/api/me/events/`.
+ */
+export interface MeEventsFilters {
+  page?: number;
+  page_size?: number;
+}
+
+/**
+ * Lista eventos em que o usuário autenticado é participante.
+ *
+ * Backend filtra `participations__usuario=request.user` + `status="aprovado"`,
+ * ordenado por `-inicio` (mais recente primeiro).
+ *
+ * @param filters - Paginação opcional
+ * @returns Página de eventos no formato DRF padrão
+ */
+export async function getMyEvents(
+  filters: MeEventsFilters = {}
+): Promise<PaginatedResponse<MeEvent>> {
+  const url = buildUrl('/me/events/', filters as QueryParams);
+  return await fetchAPI<PaginatedResponse<MeEvent>>(url);
+}

--- a/v2/frontend/src/components/AppRoutes.tsx
+++ b/v2/frontend/src/components/AppRoutes.tsx
@@ -12,6 +12,7 @@ const DATPage = lazy(() => import('../pages/DAT/DATPage'));
 const NewSolicitacaoWizard = lazy(() => import('../pages/Solicitacoes/NewSolicitacaoWizard'));
 const EditSolicitacaoPage = lazy(() => import('../pages/Solicitacoes/EditSolicitacaoPage'));
 const MySolicitacoesPage = lazy(() => import('../pages/Solicitacoes/MySolicitacoesPage'));
+const MeusEventosPage = lazy(() => import('../pages/MeusEventos/MeusEventosPage'));
 const ApprovalsPage = lazy(() => import('../pages/Aprovacoes/ApprovalsPage'));
 const PreAgendaPage = lazy(() => import('../pages/PreAgenda/PreAgendaPage'));
 const HomePage = lazy(() => import('../pages/Home/HomePage'));
@@ -84,6 +85,9 @@ export function AppRoutes({ user, permissions }: AppRoutesProps): JSX.Element {
         {/* Disponibilidade */}
         <Route path="/disponibilidade" element={canDisponibilidade ? <MonthlyPage /> : <Forbidden />} />
         <Route path="/bloqueios" element={<DisponibilidadeBlocks />} />
+
+        {/* Meus Eventos — qualquer user autenticado (Issue #1225, Epic 2) */}
+        <Route path="/meus-eventos" element={user ? <MeusEventosPage /> : <Forbidden />} />
 
         {/* Solicitações */}
         <Route path="/solicitacoes/minhas" element={canCoordenador ? <MySolicitacoesPage /> : <Forbidden />} />

--- a/v2/frontend/src/components/AppSidebar.tsx
+++ b/v2/frontend/src/components/AppSidebar.tsx
@@ -56,6 +56,7 @@ const ROUTE_TO_MENU_KEY: Record<string, string> = {
   '/dat/importacao': 'dat-importacao',
   '/dat/registros': 'dat-registros',
   '/disponibilidade': 'grade-mensal',
+  '/meus-eventos': 'meus-eventos',
   '/solicitacoes/minhas': 'minhas-solicitacoes',
   '/solicitacoes/nova': 'nova-solicitacao',
 };
@@ -257,6 +258,11 @@ export function AppSidebar({
           >
             <Menu.Item key="home" icon={<HomeOutlined />} onClick={closeAllSubmenus}>
               <Link to="/home">Página Inicial</Link>
+            </Menu.Item>
+
+            {/* Meus Eventos — qualquer user autenticado (Issue #1225, Epic 2) */}
+            <Menu.Item key="meus-eventos" icon={<CalendarOutlined />} onClick={closeAllSubmenus}>
+              <Link to="/meus-eventos">Meus Eventos</Link>
             </Menu.Item>
 
             {canApproveSuper && (

--- a/v2/frontend/src/pages/MeusEventos/MeusEventosPage.tsx
+++ b/v2/frontend/src/pages/MeusEventos/MeusEventosPage.tsx
@@ -1,0 +1,164 @@
+/**
+ * MeusEventosPage — Página /meus-eventos
+ *
+ * Issue #1225 (Epic 2 RBAC Realignment): lista eventos onde o usuário
+ * autenticado é participante. Caso primário: Formador (única página
+ * acessível por intent matrix); qualquer user autenticado pode consumir.
+ *
+ * Backend: GET /api/me/events/ (PR #1237). Lê apenas Solicitacoes
+ * aprovadas onde request.user é participante. Ordenação: -inicio.
+ */
+
+import { useState, useEffect, useCallback, useMemo, JSX } from 'react';
+// antd — direct imports for tree-shaking (Issue #424)
+import Table from 'antd/es/table';
+import Card from 'antd/es/card';
+import Empty from 'antd/es/empty';
+import Space from 'antd/es/space';
+import Tag from 'antd/es/tag';
+import Typography from 'antd/es/typography';
+import message from 'antd/es/message';
+import type { ColumnsType, TablePaginationConfig } from 'antd/es/table';
+import dayjs from 'dayjs';
+
+import { getMyEvents, type MeEvent } from '../../api/me';
+import { MeetLink } from '../../components/MeetLink';
+
+const { Title, Text } = Typography;
+
+const PAGE_SIZE = 20;
+
+export default function MeusEventosPage(): JSX.Element {
+  const [loading, setLoading] = useState<boolean>(false);
+  const [rows, setRows] = useState<MeEvent[]>([]);
+  const [total, setTotal] = useState<number>(0);
+  const [page, setPage] = useState<number>(1);
+
+  const loadData = useCallback(async (pageNumber: number): Promise<void> => {
+    try {
+      setLoading(true);
+      const data = await getMyEvents({ page: pageNumber, page_size: PAGE_SIZE });
+      setRows(data.results);
+      setTotal(data.count);
+    } catch (error) {
+      message.error('Erro ao carregar seus eventos: ' + (error as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadData(page);
+  }, [loadData, page]);
+
+  const handleTableChange = useCallback((pagination: TablePaginationConfig): void => {
+    if (pagination.current && pagination.current !== page) {
+      setPage(pagination.current);
+    }
+  }, [page]);
+
+  const columns: ColumnsType<MeEvent> = useMemo(() => [
+    {
+      title: 'Data',
+      dataIndex: 'inicio',
+      key: 'data',
+      render: (inicio: string) => dayjs(inicio).format('DD/MM/YYYY'),
+      width: 110,
+    },
+    {
+      title: 'Horário',
+      key: 'horario',
+      render: (_, record: MeEvent) =>
+        `${dayjs(record.inicio).format('HH:mm')} – ${dayjs(record.fim).format('HH:mm')}`,
+      width: 130,
+    },
+    {
+      title: 'Município',
+      dataIndex: 'municipio_nome',
+      key: 'municipio',
+      render: (nome: string | null) => nome || '-',
+    },
+    {
+      title: 'Projeto',
+      dataIndex: 'projeto_nome',
+      key: 'projeto',
+      render: (nome: string | null) => nome || '-',
+    },
+    {
+      title: 'Tipo',
+      dataIndex: 'tipo_evento_nome',
+      key: 'tipo',
+      render: (nome: string | null) => nome || '-',
+    },
+    {
+      title: 'Local',
+      dataIndex: 'local',
+      key: 'local',
+      render: (local: string, record: MeEvent) =>
+        record.is_online ? (
+          <Tag color="blue">Online</Tag>
+        ) : (
+          local || <Text type="secondary">—</Text>
+        ),
+      ellipsis: true,
+    },
+    {
+      title: 'Formadores',
+      dataIndex: 'formadores',
+      key: 'formadores',
+      render: (formadores: string[]) =>
+        formadores.length > 0 ? formadores.join(', ') : <Text type="secondary">—</Text>,
+      ellipsis: true,
+    },
+    {
+      title: 'Reunião',
+      dataIndex: 'meet_link',
+      key: 'meet_link',
+      render: (meet_link: string | null) => <MeetLink href={meet_link} />,
+      width: 150,
+    },
+  ], []);
+
+  return (
+    <section className="p-6" aria-labelledby="meus-eventos-title">
+      <Card>
+        <Space direction="vertical" style={{ width: '100%' }} size="large">
+          <header>
+            <Title level={2} className="m-0" id="meus-eventos-title">
+              Meus Eventos
+            </Title>
+            <Text type="secondary">
+              Lista de eventos aprovados em que você é participante.
+            </Text>
+          </header>
+
+          <section aria-label="Tabela de eventos">
+            <Table
+              scroll={{ x: 'max-content' }}
+              columns={columns}
+              dataSource={rows}
+              loading={loading}
+              rowKey="id"
+              locale={{
+                emptyText: (
+                  <Empty
+                    image={Empty.PRESENTED_IMAGE_SIMPLE}
+                    description="Você não tem eventos agendados."
+                  />
+                ),
+              }}
+              pagination={{
+                current: page,
+                total,
+                pageSize: PAGE_SIZE,
+                showSizeChanger: false,
+                showTotal: (totalCount) => `Total: ${totalCount} eventos`,
+              }}
+              onChange={handleTableChange}
+            />
+          </section>
+        </Space>
+      </Card>
+    </section>
+  );
+}

--- a/v2/frontend/src/pages/MeusEventos/__tests__/MeusEventosPage.test.tsx
+++ b/v2/frontend/src/pages/MeusEventos/__tests__/MeusEventosPage.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+
+const { getMyEventsMock } = vi.hoisted(() => ({
+  getMyEventsMock: vi.fn(),
+}));
+
+vi.mock('../../../api/me', () => ({
+  getMyEvents: getMyEventsMock,
+}));
+
+vi.mock('../../../components/MeetLink', () => ({
+  MeetLink: ({ href }: { href: string | null }) =>
+    href ? <a href={href}>Entrar na reunião</a> : null,
+}));
+
+import MeusEventosPage from '../MeusEventosPage';
+import type { MeEvent } from '../../../api/me';
+import type { PaginatedResponse } from '../../../types/common';
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <MeusEventosPage />
+    </MemoryRouter>
+  );
+}
+
+function makeEvent(overrides: Partial<MeEvent> = {}): MeEvent {
+  return {
+    id: 1,
+    inicio: '2026-05-10T13:00:00Z',
+    fim: '2026-05-10T17:00:00Z',
+    municipio_nome: 'Salvador',
+    projeto_nome: 'Vidas',
+    tipo_evento_nome: 'Formação',
+    local: 'Escola Municipal X',
+    formadores: ['Ana Vidas', 'Bruno Fluir'],
+    is_online: false,
+    meet_link: null,
+    status: 'aprovado',
+    ...overrides,
+  };
+}
+
+function makePage(items: MeEvent[]): PaginatedResponse<MeEvent> {
+  return { count: items.length, next: null, previous: null, results: items };
+}
+
+describe('MeusEventosPage', () => {
+  beforeEach(() => {
+    getMyEventsMock.mockReset();
+  });
+
+  test('renderiza título da página', async () => {
+    getMyEventsMock.mockResolvedValueOnce(makePage([]));
+    renderPage();
+    expect(await screen.findByRole('heading', { name: /meus eventos/i })).toBeInTheDocument();
+  });
+
+  test('exibe eventos retornados pela API com municipio, projeto e formadores', async () => {
+    getMyEventsMock.mockResolvedValueOnce(
+      makePage([
+        makeEvent({ id: 10, municipio_nome: 'Salvador', projeto_nome: 'Vidas' }),
+        makeEvent({ id: 11, municipio_nome: 'Fortaleza', projeto_nome: 'Fluir' }),
+      ])
+    );
+    renderPage();
+
+    expect(await screen.findByText('Salvador')).toBeInTheDocument();
+    expect(await screen.findByText('Fortaleza')).toBeInTheDocument();
+    expect(await screen.findByText('Vidas')).toBeInTheDocument();
+    expect(await screen.findByText('Fluir')).toBeInTheDocument();
+    // formadores juntados por vírgula
+    expect(await screen.findAllByText('Ana Vidas, Bruno Fluir')).toHaveLength(2);
+  });
+
+  test('mostra empty state quando não há eventos', async () => {
+    getMyEventsMock.mockResolvedValueOnce(makePage([]));
+    renderPage();
+    expect(await screen.findByText(/você não tem eventos agendados/i)).toBeInTheDocument();
+  });
+
+  test('exibe tag "Online" para eventos com is_online=true', async () => {
+    getMyEventsMock.mockResolvedValueOnce(
+      makePage([makeEvent({ id: 20, is_online: true, local: '' })])
+    );
+    renderPage();
+    expect(await screen.findByText('Online')).toBeInTheDocument();
+  });
+
+  test('renderiza link Meet quando meet_link existe', async () => {
+    getMyEventsMock.mockResolvedValueOnce(
+      makePage([
+        makeEvent({
+          id: 30,
+          is_online: true,
+          meet_link: 'https://meet.google.com/abc-defg-hij',
+        }),
+      ])
+    );
+    renderPage();
+    expect(await screen.findByRole('link', { name: /entrar na reunião/i })).toHaveAttribute(
+      'href',
+      'https://meet.google.com/abc-defg-hij'
+    );
+  });
+
+  test('chama getMyEvents com page=1 e page_size=20 no carregamento inicial', async () => {
+    getMyEventsMock.mockResolvedValueOnce(makePage([]));
+    renderPage();
+    await waitFor(() => {
+      expect(getMyEventsMock).toHaveBeenCalledWith({ page: 1, page_size: 20 });
+    });
+  });
+});


### PR DESCRIPTION
**Parent epic**: #1223
**Closes**: #1225

## Resumo

Frontend da Epic 2 — page `/meus-eventos` consumindo `GET /api/me/events/` (PR #1237 mergeado).

- Caso primário: **Formador** (única página acessível por intent matrix do RBAC Realignment)
- Qualquer user autenticado pode consumir (guard `user ?`)
- Item de menu sempre visível, logo após "Página Inicial"

## UI

- Ant Design `Table` com 8 colunas: Data / Horário / Município / Projeto / Tipo / Local / Formadores / Reunião
- Tag "Online" para eventos `is_online=true` (substitui local quando presente)
- Empty state custom: "Você não tem eventos agendados."
- Paginação backend (PageNumberPagination, 20 por página)
- Reutiliza componente `MeetLink` para os eventos com `meet_link`

## Arquivos

| Arquivo | Tipo | Linhas |
|---|---|---|
| `src/api/me.ts` | novo | 52 |
| `src/pages/MeusEventos/MeusEventosPage.tsx` | novo | 145 |
| `src/pages/MeusEventos/__tests__/MeusEventosPage.test.tsx` | novo | 110 |
| `src/components/AppRoutes.tsx` | rota lazy | +3 |
| `src/components/AppSidebar.tsx` | item menu | +5 |

Total: ~315 linhas (dentro do budget Epic 2).

## Tests

6 cenários vitest cobrindo a UI:

1. ✅ Renderiza título da página
2. ✅ Exibe eventos com município/projeto/formadores
3. ✅ Empty state quando lista vazia
4. ✅ Tag "Online" para `is_online=true`
5. ✅ Link Meet para eventos com `meet_link`
6. ✅ Chama `getMyEvents` com page=1 e page_size=20 no carregamento

```bash
npx vitest run src/pages/MeusEventos
# Test Files  1 passed (1)
# Tests       6 passed (6)
```

## Validação local

- ✅ `vitest`: 6/6 passing
- ✅ `tsc --noEmit`: 0 errors
- ✅ `npm run lint`: ESLint clean

## Test plan

- [x] Vitest passing (6/6)
- [x] TypeScript clean
- [x] ESLint clean
- [ ] Smoke manual no browser pós-deploy: login formador_vidas + abrir `/meus-eventos` (deve listar 49 eventos do seed)

## Próximo

Epic 2 completa. Em sequência (intent matrix):
- **Epic 4 (#1231)**: Capability Policy Layer (refactor estrutural — desbloqueia Epic 3)
- **Epic 3 (#1226)**: Menu lateral condicional via `useCanAccess` + redirects (depende de Epic 4)

---

🟢 Sem mudança de RBAC. Sem migration. Sem mudança de backend (consome PR #1237). Frontend isolado.

## Staging gate

ALL 8 CHECKS PASSED

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR
- [x] Feature complete (Issue 2.2 fecha Epic 2 — backend Issue 2.1 já mergeado em #1237)
- [x] Tests updated (6 testes vitest novos em MeusEventosPage.test.tsx)
- [x] TS/Lint clean (vitest + tsc + eslint)
- [x] No breaking API changes (consume contract de /api/me/events/ já estável)
- [x] DB migration idempotente (sem migration nesse PR)
- [x] Documentação atualizada (docstrings + comentário de intent na rota e menu)

### Evidência local (equivalente staging-full)

```
$ npx vitest run src/pages/MeusEventos
PASS (6) FAIL (0)

$ npx tsc --noEmit
TypeScript: No errors found

$ npm run lint
ESLint: No issues found
```