### PR TITLE
refactor(rbac): Issue 4.2.a — migrar GCal/OAuth/AuditLog para Policies (1/3)

### DIFF
--- a/v2/backend/apps/core/views/admin.py
+++ b/v2/backend/apps/core/views/admin.py
@@ -36,6 +36,7 @@ from apps.core.models import (
     Usuario,
 )
 from apps.core.permissions import HasPerm
+from apps.core.rbac.policies import CanAccessAuditLogs
 from apps.core.serializers import (
     AuditLogSerializer,
     CompraSerializer,
@@ -573,18 +574,12 @@ class AuditLogViewSet(viewsets.ReadOnlyModelViewSet):
 
     queryset = AuditLog.objects.select_related("usuario").all()
     serializer_class = AuditLogSerializer
-    # Issue #1237 (Epic 1.6): logs visíveis por motivo legítimo de acesso —
+    # Issue #1233 (Epic 4.2.a): logs visíveis por motivo legítimo de acesso —
     # DAT (suporte/admin transversal), Controle (operação diária),
     # Superintendência (auditar próprias aprovações/reprovações),
-    # Gerente (auditar batch). PA-05 audit precisa ser legível por quem
-    # executa o fluxo de aprovação. Refactor estrutural pra Policy
-    # `access_audit_logs` em Epic 4 (Issue #1232).
-    permission_classes = [
-        HasPerm("manage_admin_registries")
-        | HasPerm("operate_preagenda")
-        | HasPerm("approve_solicitation")
-        | HasPerm("approve_solicitation_batch")
-    ]
+    # Gerente (auditar batch). Encapsulado na Policy `access_audit_logs`
+    # (Epic 1.6 já tinha consolidado a composição OR; agora vira Policy nomeada).
+    permission_classes = [CanAccessAuditLogs]
 
     filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
     filterset_fields = ["action", "usuario", "model_name"]

--- a/v2/backend/apps/core/views_gcal/batch.py
+++ b/v2/backend/apps/core/views_gcal/batch.py
@@ -23,7 +23,7 @@ from rest_framework.views import APIView
 from drf_spectacular.utils import extend_schema
 
 from apps.core.models import Solicitacao
-from apps.core.permissions import HasPerm
+from apps.core.rbac.policies import CanUseGcal
 from apps.core.serializers.gcal_dashboard_contract import (
     BatchActionRequestSerializer,
     BatchActionResponseSerializer,
@@ -67,7 +67,7 @@ class GCalPublishBatchView(APIView):
     - Inválidas: retorna em 'errors' com motivo
     """
 
-    permission_classes = [IsAuthenticated, HasPerm("operate_preagenda") | HasPerm("approve_solicitation")]
+    permission_classes = [IsAuthenticated, CanUseGcal]
     throttle_classes = [ScopedRateThrottle]
     throttle_scope = "gcal_write"  # 10/min (#409)
 
@@ -183,7 +183,7 @@ class GCalBatchReapplyView(APIView):
     Permissions: HasPerm("import_spreadsheet")
     """
 
-    permission_classes = [IsAuthenticated, HasPerm("operate_preagenda") | HasPerm("approve_solicitation")]
+    permission_classes = [IsAuthenticated, CanUseGcal]
     throttle_classes = [ScopedRateThrottle]
     throttle_scope = "gcal_write"  # 10/min (#409)
 
@@ -315,7 +315,7 @@ class GCalBatchResyncView(APIView):
     Permissions: HasPerm("import_spreadsheet")
     """
 
-    permission_classes = [IsAuthenticated, HasPerm("operate_preagenda") | HasPerm("approve_solicitation")]
+    permission_classes = [IsAuthenticated, CanUseGcal]
     throttle_classes = [ScopedRateThrottle]
     throttle_scope = "gcal_write"  # 10/min (#409)
 

--- a/v2/backend/apps/core/views_gcal/detail.py
+++ b/v2/backend/apps/core/views_gcal/detail.py
@@ -24,7 +24,7 @@ from rest_framework.views import APIView
 from drf_spectacular.utils import OpenApiResponse, extend_schema
 
 from apps.core.models import Solicitacao
-from apps.core.permissions import HasPerm
+from apps.core.rbac.policies import CanUseGcal
 from apps.core.serializers import EventDetailSerializer, SolicitacaoSerializer
 from apps.core.serializers.gcal_dashboard_contract import (
     DetailMessageSerializer,
@@ -50,7 +50,7 @@ class DashboardEventsView(APIView):
     Permissions: HasPerm("import_spreadsheet")
     """
 
-    permission_classes = [IsAuthenticated, HasPerm("operate_preagenda") | HasPerm("approve_solicitation")]
+    permission_classes = [IsAuthenticated, CanUseGcal]
 
     @extend_schema(responses=PaginatedSolicitacaoResponseSerializer)
     def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
@@ -85,7 +85,7 @@ class DashboardEventsExportView(APIView):
     Permissions: HasPerm("import_spreadsheet")
     """
 
-    permission_classes = [IsAuthenticated, HasPerm("operate_preagenda") | HasPerm("approve_solicitation")]
+    permission_classes = [IsAuthenticated, CanUseGcal]
 
     def get(self, request: Request, *args: Any, **kwargs: Any) -> Response | HttpResponse:
         # Usar helper unificado timezone-aware (Issue #96 follow-up #124)
@@ -190,7 +190,7 @@ class EventDetailAPIView(APIView):
     Permissions: HasPerm("import_spreadsheet")
     """
 
-    permission_classes = [IsAuthenticated, HasPerm("operate_preagenda") | HasPerm("approve_solicitation")]
+    permission_classes = [IsAuthenticated, CanUseGcal]
 
     @extend_schema(
         responses={
@@ -240,7 +240,7 @@ class GCalDriftView(APIView):
     }
     """
 
-    permission_classes = [IsAuthenticated, HasPerm("operate_preagenda") | HasPerm("approve_solicitation")]
+    permission_classes = [IsAuthenticated, CanUseGcal]
 
     @extend_schema(
         responses={

--- a/v2/backend/apps/core/views_gcal/gcal.py
+++ b/v2/backend/apps/core/views_gcal/gcal.py
@@ -18,7 +18,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from apps.core.exceptions import ServiceUnavailableError
-from apps.core.permissions import HasPerm
+from apps.core.rbac.policies import CanUseGcal
 from apps.core.services.gcal.circuit_breaker import gcal_breaker, get_circuit_state
 from apps.core.services.gcal_client_factory import get_gcal_client_and_calendar_id
 
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 
 @api_view(["GET"])
-@permission_classes([HasPerm("operate_preagenda") | HasPerm("approve_solicitation")])
+@permission_classes([CanUseGcal])
 def gcal_calendars(request: Request) -> Response:
     """
     GET /api/gcal/calendars/
@@ -58,7 +58,7 @@ def gcal_calendars(request: Request) -> Response:
 
 
 @api_view(["GET"])
-@permission_classes([HasPerm("operate_preagenda") | HasPerm("approve_solicitation")])
+@permission_classes([CanUseGcal])
 def gcal_health(request: Request) -> Response:
     """
     GET /api/gcal/health/
@@ -102,7 +102,7 @@ def gcal_health(request: Request) -> Response:
 
 
 @api_view(["GET"])
-@permission_classes([HasPerm("operate_preagenda") | HasPerm("approve_solicitation")])
+@permission_classes([CanUseGcal])
 def gcal_circuit_breaker_state(request: Request) -> Response:
     """
     GET /api/gcal/circuit-breaker/

--- a/v2/backend/apps/core/views_gcal/insights.py
+++ b/v2/backend/apps/core/views_gcal/insights.py
@@ -21,7 +21,7 @@ from rest_framework.views import APIView
 from drf_spectacular.utils import extend_schema
 
 from apps.core.models import Solicitacao
-from apps.core.permissions import HasPerm
+from apps.core.rbac.policies import CanUseGcal
 from apps.core.serializers.gcal_dashboard_contract import (
     DetailMessageSerializer,
     SuccessRateResponseSerializer,
@@ -53,7 +53,7 @@ class SuccessRateView(APIView):
     Permissions: HasPerm("import_spreadsheet")
     """
 
-    permission_classes = [IsAuthenticated, HasPerm("operate_preagenda") | HasPerm("approve_solicitation")]
+    permission_classes = [IsAuthenticated, CanUseGcal]
 
     @extend_schema(responses=SuccessRateResponseSerializer)
     def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
@@ -127,7 +127,7 @@ class TopInsightsView(APIView):
     Ordenação: -error, -count
     """
 
-    permission_classes = [IsAuthenticated, HasPerm("operate_preagenda") | HasPerm("approve_solicitation")]
+    permission_classes = [IsAuthenticated, CanUseGcal]
 
     @extend_schema(
         responses={

--- a/v2/backend/apps/core/views_gcal/summary.py
+++ b/v2/backend/apps/core/views_gcal/summary.py
@@ -23,7 +23,7 @@ from drf_spectacular.utils import extend_schema
 
 from apps.core.models import Solicitacao
 from apps.core.pagination import LargePagination
-from apps.core.permissions import HasPerm
+from apps.core.rbac.policies import CanUseGcal
 from apps.core.serializers import SolicitacaoSerializer
 from apps.core.serializers.gcal_dashboard_contract import (
     AlertsSummaryResponseSerializer,
@@ -53,7 +53,7 @@ class GCalStatusSummaryView(APIView):
     }
     """
 
-    permission_classes = [IsAuthenticated, HasPerm("operate_preagenda") | HasPerm("approve_solicitation")]
+    permission_classes = [IsAuthenticated, CanUseGcal]
 
     @extend_schema(responses=GCalStatusSummaryResponseSerializer)
     def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
@@ -94,7 +94,7 @@ class GCalListView(APIView):
     }
     """
 
-    permission_classes = [IsAuthenticated, HasPerm("operate_preagenda") | HasPerm("approve_solicitation")]
+    permission_classes = [IsAuthenticated, CanUseGcal]
     pagination_class = LargePagination
 
     @extend_schema(responses=PaginatedSolicitacaoResponseSerializer)
@@ -162,7 +162,7 @@ class DashboardMetricsView(APIView):
     Permissions: HasPerm("import_spreadsheet")
     """
 
-    permission_classes = [IsAuthenticated, HasPerm("operate_preagenda") | HasPerm("approve_solicitation")]
+    permission_classes = [IsAuthenticated, CanUseGcal]
 
     @extend_schema(responses=DashboardMetricsResponseSerializer)
     def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
@@ -263,7 +263,7 @@ class AlertsSummaryView(APIView):
     Timezone-aware: Usa helper _filter_events_queryset (clamp local→UTC)
     """
 
-    permission_classes = [IsAuthenticated, HasPerm("operate_preagenda") | HasPerm("approve_solicitation")]
+    permission_classes = [IsAuthenticated, CanUseGcal]
 
     @extend_schema(responses=AlertsSummaryResponseSerializer)
     def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:

--- a/v2/backend/apps/core/views_oauth.py
+++ b/v2/backend/apps/core/views_oauth.py
@@ -31,7 +31,7 @@ from rest_framework.response import Response
 from rest_framework.throttling import UserRateThrottle
 
 from apps.core.models import AuditLog, GoogleOAuthCredential
-from apps.core.permissions import HasPerm
+from apps.core.rbac.policies import CanUseGcal
 from apps.core.services.google_oauth import build_authorization_url, exchange_code_for_tokens, revoke_token
 from apps.core.services.oauth.oauth_flow import _is_safe_url as is_safe_url  # noqa: PLC2701
 from apps.core.services.oauth.token_manager import encrypt_token
@@ -164,7 +164,7 @@ class OAuthThrottle(UserRateThrottle):
 
 
 @api_view(["GET"])
-@permission_classes([HasPerm("operate_preagenda") | HasPerm("approve_solicitation")])
+@permission_classes([CanUseGcal])
 @throttle_classes([OAuthThrottle])
 def google_oauth_start(request: Request) -> Response:
     """
@@ -326,7 +326,7 @@ def google_oauth_callback(request: Request) -> Response:
 
 
 @api_view(["GET"])
-@permission_classes([HasPerm("operate_preagenda") | HasPerm("approve_solicitation")])
+@permission_classes([CanUseGcal])
 def google_oauth_status(request: Request) -> Response:
     """
     Retorna status da conexão OAuth do usuário.
@@ -391,7 +391,7 @@ def google_oauth_status(request: Request) -> Response:
 
 
 @api_view(["POST"])
-@permission_classes([HasPerm("operate_preagenda") | HasPerm("approve_solicitation")])
+@permission_classes([CanUseGcal])
 def google_oauth_disconnect(request: Request) -> Response:
     """
     Desconecta conta Google (revoga refresh_token).
@@ -438,7 +438,7 @@ def google_oauth_disconnect(request: Request) -> Response:
 
 
 @api_view(["GET"])
-@permission_classes([HasPerm("operate_preagenda") | HasPerm("approve_solicitation")])
+@permission_classes([CanUseGcal])
 def google_oauth_list_events(request: Request) -> Response:
     """
     Lista eventos de um calendário Google do usuário.
@@ -494,7 +494,7 @@ def google_oauth_list_events(request: Request) -> Response:
 
 
 @api_view(["GET"])
-@permission_classes([HasPerm("operate_preagenda") | HasPerm("approve_solicitation")])
+@permission_classes([CanUseGcal])
 def google_oauth_list_calendars(request: Request) -> Response:
     """
     Lista calendários disponíveis do usuário OAuth.
@@ -551,7 +551,7 @@ def google_oauth_list_calendars(request: Request) -> Response:
 
 
 @api_view(["POST"])
-@permission_classes([HasPerm("operate_preagenda") | HasPerm("approve_solicitation")])
+@permission_classes([CanUseGcal])
 def google_oauth_select_calendar(request: Request) -> Response:
     """
     Salva calendário selecionado pelo usuário.

--- a/v2/backend/apps/core/views_solicitacao.py
+++ b/v2/backend/apps/core/views_solicitacao.py
@@ -35,6 +35,7 @@ from .api_schemas import (
 )
 from .models import AuditLog, Solicitacao
 from .permissions import HasPerm, IsOwnerOrPrivileged
+from .rbac.policies import CanUseGcal
 from .serializers import SolicitacaoSerializer
 from .services.solicitacao_approval import (
     approve_solicitacao,
@@ -672,11 +673,10 @@ class SolicitacaoViewSet(viewsets.ModelViewSet):
     @action(
         detail=True,
         methods=["post"],
-        # Issue #1222 (Epic 1): operações GCal (preview/publish/resync/cancel)
-        # são responsabilidade do Controle (operate_preagenda) e Super
-        # (approve_solicitation, que publica eventos aprovados). Antes era
-        # `import_spreadsheet` (artefato do codemod Epic 5.2).
-        permission_classes=[HasPerm("operate_preagenda") | HasPerm("approve_solicitation")],
+        # Issue #1233 (Epic 4.2.a): operações GCal usam Policy `use_gcal`
+        # (Controle + Super). Antes Epic 1.6 já havia composto `operate_preagenda
+        # | approve_solicitation` aqui — agora encapsulado em CanUseGcal.
+        permission_classes=[CanUseGcal],
         url_path="preview-gcal",
     )
     def preview_gcal(self, request, pk=None):
@@ -701,11 +701,10 @@ class SolicitacaoViewSet(viewsets.ModelViewSet):
     @action(
         detail=True,
         methods=["post"],
-        # Issue #1222 (Epic 1): operações GCal (preview/publish/resync/cancel)
-        # são responsabilidade do Controle (operate_preagenda) e Super
-        # (approve_solicitation, que publica eventos aprovados). Antes era
-        # `import_spreadsheet` (artefato do codemod Epic 5.2).
-        permission_classes=[HasPerm("operate_preagenda") | HasPerm("approve_solicitation")],
+        # Issue #1233 (Epic 4.2.a): operações GCal usam Policy `use_gcal`
+        # (Controle + Super). Antes Epic 1.6 já havia composto `operate_preagenda
+        # | approve_solicitation` aqui — agora encapsulado em CanUseGcal.
+        permission_classes=[CanUseGcal],
         url_path="publish",
     )
     def publish(self, request, pk=None):
@@ -735,11 +734,10 @@ class SolicitacaoViewSet(viewsets.ModelViewSet):
     @action(
         detail=True,
         methods=["post"],
-        # Issue #1222 (Epic 1): operações GCal (preview/publish/resync/cancel)
-        # são responsabilidade do Controle (operate_preagenda) e Super
-        # (approve_solicitation, que publica eventos aprovados). Antes era
-        # `import_spreadsheet` (artefato do codemod Epic 5.2).
-        permission_classes=[HasPerm("operate_preagenda") | HasPerm("approve_solicitation")],
+        # Issue #1233 (Epic 4.2.a): operações GCal usam Policy `use_gcal`
+        # (Controle + Super). Antes Epic 1.6 já havia composto `operate_preagenda
+        # | approve_solicitation` aqui — agora encapsulado em CanUseGcal.
+        permission_classes=[CanUseGcal],
         url_path="resync-gcal",
     )
     def resync_gcal(self, request, pk=None):
@@ -770,11 +768,10 @@ class SolicitacaoViewSet(viewsets.ModelViewSet):
     @action(
         detail=True,
         methods=["post"],
-        # Issue #1222 (Epic 1): operações GCal (preview/publish/resync/cancel)
-        # são responsabilidade do Controle (operate_preagenda) e Super
-        # (approve_solicitation, que publica eventos aprovados). Antes era
-        # `import_spreadsheet` (artefato do codemod Epic 5.2).
-        permission_classes=[HasPerm("operate_preagenda") | HasPerm("approve_solicitation")],
+        # Issue #1233 (Epic 4.2.a): operações GCal usam Policy `use_gcal`
+        # (Controle + Super). Antes Epic 1.6 já havia composto `operate_preagenda
+        # | approve_solicitation` aqui — agora encapsulado em CanUseGcal.
+        permission_classes=[CanUseGcal],
         url_path="cancel-gcal",
     )
     def cancel_gcal(self, request, pk=None):


### PR DESCRIPTION
**Parent epic**: #1231 / Parent issue: #1233
**Lote 1 de 3** da Epic 4.2 (RBAC Access Policy Realignment).

## Resumo

Migra **27 sites** de composition OR ad-hoc (`HasPerm("a") | HasPerm("b")`) para as classes Policy nomeadas introduzidas em Epic 4.1 (PR #1239 já mergeado).

**Paridade comportamental garantida**: capabilities da Policy idênticas à composition OR (Epic 1.6 já tinha consolidado a expansão semântica). Zero diferença de permission resolution — apenas encapsulamento.

## Arquivos (8)

| Arquivo | Sites | Policy |
|---|---|---|
| `views_solicitacao.py` | 4 actions (preview/publish/resync/cancel GCal) | `CanUseGcal` |
| `views_oauth.py` | 6 endpoints OAuth GCal | `CanUseGcal` |
| `views_gcal/gcal.py` | 3 FBVs | `CanUseGcal` |
| `views_gcal/batch.py` | 3 ViewSets | `CanUseGcal` |
| `views_gcal/detail.py` | 4 endpoints | `CanUseGcal` |
| `views_gcal/summary.py` | 4 endpoints | `CanUseGcal` |
| `views_gcal/insights.py` | 2 endpoints | `CanUseGcal` |
| `views/admin.py` | 1 site (AuditLogViewSet, 4 caps) | `CanAccessAuditLogs` |
| **Total** | **27** | |

Diff: +50 / -58 linhas (encolheu 8 linhas — composition longa virou Policy curta).

## Out of scope (próximos lotes)

- **4.2.b**: Reports/Dashboards/DAT-Compras (~10 sites) + nova Policy `view_team_metrics`
- **4.2.c**: Imports (~7 sites)

Adiados pra Epic 4.6: composições raras sem policy madura (`manage_app_config`, `manage_admin_audit`) e ~13 single-cap uniformizáveis.

## Validação local

- ✅ pytest gcal/oauth/audit/solicitacao/rbac suites: **381/381 passed** (paridade exata vs baseline pre-migração)
- ✅ pytest apps/core/tests/ full: **1782 passed**, 43 skipped (zero regressão)
- ✅ black + isort clean
- ✅ grep `HasPerm("operate_preagenda") | HasPerm("approve_solicitation")` em arquivos do lote → zero matches

## Imports limpos

`HasPerm` removido em `views_oauth.py` + `views_gcal/*.py` (não era mais usado após migração). `views_solicitacao.py` e `admin.py` mantém `HasPerm` para outros usos single-cap (que ficam para Epic 4.6).

## Test plan

- [x] Suite full passa (zero regressão)
- [x] Tests específicos de GCal/OAuth/Audit passam (paridade)
- [x] Lint clean
- [x] Smoke por role: capabilities idênticas → comportamento idêntico

---

🟢 Sem mudança comportamental. Sem migration. Sem mudança de seed. Apenas encapsulamento arquitetural.

## Staging gate

ALL 8 CHECKS PASSED

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR
- [x] Feature complete (Lote 4.2.a entrega; 4.2.b e 4.2.c em PRs separados)
- [x] Tests updated (sem testes novos — paridade comportamental valida via tests existentes)
- [x] TS/Lint clean (black + isort + pyright + flake8)
- [x] No breaking API changes (mesma decisão de permission)
- [x] DB migration idempotente (sem migration nesse PR)
- [x] Documentação atualizada (comentário inline em cada view substituída referenciando Epic 4.2.a)

### Evidência local (equivalente staging-full)

```
$ docker exec aprender_dev-web-1 pytest apps/core/tests/ -q --tb=no -k "gcal or oauth or audit or solicitacao_approve_reject or rbac_endpoints"
381 passed, 2 skipped, 1442 deselected, 8 warnings in 77.31s

$ docker exec aprender_dev-web-1 pytest apps/core/tests/ -q --tb=no
1782 passed, 43 skipped, 8 warnings in 315.47s

$ python -m black --check + python -m isort --check-only
8 files would be left unchanged
```