### PR TITLE
feat(rbac): Issue 4.4 — endpoint GET /api/me/policies/ + DRY semântico

### DIFF
--- a/v2/backend/apps/core/rbac/__init__.py
+++ b/v2/backend/apps/core/rbac/__init__.py
@@ -39,9 +39,10 @@ from apps.core.rbac.permissions import (
     IsOwnerOrPrivileged,
 )
 
-# Capability Policy Layer (Epic 4.1, Issue #1232)
+# Capability Policy Layer (Epic 4.1, Issue #1232 + Epic 4.4, Issue #1235)
 from apps.core.rbac.policies import (
     ACCESS_POLICIES,
+    PUBLIC_POLICY_KEYS,
     CanAccessAuditLogs,
     CanImportAvailabilityBlocks,
     CanImportCompras,
@@ -57,6 +58,8 @@ from apps.core.rbac.policies import (
     CanViewMapMetrics,
     CanViewOverviewDashboard,
     CanViewReports,
+    resolve_public_policies,
+    user_has_policy,
 )
 
 __all__ = [
@@ -69,8 +72,11 @@ __all__ = [
     "user_has_all_perms",
     "COORDENADOR_ROLE_GROUPS",
     "FORMADOR_ROLE_GROUPS",
-    # Capability Policy Layer (Epic 4.1)
+    # Capability Policy Layer (Epic 4.1 + 4.4)
     "ACCESS_POLICIES",
+    "PUBLIC_POLICY_KEYS",
+    "user_has_policy",
+    "resolve_public_policies",
     "CanAccessAuditLogs",
     "CanImportAvailabilityBlocks",
     "CanImportCompras",

--- a/v2/backend/apps/core/rbac/policies.py
+++ b/v2/backend/apps/core/rbac/policies.py
@@ -155,6 +155,10 @@ class _PolicyPermission(permissions.BasePermission):  # type: ignore[misc]
       3. Policy key ausente / matriz vazia → False (fail-secure)
       4. Caso geral → `user_has_any_perm(user, *capabilities)`
 
+    DRY (Epic 4.4): a semântica vive em `user_has_policy`. Esta classe
+    apenas delega — view, tests e helpers compartilham a mesma fonte de
+    verdade. Mudar política de avaliação = mudar `user_has_policy`.
+
     Composition `CanA() | CanB()` funciona via DRF OR (monkey-patch de
     `permissions.OR.__call__` aplicado em `apps.core.rbac.permissions`).
     """
@@ -162,15 +166,7 @@ class _PolicyPermission(permissions.BasePermission):  # type: ignore[misc]
     policy: str = ""  # subclasses override
 
     def has_permission(self, request: Request, view: APIView) -> bool:
-        user = request.user
-        if not user or not user.is_authenticated:
-            return False
-        if getattr(user, "is_superuser", False):
-            return True
-        codenames = ACCESS_POLICIES.get(self.policy)
-        if not codenames:
-            return False
-        return user_has_any_perm(user, *codenames)
+        return user_has_policy(request.user, self.policy)
 
     def __repr__(self) -> str:
         return f"{type(self).__name__}(policy={self.policy!r})"
@@ -259,9 +255,102 @@ class CanManagePurchasesAndMaterials(_PolicyPermission):
     policy = "manage_purchases_and_materials"
 
 
+# ============================================================================
+# Public surface (Epic 4.4, Issue #1235): contrato externo `/api/me/policies/`
+# ============================================================================
+#
+# `PUBLIC_POLICY_KEYS` é o conjunto de policy keys EXPOSTAS via
+# `GET /api/me/policies/`. Subset de `ACCESS_POLICIES` — futuras policies
+# internas (não públicas) ficariam fora deste registro.
+#
+# Stability rules (memória `feedback_capability_policy_layer_pattern.md §6`):
+#   - Adicionar key aqui = compatível (frontend opt-in via `policies.includes`)
+#   - Renomear key = BREAKING (deprecation period de 2 releases)
+#   - Remover key = BREAKING (deprecation period)
+#   - Mudar capabilities elegíveis (ACCESS_POLICIES[k]) = compatível
+#
+# Procedure para nova policy pública:
+#   1. Adicionar entrada em ACCESS_POLICIES
+#   2. Criar classe Can<CamelCase>(_PolicyPermission)
+#   3. Adicionar key aqui em PUBLIC_POLICY_KEYS
+#   4. Atualizar snapshot test (Epic 4.5)
+#   5. Re-export classe em apps/core/rbac/__init__.py
+#
+# Test de paridade em test_me_policies.py garante que dev não esqueça step 3.
+
+PUBLIC_POLICY_KEYS: Final[frozenset[str]] = frozenset(
+    {
+        "access_audit_logs",
+        "manage_solicitacao_status",
+        "view_compras_dashboard",
+        "view_compras_pendencias",
+        "view_compras_stats",
+        "view_overview_dashboard",
+        "view_map_metrics",
+        "view_reports",
+        "use_gcal",
+        "view_all_availability",
+        "import_availability_blocks",
+        "import_compras",
+        "import_generic_spreadsheet",
+        "manage_admin_registries",
+        "manage_purchases_and_materials",
+    }
+)
+
+
+# ============================================================================
+# Helpers (SSOT da semântica de Policy — usado por View, tests, admin futuro)
+# ============================================================================
+
+
+def user_has_policy(user, key: str) -> bool:
+    """
+    True sse o usuário possui a policy identificada por `key`.
+
+    Semântica (idêntica a `_PolicyPermission.has_permission` — esta função
+    é a fonte única de verdade; `_PolicyPermission` delega para cá):
+
+        anonymous / None  → False
+        superuser         → True
+        key não na matriz → False (fail-secure)
+        caso geral        → user_has_any_perm(user, *capabilities) (OR)
+
+    Aceita keys de ACCESS_POLICIES inteiro (públicas OU internas), porque
+    a função é o universal "user holds this policy?" — exposição pública
+    é responsabilidade de `resolve_public_policies` / endpoint, não da
+    semântica subjacente.
+    """
+    if not user or not getattr(user, "is_authenticated", False):
+        return False
+    if getattr(user, "is_superuser", False):
+        return True
+    codenames = ACCESS_POLICIES.get(key)
+    if not codenames:
+        return False
+    return user_has_any_perm(user, *codenames)
+
+
+def resolve_public_policies(user) -> list[str]:
+    """
+    Retorna lista ordenada (alfabética) das `PUBLIC_POLICY_KEYS` que o
+    usuário possui. Backend de `GET /api/me/policies/`.
+
+    - Anonymous → [] (endpoint trata 401 antes via IsAuthenticated)
+    - Superuser → todas as PUBLIC_POLICY_KEYS sorted
+    - User regular → subset baseado em capabilities (OR semantics)
+
+    Não vaza capability codenames — só keys do registro público.
+    """
+    return sorted(k for k in PUBLIC_POLICY_KEYS if user_has_policy(user, k))
+
+
 __all__ = [
     "ACCESS_POLICIES",
+    "PUBLIC_POLICY_KEYS",
     "_PolicyPermission",
+    "user_has_policy",
+    "resolve_public_policies",
     "CanAccessAuditLogs",
     "CanManageSolicitacaoStatus",
     "CanViewComprasDashboard",

--- a/v2/backend/apps/core/rbac/policies.py
+++ b/v2/backend/apps/core/rbac/policies.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 
 from typing import Final
 
+from django.contrib.auth.models import AbstractBaseUser, AnonymousUser
 from rest_framework import permissions
 from rest_framework.request import Request
 from rest_framework.views import APIView
@@ -304,7 +305,7 @@ PUBLIC_POLICY_KEYS: Final[frozenset[str]] = frozenset(
 # ============================================================================
 
 
-def user_has_policy(user, key: str) -> bool:
+def user_has_policy(user: AbstractBaseUser | AnonymousUser | None, key: str) -> bool:
     """
     True sse o usuário possui a policy identificada por `key`.
 
@@ -331,7 +332,7 @@ def user_has_policy(user, key: str) -> bool:
     return user_has_any_perm(user, *codenames)
 
 
-def resolve_public_policies(user) -> list[str]:
+def resolve_public_policies(user: AbstractBaseUser | AnonymousUser | None) -> list[str]:
     """
     Retorna lista ordenada (alfabética) das `PUBLIC_POLICY_KEYS` que o
     usuário possui. Backend de `GET /api/me/policies/`.

--- a/v2/backend/apps/core/tests/test_me_policies.py
+++ b/v2/backend/apps/core/tests/test_me_policies.py
@@ -77,11 +77,7 @@ def _public_policies_for_cap(cap: str) -> list[str]:
     Subset de PUBLIC_POLICY_KEYS cujas capabilities elegíveis incluem `cap`.
     Usa a matriz como SSOT para o assert (não hand-written).
     """
-    return sorted(
-        key
-        for key, caps in ACCESS_POLICIES.items()
-        if key in PUBLIC_POLICY_KEYS and cap in caps
-    )
+    return sorted(key for key, caps in ACCESS_POLICIES.items() if key in PUBLIC_POLICY_KEYS and cap in caps)
 
 
 # ============================================================================
@@ -172,9 +168,7 @@ class TestContract:
         client.force_authenticate(user=user)
         res = client.get(reverse(ENDPOINT_URL_NAME))
         body = res.json()
-        assert isinstance(body, list), (
-            f"Response deve ser JSON list (flat), não object. Got: {type(body).__name__}"
-        )
+        assert isinstance(body, list), f"Response deve ser JSON list (flat), não object. Got: {type(body).__name__}"
 
     def test_response_is_alphabetically_sorted(self, seeded_db):
         User = get_user_model()
@@ -285,6 +279,4 @@ class TestParity:
     def test_all_public_keys_exist_in_access_policies_matrix(self):
         """PUBLIC_POLICY_KEYS é subset de ACCESS_POLICIES (sem keys fantasmas)."""
         orphans = set(PUBLIC_POLICY_KEYS) - set(ACCESS_POLICIES.keys())
-        assert not orphans, (
-            f"PUBLIC_POLICY_KEYS contém keys ausentes de ACCESS_POLICIES: {sorted(orphans)}"
-        )
+        assert not orphans, f"PUBLIC_POLICY_KEYS contém keys ausentes de ACCESS_POLICIES: {sorted(orphans)}"

--- a/v2/backend/apps/core/tests/test_me_policies.py
+++ b/v2/backend/apps/core/tests/test_me_policies.py
@@ -1,0 +1,290 @@
+"""
+Testes para `GET /api/me/policies/` (Epic 4.4, Issue #1235).
+
+Cobertura:
+- Anonymous → 401/403
+- Authenticated sem capabilities → []
+- Superuser → todas as PUBLIC_POLICY_KEYS ordenadas
+- User com cap específica (manage_admin_registries / view_compras_dashboard /
+  operate_preagenda) → subset derivado da matriz (assert robusto, não hand-written)
+- Contrato: response é JSON list, sorted, sem leakage de codenames
+- Parity: PUBLIC_POLICY_KEYS == set de todas as classes Can* declaradas em
+  apps.core.rbac.policies (guarda Epic 4.5)
+
+Padrão: TDD-first — testes escritos antes da implementação.
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportOptionalMemberAccess=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportMissingTypeArgument=false, reportCallIssue=false, reportIndexIssue=false, reportOperatorIssue=false, reportOptionalSubscript=false, reportUnknownLambdaType=false, reportPrivateUsage=false
+
+from __future__ import annotations
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+from django.core.management import call_command
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+import pytest
+
+from apps.core.models import PermissaoFuncional
+from apps.core.rbac.policies import ACCESS_POLICIES, PUBLIC_POLICY_KEYS, _PolicyPermission
+
+pytestmark = pytest.mark.django_db
+
+ENDPOINT_URL_NAME = "core:me-policies"
+
+
+# ============================================================================
+# Helpers (espelham test_rbac_policies.py — atomic counter, NÃO hash)
+# ============================================================================
+
+
+_USER_COUNTER = {"i": 0}
+
+
+def _next_cpf() -> str:
+    """CPF único determinístico por test session."""
+    _USER_COUNTER["i"] += 1
+    return f"99988{_USER_COUNTER['i']:06d}"
+
+
+def _make_user(username: str, *codenames: str):
+    """Cria User autenticado e atribui capabilities via grupo dedicado."""
+    User = get_user_model()
+    user = User.objects.create_user(
+        username=username,
+        email=f"{username}@example.com",
+        password="testpass123",
+        cpf=_next_cpf(),
+    )
+    if codenames:
+        group, _ = Group.objects.get_or_create(name=f"test-group-{username}")
+        user.groups.add(group)
+        for code in codenames:
+            perm = PermissaoFuncional.objects.filter(codename=code).first()
+            assert perm is not None, f"PermissaoFuncional '{code}' não está no seed"
+            perm.groups.add(group)
+    return user
+
+
+@pytest.fixture
+def seeded_db(db):
+    call_command("seed_rbac")
+
+
+def _public_policies_for_cap(cap: str) -> list[str]:
+    """
+    Subset de PUBLIC_POLICY_KEYS cujas capabilities elegíveis incluem `cap`.
+    Usa a matriz como SSOT para o assert (não hand-written).
+    """
+    return sorted(
+        key
+        for key, caps in ACCESS_POLICIES.items()
+        if key in PUBLIC_POLICY_KEYS and cap in caps
+    )
+
+
+# ============================================================================
+# A. Auth
+# ============================================================================
+
+
+class TestAuth:
+    def test_anonymous_returns_401_or_403(self):
+        """User não autenticado → 401 (ou 403, depende do auth backend)."""
+        client = APIClient()
+        res = client.get(reverse(ENDPOINT_URL_NAME))
+        assert res.status_code in (401, 403)
+
+
+# ============================================================================
+# B. Empty / Superuser
+# ============================================================================
+
+
+class TestBasicCases:
+    def test_authenticated_user_with_no_capabilities_returns_empty_list(self, seeded_db):
+        user = _make_user("noperms")
+        client = APIClient()
+        client.force_authenticate(user=user)
+        res = client.get(reverse(ENDPOINT_URL_NAME))
+        assert res.status_code == 200
+        body = res.json()
+        assert isinstance(body, list)
+        assert body == []
+
+    def test_superuser_returns_all_public_policy_keys_sorted(self, seeded_db):
+        User = get_user_model()
+        super_user = User.objects.create_superuser(
+            username="super_test",
+            email="super_test@example.com",
+            password="testpass123",
+            cpf="99900000999",
+        )
+        client = APIClient()
+        client.force_authenticate(user=super_user)
+        res = client.get(reverse(ENDPOINT_URL_NAME))
+        assert res.status_code == 200
+        body = res.json()
+        assert body == sorted(PUBLIC_POLICY_KEYS)
+
+
+# ============================================================================
+# C. Capability-derived subsets (assert robusto via matriz)
+# ============================================================================
+
+
+class TestCapabilityDerivedSubsets:
+    def test_dat_user_returns_policies_with_manage_admin_registries(self, seeded_db):
+        user = _make_user("dat_user", "manage_admin_registries")
+        client = APIClient()
+        client.force_authenticate(user=user)
+        res = client.get(reverse(ENDPOINT_URL_NAME))
+        assert res.status_code == 200
+        assert res.json() == _public_policies_for_cap("manage_admin_registries")
+
+    def test_diretoria_user_returns_policies_with_view_compras_dashboard(self, seeded_db):
+        user = _make_user("dir_user", "view_compras_dashboard")
+        client = APIClient()
+        client.force_authenticate(user=user)
+        res = client.get(reverse(ENDPOINT_URL_NAME))
+        assert res.status_code == 200
+        assert res.json() == _public_policies_for_cap("view_compras_dashboard")
+
+    def test_controle_user_returns_policies_with_operate_preagenda(self, seeded_db):
+        user = _make_user("controle_user", "operate_preagenda")
+        client = APIClient()
+        client.force_authenticate(user=user)
+        res = client.get(reverse(ENDPOINT_URL_NAME))
+        assert res.status_code == 200
+        assert res.json() == _public_policies_for_cap("operate_preagenda")
+
+
+# ============================================================================
+# D. Contract (shape, sorting, no leakage)
+# ============================================================================
+
+
+class TestContract:
+    def test_response_is_a_json_list_not_object(self, seeded_db):
+        user = _make_user("contract_user", "manage_admin_registries")
+        client = APIClient()
+        client.force_authenticate(user=user)
+        res = client.get(reverse(ENDPOINT_URL_NAME))
+        body = res.json()
+        assert isinstance(body, list), (
+            f"Response deve ser JSON list (flat), não object. Got: {type(body).__name__}"
+        )
+
+    def test_response_is_alphabetically_sorted(self, seeded_db):
+        User = get_user_model()
+        super_user = User.objects.create_superuser(
+            username="sorted_test",
+            email="sorted_test@example.com",
+            password="testpass123",
+            cpf="99900001000",
+        )
+        client = APIClient()
+        client.force_authenticate(user=super_user)
+        res = client.get(reverse(ENDPOINT_URL_NAME))
+        body = res.json()
+        assert body == sorted(body), "Response deve estar ordenada alfabeticamente"
+
+    def test_response_never_leaks_keys_outside_public_registry(self, seeded_db):
+        """
+        Anti-leakage guard: nenhum elemento da response pode ser uma key fora
+        de PUBLIC_POLICY_KEYS. Garante que policy interna futura não vaze.
+        """
+        User = get_user_model()
+        super_user = User.objects.create_superuser(
+            username="leak_test",
+            email="leak_test@example.com",
+            password="testpass123",
+            cpf="99900001001",
+        )
+        client = APIClient()
+        client.force_authenticate(user=super_user)
+        res = client.get(reverse(ENDPOINT_URL_NAME))
+        body = set(res.json())
+        leaked = body - PUBLIC_POLICY_KEYS
+        assert not leaked, (
+            f"Response contém keys fora do registry público: {sorted(leaked)}. "
+            "PUBLIC_POLICY_KEYS é o contrato — nada além dele pode aparecer."
+        )
+
+    def test_response_never_contains_capability_codenames(self, seeded_db):
+        """
+        Defesa em profundidade: garante que nenhum codename "nu" (ex:
+        "approve_solicitation_batch") apareça na response. As únicas keys
+        que coincidem com codenames são single-cap policies registradas em
+        PUBLIC_POLICY_KEYS (manage_admin_registries, manage_purchases_and_materials,
+        view_compras_dashboard, view_overview_dashboard, view_map_metrics,
+        view_all_availability) — essas são intencionais.
+        """
+        User = get_user_model()
+        super_user = User.objects.create_superuser(
+            username="codename_leak_test",
+            email="codename_leak_test@example.com",
+            password="testpass123",
+            cpf="99900001002",
+        )
+        client = APIClient()
+        client.force_authenticate(user=super_user)
+        res = client.get(reverse(ENDPOINT_URL_NAME))
+        body = set(res.json())
+
+        # Capabilities multi-cap (compostas em policies via OR) NÃO podem
+        # aparecer como key direta na response — só policies semânticas.
+        all_caps: set[str] = set()
+        for caps in ACCESS_POLICIES.values():
+            all_caps.update(caps)
+        # Codenames que são também keys públicas são intencionais (single-cap policies)
+        intentional_overlap = all_caps & PUBLIC_POLICY_KEYS
+        forbidden_codenames = all_caps - intentional_overlap
+        leaked = body & forbidden_codenames
+        assert not leaked, (
+            f"Capability codenames vazaram na response: {sorted(leaked)}. "
+            "Endpoint deve expor APENAS policy keys, nunca capabilities brutas."
+        )
+
+
+# ============================================================================
+# E. Parity (guarda contra esquecimento de registrar Can* nova)
+# ============================================================================
+
+
+class TestParity:
+    def test_public_policy_keys_match_all_policy_classes_in_module(self):
+        """
+        PUBLIC_POLICY_KEYS deve cobrir EXATAMENTE o conjunto de policies
+        declaradas como Can* em apps.core.rbac.policies. Falha se:
+          - Dev adicionou Can* nova mas esqueceu de registrar em PUBLIC_POLICY_KEYS
+          - Dev removeu Can* mas esqueceu de remover de PUBLIC_POLICY_KEYS
+
+        Quando Epic 4.5+ introduzir Policy interna (não pública), upgrade:
+            INTERNAL_POLICY_KEYS = frozenset(...)
+            assert all_class_policies == PUBLIC_POLICY_KEYS | INTERNAL_POLICY_KEYS
+            assert PUBLIC_POLICY_KEYS.isdisjoint(INTERNAL_POLICY_KEYS)
+        """
+        all_class_policies = {
+            cls.policy
+            for cls in _PolicyPermission.__subclasses__()
+            if cls.policy and cls.__module__ == "apps.core.rbac.policies"
+        }
+        missing_in_registry = all_class_policies - set(PUBLIC_POLICY_KEYS)
+        extra_in_registry = set(PUBLIC_POLICY_KEYS) - all_class_policies
+        assert not missing_in_registry, (
+            f"Classes Can* sem entrada em PUBLIC_POLICY_KEYS: {sorted(missing_in_registry)}. "
+            "Toda Can* nova deve ser registrada conscientemente como pública."
+        )
+        assert not extra_in_registry, (
+            f"PUBLIC_POLICY_KEYS contém keys sem classe Can* correspondente: "
+            f"{sorted(extra_in_registry)}. Remover key órfã."
+        )
+
+    def test_all_public_keys_exist_in_access_policies_matrix(self):
+        """PUBLIC_POLICY_KEYS é subset de ACCESS_POLICIES (sem keys fantasmas)."""
+        orphans = set(PUBLIC_POLICY_KEYS) - set(ACCESS_POLICIES.keys())
+        assert not orphans, (
+            f"PUBLIC_POLICY_KEYS contém keys ausentes de ACCESS_POLICIES: {sorted(orphans)}"
+        )

--- a/v2/backend/apps/core/urls.py
+++ b/v2/backend/apps/core/urls.py
@@ -40,7 +40,7 @@ from .views import (  # ASQ-005: async imports; DAT Module ViewSets; Plano Forma
 )
 
 # Imports de módulos isolados (GAP-001 fix)
-from .views.me import MeEventsListView
+from .views.me import MeEventsListView, MePoliciesView
 from .views.stats import HomeStatsView
 from .views_auth import csrf_token, login, logout, ping
 from .views_availability import AvailabilityBlockViewSet, AvailabilityCheckManyView, AvailabilityCheckView
@@ -162,6 +162,7 @@ urlpatterns = [
     path("features/", features, name="features"),
     path("me/", CurrentUserView.as_view(), name="current-user"),
     path("me/events/", MeEventsListView.as_view(), name="me-events"),
+    path("me/policies/", MePoliciesView.as_view(), name="me-policies"),
     path("rbac/meta/", RBACMetaView.as_view(), name="rbac-meta"),
     path("stats/home/", HomeStatsView.as_view(), name="stats-home"),
     # CSRF Token (Issue #135)

--- a/v2/backend/apps/core/views/me.py
+++ b/v2/backend/apps/core/views/me.py
@@ -8,6 +8,10 @@ Issue #1224 (Epic 2 RBAC Access Policy Realignment): novo endpoint
 o caso primário (única página acessível por intent matrix); qualquer user
 autenticado pode chamar.
 
+Issue #1235 (Epic 4.4): `GET /api/me/policies/` expõe a lista ordenada de
+PUBLIC_POLICY_KEYS que o usuário possui — contrato externo consumido pelo
+frontend para menu condicional, redirects, mensagens de erro genéricas.
+
 Type-checked with Pyright (strict mode).
 """
 
@@ -16,13 +20,17 @@ Type-checked with Pyright (strict mode).
 from __future__ import annotations
 
 from django.db.models import QuerySet
-from rest_framework import generics
+from rest_framework import generics, serializers
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
 
-from drf_spectacular.utils import extend_schema, extend_schema_view
+from drf_spectacular.utils import extend_schema, extend_schema_view, inline_serializer
 
 from apps.core.api_schemas import COMMON_ERROR_RESPONSES
 from apps.core.models import Solicitacao
+from apps.core.rbac.policies import resolve_public_policies
 from apps.core.serializers.me import MeEventSerializer
 
 
@@ -69,3 +77,52 @@ class MeEventsListView(generics.ListAPIView):
             .order_by("-inicio")
             .distinct()
         )
+
+
+@extend_schema_view(
+    get=extend_schema(
+        summary="Listar policies do usuário autenticado",
+        description=(
+            "Retorna a lista ordenada das policy keys públicas que o usuário "
+            "autenticado possui (subset de `PUBLIC_POLICY_KEYS`). Frontend usa "
+            "esta lista para menu condicional, redirects e mensagens de erro "
+            "genéricas (ex: `policies.includes('view_compras_dashboard')`).\n\n"
+            "Semântica:\n"
+            "- Anonymous → 401\n"
+            "- Authenticated sem capabilities → []\n"
+            "- Superuser → todas as PUBLIC_POLICY_KEYS\n"
+            "- User regular → subset baseado em capabilities (OR semantics)\n\n"
+            "Contrato: response NUNCA contém capability codenames brutos — "
+            "expõe apenas policy keys do registro público. Keys são imutáveis "
+            "após release (renomear = breaking; ver `feedback_capability_policy_layer_pattern.md` §6)."
+        ),
+        responses={
+            200: inline_serializer(
+                name="MePoliciesResponse",
+                fields={"policies": serializers.ListField(child=serializers.CharField())},
+            ),
+            401: COMMON_ERROR_RESPONSES[401],
+        },
+        tags=["me"],
+    )
+)
+class MePoliciesView(APIView):
+    """
+    Lista policy keys públicas que o user autenticado possui.
+
+    GET /api/me/policies/
+
+    Response: JSON array de strings, ordenado alfabeticamente.
+    Exemplo: `["access_audit_logs", "use_gcal", "view_compras_dashboard"]`
+
+    Permission: `IsAuthenticated`. Anonymous → 401. Superuser bypass.
+
+    Implementação delega para `apps.core.rbac.policies.resolve_public_policies`
+    (SSOT). Cache-aware via `user_has_any_perm` — ~15 lookups O(1) por request
+    após primeiro hit.
+    """
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request: Request) -> Response:
+        return Response(resolve_public_policies(request.user))

--- a/v2/docs/RBAC_NAMING.md
+++ b/v2/docs/RBAC_NAMING.md
@@ -266,7 +266,7 @@ python scripts/rbac_lint.py apps/
 
 ## 9. Policy Resolution Rules (Epic 4 — Capability Policy Layer)
 
-**Em planejamento (Issue #1231)** — adiciona 3ª camada NIST RBAC: `User → Roles → Capabilities → Policies → Views`.
+**Implementada (Issues #1231, #1232, #1233, #1234, #1235)** — 3ª camada NIST RBAC: `User → Roles → Capabilities → Policies → Views`.
 
 ### Princípios
 
@@ -317,9 +317,75 @@ ACCESS_POLICIES["access_audit_logs"] = frozenset({
 })
 ```
 
+### Public surface — `GET /api/me/policies/` (Epic 4.4, Issue #1235)
+
+Endpoint público que expõe a lista ordenada de policy keys que o usuário autenticado possui. Frontend consome para menu condicional, redirects e mensagens de erro genéricas.
+
+**Contract**:
+
+```http
+GET /api/me/policies/
+Authorization: required (IsAuthenticated)
+
+200 OK
+["access_audit_logs", "use_gcal", "view_compras_dashboard"]
+```
+
+- Response: JSON array de strings, alfabético, **sem leakage de capability codenames**.
+- Anonymous → `401`. Superuser → todas as `PUBLIC_POLICY_KEYS`. User regular → subset baseado em capabilities (OR semantics).
+
+**Public registry**:
+
+`apps.core.rbac.policies.PUBLIC_POLICY_KEYS` é o `frozenset` que define **o que é público**. Subset de `ACCESS_POLICIES`:
+
+```python
+PUBLIC_POLICY_KEYS: Final[frozenset[str]] = frozenset({
+    "access_audit_logs",
+    "use_gcal",
+    "view_compras_dashboard",
+    # ... 12 outras
+})
+```
+
+Internal-only policies futuras (não expostas via endpoint) ficam fora deste registro. Test de paridade em `test_me_policies.py::TestParity` garante que dev não esqueça de registrar Can* nova como pública conscientemente.
+
+**Stability rules**:
+
+| Operação                                              | Compatibilidade                                            |
+| ----------------------------------------------------- | ---------------------------------------------------------- |
+| Adicionar key em `PUBLIC_POLICY_KEYS`                 | Compatível (frontend opt-in via `policies.includes`)       |
+| Remover key de `PUBLIC_POLICY_KEYS`                   | Breaking (deprecation period 2 releases)                   |
+| Renomear key                                          | Breaking (deprecation period 2 releases)                   |
+| Alterar `ACCESS_POLICIES[k]` (capabilities elegíveis) | Compatível (frontend não depende)                          |
+
+**Procedure para nova policy pública**:
+
+1. Adicionar entrada em `ACCESS_POLICIES` (matriz interna)
+2. Criar classe `Can<CamelCase>(_PolicyPermission)` com `policy = "<key>"`
+3. Adicionar `<key>` em `PUBLIC_POLICY_KEYS`
+4. Atualizar snapshot (Epic 4.5 #1236)
+5. Re-export classe em `apps/core/rbac/__init__.py`
+
+**SSOT da semântica**:
+
+`apps.core.rbac.policies.user_has_policy(user, key)` é a fonte única de verdade. `_PolicyPermission.has_permission` delega para essa função (DRY); view, tests e helpers compartilham a mesma avaliação. Mudar política = mudar `user_has_policy` num único lugar.
+
+```python
+def user_has_policy(user, key: str) -> bool:
+    if not user or not user.is_authenticated:
+        return False
+    if user.is_superuser:
+        return True
+    codenames = ACCESS_POLICIES.get(key)
+    if not codenames:
+        return False
+    return user_has_any_perm(user, *codenames)
+```
+
 ---
 
 ## 10. Changelog
 
 - **2026-04-23** — v1.0 criada com Epic 2 (#1181). `HasPerm` introduzido, 12 classes factory marcadas com `warnings.warn(DeprecationWarning)` + aviso para remoção no Epic 5.
 - **2026-04-26** — v1.1 adicionou §9 Policy Resolution Rules em planejamento para Epic 4 (Issue #1231). Documenta princípios de naming, vocabulário canônico, motivo legítimo de acesso, e anti-pattern de hardcode de role.
+- **2026-04-26** — v1.2 §9 atualizado para "implementada" (Epics 4.1–4.4) + adicionado bloco "Public surface" descrevendo `GET /api/me/policies/`, `PUBLIC_POLICY_KEYS`, stability rules, procedure para nova policy pública, e SSOT da semântica via `user_has_policy` (Epic 4.4, Issue #1235).


### PR DESCRIPTION
**Parent epic**: #1231
**Closes**: #1235

## Summary

- **Endpoint público** `GET /api/me/policies/` expõe contrato externo da Capability Policy Layer (Epics 4.1-4.3) — frontend consumirá para menu condicional, redirects e mensagens de erro genéricas (Epic 3).
- **`PUBLIC_POLICY_KEYS`** explícito em `apps.core.rbac.policies` (frozenset de 15 keys) — registro consciente do que é público; futuras policies internas ficam fora.
- **DRY semântico**: `user_has_policy(user, key)` é a SSOT. `_PolicyPermission.has_permission` delega; view, tests e helpers compartilham a mesma avaliação. Mudar política = uma única edição.
- **Contract guards**: response é JSON array sorted, sem leakage de capability codenames brutos. Test de paridade impede esquecer de registrar `Can*` nova como pública.
- **Docs**: `RBAC_NAMING.md` §9 atualizado para "implementada" + bloco "Public surface" (stability rules, procedure, SSOT) + §10 changelog v1.2.

## Contract

```http
GET /api/me/policies/
Authorization: required (IsAuthenticated)

200 OK
["access_audit_logs", "use_gcal", "view_compras_dashboard"]
```

| Caso | Comportamento |
| ---- | ------------- |
| Anonymous | 401 (ou 403 conforme backend de auth) |
| User sem capabilities | 200 + `[]` |
| Superuser | 200 + todas as 15 `PUBLIC_POLICY_KEYS` ordenadas |
| User regular | 200 + subset baseado em capabilities (OR semantics) |

## Stability rules

| Operação | Compatibilidade |
| -------- | --------------- |
| Adicionar key em `PUBLIC_POLICY_KEYS` | Compatível |
| Renomear / remover key | Breaking (deprecation 2 releases) |
| Alterar `ACCESS_POLICIES[k]` (capabilities elegíveis) | Compatível |

## Test plan

- pytest apps/core/tests/test_me_policies.py — 12/12 PASS
- pytest apps/core/tests/test_rbac_policies.py (Epic 4.1) — 118/118 PASS, sem regressão do refactor DRY
- pytest apps/core/tests/ (suite completa) — 1810/1810 PASS, 43 skipped
- python manage.py check — 0 issues
- python manage.py spectacular — endpoint `/api/me/policies/` registrado corretamente
- python scripts/rbac_lint.py apps/ — 0 violações
- Naming convention: `me-policies` (kebab-case URL name, consistente com `me-events`)
- Pyright: arquivos modificados usam header existente

## Próximas etapas Epic 4

- **4.5 (#1236)**: contract snapshot tests sobre `PUBLIC_POLICY_KEYS`
- **3 (#1226)**: menu condicional via `useCanAccess` consumindo `/api/me/policies/`

## Staging gate

ALL 8 CHECKS PASSED

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR
- [x] Feature complete (Epic 4.4 — endpoint público + DRY semântico)
- [x] Tests updated (12 tests novos: auth/empty/superuser/3 capability subsets/contract guards/parity)
- [x] TS/Lint clean (black + isort + rbac_lint, 1810/1810 testes verde)