### PR TITLE
test(rbac): Issue 4.5 — contract snapshot tests para Capability Policy Layer

### DIFF
--- a/v2/backend/apps/core/tests/test_rbac_policies_contract.py
+++ b/v2/backend/apps/core/tests/test_rbac_policies_contract.py
@@ -1,0 +1,133 @@
+"""
+Contract snapshot tests para o Capability Policy Layer (Epic 4.5, Issue #1236).
+
+Estes testes congelam o **contrato externo** da camada de policies para que
+qualquer rename, remoção, adição ou drift de shape force revisão consciente
+no PR (diff do snapshot = checklist de breaking change).
+
+Escopo intencionalmente mínimo (memória `feedback_capability_policy_layer_pattern.md`):
+
+- ✅ Snapshot literal de `PUBLIC_POLICY_KEYS` (contrato externo)
+- ✅ Snapshot literal do response do endpoint `GET /api/me/policies/`
+- ✅ Defense-in-depth do shape (sorted list[str])
+
+NÃO duplica:
+- Matrix integrity / no empty / frozenset type → cobertos em `test_rbac_policies.py`
+- Naming convention regex / no `_policy` suffix → idem
+- Parity Can* ↔ PUBLIC_POLICY_KEYS → coberto em `test_me_policies.py::TestParity`
+
+NÃO snapshota:
+- `ACCESS_POLICIES` completo. A matriz interna é "implementação mutável"
+  (capabilities elegíveis podem mudar sem breaking — ver
+  `feedback_capability_policy_layer_pattern.md §6`). Snapshotar tudo geraria
+  ruído de PR sem proteção real.
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportOptionalMemberAccess=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportMissingTypeArgument=false, reportCallIssue=false, reportPrivateUsage=false
+
+from __future__ import annotations
+
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+import pytest
+
+from apps.core.rbac.policies import PUBLIC_POLICY_KEYS
+
+pytestmark = pytest.mark.django_db
+
+
+# ============================================================================
+# Snapshot literal — contrato externo
+# ============================================================================
+#
+# Esta lista É o contrato. Atualizá-la deve ser DECISÃO CONSCIENTE no PR:
+#   - Adicionar key      → compatible (frontend opt-in)
+#   - Remover/renomear   → BREAKING (deprecation period 2 releases)
+#
+# Diff desta lista no PR review = checklist obrigatório.
+
+EXPECTED_PUBLIC_POLICY_KEYS_SORTED: list[str] = [
+    "access_audit_logs",
+    "import_availability_blocks",
+    "import_compras",
+    "import_generic_spreadsheet",
+    "manage_admin_registries",
+    "manage_purchases_and_materials",
+    "manage_solicitacao_status",
+    "use_gcal",
+    "view_all_availability",
+    "view_compras_dashboard",
+    "view_compras_pendencias",
+    "view_compras_stats",
+    "view_map_metrics",
+    "view_overview_dashboard",
+    "view_reports",
+]
+
+
+class TestPublicPolicyContract:
+    def test_public_policy_keys_snapshot(self):
+        """
+        Snapshot literal de `PUBLIC_POLICY_KEYS`. Falha se alguém adiciona,
+        remove ou renomeia uma key sem atualizar este teste — forçando
+        revisão consciente do contrato público no PR.
+        """
+        assert sorted(PUBLIC_POLICY_KEYS) == EXPECTED_PUBLIC_POLICY_KEYS_SORTED
+
+
+# ============================================================================
+# Snapshot do endpoint real
+# ============================================================================
+
+
+class TestPoliciesEndpointContract:
+    def test_me_policies_endpoint_response_snapshot(self):
+        """
+        Superuser → response idêntico à lista snapshotada acima. Cobre num
+        único teste:
+            - shape (lista flat, não dict/object)
+            - ordenação alfabética
+            - conteúdo público
+            - integração view ↔ auth ↔ resolve_public_policies
+            - paridade com PUBLIC_POLICY_KEYS
+        """
+        User = get_user_model()
+        super_user = User.objects.create_superuser(
+            username="contract_snapshot_super",
+            email="contract_snapshot@example.com",
+            password="testpass123",
+            cpf="99900099999",
+        )
+        client = APIClient()
+        client.force_authenticate(user=super_user)
+        res = client.get(reverse("core:me-policies"))
+        assert res.status_code == 200
+        assert res.json() == EXPECTED_PUBLIC_POLICY_KEYS_SORTED
+
+    def test_endpoint_response_is_sorted_string_list(self):
+        """
+        Defense-in-depth: mesmo se alguém atualizar o snapshot acima sem
+        pensar, este teste semântico continua pegando drift de shape:
+            - response NÃO pode ser dict / object
+            - todos os elementos devem ser str
+            - ordem alfabética obrigatória
+
+        Esta é a última linha de defesa antes de quebrar consumidor frontend
+        que faz `policies.includes("...")`.
+        """
+        User = get_user_model()
+        super_user = User.objects.create_superuser(
+            username="contract_shape_super",
+            email="contract_shape@example.com",
+            password="testpass123",
+            cpf="99900099998",
+        )
+        client = APIClient()
+        client.force_authenticate(user=super_user)
+        res = client.get(reverse("core:me-policies"))
+        body = res.json()
+        assert isinstance(body, list), f"Response deve ser list, got {type(body).__name__}"
+        assert all(isinstance(x, str) for x in body), "Todos os elementos devem ser str"
+        assert body == sorted(body), "Response deve estar ordenado alfabeticamente"


### PR DESCRIPTION
**Parent epic**: #1231
**Closes**: #1236

## Summary

- **3 snapshot tests** congelando o contrato externo da Capability Policy Layer (Epic 4.1-4.4) para forçar revisão consciente em PR diff caso alguém adicione/remova/renomeie key pública ou cause drift do shape.
- **Sem mudança em código de produção**: PR puramente defensivo de governança.
- **Sem duplicar invariantes existentes**: matrix integrity, naming, frozenset type, no `_policy` suffix, parity Can* ↔ PUBLIC_POLICY_KEYS já cobertos em Epic 4.1 e 4.4. Este PR adiciona apenas o que estava faltando.
- **Sem snapshot literal de `ACCESS_POLICIES`**: matriz interna é "implementação mutável" (capabilities elegíveis podem mudar sem breaking — ver `feedback_capability_policy_layer_pattern.md §6`). Snapshot completo geraria ruído de PR sem proteção real.

## Tests adicionados

`apps/core/tests/test_rbac_policies_contract.py` (~130 LOC):

| Test | O que protege |
| ---- | ------------- |
| `test_public_policy_keys_snapshot` | rename / remoção / adição na public surface (diff no PR = checklist breaking) |
| `test_me_policies_endpoint_response_snapshot` | conteúdo público + ordenação + shape + integração view↔auth↔resolver |
| `test_endpoint_response_is_sorted_string_list` | defense-in-depth: `isinstance(body, list)`, todos `str`, `sorted` |

## Decisões de escopo

Discussão técnica: snapshot completo de `ACCESS_POLICIES` foi rejeitado por gerar atrito desnecessário. Memória do projeto define explicitamente que mudar capabilities elegíveis dentro de uma policy é compatível (frontend não depende). Snapshot literal seria ruído.

Snapshots focados em **3 pontos críticos**: contrato público (lista de keys), response do endpoint, defesa do shape.

## Test plan

- pytest apps/core/tests/test_rbac_policies_contract.py — 3/3 PASS
- pytest apps/core/tests/test_rbac_policies.py + test_me_policies.py + test_rbac_policies_contract.py — 133/133 PASS
- black + isort + flake8 sobre arquivo novo — clean

## Próximas etapas Epic 4

- **Epic 4 conclui** com este PR (4.1–4.5 mergeadas).
- **Epic 3 (#1226)**: menu condicional via `useCanAccess` consumindo `/api/me/policies/`.

## Staging gate

ALL 8 CHECKS PASSED

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR
- [x] Feature complete (Epic 4.5 — snapshot tests defensivos)
- [x] Tests updated (3 testes novos: snapshot público, snapshot endpoint, defesa de shape)
- [x] TS/Lint clean (black + isort + flake8 + pytest 133/133 verde)