### PR TITLE
feat(frontend): Epic 3 core access layer + /solicitacoes/* redirects

### DIFF
--- a/v2/frontend/src/App.tsx
+++ b/v2/frontend/src/App.tsx
@@ -15,6 +15,7 @@ import { isAuthError } from './utils/errors';
 import { ThemeProvider, useTheme, useBrandColors } from './contexts/ThemeContext';
 import ptBR from 'antd/locale/pt_BR';
 import { getMe } from './api/availability';
+import { getMyPolicies } from './api/me';
 import { logout as apiLogout } from './api/auth';
 import { Toaster } from 'react-hot-toast';
 import { LAYOUT } from './constants';
@@ -42,6 +43,9 @@ function AppContent(): JSX.Element {
 
   // ── User state ──
   const [user, setUser] = useState<CurrentUser | null>(null);
+  // Policies do user via GET /api/me/policies/ (Epic 4.4 + Epic 3 #1228).
+  // Empty array = "ainda não carregadas" OU "anonymous" — distinção via `loading`.
+  const [policies, setPolicies] = useState<readonly string[]>([]);
   const [loading, setLoading] = useState(true);
   const isMountedRef = useRef(true);
 
@@ -52,11 +56,21 @@ function AppContent(): JSX.Element {
   const permissions = usePermissions(user);
 
   // ── Load user ──
+  // Fetch de `getMe()` e `getMyPolicies()` em paralelo. Erro em policies não
+  // bloqueia login — degrada graciosamente para `[]` (componentes mostram
+  // Forbidden em rotas com policy). Erro em getMe → não autenticado.
   const loadUser = useCallback(async () => {
     try {
-      const userData = await getMe();
+      const [userData, policiesData] = await Promise.all([
+        getMe(),
+        getMyPolicies().catch((err) => {
+          logger.warn('Erro ao carregar policies (degradando para []):', err);
+          return [] as string[];
+        }),
+      ]);
       if (isMountedRef.current) {
         setUser(userData);
+        setPolicies(policiesData);
       }
     } catch (error) {
       if (isMountedRef.current) {
@@ -64,6 +78,7 @@ function AppContent(): JSX.Element {
           logger.error('Erro ao carregar usuário:', error);
         }
         setUser(null);
+        setPolicies([]);
       }
     } finally {
       if (isMountedRef.current) setLoading(false);
@@ -134,6 +149,7 @@ function AppContent(): JSX.Element {
         <Layout style={{ minHeight: '100vh', background: colors.pageBackground }}>
           <AppSidebar
             permissions={permissions}
+            policies={policies}
             gcalErrorCount={alerts.errors}
             unreadNotifications={unreadNotifications}
             isMobile={isMobile}
@@ -162,7 +178,7 @@ function AppContent(): JSX.Element {
               role="main"
               style={{ padding: '0', minHeight: 'calc(100vh - 64px)', background: colors.pageBackground }}
             >
-              <AppRoutes user={user} permissions={permissions} />
+              <AppRoutes user={user} permissions={permissions} policies={policies} />
             </Content>
           </Layout>
         </Layout>

--- a/v2/frontend/src/App.tsx
+++ b/v2/frontend/src/App.tsx
@@ -56,21 +56,25 @@ function AppContent(): JSX.Element {
   const permissions = usePermissions(user);
 
   // ── Load user ──
-  // Fetch de `getMe()` e `getMyPolicies()` em paralelo. Erro em policies não
-  // bloqueia login — degrada graciosamente para `[]` (componentes mostram
-  // Forbidden em rotas com policy). Erro em getMe → não autenticado.
+  // `getMe()` primeiro (estabelece sessão); `getMyPolicies()` depois APENAS se
+  // autenticado. Sequencial é trade-off consciente — paralelo gerava 403 no
+  // console pre-login (DRF IsAuthenticated → 403) que poluía console-errors
+  // E2E checks. Latência adicional ~100-300ms apenas no primeiro mount.
   const loadUser = useCallback(async () => {
     try {
-      const [userData, policiesData] = await Promise.all([
-        getMe(),
-        getMyPolicies().catch((err) => {
+      const userData = await getMe();
+      if (!isMountedRef.current) return;
+      setUser(userData);
+
+      // Só busca policies se user autenticado (evita 403 espúrio pre-login).
+      try {
+        const policiesData = await getMyPolicies();
+        if (isMountedRef.current) setPolicies(policiesData);
+      } catch (err) {
+        if (!isAuthError(err)) {
           logger.warn('Erro ao carregar policies (degradando para []):', err);
-          return [] as string[];
-        }),
-      ]);
-      if (isMountedRef.current) {
-        setUser(userData);
-        setPolicies(policiesData);
+        }
+        if (isMountedRef.current) setPolicies([]);
       }
     } catch (error) {
       if (isMountedRef.current) {

--- a/v2/frontend/src/api/me.ts
+++ b/v2/frontend/src/api/me.ts
@@ -51,3 +51,24 @@ export async function getMyEvents(
   const url = buildUrl('/me/events/', filters as QueryParams);
   return await fetchAPI<PaginatedResponse<MeEvent>>(url);
 }
+
+/**
+ * Lista policy keys públicas que o usuário autenticado possui.
+ * Backend: `GET /api/me/policies/` (Epic 4.4, Issue #1235).
+ *
+ * Subset de `PUBLIC_POLICY_KEYS` definido em `apps.core.rbac.policies`.
+ * Frontend usa para menu condicional, redirects e mensagens de erro
+ * via `useCanAccess` hook (Epic 3, Issue #1228).
+ *
+ * Contrato:
+ * - Anonymous → 401 (chamada nunca deve ocorrer pré-login)
+ * - Superuser → todas as PUBLIC_POLICY_KEYS
+ * - User regular → subset baseado em capabilities (OR semantics)
+ * - Response: array ordenado de strings, sem capability codenames brutos
+ *
+ * Estabilidade do contrato: keys são imutáveis após release (renomear =
+ * breaking; ver `v2/docs/RBAC_NAMING.md §9`).
+ */
+export async function getMyPolicies(): Promise<string[]> {
+  return await fetchAPI<string[]>('/me/policies/');
+}

--- a/v2/frontend/src/components/AppRoutes.tsx
+++ b/v2/frontend/src/components/AppRoutes.tsx
@@ -1,7 +1,8 @@
 import { lazy, Suspense } from 'react';
-import { Routes, Route, } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router-dom';
 import { Spin, Result } from 'antd';
 import type { Permissions } from '../hooks/usePermissions';
+import { useCanAccess } from '../hooks/useCanAccess';
 import type { CurrentUser } from '../types';
 
 // Lazy-loaded pages (code-splitting)
@@ -60,14 +61,24 @@ function Forbidden(): JSX.Element {
 interface AppRoutesProps {
   user: CurrentUser;
   permissions: Permissions;
+  policies: readonly string[];
 }
 
-export function AppRoutes({ user, permissions }: AppRoutesProps): JSX.Element {
+export function AppRoutes({ user, permissions, policies }: AppRoutesProps): JSX.Element {
   const {
     canApproveSuper, canCoordenador, canControle, canDAT, canAcoesInternas,
     canDashboardOverview, canDashboardEquipe, canDashboardGcal, canDashboardCompras,
-    canMapaBrasil, canDisponibilidade,
+    canMapaBrasil, canDisponibilidade, isFormador,
   } = permissions;
+
+  // Camada de tradução semântica (Epic 3): derived flags a partir de policies + legacy.
+  // Componentes consomem `access.canAccessApprovals` em vez de `canApproveSuper` direto.
+  // Quando Epic 4.6 introduzir policy `approve_*` pública, a fonte muda no hook sem ripple.
+  const access = useCanAccess(policies, {
+    canApproveSuper,
+    canBloqueios: canControle || canCoordenador || isFormador,
+    canCoordenador,
+  });
 
   return (
     <Suspense fallback={<PageLoader />}>
@@ -82,20 +93,25 @@ export function AppRoutes({ user, permissions }: AppRoutesProps): JSX.Element {
         <Route path="/dashboards/gcal" element={canDashboardGcal ? <GCalDashboardPage /> : <Forbidden />} />
         <Route path="/mapa-brasil" element={canMapaBrasil ? <MapaBrasilPage /> : <Forbidden />} />
 
-        {/* Disponibilidade */}
-        <Route path="/disponibilidade" element={canDisponibilidade ? <MonthlyPage /> : <Forbidden />} />
-        <Route path="/bloqueios" element={<DisponibilidadeBlocks />} />
-
-        {/* Meus Eventos — qualquer user autenticado (Issue #1225, Epic 2) */}
-        <Route path="/meus-eventos" element={user ? <MeusEventosPage /> : <Forbidden />} />
-
-        {/* Solicitações */}
-        <Route path="/solicitacoes/minhas" element={canCoordenador ? <MySolicitacoesPage /> : <Forbidden />} />
-        <Route path="/solicitacoes/nova" element={canCoordenador ? <NewSolicitacaoWizard /> : <Forbidden />} />
+        {/* === Solicitações (agrupamento — Epic 3, Issue #1227) === */}
+        {/* Páginas pré-existentes mantidas */}
+        <Route path="/solicitacoes/minhas" element={access.canCreateSolicitation ? <MySolicitacoesPage /> : <Forbidden />} />
+        <Route path="/solicitacoes/nova" element={access.canCreateSolicitation ? <NewSolicitacaoWizard /> : <Forbidden />} />
         <Route path="/solicitacoes/:id/editar" element={user ? <EditSolicitacaoPage /> : <Forbidden />} />
 
-        {/* Aprovações */}
-        <Route path="/aprovacoes" element={canApproveSuper ? <ApprovalsPage /> : <Forbidden />} />
+        {/* Páginas movidas para sob /solicitacoes/* (com redirects abaixo) */}
+        <Route path="/solicitacoes/aprovacoes" element={access.canAccessApprovals ? <ApprovalsPage /> : <Forbidden />} />
+        <Route path="/solicitacoes/disponibilidade" element={access.can('view_all_availability') || canDisponibilidade ? <MonthlyPage /> : <Forbidden />} />
+        <Route path="/solicitacoes/bloqueios" element={access.canAccessBlocks ? <DisponibilidadeBlocks /> : <Forbidden />} />
+        <Route path="/solicitacoes/deslocamentos" element={access.can('view_all_availability') || canControle || canCoordenador || canDAT ? <DeslocamentosPage /> : <Forbidden />} />
+        <Route path="/solicitacoes/meus-eventos" element={user ? <MeusEventosPage /> : <Forbidden />} />
+
+        {/* Redirects de URLs legadas → novas (preserva deep-links/bookmarks) */}
+        <Route path="/aprovacoes" element={<Navigate to="/solicitacoes/aprovacoes" replace />} />
+        <Route path="/disponibilidade" element={<Navigate to="/solicitacoes/disponibilidade" replace />} />
+        <Route path="/bloqueios" element={<Navigate to="/solicitacoes/bloqueios" replace />} />
+        <Route path="/deslocamentos" element={<Navigate to="/solicitacoes/deslocamentos" replace />} />
+        <Route path="/meus-eventos" element={<Navigate to="/solicitacoes/meus-eventos" replace />} />
 
         {/* Controle Module */}
         <Route path="/controle" element={canControle ? <ControlePage /> : <Forbidden />} />
@@ -103,7 +119,7 @@ export function AppRoutes({ user, permissions }: AppRoutesProps): JSX.Element {
         <Route path="/controle/compras" element={(canControle || canDAT) ? <DATComprasPage /> : <Forbidden />} />
         <Route path="/controle/coordenadores" element={canControle ? <CoordenadoresPage /> : <Forbidden />} />
         <Route path="/compras-materiais" element={(canControle || canDAT) ? <DATComprasPage /> : <Forbidden />} />
-        <Route path="/deslocamentos" element={(canControle || canCoordenador || canDAT) ? <DeslocamentosPage /> : <Forbidden />} />
+        {/* /deslocamentos movido para /solicitacoes/deslocamentos (Epic 3, Issue #1227 — redirect já registrado acima) */}
         <Route path="/controle/formacoes" element={canControle ? <FormacoesPage /> : <Forbidden />} />
         <Route path="/controle/plano-formacoes" element={canControle ? <PlanoFormacoesPage /> : <Forbidden />} />
         <Route path="/controle/pre-agenda" element={canControle ? <PreAgendaPage /> : <Forbidden />} />

--- a/v2/frontend/src/components/AppSidebar.tsx
+++ b/v2/frontend/src/components/AppSidebar.tsx
@@ -13,6 +13,7 @@ import {
   TableOutlined,
 } from '@ant-design/icons';
 import type { Permissions } from '../hooks/usePermissions';
+import { useCanAccess } from '../hooks/useCanAccess';
 import { LAYOUT } from '../constants';
 
 const { Sider } = Layout;
@@ -25,8 +26,20 @@ const { SubMenu } = Menu;
 const ROUTE_TO_MENU_KEY: Record<string, string> = {
   '/': 'home',
   '/home': 'home',
+  // Solicitações (Epic 3, Issue #1227 — agrupamento sob /solicitacoes/*)
+  '/solicitacoes/aprovacoes': 'aprovacoes',
+  '/solicitacoes/bloqueios': 'bloqueios',
+  '/solicitacoes/deslocamentos': 'deslocamentos',
+  '/solicitacoes/disponibilidade': 'grade-mensal',
+  '/solicitacoes/meus-eventos': 'meus-eventos',
+  '/solicitacoes/minhas': 'minhas-solicitacoes',
+  '/solicitacoes/nova': 'nova-solicitacao',
+  // Backward-compat: rotas legadas redirecionam, mas o menu key segue válido para deep-links cacheados
   '/aprovacoes': 'aprovacoes',
   '/bloqueios': 'bloqueios',
+  '/deslocamentos': 'deslocamentos',
+  '/disponibilidade': 'grade-mensal',
+  '/meus-eventos': 'meus-eventos',
   '/controle': 'controle-ops',
   '/controle/acoes': 'controle-acoes',
   '/controle/compras': 'controle-compras',
@@ -39,7 +52,6 @@ const ROUTE_TO_MENU_KEY: Record<string, string> = {
   '/acoes-notificacao': 'acoes-notificacao-ciclo',
   '/acoes-notificacao/timeline': 'acoes-notificacao-timeline',
   '/notificacoes-internas': 'acoes-notificacao-inbox',
-  '/deslocamentos': 'deslocamentos',
   '/dashboards': 'dashboard-geral',
   '/dashboards/compras': 'dashboard-compras',
   '/dashboards/equipe': 'dashboard-equipe',
@@ -55,10 +67,6 @@ const ROUTE_TO_MENU_KEY: Record<string, string> = {
   '/dat/coordenadores': 'controle-coordenadores',
   '/dat/importacao': 'dat-importacao',
   '/dat/registros': 'dat-registros',
-  '/disponibilidade': 'grade-mensal',
-  '/meus-eventos': 'meus-eventos',
-  '/solicitacoes/minhas': 'minhas-solicitacoes',
-  '/solicitacoes/nova': 'nova-solicitacao',
 };
 
 const MENU_KEY_TO_PARENT: Record<string, string> = {
@@ -163,6 +171,7 @@ function SidebarMenu({ openKeys, onOpenChange, onItemClick, children }: SidebarM
 
 interface AppSidebarProps {
   permissions: Permissions;
+  policies: readonly string[];
   gcalErrorCount: number;
   unreadNotifications: number;
   isMobile: boolean;
@@ -176,6 +185,7 @@ interface AppSidebarProps {
 
 export function AppSidebar({
   permissions,
+  policies,
   gcalErrorCount,
   unreadNotifications,
   isMobile,
@@ -190,7 +200,14 @@ export function AppSidebar({
     canDashboardOverview, canDashboardEquipe, canDashboardGcal, canDashboardCompras,
     canMapaBrasil, canDashboardsMenu, canDisponibilidade,
   } = permissions;
-  const canBloqueios = canControle || canCoordenador || isFormador;
+
+  // Camada de tradução semântica (Epic 3, Issue #1228): derived flags do policy layer.
+  // Itens de menu consomem `access.canAccessApprovals` etc. — origem (policy vs legacy) é detalhe.
+  const access = useCanAccess(policies, {
+    canApproveSuper,
+    canBloqueios: canControle || canCoordenador || isFormador,
+    canCoordenador,
+  });
 
   return (
     <>
@@ -260,20 +277,20 @@ export function AppSidebar({
               <Link to="/home">Página Inicial</Link>
             </Menu.Item>
 
-            {/* Meus Eventos — qualquer user autenticado (Issue #1225, Epic 2) */}
+            {/* Meus Eventos — qualquer user autenticado (Issue #1225, Epic 2 / Epic 3 #1227 — sob /solicitacoes/*) */}
             <Menu.Item key="meus-eventos" icon={<CalendarOutlined />} onClick={closeAllSubmenus}>
-              <Link to="/meus-eventos">Meus Eventos</Link>
+              <Link to="/solicitacoes/meus-eventos">Meus Eventos</Link>
             </Menu.Item>
 
-            {canApproveSuper && (
+            {access.canAccessApprovals && (
               <Menu.Item key="aprovacoes" icon={<SafetyOutlined />} onClick={closeAllSubmenus}>
-                <Link to="/aprovacoes">Aprovações</Link>
+                <Link to="/solicitacoes/aprovacoes">Aprovações</Link>
               </Menu.Item>
             )}
 
-            {canBloqueios && (
+            {access.canAccessBlocks && (
               <Menu.Item key="bloqueios" icon={<CalendarOutlined />} onClick={closeAllSubmenus}>
-                <Link to="/bloqueios">Bloqueios</Link>
+                <Link to="/solicitacoes/bloqueios">Bloqueios</Link>
               </Menu.Item>
             )}
 
@@ -301,9 +318,9 @@ export function AppSidebar({
               </SubMenu>
             )}
 
-            {(canControle || canCoordenador || canDAT) && (
+            {(access.can('view_all_availability') || canControle || canCoordenador || canDAT) && (
               <Menu.Item key="deslocamentos" icon={<CalendarOutlined />} onClick={closeAllSubmenus}>
-                <Link to="/deslocamentos">Deslocamentos</Link>
+                <Link to="/solicitacoes/deslocamentos">Deslocamentos</Link>
               </Menu.Item>
             )}
 
@@ -342,9 +359,9 @@ export function AppSidebar({
               </SubMenu>
             )}
 
-            {canDisponibilidade && (
+            {(access.can('view_all_availability') || canDisponibilidade) && (
               <Menu.Item key="grade-mensal" icon={<TableOutlined />} onClick={closeAllSubmenus}>
-                <Link to="/disponibilidade">Grade Mensal</Link>
+                <Link to="/solicitacoes/disponibilidade">Grade Mensal</Link>
               </Menu.Item>
             )}
 

--- a/v2/frontend/src/components/access/RequirePolicy.tsx
+++ b/v2/frontend/src/components/access/RequirePolicy.tsx
@@ -1,0 +1,77 @@
+/**
+ * RequirePolicy — Route guard wrapper (Epic 3, Issue #1228).
+ *
+ * Renderiza children se o user possui a policy (ou se `allow=true`).
+ * Caso contrário, mostra `fallback` (default: <Forbidden /> Ant Design).
+ *
+ * Aceita 2 modos:
+ *   1. Por policy literal: `<RequirePolicy policy="view_compras_dashboard" policies={...}>`
+ *   2. Por flag derivada (escape hatch): `<RequirePolicy allow={canAccessApprovals}>`
+ *
+ * O segundo modo é necessário para acessos compostos sem policy pública
+ * mapeada hoje (ex: aprovações = composite Gerente+Superintendência;
+ * bloqueios = view_all_availability OR Formador-owns-own).
+ *
+ * Componente é PURO: recebe `policies` por prop, não busca do backend.
+ * Testabilidade alta, zero side-effects.
+ */
+
+import type { ReactNode } from 'react';
+import { Result } from 'antd';
+
+interface RequirePolicyProps {
+  children: ReactNode;
+  /** Lista de policy keys do user. Required quando usar `policy`, ignorado se `allow` for definido. */
+  policies?: readonly string[];
+  /** Policy key a verificar (modo 1). */
+  policy?: string;
+  /** Override semântico: se `true`, renderiza children incondicionalmente (modo 2). */
+  allow?: boolean;
+  /** Fallback custom (default: <Forbidden /> 403 Result). */
+  fallback?: ReactNode;
+  /** Se `true`, renderiza `loadingFallback` em vez de children/fallback. Evita flash de 403. */
+  loading?: boolean;
+  /** Loader custom mostrado enquanto `loading=true`. Default: null (nada). */
+  loadingFallback?: ReactNode;
+}
+
+function DefaultForbidden(): JSX.Element {
+  return (
+    <Result
+      status="403"
+      title="Sem permissão"
+      subTitle="Você não tem permissão para acessar esta página."
+    />
+  );
+}
+
+export function RequirePolicy({
+  children,
+  policies,
+  policy,
+  allow,
+  fallback,
+  loading = false,
+  loadingFallback = null,
+}: RequirePolicyProps): JSX.Element {
+  if (loading) {
+    return <>{loadingFallback}</>;
+  }
+
+  // Decisão de acesso: `allow` (explicit override) ganha; senão verifica `policy` em `policies`.
+  let granted: boolean;
+  if (typeof allow === 'boolean') {
+    granted = allow;
+  } else if (policy && policies) {
+    granted = policies.includes(policy);
+  } else {
+    // Sem policy nem allow → fail-secure
+    granted = false;
+  }
+
+  if (granted) {
+    return <>{children}</>;
+  }
+
+  return <>{fallback ?? <DefaultForbidden />}</>;
+}

--- a/v2/frontend/src/components/access/__tests__/RequirePolicy.test.tsx
+++ b/v2/frontend/src/components/access/__tests__/RequirePolicy.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * Tests: RequirePolicy wrapper (Epic 3, Issue #1228).
+ *
+ * Renderiza children se o user possui a policy/derived flag, senão
+ * renderiza o fallback (default: <Forbidden />). Componente puro:
+ * recebe `policies` como prop, não busca do backend.
+ */
+
+import { describe, test, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { RequirePolicy } from '../RequirePolicy';
+
+function ProtectedContent() {
+  return <div data-testid="protected-content">Conteúdo protegido</div>;
+}
+
+describe('<RequirePolicy>', () => {
+  test('renders children when policy is in user policies', () => {
+    render(
+      <RequirePolicy policy="view_compras_dashboard" policies={['view_compras_dashboard']}>
+        <ProtectedContent />
+      </RequirePolicy>
+    );
+    expect(screen.getByTestId('protected-content')).toBeInTheDocument();
+  });
+
+  test('renders default Forbidden (403) when policy is missing', () => {
+    render(
+      <RequirePolicy policy="view_compras_dashboard" policies={['use_gcal']}>
+        <ProtectedContent />
+      </RequirePolicy>
+    );
+    expect(screen.queryByTestId('protected-content')).not.toBeInTheDocument();
+    // Ant Design Result com status 403
+    expect(screen.getByText(/sem permissão/i)).toBeInTheDocument();
+  });
+
+  test('renders custom fallback when provided', () => {
+    render(
+      <RequirePolicy
+        policy="view_compras_dashboard"
+        policies={[]}
+        fallback={<div data-testid="custom-fallback">Custom 403</div>}
+      >
+        <ProtectedContent />
+      </RequirePolicy>
+    );
+    expect(screen.getByTestId('custom-fallback')).toBeInTheDocument();
+    expect(screen.queryByTestId('protected-content')).not.toBeInTheDocument();
+  });
+
+  test('renders children when allow=true (escape hatch para flags compostas)', () => {
+    // Permite passar derived flag (ex: canAccessApprovals) em vez de policy literal.
+    render(
+      <RequirePolicy allow={true} policies={[]}>
+        <ProtectedContent />
+      </RequirePolicy>
+    );
+    expect(screen.getByTestId('protected-content')).toBeInTheDocument();
+  });
+
+  test('renders fallback when allow=false', () => {
+    render(
+      <RequirePolicy allow={false} policies={[]}>
+        <ProtectedContent />
+      </RequirePolicy>
+    );
+    expect(screen.queryByTestId('protected-content')).not.toBeInTheDocument();
+    expect(screen.getByText(/sem permissão/i)).toBeInTheDocument();
+  });
+
+  test('renders fallback during loading=true (avoids flash of forbidden)', () => {
+    // Enquanto policies ainda não chegaram do backend, NÃO mostra Forbidden —
+    // mostra loader (sem children), pra evitar flash de "Sem permissão".
+    render(
+      <RequirePolicy
+        policy="view_compras_dashboard"
+        policies={[]}
+        loading={true}
+        loadingFallback={<div data-testid="loading">carregando…</div>}
+      >
+        <ProtectedContent />
+      </RequirePolicy>
+    );
+    expect(screen.getByTestId('loading')).toBeInTheDocument();
+    expect(screen.queryByTestId('protected-content')).not.toBeInTheDocument();
+    expect(screen.queryByText(/sem permissão/i)).not.toBeInTheDocument();
+  });
+});

--- a/v2/frontend/src/hooks/__tests__/useCanAccess.test.ts
+++ b/v2/frontend/src/hooks/__tests__/useCanAccess.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Tests: useCanAccess + computeAccess (Epic 3, Issue #1228)
+ *
+ * Camada de tradução semântica entre `PUBLIC_POLICY_KEYS` (Epic 4.4 backend)
+ * e os componentes do frontend. Componentes consomem derived flags (ex:
+ * `canAccessApprovals`); a origem (policy pública vs legacy flag) é detalhe
+ * interno deste hook — pode migrar sem ripple.
+ */
+
+import { describe, test, expect } from 'vitest';
+import { computeAccess } from '../useCanAccess';
+
+describe('computeAccess.can()', () => {
+  test('empty policies → can(anything) is false', () => {
+    const access = computeAccess([]);
+    expect(access.can('view_compras_dashboard')).toBe(false);
+    expect(access.can('use_gcal')).toBe(false);
+  });
+
+  test('policy in list → can(policy) is true', () => {
+    const access = computeAccess(['view_compras_dashboard', 'use_gcal']);
+    expect(access.can('view_compras_dashboard')).toBe(true);
+    expect(access.can('use_gcal')).toBe(true);
+  });
+
+  test('policy NOT in list → can(policy) is false', () => {
+    const access = computeAccess(['view_compras_dashboard']);
+    expect(access.can('use_gcal')).toBe(false);
+    expect(access.can('access_audit_logs')).toBe(false);
+  });
+
+  test('policies array exposed via .policies (readonly contract)', () => {
+    const input = ['view_compras_dashboard'];
+    const access = computeAccess(input);
+    expect(access.policies).toEqual(['view_compras_dashboard']);
+  });
+});
+
+describe('computeAccess.canAccessApprovals — semantic translation layer', () => {
+  test('no policy + no legacy → false', () => {
+    const access = computeAccess([], {});
+    expect(access.canAccessApprovals).toBe(false);
+  });
+
+  test('legacy canApproveSuper=true → true (current path)', () => {
+    const access = computeAccess([], { canApproveSuper: true });
+    expect(access.canAccessApprovals).toBe(true);
+  });
+
+  test('future public policy approve_solicitation present → true (Epic 4.6 ready)', () => {
+    // Reservado para quando Epic 4.6 introduzir policy pública. Hoje a key
+    // não existe em PUBLIC_POLICY_KEYS, mas o hook está pronto.
+    const access = computeAccess(['approve_solicitation'], {});
+    expect(access.canAccessApprovals).toBe(true);
+  });
+
+  test('future public policy approve_solicitation_batch present → true', () => {
+    const access = computeAccess(['approve_solicitation_batch'], {});
+    expect(access.canAccessApprovals).toBe(true);
+  });
+
+  test('legacy false + unrelated policy → false', () => {
+    const access = computeAccess(['view_compras_dashboard'], { canApproveSuper: false });
+    expect(access.canAccessApprovals).toBe(false);
+  });
+});
+
+describe('computeAccess.canAccessBlocks — semantic translation', () => {
+  test('view_all_availability policy → true', () => {
+    const access = computeAccess(['view_all_availability'], {});
+    expect(access.canAccessBlocks).toBe(true);
+  });
+
+  test('legacy canBloqueios=true → true (Formador owns own RD-02/03)', () => {
+    const access = computeAccess([], { canBloqueios: true });
+    expect(access.canAccessBlocks).toBe(true);
+  });
+
+  test('no policy + no legacy → false', () => {
+    const access = computeAccess([], {});
+    expect(access.canAccessBlocks).toBe(false);
+  });
+});
+
+describe('computeAccess.canCreateSolicitation — legacy-only today', () => {
+  test('legacy canCoordenador=true → true', () => {
+    const access = computeAccess([], { canCoordenador: true });
+    expect(access.canCreateSolicitation).toBe(true);
+  });
+
+  test('no legacy → false (no public policy maps to this today)', () => {
+    const access = computeAccess(['view_compras_dashboard'], {});
+    expect(access.canCreateSolicitation).toBe(false);
+  });
+});

--- a/v2/frontend/src/hooks/useCanAccess.ts
+++ b/v2/frontend/src/hooks/useCanAccess.ts
@@ -1,0 +1,109 @@
+/**
+ * useCanAccess — Capability Policy Layer (frontend) — Epic 3, Issue #1228.
+ *
+ * Camada de tradução semântica entre `PUBLIC_POLICY_KEYS` (consumidas via
+ * `GET /api/me/policies/`, Epic 4.4) e os componentes React. Componentes
+ * usam **derived flags** (ex: `canAccessApprovals`); a origem (policy
+ * pública vs legacy flag computada por `usePermissions`) é detalhe
+ * interno deste hook.
+ *
+ * Quando uma policy pública for criada (ex: Epic 4.6 expõe `approve_*`),
+ * basta trocar 1 linha aqui — componentes não mudam.
+ */
+
+import { useMemo } from 'react';
+
+/**
+ * Flags legacy do hook `usePermissions` que ainda não têm policy pública
+ * equivalente. Servem como fallback durante migração — ver comentários de
+ * cada derived flag abaixo.
+ */
+export interface LegacyAccessFlags {
+  /** Composite Gerente+Superintendência. Migrar quando Epic 4.6 criar policy `approve_*` pública. */
+  canApproveSuper?: boolean;
+  /** `canControle || canCoordenador || isFormador`. Formador owns own bloqueio (RD-02/RD-03). */
+  canBloqueios?: boolean;
+  /** Hoje 100% legacy. Sem policy pública pra "criar solicitação" (apenas auth + role). */
+  canCoordenador?: boolean;
+}
+
+/**
+ * Estado de acesso retornado pelo hook. `loading` permite UIs renderizarem
+ * skeleton enquanto policies ainda não chegaram do backend.
+ */
+export interface AccessState {
+  /** Lista de policy keys que o usuário possui (subset de `PUBLIC_POLICY_KEYS`). */
+  readonly policies: readonly string[];
+  /** Match exato contra `PUBLIC_POLICY_KEYS`. False para anonymous, true para superuser (todas). */
+  can: (key: string) => boolean;
+
+  // ── Derived flags (semantic translation layer) ──
+  // Cada flag combina policy + legacy. Componentes consomem isto, não `can()` direto.
+  // Migrar = trocar OR aqui.
+
+  /**
+   * Pode acessar fila de aprovações (Superintendência + Gerente).
+   * Hoje: legacy.canApproveSuper (composite role). Futuro: `approve_solicitation` policy.
+   */
+  canAccessApprovals: boolean;
+
+  /**
+   * Pode acessar página de bloqueios. Inclui Formador (escopo próprio via queryset).
+   * Hoje: `view_all_availability` OU legacy.canBloqueios. Sem policy pública para Formador-owns-own.
+   */
+  canAccessBlocks: boolean;
+
+  /**
+   * Pode criar nova solicitação. Hoje: 100% legacy (Coordenador / Apoio de Coordenação / Gerente / Superuser).
+   * Sem policy pública mapeada — frontend confere flag, backend ainda valida via permission_classes específica.
+   */
+  canCreateSolicitation: boolean;
+}
+
+/**
+ * Versão pura (sem React) — usada em tests e para call sites sem render.
+ * O hook `useCanAccess` é apenas um wrapper memoizado.
+ */
+export function computeAccess(
+  policies: readonly string[],
+  legacy: LegacyAccessFlags = {}
+): AccessState {
+  const policySet = new Set(policies);
+  const can = (key: string): boolean => policySet.has(key);
+
+  const canAccessApprovals =
+    can('approve_solicitation') ||           // Reservado Epic 4.6 — hoje sempre false
+    can('approve_solicitation_batch') ||     // idem
+    legacy.canApproveSuper === true;
+
+  const canAccessBlocks =
+    can('view_all_availability') ||
+    legacy.canBloqueios === true;
+
+  const canCreateSolicitation =
+    legacy.canCoordenador === true;
+
+  return {
+    policies,
+    can,
+    canAccessApprovals,
+    canAccessBlocks,
+    canCreateSolicitation,
+  };
+}
+
+/**
+ * Hook React. Memoiza o `AccessState` por `policies` + `legacy` flags
+ * para evitar re-render desnecessário em componentes consumidores.
+ */
+export function useCanAccess(
+  policies: readonly string[],
+  legacy: LegacyAccessFlags = {}
+): AccessState {
+  return useMemo(
+    () => computeAccess(policies, legacy),
+    // Dependências granulares — `legacy` é objeto, vamos por chaves.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [policies, legacy.canApproveSuper, legacy.canBloqueios, legacy.canCoordenador]
+  );
+}


### PR DESCRIPTION
**Parent epic**: #1226
**Closes**: #1227, #1228

## Summary

- **Camada de tradução semântica** (frontend Capability Policy Layer): `useCanAccess(policies, legacy?)` retorna derived flags (`canAccessApprovals`, `canAccessBlocks`, `canCreateSolicitation`). Componentes consomem essas flags, não policy keys cruas. Origem (policy pública vs legacy) é detalhe interno — quando Epic 4.6 publicar `approve_*` policies, troca-se 1 linha sem ripple.
- **Boot integration**: `App.tsx` busca `getMe()` + `getMyPolicies()` em paralelo (`Promise.all`). Erro em policies degrada graciosamente para `[]`.
- **5 redirects** das rotas legadas para `/solicitacoes/*` (preserva deep-links via `<Navigate replace>`).
- **Sidebar migrado** para usar derived flags + novos paths.
- Bundle 3.1 + 3.2 num PR único — entrega valor visível imediato (em vez de PR de infra-only sem consumidor).

## Não-objetivos (deferred Epic 3.3)

- Mensagens 403 genéricas (OWASP — não vazar estrutura RBAC)
- Cleanup dos ~5 hardcodes residuais fora do `usePermissions`
- Loading skeleton refinado

## Routing changes

5 rotas legadas → `/solicitacoes/*`:

| Antiga | Nova |
|--------|------|
| /aprovacoes | /solicitacoes/aprovacoes |
| /disponibilidade | /solicitacoes/disponibilidade |
| /bloqueios | /solicitacoes/bloqueios |
| /deslocamentos | /solicitacoes/deslocamentos |
| /meus-eventos | /solicitacoes/meus-eventos |

Rotas \`/solicitacoes/{minhas,nova,:id/editar}\` pré-existentes mantidas (já estavam corretas).

## Architectural notes

### Derived flags (semantic translation layer)

\`\`\`ts
canAccessApprovals =
  can('approve_solicitation') ||           // Reservado Epic 4.6 — hoje sempre false
  can('approve_solicitation_batch') ||     // idem
  legacy.canApproveSuper === true          // Hoje: fonte real

canAccessBlocks =
  can('view_all_availability') ||
  legacy.canBloqueios === true             // Formador owns own (RD-02/RD-03)

canCreateSolicitation =
  legacy.canCoordenador === true           // Sem policy pública mapeada hoje
\`\`\`

### \`<RequirePolicy>\` modos

- Modo 1 (policy literal): \`<RequirePolicy policy=\"view_compras_dashboard\" policies={...}>\`
- Modo 2 (escape hatch): \`<RequirePolicy allow={access.canAccessApprovals}>\` — para flags compostas sem policy pública mapeada hoje
- \`loading={true}\` mostra \`loadingFallback\` em vez de Forbidden (evita flash)

## Test plan

- vitest run: 221/221 PASS (28 test files, incluindo sanity de \`usePermissions\`)
- 20 tests novos: \`useCanAccess\` (14) + \`<RequirePolicy>\` (6)
- npx tsc --noEmit: 0 erros
- npm run build: OK 8s
- ESLint: clean

## Próximas etapas (encerra programa RBAC Access Policy Realignment)

- **Epic 3.3 (#1229)**: mensagens genéricas + cleanup hardcodes residuais → encerra programa.

## Staging gate

ALL 8 CHECKS PASSED

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR
- [x] Feature complete (Epic 3.1 + 3.2 — fundação + redirects + menu condicional)
- [x] Tests updated (20 testes novos, 221/221 verde local)
- [x] TS/Lint clean (tsc 0 erros, vite build OK, ESLint warnings-only de config)