### PR TITLE
feat(frontend): Epic 3.3 — generic 403 + cleanup residual role hardcodes [ENCERRA PROGRAMA]

### DIFF
--- a/v2/frontend/src/App.tsx
+++ b/v2/frontend/src/App.tsx
@@ -105,8 +105,8 @@ function AppContent(): JSX.Element {
   }, [user]);
 
   // ── GCal alerts polling ──
-  const gcalEnabled = !!(user?.setores?.includes('Controle') || user?.is_superuser);
-  const { alerts } = useGCalAlertsPolling({ enabled: gcalEnabled });
+  // Epic 3.3 cleanup: usa flag derivada do usePermissions (canControle já cobre superuser).
+  const { alerts } = useGCalAlertsPolling({ enabled: permissions.canControle });
 
   // ── Notification badge polling ──
   const { unreadNotifications } = useUnreadNotificationsPolling({

--- a/v2/frontend/src/components/AppRoutes.tsx
+++ b/v2/frontend/src/components/AppRoutes.tsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense } from 'react';
-import { Routes, Route, Navigate } from 'react-router-dom';
-import { Spin, Result } from 'antd';
+import { Routes, Route, Navigate, Link } from 'react-router-dom';
+import { Spin, Result, Button } from 'antd';
 import type { Permissions } from '../hooks/usePermissions';
 import { useCanAccess } from '../hooks/useCanAccess';
 import type { CurrentUser } from '../types';
@@ -54,8 +54,24 @@ function PageLoader(): JSX.Element {
   );
 }
 
+/**
+ * Forbidden inline (mantido para rotas que ainda não usam <RequirePolicy>).
+ * Mesma mensagem genérica do `RequirePolicy` (OWASP — não revelar
+ * existência do recurso ou permission necessária).
+ */
 function Forbidden(): JSX.Element {
-  return <Result status="403" title="Sem permissão" subTitle="Você não tem permissão para acessar esta página." />;
+  return (
+    <Result
+      status="info"
+      title="Recurso indisponível"
+      subTitle="Esta página não está disponível ou não pode ser acessada pela sua conta."
+      extra={
+        <Link to="/">
+          <Button type="primary">Voltar ao início</Button>
+        </Link>
+      }
+    />
+  );
 }
 
 interface AppRoutesProps {

--- a/v2/frontend/src/components/access/RequirePolicy.tsx
+++ b/v2/frontend/src/components/access/RequirePolicy.tsx
@@ -17,7 +17,8 @@
  */
 
 import type { ReactNode } from 'react';
-import { Result } from 'antd';
+import { Button, Result } from 'antd';
+import { Link } from 'react-router-dom';
 
 interface RequirePolicyProps {
   children: ReactNode;
@@ -35,12 +36,26 @@ interface RequirePolicyProps {
   loadingFallback?: ReactNode;
 }
 
+/**
+ * Fallback genérico (OWASP Authorization Cheat Sheet):
+ * - NÃO revela que o recurso existe ("403 sem permissão" é vazamento)
+ * - NÃO menciona qual permission/role é necessária
+ * - NÃO usa código HTTP visível
+ * - Mensagem ambígua: pode ser "não existe" ou "não disponível para você"
+ *
+ * Status visual `info` (não `403`) — neutralidade. CTA único: voltar ao início.
+ */
 function DefaultForbidden(): JSX.Element {
   return (
     <Result
-      status="403"
-      title="Sem permissão"
-      subTitle="Você não tem permissão para acessar esta página."
+      status="info"
+      title="Recurso indisponível"
+      subTitle="Esta página não está disponível ou não pode ser acessada pela sua conta."
+      extra={
+        <Link to="/">
+          <Button type="primary">Voltar ao início</Button>
+        </Link>
+      }
     />
   );
 }

--- a/v2/frontend/src/components/access/__tests__/RequirePolicy.test.tsx
+++ b/v2/frontend/src/components/access/__tests__/RequirePolicy.test.tsx
@@ -8,8 +8,13 @@
 
 import { describe, test, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 
 import { RequirePolicy } from '../RequirePolicy';
+
+function renderWithRouter(ui: React.ReactElement) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
 
 function ProtectedContent() {
   return <div data-testid="protected-content">Conteúdo protegido</div>;
@@ -17,7 +22,7 @@ function ProtectedContent() {
 
 describe('<RequirePolicy>', () => {
   test('renders children when policy is in user policies', () => {
-    render(
+    renderWithRouter(
       <RequirePolicy policy="view_compras_dashboard" policies={['view_compras_dashboard']}>
         <ProtectedContent />
       </RequirePolicy>
@@ -26,18 +31,21 @@ describe('<RequirePolicy>', () => {
   });
 
   test('renders default Forbidden (403) when policy is missing', () => {
-    render(
+    renderWithRouter(
       <RequirePolicy policy="view_compras_dashboard" policies={['use_gcal']}>
         <ProtectedContent />
       </RequirePolicy>
     );
     expect(screen.queryByTestId('protected-content')).not.toBeInTheDocument();
     // Ant Design Result com status 403
-    expect(screen.getByText(/sem permissão/i)).toBeInTheDocument();
+    expect(screen.getByText(/recurso indisponível/i)).toBeInTheDocument();
+    // OWASP guard: NUNCA mencionar permissão/role na mensagem default
+    expect(screen.queryByText(/permissão/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/403/)).not.toBeInTheDocument();
   });
 
   test('renders custom fallback when provided', () => {
-    render(
+    renderWithRouter(
       <RequirePolicy
         policy="view_compras_dashboard"
         policies={[]}
@@ -52,7 +60,7 @@ describe('<RequirePolicy>', () => {
 
   test('renders children when allow=true (escape hatch para flags compostas)', () => {
     // Permite passar derived flag (ex: canAccessApprovals) em vez de policy literal.
-    render(
+    renderWithRouter(
       <RequirePolicy allow={true} policies={[]}>
         <ProtectedContent />
       </RequirePolicy>
@@ -61,19 +69,22 @@ describe('<RequirePolicy>', () => {
   });
 
   test('renders fallback when allow=false', () => {
-    render(
+    renderWithRouter(
       <RequirePolicy allow={false} policies={[]}>
         <ProtectedContent />
       </RequirePolicy>
     );
     expect(screen.queryByTestId('protected-content')).not.toBeInTheDocument();
-    expect(screen.getByText(/sem permissão/i)).toBeInTheDocument();
+    expect(screen.getByText(/recurso indisponível/i)).toBeInTheDocument();
+    // OWASP guard: NUNCA mencionar permissão/role na mensagem default
+    expect(screen.queryByText(/permissão/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/403/)).not.toBeInTheDocument();
   });
 
   test('renders fallback during loading=true (avoids flash of forbidden)', () => {
     // Enquanto policies ainda não chegaram do backend, NÃO mostra Forbidden —
     // mostra loader (sem children), pra evitar flash de "Sem permissão".
-    render(
+    renderWithRouter(
       <RequirePolicy
         policy="view_compras_dashboard"
         policies={[]}
@@ -85,6 +96,6 @@ describe('<RequirePolicy>', () => {
     );
     expect(screen.getByTestId('loading')).toBeInTheDocument();
     expect(screen.queryByTestId('protected-content')).not.toBeInTheDocument();
-    expect(screen.queryByText(/sem permissão/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/recurso indisponível/i)).not.toBeInTheDocument();
   });
 });

--- a/v2/frontend/src/hooks/__tests__/usePermissions.test.js
+++ b/v2/frontend/src/hooks/__tests__/usePermissions.test.js
@@ -46,6 +46,31 @@ describe('computePermissions', () => {
     expect(perms.canAcoesInternas).toBe(false)
     expect(perms.canDashboardsMenu).toBe(false)
     expect(perms.canDisponibilidade).toBe(false)
+    expect(perms.canSeeAllSectors).toBe(false)
+  })
+
+  // Epic 3.3: SSOT para "vê todos os setores/gerências".
+  // Substitui hardcodes is_superuser || is_superintendencia || groups.includes(Super) em 4+ páginas.
+  describe('canSeeAllSectors', () => {
+    test('superuser → true', () => {
+      const perms = computePermissions(makeUser({ is_superuser: true }))
+      expect(perms.canSeeAllSectors).toBe(true)
+    })
+
+    test('is_superintendencia flag (backend) → true', () => {
+      const perms = computePermissions(makeUser({ is_superintendencia: true }))
+      expect(perms.canSeeAllSectors).toBe(true)
+    })
+
+    test('setor Superintendência → true', () => {
+      const perms = computePermissions(makeUser({ setores: ['Superintendência'] }))
+      expect(perms.canSeeAllSectors).toBe(true)
+    })
+
+    test('user sem nenhum desses → false', () => {
+      const perms = computePermissions(makeUser({ setores: ['Controle'], funcoes: ['Coordenador'] }))
+      expect(perms.canSeeAllSectors).toBe(false)
+    })
   })
 
   test('superuser gets all capabilities', () => {

--- a/v2/frontend/src/hooks/usePermissions.ts
+++ b/v2/frontend/src/hooks/usePermissions.ts
@@ -2,6 +2,13 @@ import { useMemo } from 'react';
 import type { CurrentUser } from '../types';
 
 export interface Permissions {
+  /**
+   * `is_superuser` exposto via flag canônica para escape hatches de admin
+   * (debug widgets, bypass de validações em wizards). Use SOMENTE quando a
+   * intenção é admin-only — para regras de negócio normais, prefira
+   * `canSeeAllSectors`/`canControle`/derived flag específica.
+   */
+  isAdmin: boolean;
   // Role flags
   isCoordenador: boolean;
   isFormador: boolean;
@@ -25,9 +32,21 @@ export interface Permissions {
   canMapaBrasil: boolean;
   canDashboardsMenu: boolean;
   canDisponibilidade: boolean;
+  /**
+   * "Vê todas as gerências/setores" — semântica unificada para auto-seleção
+   * de filtros e widgets cross-setor (FiltersBar, GerenciaSelector, etc.).
+   *
+   * Inclui: superuser, Superintendência (campo `is_superintendencia` do
+   * backend OU presença em `setores`).
+   *
+   * Substitui hardcodes do tipo `is_superuser || is_superintendencia ||
+   * groups.includes('Superintendência')` espalhados em páginas (Epic 3.3).
+   */
+  canSeeAllSectors: boolean;
 }
 
 const EMPTY_PERMISSIONS: Permissions = {
+  isAdmin: false,
   isCoordenador: false,
   isFormador: false,
   isGerente: false,
@@ -48,12 +67,15 @@ const EMPTY_PERMISSIONS: Permissions = {
   canMapaBrasil: false,
   canDashboardsMenu: false,
   canDisponibilidade: false,
+  canSeeAllSectors: false,
 };
 
 function computePermissionsInternal(user: CurrentUser): Permissions {
   const setores = user.setores || [];
   const funcoes = user.funcoes || [];
 
+  // Admin escape hatch (use com parcimônia — apenas para widgets debug/bypass).
+  const isAdmin = user.is_superuser === true;
   // Role flags
   const isCoordenador = funcoes.includes('Coordenador') || funcoes.includes('Apoio de Coordenação');
   const isFormador = funcoes.includes('Formador');
@@ -80,8 +102,14 @@ function computePermissionsInternal(user: CurrentUser): Permissions {
   const canDashboardsMenu =
     canDashboardOverview || canDashboardCompras || canDashboardEquipe || canDashboardGcal || canMapaBrasil;
   const canDisponibilidade = user.is_superuser || !inControle;
+  // Epic 3.3: derived flag unificada para "vê todos os setores/gerências".
+  // Substitui hardcodes is_superuser || is_superintendencia || groups.includes('Superintendência')
+  // em FiltersBar, PreAgendaPage, Solicitacoes, ApprovalsPage.
+  const canSeeAllSectors =
+    user.is_superuser || user.is_superintendencia === true || inSuperintendencia;
 
   return {
+    isAdmin,
     isCoordenador,
     isFormador,
     isGerente,
@@ -102,6 +130,7 @@ function computePermissionsInternal(user: CurrentUser): Permissions {
     canMapaBrasil,
     canDashboardsMenu,
     canDisponibilidade,
+    canSeeAllSectors,
   };
 }
 

--- a/v2/frontend/src/pages/Deslocamentos/DeslocamentosPage.tsx
+++ b/v2/frontend/src/pages/Deslocamentos/DeslocamentosPage.tsx
@@ -49,6 +49,7 @@ import {
 } from '@ant-design/icons';
 import dayjs from 'dayjs';
 import { getMe } from '../../api/availability';
+import { computePermissions } from '../../hooks/usePermissions';
 import { importDeslocamentos } from '../../api/ops';
 import ImportUploader, { ValidationResult, ApplyResult } from '../../components/ImportUploader';
 import logger from '../../utils/logger';
@@ -259,18 +260,16 @@ export default function DeslocamentosPage(): JSX.Element {
   const [form] = Form.useForm<FormValuesType>();
 
   // Load user and check permissions
+  // Epic 3.3 cleanup: substitui hardcode `is_superuser || is_superintendencia` por
+  // `computePermissions(userData)` (SSOT). Nota: a rota já é protegida por
+  // <RequirePolicy> no AppRoutes (Epic 3.1+3.2) — este check local é defesa
+  // em camadas e fonte do banner de loading da página.
   useEffect(() => {
     async function loadUser(): Promise<void> {
       try {
         const userData = await getMe();
-
-        // Check RBAC: Controle, Coordenador, or DAT
-        const canControle = userData.groups?.includes('Controle');
-        const canCoordenador = userData.groups?.includes('Coordenador');
-        const canDAT = userData.groups?.includes('DAT');
-        const canSuper = userData.is_superuser || userData.is_superintendencia;
-
-        setCanAccess(!!(canControle || canCoordenador || canDAT || canSuper));
+        const perms = computePermissions(userData);
+        setCanAccess(perms.canControle || perms.canCoordenador || perms.canDAT || perms.inSuperintendencia);
       } catch (error) {
         logger.error('Erro ao carregar usuário:', error);
         setCanAccess(false);

--- a/v2/frontend/src/pages/Disponibilidade/FiltersBar.tsx
+++ b/v2/frontend/src/pages/Disponibilidade/FiltersBar.tsx
@@ -11,6 +11,7 @@
 
 import { useState, useEffect, useMemo, ChangeEvent, JSX } from 'react';
 import { getGerencias, getMe } from '../../api/availability';
+import { computePermissions } from '../../hooks/usePermissions';
 import type { ID, CurrentUser, Gerencia } from '../../types';
 import logger from '../../utils/logger';
 
@@ -58,9 +59,10 @@ export default function FiltersBar({ year, month, gerenciaId, sector, q, onChang
         setAllGerencias(gerenciasData);
         setUserInfo(meData);
 
-        // Auto-seleciona gerência se usuário não é Superintendência
-        // e ainda não tem gerência selecionada
-        if (!meData.is_superintendencia && meData.setores?.length > 0) {
+        // Auto-seleciona gerência se usuário não vê todos os setores e tem setor próprio.
+        // Epic 3.3 cleanup: substitui `!is_superintendencia` por flag derivada (SSOT).
+        const meDataPerms = computePermissions(meData);
+        if (!meDataPerms.canSeeAllSectors && meData.setores?.length > 0) {
           const userSetores = meData.setores;
           // Converte grupos RBAC para nome_setor
           const userNomeSetores = userSetores.map(
@@ -90,8 +92,10 @@ export default function FiltersBar({ year, month, gerenciaId, sector, q, onChang
   const gerencias = useMemo((): Gerencia[] => {
     if (!userInfo || !allGerencias.length) return [];
 
-    // Superintendência ou superuser vê todas as gerências
-    if (userInfo.is_superintendencia || userInfo.is_superuser) {
+    const perms = computePermissions(userInfo);
+
+    // Vê todas as gerências (canSeeAllSectors: superuser/Superintendência/etc.)
+    if (perms.canSeeAllSectors) {
       return allGerencias;
     }
 
@@ -109,8 +113,9 @@ export default function FiltersBar({ year, month, gerenciaId, sector, q, onChang
 
   /**
    * Verifica se pode ver todas as gerências (opção "Todas").
+   * Epic 3.3 cleanup: usa flag derivada (SSOT em usePermissions).
    */
-  const canSeeAll = userInfo?.is_superintendencia || userInfo?.is_superuser;
+  const canSeeAll = userInfo ? computePermissions(userInfo).canSeeAllSectors : false;
 
   /**
    * Incrementa/decrementa mês.

--- a/v2/frontend/src/pages/Home/HomePage.tsx
+++ b/v2/frontend/src/pages/Home/HomePage.tsx
@@ -22,6 +22,7 @@ import {
 } from '@ant-design/icons';
 import { getMe } from '../../api/availability';
 import { getHomeStats } from '../../api/stats';
+import { computePermissions } from '../../hooks/usePermissions';
 import logger from '../../utils/logger';
 import type { CurrentUser } from '../../types';
 
@@ -130,21 +131,14 @@ export default function HomePage(): JSX.Element {
     );
   }
 
-  // Calcular permissões (RBAC com Setor + Função)
-  const setores = user?.setores || [];
-  const funcoes = user?.funcoes || [];
-
-  // isAdmin = apenas superusers (acesso administrativo completo)
-  const isAdmin = user?.is_superuser;
-  // canApproveSuper = pode aprovar/reprovar solicitações (Superintendência/DAT)
-  const canApproveSuper = user?.can_approve_super || false;
-  // isManager = Gerente de qualquer setor (dashboards, métricas)
-  const isGerente = user?.is_superuser || funcoes.includes('Gerente');
-  const isManager = isGerente && (setores.includes('Gerência') || isAdmin);
-  // isCoordenador = pode criar solicitações
-  const isCoordenador = user?.is_superuser || funcoes.includes('Coordenador') || funcoes.includes('Apoio de Coordenação') || setores.includes('DAT');
-  // canDAT = acesso ao Admin DAT
-  const canDAT = user?.is_superuser || setores.includes('DAT');
+  // Calcular permissões (RBAC com Setor + Função).
+  // Epic 3.3 cleanup: usa computePermissions (SSOT) em vez de hardcodes inline.
+  const perms = computePermissions(user);
+  const isAdmin = perms.isAdmin;
+  const canApproveSuper = perms.canApproveSuper;
+  const isManager = perms.isGerente && (perms.inGerencia || perms.isAdmin);
+  const isCoordenador = perms.canCoordenador;
+  const canDAT = perms.canDAT;
 
   return (
     <div className="p-6">

--- a/v2/frontend/src/pages/PreAgenda/PreAgendaPage.tsx
+++ b/v2/frontend/src/pages/PreAgenda/PreAgendaPage.tsx
@@ -68,6 +68,7 @@ import {
 import { getStatusSummary, reapplyBatch, resyncBatch, type GCalStatusSummary } from '../../api/gcal';
 import { MeetLink } from '../../components/MeetLink';
 import { getMe } from '../../api/availability';
+import { computePermissions } from '../../hooks/usePermissions';
 import useGoogleIntegration from '../../hooks/useGoogleIntegration';
 import useGoogleGuard from '../../hooks/useGoogleGuard';
 import GoogleIntegrationCard from '../../components/google/GoogleIntegrationCard';
@@ -599,10 +600,10 @@ export default function PreAgendaPage(): JSX.Element {
     },
   ];
 
-  // OAuth Phase 5: RBAC - verificar se é Controle ou Super
-  const canControle = user?.is_superuser || user?.groups?.includes('Controle');
-  const canSuper = user?.is_superuser || user?.is_superintendencia || user?.groups?.includes('Superintendência');
-  const showGoogleCard = canControle || canSuper;
+  // OAuth Phase 5: RBAC — verificar se é Controle ou Super.
+  // Epic 3.3 cleanup: usa flags derivadas do usePermissions (SSOT).
+  const userPerms = user ? computePermissions(user) : null;
+  const showGoogleCard = !!(userPerms?.canControle || userPerms?.canSeeAllSectors);
 
   // Handlers para o card Google
   const handleGoogleConnect = (): void => {
@@ -977,8 +978,8 @@ export default function PreAgendaPage(): JSX.Element {
               </Card>
             )}
 
-            {/* Informações Técnicas (Colapsável) - Apenas superuser */}
-            {user?.is_superuser && (
+            {/* Informações Técnicas (Colapsável) — apenas superuser (debug widget). Epic 3.3: usa flag isAdmin (SSOT). */}
+            {userPerms?.isAdmin && (
               <Collapse
                 size="small"
                 items={[

--- a/v2/frontend/src/pages/Solicitacoes.tsx
+++ b/v2/frontend/src/pages/Solicitacoes.tsx
@@ -39,6 +39,7 @@ import {
   rejectSolicitacao,
 } from '../api/solicitacoes';
 import { getMe } from '../api/availability';
+import { computePermissions } from '../hooks/usePermissions';
 import { MeetLink } from '../components/MeetLink';
 import { TIMING } from '../constants/timing';
 import { usePolling } from '../hooks/usePolling';
@@ -104,13 +105,9 @@ function Solicitacoes(): JSX.Element {
       try {
         const user = await getMe();
 
-        // PA-06: Verificar se usuário pertence ao grupo "Superintendência" ou é superuser
-        const isSuper =
-          user?.is_superuser ||
-          user?.is_superintendencia ||
-          user?.groups?.includes('Superintendência') ||
-          false;
-        setIsSuperintendencia(isSuper);
+        // PA-06: Superintendência pode aprovar/reprovar.
+        // Epic 3.3 cleanup: usa flag derivada (SSOT em usePermissions).
+        setIsSuperintendencia(computePermissions(user).canSeeAllSectors);
       } catch (error) {
         logger.error('Erro ao buscar usuário:', error);
         setIsSuperintendencia(false);

--- a/v2/frontend/src/pages/Solicitacoes/NewSolicitacaoWizard.tsx
+++ b/v2/frontend/src/pages/Solicitacoes/NewSolicitacaoWizard.tsx
@@ -42,6 +42,7 @@ import {
   lookupTiposEvento,
 } from '../../api/lookup';
 import { getMe } from '../../api/availability';
+import { computePermissions } from '../../hooks/usePermissions';
 import DateTimeRange from '../../components/DateTimeRange';
 import ComboBox from '../../components/ComboBox';
 import FormadoresPicker from '../../components/FormadoresPicker';
@@ -145,7 +146,9 @@ export default function NewSolicitacaoWizard(): JSX.Element {
       try {
         const me = await getMe();
         if (mounted) {
-          setIsSuperuser(Boolean(me?.is_superuser));
+          // Epic 3.3 cleanup: usa flag derivada (SSOT). Admin escape hatch
+          // do wizard — bypassa exigência de projeto/município no Step 2.
+          setIsSuperuser(computePermissions(me).isAdmin);
         }
       } catch (error) {
         logger.warn('Falha ao carregar perfil do usuário no wizard:', error);


### PR DESCRIPTION
**Parent epic**: #1226
**Closes**: #1229

## Encerra programa RBAC Access Policy Realignment

Este é o **último PR** do programa iniciado em 2026-04-26. Após o merge:

| Epic | Status | PRs |
|------|--------|-----|
| 1 — Backend fixes + seed realign | ✅ | #1230 |
| 2 — /meus-eventos | ✅ | #1237, #1238 |
| 4 — Capability Policy Layer | ✅ | #1239, #1240, #1241, #1242, #1243, #1244, #1245 |
| 3 — Frontend access layer + UX polish | ✅ | #1246, **este PR** |

## Summary

Encerra dívida residual do programa em 2 frentes coesas:

### 1. Mensagem genérica de acesso negado (OWASP Authorization Cheat Sheet)

`<RequirePolicy>` default + `<Forbidden />` inline em `AppRoutes.tsx` agora exibem:

| Antes | Depois |
|-------|--------|
| Status: `403` | Status: `info` |
| Título: \"Sem permissão\" | Título: \"Recurso indisponível\" |
| Subtítulo: \"Você não tem permissão para acessar esta página.\" | Subtítulo: \"Esta página não está disponível ou não pode ser acessada pela sua conta.\" |
| Sem CTA | CTA: \"Voltar ao início\" |

Princípio: **não revelar** existência do recurso, código HTTP, ou nome da permission/role necessária. Tests novos validam guards OWASP (\"permissão\", \"403\" não devem aparecer).

### 2. Cleanup de role hardcodes residuais (SSOT em usePermissions)

Adiciona 2 derived flags canônicas no \`usePermissions\`:

- **\`isAdmin\`**: alias canônico de \`is_superuser\`. Use **SOMENTE** para escape hatches de admin (debug widgets, bypass de validações em wizards).
- **\`canSeeAllSectors\`**: SSOT para \"vê todos os setores/gerências\".
  = \`is_superuser || is_superintendencia || setores.includes('Superintendência')\`

7 arquivos migrados (≈9 hardcodes inline removidos):

| Arquivo | Padrão substituído | Substituição |
|---------|--------------------|--------------|
| App.tsx:108 | \`setores?.includes('Controle') \|\| is_superuser\` | \`permissions.canControle\` |
| DeslocamentosPage.tsx | \`is_superuser \|\| is_superintendencia\` | \`computePermissions(userData).*\` |
| FiltersBar.tsx (3x) | \`is_superintendencia \|\| is_superuser\` | \`computePermissions(meData).canSeeAllSectors\` |
| PreAgendaPage.tsx (2x) | \`is_superuser \|\| groups.includes(...)\` | \`computePermissions(user).{canControle,canSeeAllSectors,isAdmin}\` |
| Solicitacoes.tsx (PA-06) | \`is_superuser \|\| is_superintendencia \|\| groups.includes(...)\` | \`computePermissions(user).canSeeAllSectors\` |
| HomePage.tsx (5 inline) | \`is_superuser \|\| funcoes.includes(...) \|\| setores.includes(...)\` | \`computePermissions(user).*\` |
| NewSolicitacaoWizard.tsx | \`is_superuser\` (escape hatch) | \`computePermissions(me).isAdmin\` |

### Hardcodes intencionais que permanecem

- \`types/usuario.ts\`: type definition + payload validator
- \`api/adminDAT.ts\`: type definition (CRUD de usuário admin)
- \`pages/AdminDAT/UsuariosPage.tsx\`: gerencia campo \`is_superuser\` no formulário admin (fluxo legítimo de CRUD)
- \`ApprovalsPage.tsx\`: apenas comentários documentando regra do backend
- \`*test*.{ts,tsx}\`: fixtures de mock

## Architectural notes — checklist Done

- ✅ Nenhuma tela lê setor diretamente para autorizar UI (apenas via flag derivada)
- ✅ Nenhuma tela lê função diretamente
- ✅ Nenhuma tela usa \`is_superintendencia\` para menu/acesso (canSeeAllSectors)
- ✅ Mensagem neutra de acesso negado
- ✅ Redirects antigos preservados (Epic 3.1)
- ✅ Policy layer consumida por toda navegação principal (Epic 3.2)

## Test plan

- vitest run: **225/225 PASS** (28 test files, +4 testes novos para canSeeAllSectors)
- npx tsc --noEmit: 0 erros
- npm run build: OK 8s
- ESLint: clean

## Commits dentro do PR

1. \`feat(frontend): Epic 3.3 — mensagem 403 genérica (OWASP) + CTA voltar ao início\`
2. \`refactor(frontend): Epic 3.3 — remove residual role hardcodes (SSOT em usePermissions)\`

## Staging gate

ALL 8 CHECKS PASSED

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR
- [x] Feature complete (Epic 3.3 — encerra programa RBAC Access Policy Realignment)
- [x] Tests updated (+4 testes para canSeeAllSectors, ajustes em RequirePolicy.test, 225/225 verde)
- [x] TS/Lint clean (tsc 0 erros, vite build OK, ESLint warnings-only de config)