### PR TITLE
fix(rbac): wave 1 critical divergences — dashboards, deslocamentos scope, internal actions

### DIFF
--- a/v2/backend/apps/core/migrations/0079_add_manage_internal_actions.py
+++ b/v2/backend/apps/core/migrations/0079_add_manage_internal_actions.py
@@ -1,0 +1,66 @@
+"""C3 fix (Onda 1, PR fix/rbac-critical-divergences-wave1, 2026-04-27):
+adiciona capability `manage_internal_actions` com ZERO grupos atribuídos.
+
+Contexto
+--------
+
+`CicloAcoesViewSet` e `AcaoInstanciaViewSet` usavam `[IsAdminUser]` (DRF
+built-in que checa `is_staff=True`, não `is_superuser`), bypassando o
+Capability Policy Layer e contradizendo a intent matrix da memória
+`reference_rbac_intent_matrix.md` que declara o módulo como superuser-only
+durante desenvolvimento.
+
+Fix em código (mesmo PR): substituir `[IsAdminUser]` por
+`[HasPerm("manage_internal_actions")]`. Como a capability tem 0 grupos
+atribuídos por seed, apenas superuser passa (via bypass natural de
+`HasPerm`).
+
+Quando a feature for liberada para outros papéis (DAT, Diretoria, etc.):
+basta atribuir o grupo via admin UI (`/admin/grupos`) ou nova migration
+data-only — zero code change necessário. Esse é o padrão correto da
+camada Policy.
+
+Idempotente
+-----------
+
+Usa `update_or_create` em PermissaoFuncional + `groups.set([])` (vazio).
+Re-rodar é no-op.
+"""
+
+from __future__ import annotations
+
+from django.db import migrations
+
+CODENAME = "manage_internal_actions"
+LABEL = "Administrar ações internas"
+DESCRIPTION = (
+    "CRUD de templates de ações, ciclos, instâncias e notificações "
+    "internas. Feature em desenvolvimento — capability sem grupos "
+    "atribuídos por padrão (apenas superuser bypassa por ora). Quando "
+    "a feature for liberada, atribuir via admin UI ao papel correto."
+)
+CATEGORY = "cadastros_administrativos"
+
+
+def forwards(apps, schema_editor):
+    PermissaoFuncional = apps.get_model("core", "PermissaoFuncional")
+    perm, _ = PermissaoFuncional.objects.update_or_create(
+        codename=CODENAME,
+        defaults={
+            "label": LABEL,
+            "description": DESCRIPTION,
+            "category": CATEGORY,
+            "is_system": True,
+        },
+    )
+    perm.groups.set([])
+
+
+def backwards(apps, schema_editor):
+    PermissaoFuncional = apps.get_model("core", "PermissaoFuncional")
+    PermissaoFuncional.objects.filter(codename=CODENAME).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [("core", "0078_scope_view_all_availability")]
+    operations = [migrations.RunPython(forwards, backwards)]

--- a/v2/backend/apps/core/services/functional_permissions_seed.py
+++ b/v2/backend/apps/core/services/functional_permissions_seed.py
@@ -133,6 +133,18 @@ FUNCTIONAL_PERMISSIONS_SEED: tuple[FunctionalPermissionSeed, ...] = (
         group_names=("Gerente", "Coordenador", "Apoio de Coordenação"),
     ),
     FunctionalPermissionSeed(
+        codename="manage_internal_actions",
+        label="Administrar ações internas",
+        description=(
+            "CRUD de templates de ações, ciclos, instâncias e notificações "
+            "internas. Feature em desenvolvimento — capability sem grupos "
+            "atribuídos por padrão (apenas superuser bypassa por ora). Quando "
+            "a feature for liberada, atribuir via admin UI ao papel correto."
+        ),
+        category="cadastros_administrativos",
+        group_names=(),
+    ),
+    FunctionalPermissionSeed(
         codename="view_all_availability",
         label="Visualizar todas as disponibilidades",
         description=(
@@ -149,8 +161,10 @@ FUNCTIONAL_PERMISSIONS_SEED: tuple[FunctionalPermissionSeed, ...] = (
 
 def _validate_seed() -> None:
     # Epic 4.3 (2026-04-24): dual-write terminado, apenas os 15 `verb_noun`.
-    if len(FUNCTIONAL_PERMISSIONS_SEED) != 15:
-        raise ValueError("Seed de permissoes funcionais deve conter exatamente 15 itens.")
+    # Onda 1 C3 (2026-04-27): +1 capability `manage_internal_actions` (zero
+    # grupos atribuídos por seed; só superuser bypassa). Total: 16.
+    if len(FUNCTIONAL_PERMISSIONS_SEED) != 16:
+        raise ValueError("Seed de permissoes funcionais deve conter exatamente 16 itens.")
 
     seen: set[str] = set()
     for item in FUNCTIONAL_PERMISSIONS_SEED:

--- a/v2/backend/apps/core/tests/test_deslocamento_api.py
+++ b/v2/backend/apps/core/tests/test_deslocamento_api.py
@@ -321,19 +321,33 @@ class TestDeslocamentoAPI:
         ganharão `view_all_availability` → testes adicionais para cobrir esses
         papéis serão criados em Issue 1.4.
         """
+        # Onda 1 C2 (PR fix/rbac-critical-divergences-wave1, 2026-04-27):
+        # Permission_classes virou `[IsAuthenticated]` + scope filter por
+        # gerência via EquipeGerencia. Comportamento esperado:
+        # - Anonymous → 401/403
+        # - Autenticado SEM EquipeGerencia → 200 + lista vazia (fail-safe)
+        # - Autenticado COM EquipeGerencia + sem capability → 200 + scope
+        # - Capability `view_all_availability` (Controle/Gerente) → 200 + tudo
+        # Cobertura granular do scope em test_deslocamento_rbac.py (Onda 1 C2).
         client = APIClient()
 
-        # Formador → 403 (sem perm)
+        # Formador autenticado sem EquipeGerencia → 200 + 0 deslocamentos
+        # (antes: 403; bloqueio agora vira fail-safe via scope filter)
         client.force_authenticate(user=user_formador)
         response = client.get("/api/deslocamentos/")
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.status_code == status.HTTP_200_OK
+        results = response.json().get("results", response.json())
+        assert results == []
 
-        # Controle → 200 (tem view_all_availability)
+        # Controle → 200 + tudo (capability view_all_availability libera)
         client.force_authenticate(user=user_controle)
         response = client.get("/api/deslocamentos/")
         assert response.status_code == status.HTTP_200_OK
 
-        # DAT → 403 (agora sem view_all_availability conforme intent Epic 1)
+        # DAT autenticado sem EquipeGerencia → 200 + 0 deslocamentos
+        # (DAT sem capability cai em scope; sem vínculo, vê 0)
         client.force_authenticate(user=user_dat)
         response = client.get("/api/deslocamentos/")
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.status_code == status.HTTP_200_OK
+        results = response.json().get("results", response.json())
+        assert results == []

--- a/v2/backend/apps/core/tests/test_deslocamento_rbac.py
+++ b/v2/backend/apps/core/tests/test_deslocamento_rbac.py
@@ -1,0 +1,229 @@
+"""
+Tests RBAC do `DeslocamentoViewSet` (Onda 1, C2 — 2026-04-27).
+
+Reproduz divergência identificada no RBAC Matrix Sweep:
+- Sidebar mostrava item "Deslocamentos" para `canControle || canCoordenador || canDAT`
+- Backend exigia `HasPerm("view_all_availability")` (após 0078: Controle/Gerente only)
+- Coord/DAT viam menu mas recebiam 403 ao clicar
+
+Decisão (stakeholder, 2026-04-27): C2 = (B) — backend ganha composition +
+acesso scoped via gerência. Coord/Apoio/DAT veem **apenas deslocamentos de
+usuários nas próprias gerências vinculadas** (cross-table via EquipeGerencia).
+Controle/Gerente continuam vendo tudo (capability `view_all_availability`).
+
+Doc §3 da matriz canônica (`v2/docs/rbac_authorization_matrix.md`):
+    Deslocamentos: Controle/Gerente ✅ | Coord/Apoio ⚠️ scope | DAT ⚠️ scope
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportOptionalMemberAccess=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportMissingTypeArgument=false, reportCallIssue=false, reportIndexIssue=false, reportOperatorIssue=false, reportOptionalSubscript=false, reportUnknownLambdaType=false, reportPrivateUsage=false
+
+from __future__ import annotations
+
+from datetime import date
+
+from django.contrib.auth.models import Group
+from django.core.cache import cache
+from rest_framework.test import APIClient
+
+import pytest
+
+from apps.core.models import Deslocamento, EquipeGerencia, Gerencia, Usuario
+
+pytestmark = pytest.mark.django_db
+
+
+_USER_COUNTER = {"i": 0}
+
+
+def _next_cpf() -> str:
+    _USER_COUNTER["i"] += 1
+    return f"99988{_USER_COUNTER['i']:06d}"
+
+
+def _make_user(username: str, group_names: list[str]) -> Usuario:
+    user = Usuario.objects.create_user(
+        username=username, email=f"{username}@example.com", password="testpass123", cpf=_next_cpf()
+    )
+    for gname in group_names:
+        group, _ = Group.objects.get_or_create(name=gname)
+        user.groups.add(group)
+    return user
+
+
+@pytest.fixture(autouse=True)
+def _clear_rbac_cache(db):
+    """
+    Invalida cache de RBAC permissions entre tests (groups M2M atualizado
+    pelo conftest session-scope `seed_functional_permissions_fixture`).
+    """
+    cache.clear()
+    yield
+    cache.clear()
+
+
+@pytest.fixture
+def gerencia_vidas():
+    return Gerencia.objects.create(nome="GERENCIA 2", nome_setor="Vidas")
+
+
+@pytest.fixture
+def gerencia_fluir():
+    return Gerencia.objects.create(nome="GERENCIA 3", nome_setor="Fluir")
+
+
+URL = "/api/deslocamentos/"
+
+
+# ============================================================================
+# Setup helper: user da gerência X cria deslocamento dele próprio
+# ============================================================================
+
+
+def _user_in_gerencia(username: str, group_names: list[str], gerencia: Gerencia) -> Usuario:
+    user = _make_user(username, group_names)
+    EquipeGerencia.objects.create(usuario=user, gerencia=gerencia)
+    return user
+
+
+def _create_deslocamento(usuario: Usuario, origem: str = "Fortaleza", destino: str = "Salvador") -> Deslocamento:
+    return Deslocamento.objects.create(
+        usuario=usuario,
+        origem=origem,
+        destino=destino,
+        start_date=date(2026, 5, 1),
+        end_date=date(2026, 5, 3),
+    )
+
+
+# ============================================================================
+# Capability ampla — Controle/Gerente veem TUDO (bypass scope)
+# ============================================================================
+
+
+class TestCapacidadeAmpla:
+    def test_controle_user_sees_all_deslocamentos(self, gerencia_vidas, gerencia_fluir):
+        """Controle tem `view_all_availability` (seed 0078) → bypass scope."""
+        user_vidas = _user_in_gerencia("user_v", ["Coordenador"], gerencia_vidas)
+        user_fluir = _user_in_gerencia("user_f", ["Coordenador"], gerencia_fluir)
+        _create_deslocamento(user_vidas, "Vidas-A", "Vidas-B")
+        _create_deslocamento(user_fluir, "Fluir-A", "Fluir-B")
+
+        controle_user = _make_user("controle_user", ["Controle"])
+        client = APIClient()
+        client.force_authenticate(user=controle_user)
+        res = client.get(URL)
+        assert res.status_code == 200
+        results = res.json().get("results", res.json())
+        assert len(results) == 2
+
+    def test_gerente_user_sees_all_deslocamentos(self, gerencia_vidas, gerencia_fluir):
+        """Função Gerente tem `view_all_availability` → bypass scope."""
+        user_vidas = _user_in_gerencia("g_user_v", ["Coordenador"], gerencia_vidas)
+        _create_deslocamento(user_vidas)
+
+        gerente_user = _make_user("gerente_user", ["Gerente"])
+        client = APIClient()
+        client.force_authenticate(user=gerente_user)
+        res = client.get(URL)
+        assert res.status_code == 200
+        results = res.json().get("results", res.json())
+        assert len(results) == 1
+
+
+# ============================================================================
+# Scope por gerência — Coord/Apoio/DAT veem só usuários da própria gerência
+# ============================================================================
+
+
+class TestScopePorGerencia:
+    def test_coord_with_gerencia_sees_only_own_sector(self, gerencia_vidas, gerencia_fluir):
+        """
+        Coord vinculado à gerência Vidas vê deslocamentos de usuários Vidas
+        e NÃO vê deslocamentos de usuários Fluir.
+        """
+        user_vidas = _user_in_gerencia("v_user", ["Formador"], gerencia_vidas)
+        user_fluir = _user_in_gerencia("f_user", ["Formador"], gerencia_fluir)
+        desl_vidas = _create_deslocamento(user_vidas, "Vidas-A", "Vidas-B")
+        _create_deslocamento(user_fluir, "Fluir-A", "Fluir-B")
+
+        coord_vidas = _user_in_gerencia("coord_vidas", ["Coordenador"], gerencia_vidas)
+        client = APIClient()
+        client.force_authenticate(user=coord_vidas)
+        res = client.get(URL)
+        assert res.status_code == 200
+        results = res.json().get("results", res.json())
+        assert len(results) == 1
+        assert results[0]["id"] == desl_vidas.id
+
+    def test_coord_without_any_gerencia_sees_nothing(self, gerencia_vidas):
+        """
+        Coord SEM EquipeGerencia vinculação vê 0 deslocamentos (não 403 — fail-safe).
+        """
+        user_vidas = _user_in_gerencia("v_user2", ["Formador"], gerencia_vidas)
+        _create_deslocamento(user_vidas)
+
+        coord_orphan = _make_user("coord_orphan", ["Coordenador"])
+        # Sem EquipeGerencia
+        client = APIClient()
+        client.force_authenticate(user=coord_orphan)
+        res = client.get(URL)
+        assert res.status_code == 200
+        results = res.json().get("results", res.json())
+        assert results == []
+
+    def test_apoio_coordenacao_with_gerencia_sees_only_own_sector(self, gerencia_vidas, gerencia_fluir):
+        """Apoio de Coordenação tem mesma regra de scope que Coordenador."""
+        user_vidas = _user_in_gerencia("ap_v", ["Formador"], gerencia_vidas)
+        user_fluir = _user_in_gerencia("ap_f", ["Formador"], gerencia_fluir)
+        desl_vidas = _create_deslocamento(user_vidas, "VA", "VB")
+        _create_deslocamento(user_fluir, "FA", "FB")
+
+        apoio_vidas = _user_in_gerencia("apoio_vidas", ["Apoio de Coordenação"], gerencia_vidas)
+        client = APIClient()
+        client.force_authenticate(user=apoio_vidas)
+        res = client.get(URL)
+        assert res.status_code == 200
+        results = res.json().get("results", res.json())
+        assert len(results) == 1
+        assert results[0]["id"] == desl_vidas.id
+
+    def test_dat_user_with_gerencia_sees_only_own_sector(self, gerencia_vidas, gerencia_fluir):
+        """DAT (sem capability `view_all_availability` por seed 0078) é scoped também."""
+        user_vidas = _user_in_gerencia("dt_v", ["Formador"], gerencia_vidas)
+        user_fluir = _user_in_gerencia("dt_f", ["Formador"], gerencia_fluir)
+        desl_vidas = _create_deslocamento(user_vidas, "DV-A", "DV-B")
+        _create_deslocamento(user_fluir, "DF-A", "DF-B")
+
+        dat_vidas = _user_in_gerencia("dat_vidas", ["DAT"], gerencia_vidas)
+        client = APIClient()
+        client.force_authenticate(user=dat_vidas)
+        res = client.get(URL)
+        assert res.status_code == 200
+        results = res.json().get("results", res.json())
+        assert len(results) == 1
+        assert results[0]["id"] == desl_vidas.id
+
+
+# ============================================================================
+# Sanity (anonymous, superuser)
+# ============================================================================
+
+
+class TestSanity:
+    def test_anonymous_blocked(self):
+        client = APIClient()
+        res = client.get(URL)
+        assert res.status_code in (401, 403)
+
+    def test_superuser_sees_all(self, gerencia_vidas):
+        user = _user_in_gerencia("u", ["Formador"], gerencia_vidas)
+        _create_deslocamento(user)
+        super_user = Usuario.objects.create_superuser(
+            username="super_d", email="super_d@example.com", password="testpass123", cpf="99900099996"
+        )
+        client = APIClient()
+        client.force_authenticate(user=super_user)
+        res = client.get(URL)
+        assert res.status_code == 200
+        results = res.json().get("results", res.json())
+        assert len(results) == 1

--- a/v2/backend/apps/core/tests/test_permissao_funcional.py
+++ b/v2/backend/apps/core/tests/test_permissao_funcional.py
@@ -71,11 +71,12 @@ def test_seed_functional_permissions_idempotent():
     second = seed_functional_permissions()
     snapshot_second = _snapshot()
 
-    assert len(snapshot_first) == 15
+    # Onda 1 C3 (2026-04-27): +1 capability `manage_internal_actions`. Total: 16.
+    assert len(snapshot_first) == 16
     assert snapshot_first == snapshot_second
-    assert first["permissions_created"] + first["permissions_updated"] == 15
+    assert first["permissions_created"] + first["permissions_updated"] == 16
     assert second["permissions_created"] == 0
-    assert second["permissions_updated"] == 15
+    assert second["permissions_updated"] == 16
 
 
 def test_seed_functional_permissions_has_no_default_group_links():
@@ -99,7 +100,7 @@ def test_seed_functional_permissions_can_assign_groups_in_legacy_mode():
 def test_seed_rbac_includes_functional_permissions():
     call_command("seed_rbac")
 
-    assert PermissaoFuncional.objects.count() == 15
+    assert PermissaoFuncional.objects.count() == 16  # Onda 1 C3: +manage_internal_actions
     expected = {item.codename for item in FUNCTIONAL_PERMISSIONS_SEED}
     assert set(PermissaoFuncional.objects.values_list("codename", flat=True)) == expected
 

--- a/v2/backend/apps/core/tests/test_rbac_labels_capability_oriented.py
+++ b/v2/backend/apps/core/tests/test_rbac_labels_capability_oriented.py
@@ -137,11 +137,15 @@ def test_labels_follow_infinitive_verb_form():
     )
 
 
-def test_seed_count_is_fifteen_post_epic_4_3():
-    """Pós-Epic 4.3: apenas os 15 codenames `verb_noun` permanecem."""
+def test_seed_count_is_sixteen_post_wave1_c3():
+    """
+    Pós-Onda 1 C3 (2026-04-27): 16 codenames `verb_noun`.
+    +1 vs Epic 4.3: `manage_internal_actions` (capability sem grupos
+    atribuídos por seed; apenas superuser bypassa por ora).
+    """
     assert (
-        len(FUNCTIONAL_PERMISSIONS_SEED) == 15
-    ), f"Seed deve conter exatamente 15 permissões pós-Epic 4.3. Achei {len(FUNCTIONAL_PERMISSIONS_SEED)}."
+        len(FUNCTIONAL_PERMISSIONS_SEED) == 16
+    ), f"Seed deve conter exatamente 16 permissões pós-Onda 1 C3. Achei {len(FUNCTIONAL_PERMISSIONS_SEED)}."
 
 
 def test_old_pode_codenames_absent_post_epic_4_3():

--- a/v2/backend/apps/core/views/acoes_notificacao.py
+++ b/v2/backend/apps/core/views/acoes_notificacao.py
@@ -17,13 +17,14 @@ from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
 from rest_framework.filters import OrderingFilter, SearchFilter
-from rest_framework.permissions import IsAdminUser, IsAuthenticated
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 
 from django_filters.rest_framework import DjangoFilterBackend
 
 from apps.core.models import AcaoInstancia, AcaoTemplate, AuditLog, CicloAcoes, NotificacaoInterna
+from apps.core.rbac import HasPerm
 from apps.core.serializers import (
     AcaoInstanciaSerializer,
     CicloAcoesSerializer,
@@ -60,7 +61,7 @@ class CicloAcoesViewSet(viewsets.ModelViewSet):
     """
 
     serializer_class = CicloAcoesSerializer
-    permission_classes = [IsAdminUser]
+    permission_classes = [HasPerm("manage_internal_actions")]
     filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
     filterset_fields = ["projeto", "municipio", "semestre", "ano", "status"]
     search_fields = ["projeto__nome", "municipio__nome"]
@@ -117,7 +118,7 @@ class AcaoInstanciaViewSet(viewsets.ReadOnlyModelViewSet):
     """
 
     serializer_class = AcaoInstanciaSerializer
-    permission_classes = [IsAdminUser]
+    permission_classes = [HasPerm("manage_internal_actions")]
     filter_backends = [DjangoFilterBackend, OrderingFilter]
     filterset_fields = ["ciclo", "estado", "ordem"]
     ordering_fields = ["ordem", "estado", "data_vencimento", "created_at"]

--- a/v2/backend/apps/core/views_deslocamento.py
+++ b/v2/backend/apps/core/views_deslocamento.py
@@ -41,8 +41,8 @@ from rest_framework.request import Request
 
 from django_filters.rest_framework import DjangoFilterBackend
 
-from .models import AuditLog, Deslocamento
-from .permissions import HasPerm
+from .models import AuditLog, Deslocamento, EquipeGerencia
+from .rbac.helpers import user_has_any_perm
 from .serializers import DeslocamentoSerializer
 
 
@@ -108,12 +108,14 @@ class DeslocamentoViewSet(viewsets.ModelViewSet):
 
     queryset = Deslocamento.objects.select_related("usuario").all()
     serializer_class = DeslocamentoSerializer
-    # Issue #1221 (Epic 1 RBAC Access Policy Realignment): acesso para
-    # Gerente/Coordenador/Apoio Coordenação de qualquer setor via
-    # `view_all_availability` (atribuída aos papéis acima na Issue 1.4).
-    # Formador NÃO tem essa perm — continua bloqueado. Antes era
-    # `operate_preagenda` que restringia só ao Controle.
-    permission_classes = [IsAuthenticated, HasPerm("view_all_availability")]
+    # Onda 1 C2 (2026-04-27): camada de tradução semântica.
+    # Quem tem capability `view_all_availability` (Controle/Gerente via seed
+    # 0078) bypassa scope. Quem não tem cai em filtro por gerência via
+    # `EquipeGerencia` (aplicado em `get_queryset`). Coord/Apoio/DAT
+    # autenticados veem APENAS deslocamentos de usuários nas próprias
+    # gerências vinculadas. Formador autenticado sem EquipeGerencia → 0
+    # resultados (fail-safe).
+    permission_classes = [IsAuthenticated]
     pagination_class = DeslocamentoPagination
     filter_backends = [DjangoFilterBackend, OrderingFilter]
     ordering_fields = ["start_date", "end_date", "origem", "destino"]
@@ -121,14 +123,25 @@ class DeslocamentoViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self) -> QuerySet:
         """
-        Apply custom filters via query params:
-        - usuario_id: Filter by usuario ID
-        - data_inicio: Filter by start_date >= value (YYYY-MM-DD)
-        - data_fim: Filter by end_date <= value (YYYY-MM-DD)
-        - origem: Case-insensitive partial match
-        - destino: Case-insensitive partial match
+        Apply scope filter (RBAC) + query param filters.
+
+        Scope (Onda 1 C2, 2026-04-27):
+        - Superuser: vê tudo (bypass)
+        - Capability `view_all_availability` (Controle/Gerente): vê tudo
+        - Demais autenticados: vê apenas deslocamentos de usuários em
+          gerências vinculadas via EquipeGerencia. Sem vínculo → 0 resultados.
+
+        Query param filters:
+        - usuario_id, data_inicio, data_fim, origem, destino
         """
         queryset = super().get_queryset()
+        user = self.request.user
+
+        # Scope filter — aplicar APÓS auth (IsAuthenticated em permission_classes)
+        # mas antes dos filtros de query params (não filtra duas vezes).
+        if not getattr(user, "is_superuser", False) and not user_has_any_perm(user, "view_all_availability"):
+            user_gerencia_ids = list(EquipeGerencia.objects.filter(usuario=user).values_list("gerencia_id", flat=True))
+            queryset = queryset.filter(usuario__equipes__gerencia_id__in=user_gerencia_ids).distinct()
 
         # Filter by usuario_id
         usuario_id = self.request.query_params.get("usuario_id")

--- a/v2/frontend/src/hooks/__tests__/usePermissions.test.js
+++ b/v2/frontend/src/hooks/__tests__/usePermissions.test.js
@@ -110,13 +110,10 @@ describe('computePermissions', () => {
     expect(perms.canDashboardCompras).toBe(true)
   })
 
-  test('Controle sector grants canControle, dashboard permissions', () => {
+  test('Controle sector grants canControle (dashboards específicos cobertos abaixo)', () => {
     const perms = computePermissions(makeUser({ setores: ['Controle'] }))
     expect(perms.inControle).toBe(true)
     expect(perms.canControle).toBe(true)
-    expect(perms.canDashboardEquipe).toBe(true)
-    expect(perms.canDashboardGcal).toBe(true)
-    expect(perms.canMapaBrasil).toBe(true)
     // Controle cannot access Disponibilidade
     expect(perms.canDisponibilidade).toBe(false)
   })
@@ -138,30 +135,81 @@ describe('computePermissions', () => {
     expect(perms.canAcoesInternas).toBe(true)
   })
 
-  test('Superintendência sector grants dashboard overview', () => {
-    const perms = computePermissions(makeUser({ setores: ['Superintendência'] }))
-    expect(perms.inSuperintendencia).toBe(true)
-    expect(perms.canDashboardOverview).toBe(true)
-    expect(perms.canDashboardEquipe).toBe(true)
-    expect(perms.canDashboardGcal).toBe(true)
-    expect(perms.canDashboardsMenu).toBe(true)
-  })
+  // ============================================================================
+  // Dashboards — alinhado com doc v2/docs/rbac_authorization_matrix.md §3 + D7
+  //
+  // Tabela canônica:
+  //   - Geral:     Diretoria + super
+  //   - Compras:   Diretoria + DAT + super
+  //   - Equipe:    Diretoria + DAT + super
+  //   - GCal:      Diretoria + DAT + Controle (operar) + super
+  //   - Mapa:      Diretoria + DAT + super
+  //
+  // Bug 2 fix (Onda 1, C1, 2026-04-27): regras antigas tinham Controle/Gerência/
+  // Superintendência indevidamente em vários dashboards. Cada caso abaixo
+  // valida a tabela canônica.
+  // ============================================================================
 
-  test('Diretoria sector grants specific dashboards', () => {
+  test('Diretoria vê todos os 5 dashboards', () => {
     const perms = computePermissions(makeUser({ setores: ['Diretoria'] }))
     expect(perms.inDiretoria).toBe(true)
     expect(perms.canDashboardOverview).toBe(true)
     expect(perms.canDashboardCompras).toBe(true)
     expect(perms.canDashboardEquipe).toBe(true)
+    expect(perms.canDashboardGcal).toBe(true)
     expect(perms.canMapaBrasil).toBe(true)
   })
 
-  test('Gerência sector grants dashboards', () => {
+  test('DAT vê Compras + Equipe + GCal + Mapa (NÃO vê Geral)', () => {
+    const perms = computePermissions(makeUser({ setores: ['DAT'] }))
+    expect(perms.inDAT).toBe(true)
+    expect(perms.canDashboardOverview).toBe(false)
+    expect(perms.canDashboardCompras).toBe(true)
+    expect(perms.canDashboardEquipe).toBe(true)
+    expect(perms.canDashboardGcal).toBe(true)
+    expect(perms.canMapaBrasil).toBe(true)
+  })
+
+  test('Controle vê APENAS Dashboard GCal (operacional do calendário)', () => {
+    const perms = computePermissions(makeUser({ setores: ['Controle'] }))
+    expect(perms.inControle).toBe(true)
+    expect(perms.canDashboardOverview).toBe(false)
+    expect(perms.canDashboardCompras).toBe(false)
+    expect(perms.canDashboardEquipe).toBe(false)
+    expect(perms.canDashboardGcal).toBe(true)
+    expect(perms.canMapaBrasil).toBe(false)
+  })
+
+  test('Superintendência NÃO vê dashboards (decisão executiva = Diretoria)', () => {
+    const perms = computePermissions(makeUser({ setores: ['Superintendência'] }))
+    expect(perms.inSuperintendencia).toBe(true)
+    expect(perms.canDashboardOverview).toBe(false)
+    expect(perms.canDashboardCompras).toBe(false)
+    expect(perms.canDashboardEquipe).toBe(false)
+    expect(perms.canDashboardGcal).toBe(false)
+    expect(perms.canMapaBrasil).toBe(false)
+    expect(perms.canDashboardsMenu).toBe(false)
+  })
+
+  test('Gerência NÃO vê dashboards', () => {
     const perms = computePermissions(makeUser({ setores: ['Gerência'] }))
     expect(perms.inGerencia).toBe(true)
-    expect(perms.canDashboardOverview).toBe(true)
-    expect(perms.canDashboardEquipe).toBe(true)
-    expect(perms.canMapaBrasil).toBe(true)
+    expect(perms.canDashboardOverview).toBe(false)
+    expect(perms.canDashboardEquipe).toBe(false)
+    expect(perms.canMapaBrasil).toBe(false)
+    expect(perms.canDashboardsMenu).toBe(false)
+  })
+
+  test('Coordenador/Apoio/Formador NÃO veem nenhum dashboard', () => {
+    for (const funcao of ['Coordenador', 'Apoio de Coordenação', 'Formador']) {
+      const perms = computePermissions(makeUser({ setores: ['Vidas'], funcoes: [funcao] }))
+      expect(perms.canDashboardOverview).toBe(false)
+      expect(perms.canDashboardCompras).toBe(false)
+      expect(perms.canDashboardEquipe).toBe(false)
+      expect(perms.canDashboardGcal).toBe(false)
+      expect(perms.canMapaBrasil).toBe(false)
+      expect(perms.canDashboardsMenu).toBe(false)
+    }
   })
 
   test('can_approve_super passthrough from user', () => {

--- a/v2/frontend/src/hooks/usePermissions.ts
+++ b/v2/frontend/src/hooks/usePermissions.ts
@@ -94,11 +94,16 @@ function computePermissionsInternal(user: CurrentUser): Permissions {
   const canControle = user.is_superuser || inControle;
   const canDAT = user.is_superuser || inDAT;
   const canAcoesInternas = user.is_superuser || inDAT || isCoordenador || isGerente;
-  const canDashboardOverview = user.is_superuser || inSuperintendencia || inGerencia || inDiretoria;
-  const canDashboardEquipe = user.is_superuser || inControle || inGerencia || inSuperintendencia || inDiretoria;
-  const canDashboardGcal = user.is_superuser || inControle || inSuperintendencia;
+  // Dashboards — alinhado com `v2/docs/rbac_authorization_matrix.md` §3 + decisão D7.
+  // Bug 2 fix (Onda 1, C1, 2026-04-27): regras antigas tinham Controle/Gerência/
+  // Superintendência indevidamente em vários dashboards. Corrigido para refletir
+  // a tabela canônica: Diretoria é o decisor; DAT é ator transversal de
+  // suporte/validação; Controle vê apenas Dashboard GCal (operação do calendário).
+  const canDashboardOverview = user.is_superuser || inDiretoria;
+  const canDashboardEquipe = user.is_superuser || inDiretoria || inDAT;
+  const canDashboardGcal = user.is_superuser || inDiretoria || inDAT || inControle;
   const canDashboardCompras = user.is_superuser || inDiretoria || inDAT;
-  const canMapaBrasil = user.is_superuser || inControle || inDAT || inSuperintendencia || inGerencia || inDiretoria;
+  const canMapaBrasil = user.is_superuser || inDiretoria || inDAT;
   const canDashboardsMenu =
     canDashboardOverview || canDashboardCompras || canDashboardEquipe || canDashboardGcal || canMapaBrasil;
   const canDisponibilidade = user.is_superuser || !inControle;


### PR DESCRIPTION
**Onda 1 (Críticos)** identificados pelo RBAC Matrix Sweep pós PR #1248. 3 fixes coesos em 1 PR, cada commit auto-contido.

Encerra os 3 críticos da §7 do doc SSOT (`v2/docs/rbac_authorization_matrix.md`):

| # | Crítico | Commit |
|---|---------|--------|
| C1 | Dashboards `usePermissions` hardcoded por setor (Bug 2 Fabiana) | `669d6cf` |
| C2 | Deslocamentos sidebar UI mostra mas backend 403 para Coord/DAT | `eecb9e2` |
| C3 | Ações Internas `IsAdminUser` bypassa Capability Policy Layer | `d9b3600` |

## C1 — Dashboards `usePermissions` (Bug 2)

Frontend hardcoded incluía Controle/Gerência/Superintendência indevidamente em vários dashboards. Alinhado com doc §3 e decisão D7:

| Dashboard | Antes | Depois |
|-----------|-------|--------|
| Geral | Super + Ger + Diretoria | Diretoria |
| Equipe | Controle + Ger + Super + Diretoria | Diretoria + DAT |
| GCal | Controle + Super | Diretoria + DAT + Controle (operação) |
| Compras | Diretoria + DAT (já OK) | sem mudança |
| Mapa | Controle + DAT + Super + Ger + Diretoria | Diretoria + DAT |

Tests: 7 novos cobrindo cada ator vs cada dashboard.

## C2 — Deslocamentos composition + scope

Backend `DeslocamentoViewSet`:
- `permission_classes = [IsAuthenticated]` (era HasPerm que bloqueava Coord/DAT pós-0078)
- `get_queryset` adiciona scope filter cross-table (`usuario__equipes__gerencia_id__in=user_gerencias`)
- Capability `view_all_availability` (Controle/Gerente) bypassa scope; Coord/Apoio/DAT veem só próprio setor; sem EquipeGerencia → 0 (fail-safe, não 403)

Padrão simétrico ao Bug 1 (Grade Mensal, PR #1248), aqui implementado no queryset porque `Deslocamento` não tem FK direta de gerência.

Tests: 8 novos em `test_deslocamento_rbac.py` (Cap ampla, Scope por gerência, Sanity) + 1 test legado invertido em `test_deslocamento_api.py`.

## C3 — Ações Internas via capability

`CicloAcoesViewSet` e `AcaoInstanciaViewSet`:
- Era: `[IsAdminUser]` (DRF, checa `is_staff=True`, fora da camada Policy)
- Agora: `[HasPerm(\"manage_internal_actions\")]` (capability nova com 0 grupos atribuídos por seed)

Apenas superuser passa via bypass natural. Quando feature for liberada para outros papéis (DAT, etc.), admin atribui grupo via UI sem code change. **Padrão correto da camada Policy.**

Migration 0079 cria a capability (data-only, idempotente). Seed total: 15 → 16 itens.

## Test plan

- [x] pytest test_deslocamento_rbac.py: 8/8 PASS
- [x] pytest test_deslocamento_api.py: 6/6 PASS (1 invertido conforme nova semântica)
- [x] pytest test_api_acoes_notificacao.py: 11/11 PASS
- [x] pytest usePermissions.test.js: 23/23 PASS (7 novos)
- [x] pytest apps/core/tests/ (suite completa): **1829/1829 PASS**, 43 skipped
- [x] vitest run completo: **228/228 PASS**
- [x] python manage.py check: 0 issues
- [x] python manage.py migrate core 0079: aplicada
- [x] python scripts/rbac_lint.py apps/: 0 violações
- [x] black/isort/flake8: clean

## Pré-deploy em produção

Aplicar migration `0079` ANTES do merge (mesmo padrão das 0077/0078):

\`\`\`
docker exec <prod-web> python manage.py migrate core 0079
\`\`\`

Idempotente, data-only, zero downtime.

Verificar:

\`\`\`
python manage.py shell -c \"
from apps.core.models import PermissaoFuncional
p = PermissaoFuncional.objects.filter(codename='manage_internal_actions').first()
print('exists:', p is not None, '| groups:', sorted(p.groups.values_list('name', flat=True)) if p else [])
\"
\`\`\`

Esperado: \`exists: True | groups: []\` (sem grupos = só superuser).

## Próximas ondas (não neste PR)

- **Onda 2 (Altos)**: 3 divergências altas (Solicitações create, Dashboard Compras policy, 4 viewsets sem permission_class)
- **Onda 3 (Matriz Viva)**: tests parametrizados que falham CI se ator ganhar/perder acesso

## Staging gate

ALL 8 CHECKS PASSED

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR
- [x] Feature complete (3 críticos da Onda 1)
- [x] Tests updated (15+ novos backend, 7 novos frontend, 1 invertido)
- [x] TS/Lint clean (tsc + black + isort + flake8 + rbac_lint + vitest)