### PR TITLE
fix(rbac): wave 2 altos — DAT em metrics endpoints + canDashboardCompras consume policy

### DIFF
--- a/v2/backend/apps/core/tests/test_metrics_team_rbac.py
+++ b/v2/backend/apps/core/tests/test_metrics_team_rbac.py
@@ -1,0 +1,157 @@
+"""
+Tests RBAC dos endpoints `/api/metrics/team/*` (Onda 2 A3 — 2026-04-27).
+
+Reproduz o mismatch identificado no RBAC Matrix Sweep:
+- Frontend `canDashboardEquipe` (após Onda 1 C1) inclui DAT
+- Backend metrics endpoints exigiam `run_daily_operations | supervise_operations`
+  (sem DAT) — DAT via menu, recebia 403 ao carregar dados
+
+Decisão (β, stakeholder 2026-04-27): adicionar `manage_admin_registries`
+à composition existente em vez de criar policy unificada nova. Preserva
+decisão prévia Lote 4.2.b2 (não consolidar 3 endpoints com objetos
+protegidos diferentes em uma policy artificial).
+
+Capabilities envolvidas (motivos legítimos):
+- `run_daily_operations`    → Controle (operar)
+- `supervise_operations`    → Diretoria (supervisionar)
+- `manage_admin_registries` → DAT (validar/suportar — ator transversal)
+
+Doc §3 da matriz canônica:
+   Dashboard Equipe: Diretoria + DAT + super
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportOptionalMemberAccess=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportMissingTypeArgument=false, reportCallIssue=false, reportIndexIssue=false, reportOperatorIssue=false, reportOptionalSubscript=false, reportUnknownLambdaType=false, reportPrivateUsage=false
+
+from __future__ import annotations
+
+from django.contrib.auth.models import Group
+from django.core.cache import cache
+from rest_framework.test import APIClient
+
+import pytest
+
+from apps.core.models import Usuario
+
+pytestmark = pytest.mark.django_db
+
+
+_USER_COUNTER = {"i": 0}
+
+
+def _next_cpf() -> str:
+    _USER_COUNTER["i"] += 1
+    return f"99988{_USER_COUNTER['i']:06d}"
+
+
+def _make_user(username: str, group_names: list[str]) -> Usuario:
+    user = Usuario.objects.create_user(
+        username=username, email=f"{username}@example.com", password="testpass123", cpf=_next_cpf()
+    )
+    for gname in group_names:
+        group, _ = Group.objects.get_or_create(name=gname)
+        user.groups.add(group)
+    return user
+
+
+@pytest.fixture(autouse=True)
+def _clear_rbac_cache(db):
+    cache.clear()
+    yield
+    cache.clear()
+
+
+ENDPOINTS = [
+    "/api/metrics/team/productivity/",
+    "/api/metrics/team/quality/",
+    "/api/metrics/team/formadores/",
+]
+
+
+# ============================================================================
+# β: DAT acessa via `manage_admin_registries` (ator transversal)
+# ============================================================================
+
+
+class TestDATAccessTeamMetrics:
+    @pytest.mark.parametrize("endpoint", ENDPOINTS)
+    def test_dat_user_can_access_team_metrics(self, endpoint):
+        """
+        DAT é ator transversal de validação/suporte. Após Onda 2 A3 (β),
+        composition `run_daily_operations | supervise_operations |
+        manage_admin_registries` libera DAT para os 3 endpoints metrics.
+
+        Antes do fix: 403 (DAT sem run_daily_operations nem supervise_operations).
+        Depois do fix: 200.
+        """
+        dat_user = _make_user("dat_metrics", ["DAT"])
+        client = APIClient()
+        client.force_authenticate(user=dat_user)
+        res = client.get(endpoint)
+        assert res.status_code == 200, (
+            f"DAT deveria acessar {endpoint} via manage_admin_registries. " f"Got {res.status_code}: {res.content!r}"
+        )
+
+
+# ============================================================================
+# Comportamento mantido (Controle, Diretoria, Super continuam acessando)
+# ============================================================================
+
+
+class TestExistingAccessPreserved:
+    @pytest.mark.parametrize("endpoint", ENDPOINTS)
+    def test_controle_continues_to_access(self, endpoint):
+        """Controle tem `run_daily_operations` → mantém acesso."""
+        user = _make_user("controle_metrics", ["Controle"])
+        client = APIClient()
+        client.force_authenticate(user=user)
+        res = client.get(endpoint)
+        assert res.status_code == 200
+
+    @pytest.mark.parametrize("endpoint", ENDPOINTS)
+    def test_diretoria_continues_to_access(self, endpoint):
+        """Diretoria tem `supervise_operations` → mantém acesso."""
+        user = _make_user("diretoria_metrics", ["Diretoria"])
+        client = APIClient()
+        client.force_authenticate(user=user)
+        res = client.get(endpoint)
+        assert res.status_code == 200
+
+    @pytest.mark.parametrize("endpoint", ENDPOINTS)
+    def test_superuser_bypass(self, endpoint):
+        super_user = Usuario.objects.create_superuser(
+            username="super_metrics", email="sm@example.com", password="testpass123", cpf="99900099995"
+        )
+        client = APIClient()
+        client.force_authenticate(user=super_user)
+        res = client.get(endpoint)
+        assert res.status_code == 200
+
+
+# ============================================================================
+# Bloqueio mantido (Coordenador/Apoio/Formador NÃO acessam)
+# ============================================================================
+
+
+class TestBlockingPreserved:
+    @pytest.mark.parametrize("endpoint", ENDPOINTS)
+    def test_coordenador_blocked(self, endpoint):
+        """Coordenador não tem nenhuma das 3 capabilities → 403."""
+        user = _make_user("coord_metrics", ["Coordenador"])
+        client = APIClient()
+        client.force_authenticate(user=user)
+        res = client.get(endpoint)
+        assert res.status_code == 403
+
+    @pytest.mark.parametrize("endpoint", ENDPOINTS)
+    def test_formador_blocked(self, endpoint):
+        user = _make_user("form_metrics", ["Formador"])
+        client = APIClient()
+        client.force_authenticate(user=user)
+        res = client.get(endpoint)
+        assert res.status_code == 403
+
+    @pytest.mark.parametrize("endpoint", ENDPOINTS)
+    def test_anonymous_blocked(self, endpoint):
+        client = APIClient()
+        res = client.get(endpoint)
+        assert res.status_code in (401, 403)

--- a/v2/backend/apps/core/views/metrics/dashboard_metrics.py
+++ b/v2/backend/apps/core/views/metrics/dashboard_metrics.py
@@ -24,7 +24,17 @@ from apps.core.permissions import HasPerm
 
 
 @api_view(["GET"])
-@permission_classes([HasPerm("run_daily_operations") | HasPerm("supervise_operations")])
+@permission_classes(
+    # Onda 2 A3 (β, 2026-04-27): adicionado `manage_admin_registries` para DAT
+    # como ator transversal (validar/suportar). Composition OR mantida em vez
+    # de policy unificada — decisão Lote 4.2.b2 preservada (3 endpoints
+    # protegem objetos semanticamente diferentes: pessoas vs fluxo).
+    # Motivos legítimos:
+    #   run_daily_operations    → Controle (operar)
+    #   supervise_operations    → Diretoria (supervisionar)
+    #   manage_admin_registries → DAT (validar/suportar)
+    [HasPerm("run_daily_operations") | HasPerm("supervise_operations") | HasPerm("manage_admin_registries")]
+)
 @throttle_classes([ScopedRateThrottle])
 def productivity_metrics(request: Request) -> Response:
     """
@@ -113,7 +123,17 @@ productivity_metrics.throttle_scope = "metrics"  # type: ignore[attr-defined]
 
 
 @api_view(["GET"])
-@permission_classes([HasPerm("run_daily_operations") | HasPerm("supervise_operations")])
+@permission_classes(
+    # Onda 2 A3 (β, 2026-04-27): adicionado `manage_admin_registries` para DAT
+    # como ator transversal (validar/suportar). Composition OR mantida em vez
+    # de policy unificada — decisão Lote 4.2.b2 preservada (3 endpoints
+    # protegem objetos semanticamente diferentes: pessoas vs fluxo).
+    # Motivos legítimos:
+    #   run_daily_operations    → Controle (operar)
+    #   supervise_operations    → Diretoria (supervisionar)
+    #   manage_admin_registries → DAT (validar/suportar)
+    [HasPerm("run_daily_operations") | HasPerm("supervise_operations") | HasPerm("manage_admin_registries")]
+)
 @throttle_classes([ScopedRateThrottle])
 def quality_metrics(request: Request) -> Response:
     """

--- a/v2/backend/apps/core/views/metrics/formador_metrics.py
+++ b/v2/backend/apps/core/views/metrics/formador_metrics.py
@@ -24,7 +24,13 @@ from apps.core.permissions import HasPerm
 
 
 @api_view(["GET"])
-@permission_classes([HasPerm("run_daily_operations") | HasPerm("supervise_operations")])
+@permission_classes(
+    # Onda 2 A3 (β, 2026-04-27): adicionado `manage_admin_registries` para DAT
+    # como ator transversal (validar/suportar). Mesma decisão dos demais
+    # endpoints metrics — preserva Lote 4.2.b2 (composition OR ad-hoc por
+    # objetos semanticamente diferentes).
+    [HasPerm("run_daily_operations") | HasPerm("supervise_operations") | HasPerm("manage_admin_registries")]
+)
 @throttle_classes([ScopedRateThrottle])
 def formadores_metrics(request: Request) -> Response:
     """

--- a/v2/frontend/src/components/AppRoutes.tsx
+++ b/v2/frontend/src/components/AppRoutes.tsx
@@ -94,6 +94,7 @@ export function AppRoutes({ user, permissions, policies }: AppRoutesProps): JSX.
     canApproveSuper,
     canBloqueios: canControle || canCoordenador || isFormador,
     canCoordenador,
+    canDashboardCompras,
   });
 
   return (
@@ -104,7 +105,7 @@ export function AppRoutes({ user, permissions, policies }: AppRoutesProps): JSX.
 
         {/* Dashboards */}
         <Route path="/dashboards" element={canDashboardOverview ? <DashboardsPage /> : <Forbidden />} />
-        <Route path="/dashboards/compras" element={canDashboardCompras ? <ComprasDashboardPage /> : <Forbidden />} />
+        <Route path="/dashboards/compras" element={access.canViewComprasDashboard ? <ComprasDashboardPage /> : <Forbidden />} />
         <Route path="/dashboards/equipe" element={canDashboardEquipe ? <EquipeDashboardPage /> : <Forbidden />} />
         <Route path="/dashboards/gcal" element={canDashboardGcal ? <GCalDashboardPage /> : <Forbidden />} />
         <Route path="/mapa-brasil" element={canMapaBrasil ? <MapaBrasilPage /> : <Forbidden />} />

--- a/v2/frontend/src/components/AppSidebar.tsx
+++ b/v2/frontend/src/components/AppSidebar.tsx
@@ -206,6 +206,7 @@ export function AppSidebar({
   const access = useCanAccess(policies, {
     canApproveSuper,
     canBloqueios: canControle || canCoordenador || isFormador,
+    canDashboardCompras,
     canCoordenador,
   });
 
@@ -329,7 +330,7 @@ export function AppSidebar({
                 {canDashboardOverview && (
                   <Menu.Item key="dashboard-geral"><Link to="/dashboards">Dashboard Geral</Link></Menu.Item>
                 )}
-                {canDashboardCompras && (
+                {access.canViewComprasDashboard && (
                   <Menu.Item key="dashboard-compras"><Link to="/dashboards/compras">Dashboard Compras</Link></Menu.Item>
                 )}
                 {canDashboardEquipe && (

--- a/v2/frontend/src/hooks/__tests__/useCanAccess.test.ts
+++ b/v2/frontend/src/hooks/__tests__/useCanAccess.test.ts
@@ -82,6 +82,28 @@ describe('computeAccess.canAccessBlocks — semantic translation', () => {
   });
 });
 
+describe('computeAccess.canViewComprasDashboard — Onda 2 A2 consome policy', () => {
+  test('public policy view_compras_dashboard → true', () => {
+    const access = computeAccess(['view_compras_dashboard'], {});
+    expect(access.canViewComprasDashboard).toBe(true);
+  });
+
+  test('legacy canDashboardCompras=true → true (fallback durante transição)', () => {
+    const access = computeAccess([], { canDashboardCompras: true });
+    expect(access.canViewComprasDashboard).toBe(true);
+  });
+
+  test('sem policy + sem legacy → false', () => {
+    const access = computeAccess([], {});
+    expect(access.canViewComprasDashboard).toBe(false);
+  });
+
+  test('legacy false + policy ausente → false', () => {
+    const access = computeAccess(['use_gcal'], { canDashboardCompras: false });
+    expect(access.canViewComprasDashboard).toBe(false);
+  });
+});
+
 describe('computeAccess.canCreateSolicitation — legacy-only today', () => {
   test('legacy canCoordenador=true → true', () => {
     const access = computeAccess([], { canCoordenador: true });

--- a/v2/frontend/src/hooks/useCanAccess.ts
+++ b/v2/frontend/src/hooks/useCanAccess.ts
@@ -25,6 +25,8 @@ export interface LegacyAccessFlags {
   canBloqueios?: boolean;
   /** Hoje 100% legacy. Sem policy pública pra "criar solicitação" (apenas auth + role). */
   canCoordenador?: boolean;
+  /** Hardcoded `is_superuser || inDiretoria || inDAT`. Migrável agora — policy `view_compras_dashboard` em PUBLIC_POLICY_KEYS. */
+  canDashboardCompras?: boolean;
 }
 
 /**
@@ -58,6 +60,13 @@ export interface AccessState {
    * Sem policy pública mapeada — frontend confere flag, backend ainda valida via permission_classes específica.
    */
   canCreateSolicitation: boolean;
+
+  /**
+   * Pode ver Dashboard de Compras. Onda 2 A2 (2026-04-27): consome policy
+   * pública `view_compras_dashboard` (atribuída a Diretoria + DAT no seed).
+   * Legacy fallback preservado durante transição.
+   */
+  canViewComprasDashboard: boolean;
 }
 
 /**
@@ -83,12 +92,17 @@ export function computeAccess(
   const canCreateSolicitation =
     legacy.canCoordenador === true;
 
+  const canViewComprasDashboard =
+    can('view_compras_dashboard') ||
+    legacy.canDashboardCompras === true;
+
   return {
     policies,
     can,
     canAccessApprovals,
     canAccessBlocks,
     canCreateSolicitation,
+    canViewComprasDashboard,
   };
 }
 
@@ -104,6 +118,12 @@ export function useCanAccess(
     () => computeAccess(policies, legacy),
     // Dependências granulares — `legacy` é objeto, vamos por chaves.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [policies, legacy.canApproveSuper, legacy.canBloqueios, legacy.canCoordenador]
+    [
+      policies,
+      legacy.canApproveSuper,
+      legacy.canBloqueios,
+      legacy.canCoordenador,
+      legacy.canDashboardCompras,
+    ]
   );
 }


### PR DESCRIPTION
**Onda 2 (Altos)** identificados pelo RBAC Matrix Sweep. 2 fixes coesos.

## Achados da auditoria que reduziram o escopo

| # | Item Sweep | Realidade |
|---|------------|-----------|
| A1 SolicitacaoViewSet.create | **Já resolvido** — \`get_permissions()\` linha 177 retorna \`[HasPerm(\"create_solicitation\")()]\` para action create. Sweep estava errado. |
| A2 canDashboardCompras hardcoded | ✅ **Migrado neste PR** — frontend consome policy via useCanAccess |
| A3 \"4 viewsets sem permission_class\" | Restou só 1 fix real: |
| → A3.1 AvailabilityBlockViewSet | **Manter** — comentário inline (linha 64-69) documenta decisão consciente; queryset scope já correto |
| → A3.2 AvailabilityCheckView | **Já tem HasPerm** — Sweep errado |
| → A3.3 AvailabilityUserListView | **View não existe** — Sweep inventou |
| → A3.4 \"DashboardEquipeStatsView\" | **View não existe** com esse nome — investigação encontrou bug real disfarçado em \`/api/metrics/team/*\` (frontend mostra Dashboard Equipe para DAT, backend bloqueia) — fix β neste PR |

## Commits

| Commit | Mudança |
|--------|---------|
| \`6fea629\` | A3 (β) — adiciona \`manage_admin_registries\` à composition de 3 metrics endpoints |
| \`13a3736\` | A2 — canDashboardCompras consome policy via useCanAccess |

## A3 (β) — Decisão arquitetural preservada

Stakeholder escolheu **β** sobre α (criar policy unificada \`view_team_dashboard\`). Razão: preservar decisão prévia do **Lote 4.2.b2** (programa anterior) que explicitamente DEFERIU consolidar 3 endpoints metrics em uma única policy porque protegem objetos semanticamente diferentes:

- \`formadores_metrics\` → pessoas/equipe
- \`productivity_metrics\` → fluxo/processo
- \`quality_metrics\` → fluxo/qualidade

\"β corrige o bug sem mentir na arquitetura.\"

Composition resultante:

\`\`\`
[HasPerm(\"run_daily_operations\") | HasPerm(\"supervise_operations\") | HasPerm(\"manage_admin_registries\")]
\`\`\`

Motivos legítimos por capability:

| Capability | Ator | Motivo |
|------------|------|--------|
| run_daily_operations | Controle | operar |
| supervise_operations | Diretoria | supervisionar |
| manage_admin_registries | DAT | validar/suportar (ator transversal) |

## A2 — Frontend consume policy

\`useCanAccess\` ganha derived flag \`canViewComprasDashboard\`:

\`\`\`ts
canViewComprasDashboard =
  can('view_compras_dashboard') ||      // policy real (PUBLIC_POLICY_KEYS)
  legacy.canDashboardCompras === true   // fallback transição
\`\`\`

\`AppSidebar\` e \`AppRoutes\` passam \`canDashboardCompras\` do \`usePermissions\` como legacy + consomem \`access.canViewComprasDashboard\` em vez de \`permissions.canDashboardCompras\` direto. Pattern simétrico ao estabelecido em Onda 1 (canAccessApprovals, canAccessBlocks).

## Test plan

- [x] pytest test_metrics_team_rbac.py: 21/21 PASS (3 casos × 3 endpoints + sanity)
- [x] pytest test_metrics_api.py + test_views_metrics_coverage.py: 32/32 PASS (sem regressão)
- [x] pytest apps/core/tests/ (suite completa): **1850/1850 PASS**, 43 skipped
- [x] vitest run completo: **232/232 PASS** (era 228, +4 novos)
- [x] tsc --noEmit: 0 erros
- [x] black/isort/flake8: clean
- [x] python scripts/rbac_lint.py apps/: 0 violações

## Sem migration nova

Esta Onda 2 **não cria capability nem migration nova**. Reusa \`manage_admin_registries\` (já no seed, atribuída a DAT desde 0077) e \`view_compras_dashboard\` (já em PUBLIC_POLICY_KEYS desde Epic 4.4).

## Próxima

- **Onda 3 (Matriz Viva)**: tests parametrizados que falham CI se ator ganhar/perder acesso inesperado. Nasce verde após este PR mergear (código alinhado com matriz canônica).

## Decisão deferida (registrada)

\`view_team_dashboard\` policy unificada **fica deferida** para Epic separado se domínio amadurecer (formadores vs productivity vs quality podem divergir mais). Documentado em comentário inline + commit message.

## Staging gate

ALL 8 CHECKS PASSED

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR
- [x] Feature complete (A2 + A3, A1 já estava OK)
- [x] Tests updated (21 backend novos + 4 frontend novos)
- [x] TS/Lint clean (tsc + black + isort + flake8 + rbac_lint + 1850/1850 + 232/232)


---

Closes #1257
Closes #1264
