### PR TITLE
fix(admin): Bug 3 — UX correta do CPF no edit de usuário (LGPD-compliant)

### DIFF
--- a/v2/frontend/src/pages/AdminDAT/UsuariosPage.tsx
+++ b/v2/frontend/src/pages/AdminDAT/UsuariosPage.tsx
@@ -33,6 +33,7 @@ import { ReloadOutlined, EditOutlined, PlusOutlined, DeleteOutlined } from '@ant
 import { Link } from 'react-router-dom';
 import { checkAuth } from '../../api/auth';
 import { listUsers, createUser, updateUser, deleteUser, listGroups, getRBACMeta } from '../../api/adminDAT';
+import { buildUsuarioPayload } from './usuario_form_helpers';
 import type { PermissaoFuncional, RBACMetaPayload } from '../../api/adminDAT';
 import { importUsuarios } from '../../api/ops';
 import type { ImportResult } from '../../api/ops';
@@ -151,6 +152,11 @@ export default function UsuariosPage(): JSX.Element {
   });
   const [modalVisible, setModalVisible] = useState(false);
   const [editingUser, setEditingUser] = useState<UserRecord | null>(null);
+  // Bug 3 fix (2026-04-27): CPF é write-only por LGPD (serializer), então API
+  // nunca retorna o CPF raw — apenas `cpf_masked`. No modo edit, manter o
+  // campo disabled mostrando o mascarado, e exigir clique em "Alterar CPF"
+  // para liberar nova entrada. Submit omite `cpf` do payload se locked.
+  const [cpfEditUnlocked, setCpfEditUnlocked] = useState(false);
   const [grupos, setGrupos] = useState<GroupRecord[]>([]);
   const [rbacMeta, setRbacMeta] = useState<RBACMetaPayload | null>(null);
   const [currentIsSuperuser, setCurrentIsSuperuser] = useState(false);
@@ -278,6 +284,7 @@ export default function UsuariosPage(): JSX.Element {
 
   const handleCreate = (): void => {
     setEditingUser(null);
+    setCpfEditUnlocked(true);  // Create: campo CPF sempre liberado
     form.resetFields();
     form.setFieldsValue({
       is_active: true,
@@ -290,6 +297,7 @@ export default function UsuariosPage(): JSX.Element {
 
   const handleEdit = (user: UserRecord): void => {
     setEditingUser(user);
+    setCpfEditUnlocked(false);  // Edit: CPF locked até user clicar "Alterar"
     // Separar IDs de grupos por tipo
     const userGroupIds = user.group_ids_display || [];
     const setorIds = grupos
@@ -304,7 +312,8 @@ export default function UsuariosPage(): JSX.Element {
       email: user.email,
       first_name: user.first_name,
       last_name: user.last_name,
-      cpf: user.cpf,
+      // CPF não é populado no modo edit — write-only por LGPD; o input mostra
+      // `cpf_masked` como placeholder/valor visual via prop, não via setFieldsValue.
       telefone: user.telefone,
       cargo: user.cargo,
       is_active: user.is_active,
@@ -336,13 +345,13 @@ export default function UsuariosPage(): JSX.Element {
 
   const handleSave = async (values: UserFormValues): Promise<void> => {
     try {
-      // Combinar setor_ids e funcao_ids em group_ids
-      const { setor_ids = [], funcao_ids = [], is_superuser, ...rest } = values;
-      const payload = {
-        ...rest,
-        ...(currentIsSuperuser ? { is_superuser } : {}),
-        group_ids: [...setor_ids, ...funcao_ids],
-      };
+      // Bug 3 fix (2026-04-27): payload construído via helper puro testável.
+      // Regras LGPD para CPF: omitir do payload se edit+locked (mantém atual).
+      const payload = buildUsuarioPayload(values, {
+        isEditing: !!editingUser,
+        cpfEditUnlocked,
+        currentIsSuperuser,
+      });
 
       if (editingUser) {
         await updateUser(editingUser.id, payload);
@@ -598,15 +607,47 @@ export default function UsuariosPage(): JSX.Element {
           <Form.Item
             name="cpf"
             label="CPF"
-            rules={[
-              { required: true, message: 'CPF é obrigatório' },
-              {
-                pattern: /^[0-9]{11}$/,
-                message: 'CPF deve conter exatamente 11 dígitos numéricos',
-              },
-            ]}
+            // Bug 3 fix (2026-04-27): no edit, CPF não é required (write-only
+            // por LGPD; backend mantém valor existente se omitido). No create
+            // segue obrigatório.
+            rules={
+              !editingUser || cpfEditUnlocked
+                ? [
+                    { required: !editingUser, message: 'CPF é obrigatório' },
+                    {
+                      pattern: /^[0-9]{11}$/,
+                      message: 'CPF deve conter exatamente 11 dígitos numéricos',
+                    },
+                  ]
+                : []
+            }
+            // Em edit + locked, mostra cpf_masked como valor visual; o form
+            // não captura porque o input fica disabled.
+            help={
+              editingUser && !cpfEditUnlocked
+                ? 'CPF protegido por LGPD. Clique em "Alterar CPF" para editar.'
+                : undefined
+            }
           >
-            <Input placeholder="12345678901 (apenas números)" maxLength={11} />
+            {editingUser && !cpfEditUnlocked ? (
+              <Input
+                value={editingUser.cpf_masked || ''}
+                disabled
+                addonAfter={
+                  <Button
+                    type="link"
+                    size="small"
+                    onClick={() => setCpfEditUnlocked(true)}
+                    data-testid="alterar-cpf-button"
+                    style={{ padding: 0, height: 'auto' }}
+                  >
+                    Alterar CPF
+                  </Button>
+                }
+              />
+            ) : (
+              <Input placeholder="12345678901 (apenas números)" maxLength={11} />
+            )}
           </Form.Item>
 
           <Form.Item name="telefone" label="Telefone">

--- a/v2/frontend/src/pages/AdminDAT/__tests__/UsuariosPage.cpf.test.tsx
+++ b/v2/frontend/src/pages/AdminDAT/__tests__/UsuariosPage.cpf.test.tsx
@@ -1,0 +1,146 @@
+/**
+ * Tests do comportamento CPF na edição de usuário (Bug 3 fix, 2026-04-27).
+ *
+ * Cenário:
+ * - CPF é write-only no serializer backend (LGPD compliance) — API nunca
+ *   retorna CPF raw, apenas `cpf_masked`.
+ * - No edit, o input deve mostrar `cpf_masked` (visual), NÃO ser obrigatório,
+ *   e exigir clique em "Alterar CPF" para liberar nova entrada.
+ * - Submit sem alterar CPF deve omitir `cpf` do payload (backend mantém atual).
+ * - Submit após "Alterar CPF" + novo valor deve enviar `cpf` no payload.
+ *
+ * Foco: helper puro `buildUsuarioPayload` (testável sem render do form).
+ */
+
+import { describe, expect, test } from 'vitest';
+
+import { buildUsuarioPayload, type UsuarioFormValues } from '../usuario_form_helpers';
+
+
+function makeValues(overrides: Partial<UsuarioFormValues> = {}): UsuarioFormValues {
+  return {
+    username: 'fabiana.veras',
+    email: 'fabiana@example.com',
+    first_name: 'Fabiana',
+    last_name: 'Veras',
+    telefone: '85999991111',
+    cargo: 'Apoio de Coordenação',
+    is_active: true,
+    is_superuser: false,
+    setor_ids: [1],
+    funcao_ids: [2],
+    ...overrides,
+  };
+}
+
+
+describe('buildUsuarioPayload — CPF write-only LGPD (Bug 3 fix)', () => {
+  describe('Modo CREATE (isEditing=false, cpfEditUnlocked=true)', () => {
+    test('cpf preenchido → enviado no payload', () => {
+      const values = makeValues({ cpf: '12345678901' });
+      const payload = buildUsuarioPayload(values, {
+        isEditing: false,
+        cpfEditUnlocked: true,
+        currentIsSuperuser: true,
+      });
+      expect(payload.cpf).toBe('12345678901');
+      expect(payload.username).toBe('fabiana.veras');
+      expect(payload.group_ids).toEqual([1, 2]);
+    });
+
+    test('cpf vazio → não enviado (defesa em profundidade — schema já marca required)', () => {
+      const values = makeValues({ cpf: '' });
+      const payload = buildUsuarioPayload(values, {
+        isEditing: false,
+        cpfEditUnlocked: true,
+        currentIsSuperuser: true,
+      });
+      expect(payload).not.toHaveProperty('cpf');
+    });
+  });
+
+  describe('Modo EDIT + LOCKED (isEditing=true, cpfEditUnlocked=false)', () => {
+    test('cpf locked: payload NUNCA inclui cpf (backend mantém atual)', () => {
+      const values = makeValues({ cpf: undefined });  // form não captura porque input disabled
+      const payload = buildUsuarioPayload(values, {
+        isEditing: true,
+        cpfEditUnlocked: false,
+        currentIsSuperuser: true,
+      });
+      expect(payload).not.toHaveProperty('cpf');
+      // outros campos preservados
+      expect(payload.username).toBe('fabiana.veras');
+      expect(payload.telefone).toBe('85999991111');
+    });
+
+    test('cpf locked + valor "vazado" no values → ainda assim NÃO inclui (defesa)', () => {
+      // Mesmo se algum bug fizer o form capturar valor com CPF locked,
+      // o helper protege omitindo. Defesa em profundidade.
+      const values = makeValues({ cpf: '12345678901' });
+      const payload = buildUsuarioPayload(values, {
+        isEditing: true,
+        cpfEditUnlocked: false,  // ← locked
+        currentIsSuperuser: true,
+      });
+      expect(payload).not.toHaveProperty('cpf');
+    });
+  });
+
+  describe('Modo EDIT + UNLOCKED (isEditing=true, cpfEditUnlocked=true)', () => {
+    test('user clicou "Alterar CPF" + digitou novo → cpf novo enviado', () => {
+      const values = makeValues({ cpf: '98765432100' });
+      const payload = buildUsuarioPayload(values, {
+        isEditing: true,
+        cpfEditUnlocked: true,
+        currentIsSuperuser: true,
+      });
+      expect(payload.cpf).toBe('98765432100');
+    });
+
+    test('user clicou "Alterar CPF" mas não digitou → omitido (não substitui por vazio)', () => {
+      const values = makeValues({ cpf: '' });
+      const payload = buildUsuarioPayload(values, {
+        isEditing: true,
+        cpfEditUnlocked: true,
+        currentIsSuperuser: true,
+      });
+      expect(payload).not.toHaveProperty('cpf');
+    });
+  });
+
+  describe('is_superuser visibility (regra ortogonal)', () => {
+    test('currentIsSuperuser=true → is_superuser presente no payload', () => {
+      const values = makeValues({ is_superuser: true });
+      const payload = buildUsuarioPayload(values, {
+        isEditing: true,
+        cpfEditUnlocked: false,
+        currentIsSuperuser: true,
+      });
+      expect(payload.is_superuser).toBe(true);
+    });
+
+    test('currentIsSuperuser=false → is_superuser OMITIDO (não-super não pode mudar)', () => {
+      const values = makeValues({ is_superuser: true });  // tentativa de escalation
+      const payload = buildUsuarioPayload(values, {
+        isEditing: true,
+        cpfEditUnlocked: false,
+        currentIsSuperuser: false,  // ← user comum
+      });
+      expect(payload).not.toHaveProperty('is_superuser');
+    });
+  });
+
+  describe('group_ids consolida setor_ids + funcao_ids', () => {
+    test('setor_ids + funcao_ids agregados em group_ids', () => {
+      const values = makeValues({ setor_ids: [10, 20], funcao_ids: [30] });
+      const payload = buildUsuarioPayload(values, {
+        isEditing: false,
+        cpfEditUnlocked: true,
+        currentIsSuperuser: true,
+      });
+      expect(payload.group_ids).toEqual([10, 20, 30]);
+      expect(payload).not.toHaveProperty('setor_ids');
+      expect(payload).not.toHaveProperty('funcao_ids');
+    });
+  });
+});

--- a/v2/frontend/src/pages/AdminDAT/usuario_form_helpers.ts
+++ b/v2/frontend/src/pages/AdminDAT/usuario_form_helpers.ts
@@ -1,0 +1,70 @@
+/**
+ * Helpers puros (sem React) para o formulário de Usuário (Bug 3 fix, 2026-04-27).
+ *
+ * CPF é write-only por LGPD no serializer backend (`extra_kwargs` em
+ * `UsuarioAdminSerializer`). API nunca retorna CPF raw — apenas `cpf_masked`.
+ * Por isso no edit precisamos:
+ * - Mostrar `cpf_masked` como visual (input disabled)
+ * - Não exigir CPF como required
+ * - Liberar nova entrada apenas após clique em "Alterar CPF"
+ * - Omitir `cpf` do payload se user não optou por alterar (backend mantém atual)
+ *
+ * Esta lógica é extraída em função pura para ser testável sem render do form.
+ */
+
+import type { ID } from '../../types';
+
+export interface UsuarioFormValues {
+  username: string;
+  email: string;
+  first_name?: string;
+  last_name?: string;
+  cpf?: string;
+  telefone?: string;
+  cargo?: string;
+  is_active: boolean;
+  is_superuser: boolean;
+  setor_ids: ID[];
+  funcao_ids: ID[];
+  password?: string;
+}
+
+export interface BuildPayloadOptions {
+  /** Se está em modo edit (true) ou create (false) */
+  isEditing: boolean;
+  /** Se o user clicou em "Alterar CPF" no edit (sempre true em create) */
+  cpfEditUnlocked: boolean;
+  /** Se o user logado é superuser (controla visibilidade de is_superuser no payload) */
+  currentIsSuperuser: boolean;
+}
+
+/**
+ * Constrói payload para createUser/updateUser a partir dos valores do form.
+ *
+ * Regras LGPD-compliant para CPF:
+ * - Create: sempre enviar `cpf` (required no schema)
+ * - Edit + locked: omitir `cpf` do payload (backend mantém valor atual)
+ * - Edit + unlocked + valor preenchido: enviar `cpf` novo
+ * - Edit + unlocked + valor vazio: omitir (não substitui CPF existente por vazio)
+ */
+export function buildUsuarioPayload(
+  values: UsuarioFormValues,
+  options: BuildPayloadOptions,
+): Record<string, unknown> {
+  const { setor_ids = [], funcao_ids = [], is_superuser, cpf, ...rest } = values;
+  const { isEditing, cpfEditUnlocked, currentIsSuperuser } = options;
+
+  // CPF: incluir se create OU se edit+unlocked com valor preenchido
+  const includeCpf = !isEditing || cpfEditUnlocked;
+  const cpfPayload = includeCpf && cpf ? { cpf } : {};
+
+  // is_superuser: incluir apenas se quem está editando é superuser
+  const superuserPayload = currentIsSuperuser ? { is_superuser } : {};
+
+  return {
+    ...rest,
+    ...cpfPayload,
+    ...superuserPayload,
+    group_ids: [...setor_ids, ...funcao_ids],
+  };
+}


### PR DESCRIPTION
## Bug reportado em produção (2026-04-27)

Ao editar qualquer usuário no AdminDAT/Usuários, campo CPF aparecia vazio + form pedia \"CPF é obrigatório\" mesmo com CPF cadastrado.

## Causa raiz: decisão de privacidade LGPD, não bug de código

\`UsuarioAdminSerializer\` marca CPF como **write-only** por LGPD:

\`\`\`python
extra_kwargs = {
    \"cpf\": {\"write_only\": True},  # LGPD: don't expose full CPF in responses
}
\`\`\`

API retorna apenas \`cpf_masked\` (\`***.***.123456\`). Frontend tentava popular form com \`user.cpf\` sempre \`undefined\` → validation required disparava.

**Não vamos relaxar LGPD.** O serializer está correto. O bug é UX, não compliance.

## Solução (opção B confirmada pelo stakeholder)

No modo edit:
- Exibir \`cpf_masked\` como valor visual (input disabled)
- Botão \"Alterar CPF\" libera campo para nova entrada
- Submit omite \`cpf\` do payload se locked → backend mantém valor existente

## Diff

3 arquivos:
- \`UsuariosPage.tsx\`: novo state \`cpfEditUnlocked\`, campo CPF condicional, helper centraliza payload
- \`usuario_form_helpers.ts\` (NEW): função pura \`buildUsuarioPayload(values, options)\` testável
- \`__tests__/UsuariosPage.cpf.test.tsx\` (NEW, 9 tests)

## Comportamento por cenário

| Modo | cpf no payload? |
|------|-----------------|
| Create + cpf preenchido | ✅ enviado |
| Create + cpf vazio | ❌ omitido (schema marca required) |
| Edit + locked (default) | ❌ omitido — backend mantém atual |
| Edit + unlocked + novo cpf | ✅ enviado |
| Edit + unlocked + vazio | ❌ omitido (não substitui por vazio) |

## Defesa em profundidade

Mesmo se algum bug fizer o form capturar \`cpf\` com locked=true, o helper protege omitindo. CPF nunca é enviado quando não deveria.

## Test plan

- [x] vitest run UsuariosPage.cpf.test.tsx: 9/9 PASS
- [x] vitest run completo: 250/250 PASS (era 241, +9 novos)
- [x] tsc --noEmit: 0 erros
- [x] npm run build: OK 7s

## Sem alteração backend

Conforme escopo restrito autorizado pelo stakeholder. Serializer e endpoints não tocados.

## Decisões registradas

Opções consideradas e rejeitadas:
- **(A)** Campo vazio com nota \"deixe vazio para manter\": UX confuso
- **(C)** Esconder CPF + fluxo separado: mais código, mesma UX
- **(D)** Backend retornar CPF raw: viola LGPD documentada

## Staging gate

ALL 8 CHECKS PASSED

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR
- [x] Feature complete (Bug 3 fix LGPD-compliant)
- [x] Tests updated (9 testes novos cobrindo helper puro)
- [x] TS/Lint clean (tsc + vitest 250/250 + build)