### PR TITLE
fix(rbac): Formador não acessa Grade Mensal (D8) (closes #1287)

### DIFF
--- a/v2/backend/apps/core/rbac/matrix.py
+++ b/v2/backend/apps/core/rbac/matrix.py
@@ -135,13 +135,13 @@ ACCESS_MATRIX: Final[dict[str, dict[str, int]]] = {
     # Scope discriminante coberto em test_availability_monthly_rbac.py.
     "grade_mensal": {
         SUPERUSER: ALLOW,
-        DAT: DENY,           # D8: sem motivo legítimo + sem cap + fixture sem EquipeGerencia
-        CONTROLE: ALLOW,     # view_all_availability via seed 0078 (D6)
-        DIRETORIA: DENY,     # D8: decisão executiva, não consulta operacional
-        GERENTE: ALLOW,      # view_all_availability via seed 0078 (D6)
+        DAT: DENY,  # D8: sem motivo legítimo + sem cap + fixture sem EquipeGerencia
+        CONTROLE: ALLOW,  # view_all_availability via seed 0078 (D6)
+        DIRETORIA: DENY,  # D8: decisão executiva, não consulta operacional
+        GERENTE: ALLOW,  # view_all_availability via seed 0078 (D6)
         COORDENADOR: ALLOW,  # scoped via EquipeGerencia (D6) — fixture cria vínculo
-        APOIO: ALLOW,        # scoped via EquipeGerencia (D6) — fixture cria vínculo
-        FORMADOR: DENY,      # D8: caso especial; só Meus Eventos + Bloqueios próprios
+        APOIO: ALLOW,  # scoped via EquipeGerencia (D6) — fixture cria vínculo
+        FORMADOR: DENY,  # D8: caso especial; só Meus Eventos + Bloqueios próprios
     },
     #
     # Deslocamentos: `[IsAuthenticated]` + queryset scope filter (Onda 1 C2).

--- a/v2/backend/apps/core/rbac/matrix.py
+++ b/v2/backend/apps/core/rbac/matrix.py
@@ -129,10 +129,20 @@ _ALL_AUTH: Final[dict[str, int]] = {actor: ALLOW for actor in ACTORS}
 
 
 ACCESS_MATRIX: Final[dict[str, dict[str, int]]] = {
-    # Grade Mensal: composition `[IsAuthenticated, CanViewAllAvailability | HasSectorAccess]`.
-    # Sem gerencia_id, HasSectorAccess retorna True (SUPER comportamento) → todos autenticados 200.
-    # Scope discriminante coberto em test_availability_monthly_rbac.py (Bug 1 PR #1248).
-    "grade_mensal": _ALL_AUTH,
+    # Grade Mensal — D8 (2026-04-28): composition `[IsAuthenticated, CanViewAllAvailability | HasSectorAccess]`
+    # com HasSectorAccess endurecida (sem gerencia_id exige EquipeGerencia ativa).
+    # Para Coord/Apoio retornar 200, a fixture `_make_user_for_actor` cria EquipeGerencia.
+    # Scope discriminante coberto em test_availability_monthly_rbac.py.
+    "grade_mensal": {
+        SUPERUSER: ALLOW,
+        DAT: DENY,           # D8: sem motivo legítimo + sem cap + fixture sem EquipeGerencia
+        CONTROLE: ALLOW,     # view_all_availability via seed 0078 (D6)
+        DIRETORIA: DENY,     # D8: decisão executiva, não consulta operacional
+        GERENTE: ALLOW,      # view_all_availability via seed 0078 (D6)
+        COORDENADOR: ALLOW,  # scoped via EquipeGerencia (D6) — fixture cria vínculo
+        APOIO: ALLOW,        # scoped via EquipeGerencia (D6) — fixture cria vínculo
+        FORMADOR: DENY,      # D8: caso especial; só Meus Eventos + Bloqueios próprios
+    },
     #
     # Deslocamentos: `[IsAuthenticated]` + queryset scope filter (Onda 1 C2).
     # Todos autenticados retornam 200; queryset filtra cross-table via EquipeGerencia.

--- a/v2/backend/apps/core/rbac/permissions.py
+++ b/v2/backend/apps/core/rbac/permissions.py
@@ -186,10 +186,17 @@ class HasSectorAccess(permissions.BasePermission):  # type: ignore[misc]
     """
     Permissão de scope por gerência para a grade mensal de disponibilidade.
 
-    Regras:
+    Regras (D8 — 2026-04-28):
     - Superusers: acesso a todos os setores.
-    - Sem gerencia_id: permite (comportamento SUPER — escopo "todos os setores").
-    - Com gerencia_id: verifica se usuário pertence à gerência via EquipeGerencia.
+    - Sem `gerencia_id` na query: exige pelo menos 1 vínculo de
+      `EquipeGerencia` ativa. Antes era "comportamento SUPER" (permitido a
+      todos autenticados), mas isso permitia que Formador/DAT/Diretoria
+      sem cap global e sem vínculo entrassem na Grade Mensal indevidamente.
+      A composition `CanViewAllAvailability | HasSectorAccess` em
+      `MonthlyAvailabilityView` ainda permite que Controle/Gerente passem
+      pela cap, sem precisar de vínculo de gerência.
+    - Com `gerencia_id`: verifica se usuário pertence à gerência específica
+      via `EquipeGerencia`.
 
     Block antigo de "grupo Controle" foi REMOVIDO em 2026-04-27 (Bug 1 fix
     pós RBAC Access Policy Realignment). Razão: o seed 0077 atribui a
@@ -197,8 +204,7 @@ class HasSectorAccess(permissions.BasePermission):  # type: ignore[misc]
     intent matrix (memória `reference_rbac_intent_matrix.md`). O block por
     nome de grupo contradizia a capability declarada.
 
-    Para autorização ampla baseada em capability, prefira compor com
-    `CanViewAllAvailability` no `permission_classes`:
+    Composição idiomática:
 
         permission_classes = [IsAuthenticated, CanViewAllAvailability | HasSectorAccess]
 
@@ -223,9 +229,21 @@ class HasSectorAccess(permissions.BasePermission):  # type: ignore[misc]
         if gerencia_id_raw is None:
             gerencia_id_raw = request.query_params.get("gerencia_id")
 
-        # Sem gerencia_id = comportamento SUPER (permitido para todos autenticados)
+        # Importação local para evitar circular import na inicialização do módulo.
+        from apps.core.models import EquipeGerencia
+
+        # D8 (2026-04-28): sem `gerencia_id` exige vínculo organizacional.
+        # Quem precisa de visão ampla (Controle/Gerente) bate antes em
+        # `CanViewAllAvailability` na composition; quem cai aqui sem vínculo
+        # é Formador/DAT/Diretoria/sem-vínculo → 403.
         if gerencia_id_raw is None:
-            return True
+            has_any_vinculo = EquipeGerencia.objects.filter(
+                usuario=request.user,
+                ativo=True,
+            ).exists()
+            if not has_any_vinculo:
+                self.message = "Você não tem acesso à grade mensal de disponibilidade."
+            return has_any_vinculo
 
         # Hardening: evitar ValueError em query params inválidos
         try:
@@ -235,8 +253,6 @@ class HasSectorAccess(permissions.BasePermission):  # type: ignore[misc]
             return False
 
         # Com gerencia_id = verificar se usuário pertence à gerência
-        from apps.core.models import EquipeGerencia
-
         has_access = EquipeGerencia.objects.filter(
             usuario=request.user,
             gerencia_id=gerencia_id,

--- a/v2/backend/apps/core/tests/test_availability_monthly_api.py
+++ b/v2/backend/apps/core/tests/test_availability_monthly_api.py
@@ -34,8 +34,15 @@ def api_client():
 
 @pytest.fixture
 def user_auth():
-    """Usuário autenticado para requisições."""
-    user = Usuario.objects.create_user(
+    """
+    Usuário autenticado privilegiado (superuser) para requisições.
+
+    Estes tests focam em cache e validação de parâmetros — não em RBAC.
+    Pós D8 (issue #1287, 2026-04-28), `MonthlyAvailabilityView` exige
+    `view_all_availability` OU `EquipeGerencia` ativa quando `gerencia_id`
+    é omitido. Superuser bypassa, mantendo o foco do test.
+    """
+    user = Usuario.objects.create_superuser(
         username="api_user",
         email="api@example.com",
         password="test123",

--- a/v2/backend/apps/core/tests/test_availability_monthly_rbac.py
+++ b/v2/backend/apps/core/tests/test_availability_monthly_rbac.py
@@ -150,8 +150,7 @@ class TestSectorScopePreserved:
         client.force_authenticate(user=user)
         res = client.get(URL + QS)
         assert res.status_code == 403, (
-            f"Coord sem cap E sem EquipeGerencia deve receber 403 (D8). "
-            f"Got {res.status_code}: {res.content!r}"
+            f"Coord sem cap E sem EquipeGerencia deve receber 403 (D8). " f"Got {res.status_code}: {res.content!r}"
         )
 
     def test_user_without_capability_with_invalid_gerencia_returns_403(self):
@@ -197,8 +196,7 @@ class TestFormadorAndOthersDenied:
         client.force_authenticate(user=user)
         res = client.get(URL + QS)
         assert res.status_code == 403, (
-            f"Formador NÃO deve acessar Grade Mensal (D8). "
-            f"Got {res.status_code}: {res.content!r}"
+            f"Formador NÃO deve acessar Grade Mensal (D8). " f"Got {res.status_code}: {res.content!r}"
         )
 
     def test_dat_returns_403(self):
@@ -211,8 +209,7 @@ class TestFormadorAndOthersDenied:
         client.force_authenticate(user=user)
         res = client.get(URL + QS)
         assert res.status_code == 403, (
-            f"DAT NÃO deve acessar Grade Mensal (D8). "
-            f"Got {res.status_code}: {res.content!r}"
+            f"DAT NÃO deve acessar Grade Mensal (D8). " f"Got {res.status_code}: {res.content!r}"
         )
 
     def test_diretoria_returns_403(self):
@@ -225,8 +222,7 @@ class TestFormadorAndOthersDenied:
         client.force_authenticate(user=user)
         res = client.get(URL + QS)
         assert res.status_code == 403, (
-            f"Diretoria NÃO deve acessar Grade Mensal (D8). "
-            f"Got {res.status_code}: {res.content!r}"
+            f"Diretoria NÃO deve acessar Grade Mensal (D8). " f"Got {res.status_code}: {res.content!r}"
         )
 
 
@@ -281,8 +277,7 @@ class TestCoordenadorScopedAccess:
         client.force_authenticate(user=user)
         res = client.get(URL + QS)
         assert res.status_code == 403, (
-            f"Coord sem EquipeGerencia deve receber 403 (D8). "
-            f"Got {res.status_code}: {res.content!r}"
+            f"Coord sem EquipeGerencia deve receber 403 (D8). " f"Got {res.status_code}: {res.content!r}"
         )
 
 

--- a/v2/backend/apps/core/tests/test_availability_monthly_rbac.py
+++ b/v2/backend/apps/core/tests/test_availability_monthly_rbac.py
@@ -30,7 +30,7 @@ from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import PermissaoFuncional, Usuario
+from apps.core.models import EquipeGerencia, Gerencia, PermissaoFuncional, Usuario
 
 pytestmark = pytest.mark.django_db
 
@@ -132,20 +132,27 @@ class TestControleAccessViaCapability:
 
 
 class TestSectorScopePreserved:
-    def test_user_without_capability_no_gerencia_returns_200(self):
+    def test_user_without_capability_no_gerencia_no_vinculo_returns_403(self):
         """
-        Sem capability + sem gerencia_id = SUPER comportamento (permitido).
-        Mantém regra original de HasSectorAccess.
+        D8 (2026-04-28): sem capability + sem gerencia_id na query + sem
+        EquipeGerencia ativa → 403. Antes era "SUPER comportamento" (200) mas
+        permitia que Formador/DAT/Diretoria entrassem na Grade Mensal sem
+        vínculo organizacional. Agora HasSectorAccess exige `view_all_availability`
+        OU pelo menos 1 EquipeGerencia ativo.
         """
         user = _make_user_with_groups_and_caps(
             "no_cap_user",
             group_names=["Coordenador"],
-            capability_codenames=[],  # propositalmente vazio
+            capability_codenames=[],
         )
+        # Sem EquipeGerencia ativa para esse user.
         client = APIClient()
         client.force_authenticate(user=user)
         res = client.get(URL + QS)
-        assert res.status_code == 200
+        assert res.status_code == 403, (
+            f"Coord sem cap E sem EquipeGerencia deve receber 403 (D8). "
+            f"Got {res.status_code}: {res.content!r}"
+        )
 
     def test_user_without_capability_with_invalid_gerencia_returns_403(self):
         """
@@ -161,6 +168,122 @@ class TestSectorScopePreserved:
         client.force_authenticate(user=user)
         res = client.get(URL + QS + "&gerencia_id=99999")
         assert res.status_code == 403
+
+
+# ============================================================================
+# D8 (2026-04-28) — Formador, DAT e Diretoria não acessam Grade Mensal
+# ============================================================================
+
+
+class TestFormadorAndOthersDenied:
+    """
+    Decisão D8: Formador, DAT e Diretoria não devem acessar Grade Mensal.
+
+    - Formador: caso especial RD-02/RD-03; acessa apenas Meus Eventos + Bloqueios próprios
+    - DAT: não tem motivo legítimo para consultar grade
+    - Diretoria: decisão executiva, não consulta operacional
+
+    Regra do backend após D8: sem `view_all_availability` E sem EquipeGerencia
+    ativa → 403, mesmo sem `gerencia_id` na query.
+    """
+
+    def test_formador_returns_403(self):
+        user = _make_user_with_groups_and_caps(
+            "formador_user",
+            group_names=["Formador"],
+            capability_codenames=[],
+        )
+        client = APIClient()
+        client.force_authenticate(user=user)
+        res = client.get(URL + QS)
+        assert res.status_code == 403, (
+            f"Formador NÃO deve acessar Grade Mensal (D8). "
+            f"Got {res.status_code}: {res.content!r}"
+        )
+
+    def test_dat_returns_403(self):
+        user = _make_user_with_groups_and_caps(
+            "dat_user",
+            group_names=["DAT"],
+            capability_codenames=[],
+        )
+        client = APIClient()
+        client.force_authenticate(user=user)
+        res = client.get(URL + QS)
+        assert res.status_code == 403, (
+            f"DAT NÃO deve acessar Grade Mensal (D8). "
+            f"Got {res.status_code}: {res.content!r}"
+        )
+
+    def test_diretoria_returns_403(self):
+        user = _make_user_with_groups_and_caps(
+            "diretoria_user",
+            group_names=["Diretoria"],
+            capability_codenames=[],
+        )
+        client = APIClient()
+        client.force_authenticate(user=user)
+        res = client.get(URL + QS)
+        assert res.status_code == 403, (
+            f"Diretoria NÃO deve acessar Grade Mensal (D8). "
+            f"Got {res.status_code}: {res.content!r}"
+        )
+
+
+class TestCoordenadorScopedAccess:
+    """
+    Coordenador/Apoio acessam Grade Mensal apenas com vínculo de EquipeGerencia
+    ativa (D6 — scope via gerência). Sem vínculo, 403.
+    """
+
+    def test_coordenador_with_equipe_gerencia_returns_200(self):
+        """
+        Coordenador com EquipeGerencia ativa → 200. View escopa pessoas pela
+        gerência vinculada. Sem `gerencia_id` na query, HasSectorAccess
+        confirma que tem ao menos 1 vínculo e libera; view filtra dados.
+        """
+        user = _make_user_with_groups_and_caps(
+            "coord_with_gerencia",
+            group_names=["Coordenador"],
+            capability_codenames=[],
+        )
+        gerencia = Gerencia.objects.create(
+            nome="GERENCIA D8 TEST",
+            nome_setor="Vidas D8",
+        )
+        EquipeGerencia.objects.create(
+            gerencia=gerencia,
+            usuario=user,
+            papel="COORDENADOR",
+            ativo=True,
+        )
+        client = APIClient()
+        client.force_authenticate(user=user)
+        res = client.get(URL + QS)
+        assert res.status_code == 200, (
+            f"Coord com EquipeGerencia ativa deve acessar Grade Mensal (escopo "
+            f"resolvido em runtime). Got {res.status_code}: {res.content!r}"
+        )
+
+    def test_coordenador_without_equipe_gerencia_returns_403(self):
+        """
+        Coordenador SEM EquipeGerencia ativa → 403 (D8).
+
+        Esse é o ponto-chave do hardening: antes era 200 com lista vazia; agora
+        é 403 explícito porque nem cap global nem vínculo de gerência.
+        """
+        user = _make_user_with_groups_and_caps(
+            "coord_no_gerencia",
+            group_names=["Coordenador"],
+            capability_codenames=[],
+        )
+        client = APIClient()
+        client.force_authenticate(user=user)
+        res = client.get(URL + QS)
+        assert res.status_code == 403, (
+            f"Coord sem EquipeGerencia deve receber 403 (D8). "
+            f"Got {res.status_code}: {res.content!r}"
+        )
 
 
 # ============================================================================

--- a/v2/backend/apps/core/tests/test_multi_sector_permissions.py
+++ b/v2/backend/apps/core/tests/test_multi_sector_permissions.py
@@ -142,25 +142,36 @@ class TestHasSectorAccessPermission(TestCase):
         view = MockView()
         self.assertFalse(self.permission.has_permission(request, view))
 
-    def test_user_without_gerencia_id_is_allowed_super_behavior(self):
-        """Sem gerencia_id = assume SUPER (permitido para autenticados)."""
+    def test_user_with_gerencia_without_gerencia_id_is_allowed(self):
+        """
+        Usuário com EquipeGerencia ativa (qualquer gerência) e sem gerencia_id na query → permitido.
+        D8 (2026-04-28): vínculo organizacional autoriza acesso; view escopa dados em runtime.
+        """
         request = self.factory.get("/")
-        request.user = self.user_vidas
+        request.user = self.user_vidas  # tem EquipeGerencia (Vidas)
         request.query_params = {}
 
         view = MockView()
-        # Conforme plano: sem gerencia_id assume SUPER (comportamento atual)
         self.assertTrue(self.permission.has_permission(request, view))
 
-    def test_user_without_gerencia_without_gerencia_id_is_allowed(self):
-        """Usuário sem gerência vinculada mas sem gerencia_id = permitido (SUPER)."""
+    def test_user_without_gerencia_without_gerencia_id_is_blocked(self):
+        """
+        D8 (2026-04-28): usuário sem EquipeGerencia ativa e sem capability
+        global → 403, mesmo sem gerencia_id na query.
+
+        Antes era "SUPER comportamento" (200), mas isso permitia que
+        Formador/DAT/Diretoria sem vínculo organizacional entrassem na Grade
+        Mensal indevidamente. Agora HasSectorAccess exige vínculo positivo —
+        a composition `CanViewAllAvailability | HasSectorAccess` em
+        `MonthlyAvailabilityView` ainda permite que Controle/Gerente passem
+        pela cap, sem precisar de EquipeGerencia.
+        """
         request = self.factory.get("/")
         request.user = self.user_sem_gerencia
         request.query_params = {}
 
         view = MockView()
-        # Conforme plano: sem gerencia_id assume SUPER (comportamento atual)
-        self.assertTrue(self.permission.has_permission(request, view))
+        self.assertFalse(self.permission.has_permission(request, view))
 
 
 @pytest.mark.django_db

--- a/v2/backend/apps/core/tests/test_rbac_matrix_living.py
+++ b/v2/backend/apps/core/tests/test_rbac_matrix_living.py
@@ -19,11 +19,13 @@ from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import Usuario
+from apps.core.models import EquipeGerencia, Gerencia, Usuario
 from apps.core.rbac.matrix import (
     ACCESS_MATRIX,
     ACTOR_GROUPS,
     ACTORS,
+    APOIO,
+    COORDENADOR,
     RESOURCES,
     SUPERUSER,
     ResourceCase,
@@ -46,6 +48,12 @@ def _make_user_for_actor(actor: str) -> Usuario:
     """
     Cria user com grupos correspondentes ao ator. Superuser é caso especial.
     Cada test gera CPF/username único via atomic counter.
+
+    D8 (2026-04-28): Coordenador e Apoio de Coordenação ganham EquipeGerencia
+    ativa pré-criada. Sem o vínculo, eles cairiam em 403 pelo HasSectorAccess
+    endurecido (sem cap global E sem gerência → DENY). Outros atores não
+    precisam — Controle/Gerente passam pela cap; DAT/Diretoria/Formador são
+    DENY por design.
     """
     if actor == SUPERUSER:
         return Usuario.objects.create_superuser(
@@ -63,6 +71,44 @@ def _make_user_for_actor(actor: str) -> Usuario:
     for gname in ACTOR_GROUPS[actor]:
         group, _ = Group.objects.get_or_create(name=gname)
         user.groups.add(group)
+
+    # D8: Coord/Apoio precisam de vínculo organizacional para passar HasSectorAccess.
+    if actor in (COORDENADOR, APOIO):
+        gerencia, _ = Gerencia.objects.get_or_create(
+            nome=f"GERENCIA MATRIX {_USER_COUNTER['i']:06d}",
+            defaults={"nome_setor": "Vidas"},
+        )
+        if actor == COORDENADOR:
+            # Coordenador: papel direto, sem supervisor.
+            EquipeGerencia.objects.create(
+                gerencia=gerencia,
+                usuario=user,
+                papel="COORDENADOR",
+                ativo=True,
+            )
+        else:
+            # Apoio: check constraint `apoio_requires_supervisor` exige
+            # `coordenador_supervisor` (FK Usuario) não-nulo. Criamos um Coord
+            # auxiliar para servir de supervisor.
+            supervisor_user = Usuario.objects.create_user(
+                username=f"matrix_supervisor_{_USER_COUNTER['i']:06d}",
+                email=f"matrix_supervisor_{_USER_COUNTER['i']:06d}@example.com",
+                password="testpass123",
+                cpf=_next_cpf(),
+            )
+            EquipeGerencia.objects.create(
+                gerencia=gerencia,
+                usuario=supervisor_user,
+                papel="COORDENADOR",
+                ativo=True,
+            )
+            EquipeGerencia.objects.create(
+                gerencia=gerencia,
+                usuario=user,
+                papel="APOIO",
+                ativo=True,
+                coordenador_supervisor=supervisor_user,
+            )
     return user
 
 

--- a/v2/docs/rbac_authorization_matrix.md
+++ b/v2/docs/rbac_authorization_matrix.md
@@ -156,6 +156,7 @@ permission_classes = [IsAdminUser]                    # ❌ DRF built-in fora da
 | D5 | Frontend tem **camada de tradução semântica** (`canAccessApprovals` etc.) | 2026-04-26 | Componentes não conhecem origem (policy vs legacy) — migrar p/ Epic 4.6 = 1 linha sem ripple |
 | D6 | Coordenador/Apoio são SCOPED (não recebem `view_all_availability`) | 2026-04-27 (Bug 1) | E2E J05 protegia regra de privacidade legítima; capability deve ser literal "ver TODAS sem restrição" |
 | D7 | Dashboards = Diretoria + DAT + superuser only | 2026-04-26 | `project_rbac_invariants.md` — Controle não vê Dashboards (Onda 1 corrige `usePermissions` hardcoded) |
+| D8 | Formador, DAT e Diretoria **não acessam** Grade Mensal; Coord/Apoio só com `EquipeGerencia` ativa | 2026-04-28 (issue #1287) | Formador é caso especial RD-02/RD-03 (acessa só Meus Eventos + Bloqueios). DAT/Diretoria não têm motivo legítimo de consultar grade. Antes do fix, frontend `canDisponibilidade=!inControle` (lógica invertida) e backend `HasSectorAccess` retornava True sem `gerencia_id` — Formador via menu e abria página com 200. Reescrita como lista positiva no frontend + endurecimento no backend (sem `gerencia_id` exige vínculo de gerência) |
 
 ---
 

--- a/v2/frontend/src/__tests__/grade_mensal_visibility.test.ts
+++ b/v2/frontend/src/__tests__/grade_mensal_visibility.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Tests de visibilidade da Grade Mensal (D8 — 2026-04-28).
+ *
+ * Valida o predicate exato usado em `AppSidebar.tsx` e `AppRoutes.tsx`:
+ *
+ *     access.can('view_all_availability') || canDisponibilidade
+ *
+ * sem renderizar componentes (helper extraction pattern documentado em
+ * `feedback_stabilization_pos_programa_pattern.md` — modal/router antd
+ * gigante mockear é flaky; testar a regra pura do predicate é suficiente).
+ *
+ * Regra D8:
+ *   ALLOW: Superuser, Controle, Gerente, Coordenador, Apoio
+ *   DENY:  DAT, Diretoria, Formador, user sem nada
+ *
+ * Quem é ALLOW pelo `view_all_availability` (Controle/Gerente) basta a policy.
+ * Quem é ALLOW pelo `canDisponibilidade` (Coord/Apoio) entra pelo segundo termo
+ * do OR e o backend valida scope via `EquipeGerencia` em runtime.
+ */
+
+import { describe, test, expect } from 'vitest';
+import { computePermissions } from '../hooks/usePermissions';
+import { computeAccess } from '../hooks/useCanAccess';
+
+function makeUser(overrides = {}) {
+  return {
+    id: 1,
+    username: 'testuser',
+    email: 'test@test.com',
+    first_name: 'Test',
+    last_name: 'User',
+    name: 'Test User',
+    groups: [],
+    setores: [],
+    funcoes: [],
+    is_superuser: false,
+    is_superintendencia: false,
+    can_approve_super: false,
+    permissions: [],
+    ...overrides,
+  };
+}
+
+/**
+ * Replica o predicate usado em AppSidebar.tsx:363 e AppRoutes.tsx:121:
+ *     access.can('view_all_availability') || canDisponibilidade
+ */
+function shouldShowGradeMensal(user: ReturnType<typeof makeUser>, policies: readonly string[]): boolean {
+  const perms = computePermissions(user);
+  const access = computeAccess(policies, {});
+  return access.can('view_all_availability') || perms.canDisponibilidade;
+}
+
+describe('Grade Mensal visibility (D8 — 2026-04-28)', () => {
+  describe('ALLOW', () => {
+    test('Superuser', () => {
+      // Superuser bypassa policies no backend; useCanAccess recebe lista vazia
+      // mas computePermissions já dá canDisponibilidade=true via is_superuser.
+      expect(shouldShowGradeMensal(makeUser({ is_superuser: true }), [])).toBe(true);
+    });
+
+    test('Controle (via view_all_availability)', () => {
+      // Backend atribui `view_all_availability` ao grupo Controle no seed 0078.
+      // Frontend recebe a policy via GET /api/me/policies/.
+      expect(
+        shouldShowGradeMensal(makeUser({ setores: ['Controle'] }), ['view_all_availability']),
+      ).toBe(true);
+    });
+
+    test('Gerente (via view_all_availability)', () => {
+      expect(
+        shouldShowGradeMensal(makeUser({ funcoes: ['Gerente'] }), ['view_all_availability']),
+      ).toBe(true);
+    });
+
+    test('Coordenador (canDisponibilidade — scoped via EquipeGerencia em runtime)', () => {
+      // Coord não tem `view_all_availability` no seed; entra pelo predicate
+      // canDisponibilidade. Backend valida EquipeGerencia ativo em runtime.
+      expect(
+        shouldShowGradeMensal(makeUser({ funcoes: ['Coordenador'], setores: ['Vidas'] }), []),
+      ).toBe(true);
+    });
+
+    test('Apoio de Coordenação (canDisponibilidade — scoped via EquipeGerencia em runtime)', () => {
+      expect(
+        shouldShowGradeMensal(makeUser({ funcoes: ['Apoio de Coordenação'], setores: ['Vidas'] }), []),
+      ).toBe(true);
+    });
+  });
+
+  describe('DENY', () => {
+    test('Formador (caso especial — só Meus Eventos + Bloqueios)', () => {
+      expect(shouldShowGradeMensal(makeUser({ funcoes: ['Formador'] }), [])).toBe(false);
+    });
+
+    test('DAT (não consulta disponibilidade — D8)', () => {
+      expect(shouldShowGradeMensal(makeUser({ setores: ['DAT'] }), [])).toBe(false);
+    });
+
+    test('Diretoria (decisão executiva, não consulta operacional — D8)', () => {
+      expect(shouldShowGradeMensal(makeUser({ setores: ['Diretoria'] }), [])).toBe(false);
+    });
+
+    test('Usuário sem setor/função', () => {
+      expect(shouldShowGradeMensal(makeUser(), [])).toBe(false);
+    });
+
+    test('Usuário só com setor "Vidas" sem função', () => {
+      expect(shouldShowGradeMensal(makeUser({ setores: ['Vidas'] }), [])).toBe(false);
+    });
+  });
+});

--- a/v2/frontend/src/hooks/__tests__/usePermissions.test.js
+++ b/v2/frontend/src/hooks/__tests__/usePermissions.test.js
@@ -114,8 +114,8 @@ describe('computePermissions', () => {
     const perms = computePermissions(makeUser({ setores: ['Controle'] }))
     expect(perms.inControle).toBe(true)
     expect(perms.canControle).toBe(true)
-    // Controle cannot access Disponibilidade
-    expect(perms.canDisponibilidade).toBe(false)
+    // D8 (2026-04-28): Controle agora ACESSA Grade Mensal via view_all_availability (D6).
+    expect(perms.canDisponibilidade).toBe(true)
   })
 
   test('Gerente role grants canAcoesInternas', () => {
@@ -222,9 +222,69 @@ describe('computePermissions', () => {
     expect(perms.isFormador).toBe(true)
   })
 
-  test('canDisponibilidade is true for non-Controle users', () => {
-    const perms = computePermissions(makeUser({ setores: ['Vidas'] }))
-    expect(perms.canDisponibilidade).toBe(true)
+  // ============================================================================
+  // canDisponibilidade — alinhado com decisão D8 (2026-04-28)
+  //
+  // Acesso à Grade Mensal:
+  //   - Superuser, Controle, Gerente, Coordenador, Apoio → ALLOW
+  //   - DAT, Diretoria, Formador → DENY
+  //
+  // Antes de D8, a flag era `!inControle` (lógica invertida) — qualquer não-Controle
+  // entrava, incluindo Formador. Bug reportado em 2026-04-28: Formador via item
+  // "Grade Mensal" no menu sem ter acesso real. Lógica reescrita como positiva.
+  // Backend reforça via composition `CanViewAllAvailability | HasSectorAccess`.
+  // ============================================================================
+
+  describe('canDisponibilidade (D8)', () => {
+    test('Superuser → ALLOW', () => {
+      const perms = computePermissions(makeUser({ is_superuser: true }))
+      expect(perms.canDisponibilidade).toBe(true)
+    })
+
+    test('Controle → ALLOW (view_all_availability via D6)', () => {
+      const perms = computePermissions(makeUser({ setores: ['Controle'] }))
+      expect(perms.canDisponibilidade).toBe(true)
+    })
+
+    test('Gerente → ALLOW (view_all_availability via D6)', () => {
+      const perms = computePermissions(makeUser({ funcoes: ['Gerente'] }))
+      expect(perms.canDisponibilidade).toBe(true)
+    })
+
+    test('Coordenador → ALLOW (scoped via EquipeGerencia)', () => {
+      const perms = computePermissions(makeUser({ funcoes: ['Coordenador'], setores: ['Vidas'] }))
+      expect(perms.canDisponibilidade).toBe(true)
+    })
+
+    test('Apoio de Coordenação → ALLOW (scoped via EquipeGerencia)', () => {
+      const perms = computePermissions(makeUser({ funcoes: ['Apoio de Coordenação'], setores: ['Vidas'] }))
+      expect(perms.canDisponibilidade).toBe(true)
+    })
+
+    test('Formador → DENY (caso especial: só Meus Eventos + Bloqueios próprios)', () => {
+      const perms = computePermissions(makeUser({ funcoes: ['Formador'] }))
+      expect(perms.canDisponibilidade).toBe(false)
+    })
+
+    test('DAT → DENY (não tem capability nem precisa consultar grade)', () => {
+      const perms = computePermissions(makeUser({ setores: ['DAT'] }))
+      expect(perms.canDisponibilidade).toBe(false)
+    })
+
+    test('Diretoria → DENY (decisão executiva, não consulta operacional)', () => {
+      const perms = computePermissions(makeUser({ setores: ['Diretoria'] }))
+      expect(perms.canDisponibilidade).toBe(false)
+    })
+
+    test('Usuário sem setor/função → DENY', () => {
+      const perms = computePermissions(makeUser())
+      expect(perms.canDisponibilidade).toBe(false)
+    })
+
+    test('Usuário só com setor "Vidas" (sem função) → DENY', () => {
+      const perms = computePermissions(makeUser({ setores: ['Vidas'] }))
+      expect(perms.canDisponibilidade).toBe(false)
+    })
   })
 
   test('regular user with no roles/sectors has minimal permissions', () => {
@@ -236,8 +296,8 @@ describe('computePermissions', () => {
     expect(perms.canDAT).toBe(false)
     expect(perms.canAcoesInternas).toBe(false)
     expect(perms.canDashboardsMenu).toBe(false)
-    // Non-Controle user can access Disponibilidade
-    expect(perms.canDisponibilidade).toBe(true)
+    // D8 (2026-04-28): user sem nada não acessa Grade Mensal.
+    expect(perms.canDisponibilidade).toBe(false)
   })
 
   test('multiple sectors combine permissions', () => {

--- a/v2/frontend/src/hooks/usePermissions.ts
+++ b/v2/frontend/src/hooks/usePermissions.ts
@@ -106,7 +106,19 @@ function computePermissionsInternal(user: CurrentUser): Permissions {
   const canMapaBrasil = user.is_superuser || inDiretoria || inDAT;
   const canDashboardsMenu =
     canDashboardOverview || canDashboardCompras || canDashboardEquipe || canDashboardGcal || canMapaBrasil;
-  const canDisponibilidade = user.is_superuser || !inControle;
+  // canDisponibilidade — decisão D8 (2026-04-28).
+  //
+  // Acesso à Grade Mensal:
+  //   ALLOW: Superuser, Controle, Gerente, Coordenador, Apoio (scoped via EquipeGerencia)
+  //   DENY:  DAT, Diretoria, Formador, sem vínculo organizacional
+  //
+  // Antes era `!inControle` (lógica invertida) — qualquer não-Controle entrava,
+  // incluindo Formador, que viola RD-02/RD-03 (Formador acessa apenas Meus
+  // Eventos + Bloqueios próprios). Reescrita como lista positiva alinhada com
+  // o backend: Controle/Gerente passam pela cap `view_all_availability`,
+  // Coord/Apoio pelo HasSectorAccess (vínculo de gerência validado em runtime).
+  const canDisponibilidade =
+    user.is_superuser || inControle || isGerente || isCoordenador;
   // Epic 3.3: derived flag unificada para "vê todos os setores/gerências".
   // Substitui hardcodes is_superuser || is_superintendencia || groups.includes('Superintendência')
   // em FiltersBar, PreAgendaPage, Solicitacoes, ApprovalsPage.


### PR DESCRIPTION
## Summary

Closes #1287.

Formador sem capabilities via item "Grade Mensal" no menu e abria a página com 200 (escopo limitava ao próprio user, sem vazamento de dados — mas violava intent declarada). Bug duplo: frontend `canDisponibilidade=!inControle` (lógica invertida legacy) + backend `HasSectorAccess` permissivo sem `gerencia_id`.

Fix:
- **Frontend**: `canDisponibilidade` reescrita como lista positiva alinhada com D8
- **Backend**: `HasSectorAccess` endurecida — sem `gerencia_id` exige `view_all_availability` OU `EquipeGerencia` ativa
- **Matriz Viva**: `grade_mensal` atualizada (Formador/DAT/Diretoria DENY); fixture cria `EquipeGerencia` para Coord/Apoio
- **Docs**: nova decisão D8 em `rbac_authorization_matrix.md`

## Regra D8 (acesso à Grade Mensal)

| Ator | Acesso |
|------|--------|
| Superuser | ALLOW |
| Controle | ALLOW (`view_all_availability`) |
| Gerente | ALLOW (`view_all_availability`) |
| Coordenador | ALLOW com `EquipeGerencia` ativa |
| Apoio de Coordenação | ALLOW com `EquipeGerencia` ativa |
| DAT | DENY |
| Diretoria | DENY |
| Formador | DENY |

## Mudanças

### Frontend
- `v2/frontend/src/hooks/usePermissions.ts`: `canDisponibilidade` lógica positiva
- `v2/frontend/src/hooks/__tests__/usePermissions.test.js`: 3 tests legacy invertidos + describe novo D8 (10 tests)
- `v2/frontend/src/__tests__/grade_mensal_visibility.test.ts` (NEW): testa o predicate exato de `AppSidebar`/`AppRoutes` para os 8 atores

### Backend
- `v2/backend/apps/core/rbac/permissions.py`: `HasSectorAccess.has_permission` exige cap OU `EquipeGerencia` ativa quando `gerencia_id` é omitido
- `v2/backend/apps/core/tests/test_availability_monthly_rbac.py`: 5 novos tests (Formador/DAT/Diretoria DENY, Coord com/sem `EquipeGerencia`); 1 test obsoleto invertido
- `v2/backend/apps/core/tests/test_multi_sector_permissions.py`: `test_user_sem_gerencia` agora `assertFalse` (D8)
- `v2/backend/apps/core/tests/test_availability_monthly_api.py`: fixture `user_auth` virou superuser (tests focam em cache/validação, não RBAC)

### Matriz Viva (governance)
- `v2/backend/apps/core/rbac/matrix.py`: `ACCESS_MATRIX["grade_mensal"]` explícito por ator (D8)
- `v2/backend/apps/core/tests/test_rbac_matrix_living.py`: fixture `_make_user_for_actor` cria `EquipeGerencia` para Coord/Apoio (Apoio com `coordenador_supervisor` por check constraint)

### Docs
- `v2/docs/rbac_authorization_matrix.md`: nova linha D8 em §6 (Decisões consolidadas)

## NÃO tocou

- ProdutoViewSet (#1258), UsuarioLookup (#1259), HomeStats (#1284 já mergeado em PR #1286)
- Solicitações batch endpoints (issue separada futura)
- Seeds, migrations, capabilities novas

## Defesa em profundidade

Frontend bloqueia o menu (UX correta). Backend defende contra acesso por URL direta ou bypass do client. Matriz Viva guarda regressão futura via test parametrizado (`test_rbac_matrix_living.py`).

## Test plan

- [x] **Backend full suite**: 1944 passed, 43 skipped (pré-existentes), 0 failed
- [x] **Frontend full suite**: 269 passed, 0 failed
- [x] **Black + isort + flake8** nos arquivos tocados: clean
- [x] **TDD ciclo**: RED reproduzindo bug → GREEN frontend → GREEN backend → matriz viva alinhada
- [x] **Cenários cobertos**:
  - [x] Formador → 403 (backend) + menu não renderiza (frontend)
  - [x] DAT → 403 (sem `EquipeGerencia` no fixture)
  - [x] Diretoria → 403 (mesmo motivo)
  - [x] Coordenador sem `EquipeGerencia` → 403
  - [x] Coordenador com `EquipeGerencia` → 200 com escopo
  - [x] Controle/Gerente → 200 via `view_all_availability`
  - [x] Superuser → 200 (bypass)

## Staging Gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR (trecho de log contendo "ALL 8 CHECKS PASSED")

### Evidencia Staging Gate

```text
==============================================
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
==============================================
```

Pipeline executado: precheck (compose !reset valido) → build (backend + frontend prod images com tag `staging-local`) → up (stack staging-gate dedicada com migrations) → smoke (8 checks) → teardown (compose down -v).