### PR TITLE
fix(backend): promove municípios IBGE para selects da plataforma

### DIFF
--- a/v2/backend/apps/core/management/commands/promote_municipios_referencia.py
+++ b/v2/backend/apps/core/management/commands/promote_municipios_referencia.py
@@ -1,0 +1,232 @@
+"""
+Promote municipios from core_municipio_referencia into core_municipio.
+
+Goal:
+- make every reference municipio available to platform dropdowns
+- keep the operation idempotent
+- avoid duplicating rows when an equivalent municipio already exists
+"""
+
+# pyright: reportUnknownMemberType=false, reportUnknownVariableType=false, reportAttributeAccessIssue=false
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from collections import defaultdict
+from typing import TYPE_CHECKING, Any
+
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from apps.core.models import Municipio, MunicipioReferencia
+from apps.core.services.options_cache import invalidate_municipios_options_cache
+
+if TYPE_CHECKING:
+    from argparse import ArgumentParser
+
+
+IBGE_CODE_RE = re.compile(r"^\d{7}$")
+
+
+def _normalize_name(value: str) -> str:
+    """Normalize names for deterministic matching without accents/case."""
+    base = unicodedata.normalize("NFKD", value.strip())
+    without_accents = "".join(char for char in base if not unicodedata.combining(char))
+    normalized_spaces = " ".join(without_accents.split())
+    return normalized_spaces.casefold()
+
+
+class Command(BaseCommand):
+    help = "Promove municipios da tabela de referencia para core_municipio."
+
+    def add_arguments(self, parser: ArgumentParser) -> None:
+        parser.add_argument(
+            "--apply",
+            action="store_true",
+            help="Persiste alteracoes no banco. Sem --apply, roda em dry-run.",
+        )
+        parser.add_argument(
+            "--fonte",
+            type=str,
+            default="ibge",
+            help="Fonte da tabela de referencia (default: ibge).",
+        )
+        parser.add_argument(
+            "--uf",
+            type=str,
+            help="Filtra municipios de uma UF especifica (ex: CE).",
+        )
+        parser.add_argument(
+            "--limit",
+            type=int,
+            help="Limita quantidade de referencias avaliadas (util para teste controlado).",
+        )
+        parser.add_argument(
+            "--include-inactive-ref",
+            action="store_true",
+            help="Inclui referencias inativas. Default: somente ativo=True.",
+        )
+        parser.add_argument(
+            "--verbose",
+            action="store_true",
+            help="Exibe exemplos de conflitos detectados.",
+        )
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        apply_changes = bool(options.get("apply", False))
+        fonte = str(options.get("fonte", "ibge")).strip()
+        uf_filter = str(options.get("uf") or "").strip().upper()
+        limit = options.get("limit")
+        include_inactive_ref = bool(options.get("include_inactive_ref", False))
+        verbose = bool(options.get("verbose", False))
+
+        referencia_base_qs = MunicipioReferencia.objects.filter(fonte=fonte).order_by("uf", "nome", "codigo_externo")
+        if uf_filter:
+            referencia_base_qs = referencia_base_qs.filter(uf__iexact=uf_filter)
+
+        ignored_inactive_refs = 0
+        if not include_inactive_ref:
+            ignored_inactive_refs = referencia_base_qs.filter(ativo=False).count()
+
+        referencia_qs = referencia_base_qs
+        if not include_inactive_ref:
+            referencia_qs = referencia_qs.filter(ativo=True)
+        if limit:
+            referencia_qs = referencia_qs[: int(limit)]
+
+        referencias = list(referencia_qs.only("nome", "uf", "codigo_externo", "ativo"))
+        municipios_existentes = list(Municipio.objects.all().only("id", "nome", "uf", "ibge_code", "ativo"))
+
+        existing_by_code: dict[str, Municipio] = {}
+        existing_by_key: dict[tuple[str, str], list[Municipio]] = defaultdict(list)
+        for municipio in municipios_existentes:
+            if municipio.ibge_code:
+                existing_by_code[municipio.ibge_code] = municipio
+            existing_by_key[(municipio.uf.strip().upper(), _normalize_name(municipio.nome))].append(municipio)
+
+        to_create: list[Municipio] = []
+        to_update: list[tuple[Municipio, list[str]]] = []
+
+        invalid_ref_code_count = 0
+        would_create = 0
+        would_update = 0
+        unchanged = 0
+        code_owned_by_other = 0
+        ambiguous_existing = 0
+        mismatched_existing_code = 0
+
+        code_conflict_examples: list[str] = []
+        ambiguous_examples: list[str] = []
+        mismatched_examples: list[str] = []
+
+        for ref in referencias:
+            code = (ref.codigo_externo or "").strip()
+            if not IBGE_CODE_RE.fullmatch(code):
+                invalid_ref_code_count += 1
+                continue
+
+            ref_name = ref.nome.strip()
+            ref_uf = ref.uf.strip().upper()
+            ref_key = (ref_uf, _normalize_name(ref_name))
+            target = existing_by_code.get(code)
+
+            if target is not None:
+                target_key = (target.uf.strip().upper(), _normalize_name(target.nome))
+                if target_key != ref_key:
+                    code_owned_by_other += 1
+                    if len(code_conflict_examples) < 10:
+                        code_conflict_examples.append(f"{ref_name}/{ref_uf} -> {code} (owner={target.nome}/{target.uf})")
+                    continue
+            else:
+                candidates = existing_by_key.get(ref_key, [])
+                if len(candidates) > 1:
+                    ambiguous_existing += 1
+                    if len(ambiguous_examples) < 10:
+                        names = ", ".join(f"{item.nome}/{item.uf}" for item in candidates[:3])
+                        ambiguous_examples.append(f"{ref_name}/{ref_uf} -> {names}")
+                    continue
+                if len(candidates) == 1:
+                    target = candidates[0]
+                    if target.ibge_code and target.ibge_code != code:
+                        mismatched_existing_code += 1
+                        if len(mismatched_examples) < 10:
+                            mismatched_examples.append(
+                                f"{ref_name}/{ref_uf} -> ref={code} existing={target.ibge_code}"
+                            )
+                        continue
+
+            if target is None:
+                municipio = Municipio(
+                    nome=ref_name,
+                    uf=ref_uf,
+                    ibge_code=code,
+                    ativo=bool(ref.ativo),
+                )
+                to_create.append(municipio)
+                would_create += 1
+                existing_by_code[code] = municipio
+                existing_by_key[ref_key].append(municipio)
+                continue
+
+            changed_fields: list[str] = []
+            if target.ibge_code != code:
+                target.ibge_code = code
+                changed_fields.append("ibge_code")
+            if target.ativo != bool(ref.ativo):
+                target.ativo = bool(ref.ativo)
+                changed_fields.append("ativo")
+
+            if changed_fields:
+                to_update.append((target, changed_fields))
+                would_update += 1
+            else:
+                unchanged += 1
+
+        created = 0
+        updated = 0
+        cache_invalidated = False
+
+        if apply_changes and (to_create or to_update):
+            with transaction.atomic():
+                if to_create:
+                    Municipio.objects.bulk_create(to_create, batch_size=1000)
+                    created = len(to_create)
+                if to_update:
+                    for municipio, fields in to_update:
+                        municipio.save(update_fields=fields)
+                    updated = len(to_update)
+
+            invalidate_municipios_options_cache()
+            cache_invalidated = True
+
+        mode = "APPLY" if apply_changes else "DRY-RUN"
+        self.stdout.write(f"[{mode}] Promote Municipios Referencia")
+        self.stdout.write(f"fonte={fonte} | uf={uf_filter or 'ALL'}")
+        self.stdout.write(f"referencias_lidas={len(referencias)}")
+        self.stdout.write(f"referencias_codigo_invalido={invalid_ref_code_count}")
+        self.stdout.write(f"ignored_inactive_refs={ignored_inactive_refs}")
+        self.stdout.write(f"would_create={would_create}")
+        self.stdout.write(f"would_update={would_update}")
+        self.stdout.write(f"unchanged={unchanged}")
+        self.stdout.write(f"conflicts_code_owned_by_other={code_owned_by_other}")
+        self.stdout.write(f"conflicts_ambiguous_existing={ambiguous_existing}")
+        self.stdout.write(f"conflicts_mismatched_existing_code={mismatched_existing_code}")
+        self.stdout.write(self.style.SUCCESS(f"created={created}"))
+        self.stdout.write(self.style.SUCCESS(f"updated={updated}"))
+        self.stdout.write(f"cache_invalidated={1 if cache_invalidated else 0}")
+        self.stdout.write(f"total_db_target={Municipio.objects.count()}")
+
+        if verbose:
+            if code_conflict_examples:
+                self.stdout.write("exemplos_code_owned_by_other:")
+                for item in code_conflict_examples:
+                    self.stdout.write(f"  - {item}")
+            if ambiguous_examples:
+                self.stdout.write("exemplos_ambiguous_existing:")
+                for item in ambiguous_examples:
+                    self.stdout.write(f"  - {item}")
+            if mismatched_examples:
+                self.stdout.write("exemplos_mismatched_existing_code:")
+                for item in mismatched_examples:
+                    self.stdout.write(f"  - {item}")

--- a/v2/backend/apps/core/management/commands/promote_municipios_referencia.py
+++ b/v2/backend/apps/core/management/commands/promote_municipios_referencia.py
@@ -136,7 +136,9 @@ class Command(BaseCommand):
                 if target_key != ref_key:
                     code_owned_by_other += 1
                     if len(code_conflict_examples) < 10:
-                        code_conflict_examples.append(f"{ref_name}/{ref_uf} -> {code} (owner={target.nome}/{target.uf})")
+                        code_conflict_examples.append(
+                            f"{ref_name}/{ref_uf} -> {code} (owner={target.nome}/{target.uf})"
+                        )
                     continue
             else:
                 candidates = existing_by_key.get(ref_key, [])
@@ -151,9 +153,7 @@ class Command(BaseCommand):
                     if target.ibge_code and target.ibge_code != code:
                         mismatched_existing_code += 1
                         if len(mismatched_examples) < 10:
-                            mismatched_examples.append(
-                                f"{ref_name}/{ref_uf} -> ref={code} existing={target.ibge_code}"
-                            )
+                            mismatched_examples.append(f"{ref_name}/{ref_uf} -> ref={code} existing={target.ibge_code}")
                         continue
 
             if target is None:

--- a/v2/backend/apps/core/services/municipios_import.py
+++ b/v2/backend/apps/core/services/municipios_import.py
@@ -22,6 +22,7 @@ from django.db import transaction
 import pandas as pd
 
 from apps.core.models import Municipio
+from apps.core.services.options_cache import invalidate_municipios_options_cache
 
 
 def import_municipios_from_file(*, path: str, dry_run: bool = True) -> dict[str, Any]:
@@ -73,6 +74,8 @@ def import_municipios_from_file(*, path: str, dry_run: bool = True) -> dict[str,
 
         if dry_run:
             transaction.set_rollback(True)
+        elif stats["created"] or stats["updated"]:
+            transaction.on_commit(invalidate_municipios_options_cache)
 
     return {
         "stats": stats,

--- a/v2/backend/apps/core/services/options_cache.py
+++ b/v2/backend/apps/core/services/options_cache.py
@@ -1,0 +1,14 @@
+"""
+Cache helpers for static options endpoints.
+"""
+
+from __future__ import annotations
+
+from django.core.cache import cache
+
+MUNICIPIOS_OPTIONS_CACHE_KEY = "static_endpoint:municipios_options"
+
+
+def invalidate_municipios_options_cache() -> None:
+    """Clear cached municipio options used by dropdowns/selects."""
+    cache.delete(MUNICIPIOS_OPTIONS_CACHE_KEY)

--- a/v2/backend/apps/core/tests/test_municipios_admin_cache.py
+++ b/v2/backend/apps/core/tests/test_municipios_admin_cache.py
@@ -1,0 +1,73 @@
+"""
+Tests for municipio cache invalidation through the admin API.
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportOptionalMemberAccess=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportMissingTypeArgument=false, reportCallIssue=false, reportIndexIssue=false, reportOperatorIssue=false, reportOptionalSubscript=false, reportUnknownLambdaType=false
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from django.contrib.auth.models import Group
+from django.core.cache import cache
+from rest_framework import status
+from rest_framework.test import APIClient
+
+import pytest
+
+from apps.core.models import Municipio, Usuario
+from apps.core.services.options_cache import MUNICIPIOS_OPTIONS_CACHE_KEY
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+
+@pytest.fixture
+def usuario_dat():
+    uid = uuid4().hex[:8]
+    user = Usuario.objects.create_user(
+        username=f"dat_{uid}",
+        email=f"dat_{uid}@example.com",
+        password="senha123",
+        cpf=str(uuid4().int % 10**11).zfill(11),
+    )
+    group_dat, _ = Group.objects.get_or_create(name="DAT")
+    user.groups.add(group_dat)
+    return user
+
+
+def test_dat_create_municipio_invalidates_options_cache(api_client, usuario_dat):
+    cache.set(MUNICIPIOS_OPTIONS_CACHE_KEY, [{"id": 1, "nome": "stale", "uf": "XX"}], timeout=300)
+
+    api_client.force_authenticate(user=usuario_dat)
+    payload = {"nome": "Caucaia", "uf": "CE", "ibge_code": "2303709", "ativo": True}
+    response = api_client.post("/api/municipios/", payload, format="json")
+
+    assert response.status_code == status.HTTP_201_CREATED
+    assert cache.get(MUNICIPIOS_OPTIONS_CACHE_KEY) is None
+
+
+def test_dat_update_municipio_invalidates_options_cache(api_client, usuario_dat):
+    municipio = Municipio.objects.create(nome="Caucaia", uf="CE", ibge_code="2303709", ativo=True)
+    cache.set(MUNICIPIOS_OPTIONS_CACHE_KEY, [{"id": municipio.id, "nome": "stale", "uf": "CE"}], timeout=300)
+
+    api_client.force_authenticate(user=usuario_dat)
+    response = api_client.patch(f"/api/municipios/{municipio.id}/", {"ativo": False}, format="json")
+
+    assert response.status_code == status.HTTP_200_OK
+    assert cache.get(MUNICIPIOS_OPTIONS_CACHE_KEY) is None
+
+
+def test_dat_delete_municipio_invalidates_options_cache(api_client, usuario_dat):
+    municipio = Municipio.objects.create(nome="Caucaia", uf="CE", ibge_code="2303709", ativo=True)
+    cache.set(MUNICIPIOS_OPTIONS_CACHE_KEY, [{"id": municipio.id, "nome": "stale", "uf": "CE"}], timeout=300)
+
+    api_client.force_authenticate(user=usuario_dat)
+    response = api_client.delete(f"/api/municipios/{municipio.id}/")
+
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    assert cache.get(MUNICIPIOS_OPTIONS_CACHE_KEY) is None

--- a/v2/backend/apps/core/tests/test_municipios_import_service.py
+++ b/v2/backend/apps/core/tests/test_municipios_import_service.py
@@ -1,0 +1,29 @@
+"""
+Tests for municipios import service side effects.
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportOptionalMemberAccess=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportMissingTypeArgument=false, reportCallIssue=false, reportIndexIssue=false, reportOperatorIssue=false, reportOptionalSubscript=false, reportUnknownLambdaType=false
+
+from __future__ import annotations
+
+from django.core.cache import cache
+
+import pytest
+
+from apps.core.models import Municipio
+from apps.core.services.municipios_import import import_municipios_from_file
+from apps.core.services.options_cache import MUNICIPIOS_OPTIONS_CACHE_KEY
+
+pytestmark = pytest.mark.django_db
+
+
+def test_import_municipios_apply_invalidates_options_cache(tmp_path):
+    csv_path = tmp_path / "municipios.csv"
+    csv_path.write_text("nome,uf,ibge_code\nFortaleza,CE,2304400\n", encoding="utf-8")
+    cache.set(MUNICIPIOS_OPTIONS_CACHE_KEY, [{"id": 999, "nome": "stale", "uf": "XX"}], timeout=300)
+
+    report = import_municipios_from_file(path=str(csv_path), dry_run=False)
+
+    assert report["stats"]["created"] == 1
+    assert Municipio.objects.filter(nome="Fortaleza", uf="CE", ibge_code="2304400").exists()
+    assert cache.get(MUNICIPIOS_OPTIONS_CACHE_KEY) is None

--- a/v2/backend/apps/core/tests/test_promote_municipios_referencia_command.py
+++ b/v2/backend/apps/core/tests/test_promote_municipios_referencia_command.py
@@ -1,0 +1,275 @@
+"""
+Tests for the promote_municipios_referencia command.
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportOptionalMemberAccess=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportMissingTypeArgument=false, reportCallIssue=false, reportIndexIssue=false, reportOperatorIssue=false, reportOptionalSubscript=false, reportUnknownLambdaType=false
+
+from __future__ import annotations
+
+from io import StringIO
+
+from django.core.cache import cache
+from django.core.management import call_command
+
+import pytest
+
+from apps.core.models import Municipio, MunicipioReferencia
+from apps.core.services.options_cache import MUNICIPIOS_OPTIONS_CACHE_KEY
+
+pytestmark = pytest.mark.django_db
+
+
+def test_promote_municipios_referencia_dry_run_does_not_persist():
+    MunicipioReferencia.objects.create(
+        nome="Fortaleza",
+        uf="CE",
+        codigo_externo="2304400",
+        fonte="ibge",
+        ativo=True,
+    )
+
+    out = StringIO()
+    call_command("promote_municipios_referencia", stdout=out)
+
+    assert Municipio.objects.count() == 0
+    text = out.getvalue()
+    assert "would_create=1" in text
+    assert "created=0" in text
+    assert "updated=0" in text
+
+
+def test_promote_municipios_referencia_apply_creates_rows_and_invalidates_cache():
+    cache.set(MUNICIPIOS_OPTIONS_CACHE_KEY, [{"id": 999, "nome": "stale", "uf": "XX"}], timeout=300)
+    MunicipioReferencia.objects.create(
+        nome="Fortaleza",
+        uf="CE",
+        codigo_externo="2304400",
+        fonte="ibge",
+        ativo=True,
+    )
+
+    out = StringIO()
+    call_command("promote_municipios_referencia", "--apply", stdout=out)
+
+    municipio = Municipio.objects.get(nome="Fortaleza", uf="CE")
+    assert municipio.ibge_code == "2304400"
+    assert municipio.ativo is True
+    assert cache.get(MUNICIPIOS_OPTIONS_CACHE_KEY) is None
+    text = out.getvalue()
+    assert "created=1" in text
+    assert "cache_invalidated=1" in text
+
+
+def test_promote_municipios_referencia_apply_is_idempotent():
+    MunicipioReferencia.objects.create(
+        nome="Fortaleza",
+        uf="CE",
+        codigo_externo="2304400",
+        fonte="ibge",
+        ativo=True,
+    )
+
+    first_out = StringIO()
+    call_command("promote_municipios_referencia", "--apply", stdout=first_out)
+    second_out = StringIO()
+    call_command("promote_municipios_referencia", "--apply", stdout=second_out)
+
+    assert Municipio.objects.filter(nome="Fortaleza", uf="CE", ibge_code="2304400").count() == 1
+    assert "created=1" in first_out.getvalue()
+    second_text = second_out.getvalue()
+    assert "would_create=0" in second_text
+    assert "would_update=0" in second_text
+    assert "unchanged=1" in second_text
+    assert "created=0" in second_text
+    assert "updated=0" in second_text
+
+
+def test_promote_municipios_referencia_apply_updates_existing_normalized_match():
+    municipio = Municipio.objects.create(nome="Sao Paulo", uf="SP", ibge_code=None, ativo=False)
+    MunicipioReferencia.objects.create(
+        nome="Sao Paulo",
+        uf="SP",
+        codigo_externo="3550308",
+        fonte="ibge",
+        ativo=True,
+    )
+
+    out = StringIO()
+    call_command("promote_municipios_referencia", "--apply", stdout=out)
+
+    municipio.refresh_from_db()
+    assert municipio.ibge_code == "3550308"
+    assert municipio.ativo is True
+    text = out.getvalue()
+    assert "would_update=1" in text
+    assert "updated=1" in text
+    assert municipio.nome == "Sao Paulo"
+    assert municipio.uf == "SP"
+
+
+def test_promote_municipios_referencia_prefers_existing_ibge_code_match():
+    Municipio.objects.create(nome="Fortaleza", uf="CE", ibge_code="2304400", ativo=False)
+    MunicipioReferencia.objects.create(
+        nome="Fortaleza",
+        uf="CE",
+        codigo_externo="2304400",
+        fonte="ibge",
+        ativo=True,
+    )
+
+    out = StringIO()
+    call_command("promote_municipios_referencia", "--apply", stdout=out)
+
+    assert Municipio.objects.filter(ibge_code="2304400").count() == 1
+    municipio = Municipio.objects.get(ibge_code="2304400")
+    assert municipio.nome == "Fortaleza"
+    assert municipio.ativo is True
+    text = out.getvalue()
+    assert "would_update=1" in text
+    assert "updated=1" in text
+
+
+def test_promote_municipios_referencia_does_not_match_by_name_without_uf():
+    Municipio.objects.create(nome="Fortaleza", uf="CE", ibge_code=None, ativo=True)
+    MunicipioReferencia.objects.create(
+        nome="Fortaleza",
+        uf="PI",
+        codigo_externo="2203909",
+        fonte="ibge",
+        ativo=True,
+    )
+
+    out = StringIO()
+    call_command("promote_municipios_referencia", "--apply", stdout=out)
+
+    assert Municipio.objects.filter(nome="Fortaleza", uf="CE", ibge_code__isnull=True).exists()
+    assert Municipio.objects.filter(nome="Fortaleza", uf="PI", ibge_code="2203909").exists()
+    assert "created=1" in out.getvalue()
+
+
+def test_promote_municipios_referencia_default_ignores_inactive_refs():
+    MunicipioReferencia.objects.create(
+        nome="Fortaleza",
+        uf="CE",
+        codigo_externo="2304400",
+        fonte="ibge",
+        ativo=False,
+    )
+
+    out = StringIO()
+    call_command("promote_municipios_referencia", stdout=out)
+
+    assert Municipio.objects.count() == 0
+    text = out.getvalue()
+    assert "referencias_lidas=0" in text
+    assert "ignored_inactive_refs=1" in text
+    assert "would_create=0" in text
+
+
+def test_promote_municipios_referencia_include_inactive_refs_creates_inactive_rows():
+    MunicipioReferencia.objects.create(
+        nome="Fortaleza",
+        uf="CE",
+        codigo_externo="2304400",
+        fonte="ibge",
+        ativo=False,
+    )
+
+    out = StringIO()
+    call_command("promote_municipios_referencia", "--apply", "--include-inactive-ref", stdout=out)
+
+    municipio = Municipio.objects.get(nome="Fortaleza", uf="CE")
+    assert municipio.ibge_code == "2304400"
+    assert municipio.ativo is False
+    text = out.getvalue()
+    assert "ignored_inactive_refs=0" in text
+    assert "created=1" in text
+
+
+def test_promote_municipios_referencia_apply_detects_code_owned_by_other():
+    Municipio.objects.create(nome="Aquiraz", uf="CE", ibge_code="2301000", ativo=True)
+    MunicipioReferencia.objects.create(
+        nome="Eusebio",
+        uf="CE",
+        codigo_externo="2301000",
+        fonte="ibge",
+        ativo=True,
+    )
+
+    out = StringIO()
+    call_command("promote_municipios_referencia", "--apply", stdout=out)
+
+    assert not Municipio.objects.filter(nome="Eusebio", uf="CE").exists()
+    text = out.getvalue()
+    assert "conflicts_code_owned_by_other=1" in text
+    assert "created=0" in text
+
+
+def test_promote_municipios_referencia_apply_detects_ambiguous_existing_candidates():
+    Municipio.objects.create(nome="Santo Antonio", uf="CE", ibge_code=None, ativo=True)
+    Municipio.objects.create(nome="Santo Antônio", uf="CE", ibge_code=None, ativo=True)
+    MunicipioReferencia.objects.create(
+        nome="Santo Antonio",
+        uf="CE",
+        codigo_externo="2300001",
+        fonte="ibge",
+        ativo=True,
+    )
+
+    out = StringIO()
+    call_command("promote_municipios_referencia", "--apply", stdout=out)
+
+    assert Municipio.objects.filter(ibge_code="2300001").count() == 0
+    text = out.getvalue()
+    assert "conflicts_ambiguous_existing=1" in text
+
+
+def test_promote_municipios_referencia_apply_detects_mismatched_existing_code():
+    Municipio.objects.create(nome="Fortaleza", uf="CE", ibge_code="2304401", ativo=True)
+    MunicipioReferencia.objects.create(
+        nome="Fortaleza",
+        uf="CE",
+        codigo_externo="2304400",
+        fonte="ibge",
+        ativo=True,
+    )
+
+    out = StringIO()
+    call_command("promote_municipios_referencia", "--apply", stdout=out)
+
+    assert Municipio.objects.filter(ibge_code="2304400").count() == 0
+    assert Municipio.objects.filter(nome="Fortaleza", uf="CE", ibge_code="2304401").exists()
+    text = out.getvalue()
+    assert "conflicts_mismatched_existing_code=1" in text
+    assert "created=0" in text
+    assert "updated=0" in text
+
+
+def test_promote_municipios_referencia_apply_rolls_back_all_changes_on_failure(monkeypatch):
+    MunicipioReferencia.objects.create(
+        nome="Fortaleza",
+        uf="CE",
+        codigo_externo="2304400",
+        fonte="ibge",
+        ativo=True,
+    )
+    MunicipioReferencia.objects.create(
+        nome="Caucaia",
+        uf="CE",
+        codigo_externo="2303709",
+        fonte="ibge",
+        ativo=True,
+    )
+    original_create = Municipio.objects.create
+
+    def failing_bulk_create(objs, batch_size=None):
+        first = objs[0]
+        original_create(nome=first.nome, uf=first.uf, ibge_code=first.ibge_code, ativo=first.ativo)
+        raise RuntimeError("forced failure")
+
+    monkeypatch.setattr(Municipio.objects, "bulk_create", failing_bulk_create)
+
+    with pytest.raises(RuntimeError, match="forced failure"):
+        call_command("promote_municipios_referencia", "--apply", stdout=StringIO())
+
+    assert Municipio.objects.count() == 0

--- a/v2/backend/apps/core/views/admin.py
+++ b/v2/backend/apps/core/views/admin.py
@@ -48,6 +48,7 @@ from apps.core.serializers import (
     ProjetoSerializer,
     UsuarioAdminSerializer,
 )
+from apps.core.services.options_cache import invalidate_municipios_options_cache
 from apps.core.services.rbac_service import get_assignable_group_names
 
 
@@ -72,6 +73,18 @@ class MunicipioViewSet(viewsets.ModelViewSet):
     search_fields = ["nome", "ibge_code"]
     ordering_fields = ["nome", "uf", "id"]
     ordering = ["nome"]
+
+    def perform_create(self, serializer: MunicipioSerializer) -> None:
+        serializer.save()
+        transaction.on_commit(invalidate_municipios_options_cache)
+
+    def perform_update(self, serializer: MunicipioSerializer) -> None:
+        serializer.save()
+        transaction.on_commit(invalidate_municipios_options_cache)
+
+    def perform_destroy(self, instance: Municipio) -> None:
+        instance.delete()
+        transaction.on_commit(invalidate_municipios_options_cache)
 
     @action(detail=False, methods=["get"], url_path="autocomplete")
     def autocomplete(self, request: Request) -> Response:


### PR DESCRIPTION
﻿## Resumo

Corrige a lacuna entre a tabela de referencia de municipios (`core_municipio_referencia`) e a tabela usada pelos selects da plataforma (`core_municipio`).

Root cause: `sync_municipios_ibge` populava/atualizava a referencia IBGE, mas os fluxos como `/controle/compras`, `/solicitacoes/nova` e `/dat/admin/municipios` consomem `Municipio`. Em ambientes onde `core_municipio` nao tinha os registros promovidos, os dropdowns ficavam vazios e bloqueavam a criacao de compras/solicitacoes.

Fix:
- adiciona `promote_municipios_referencia` para promover referencias IBGE para `core_municipio`
- usa `MunicipioReferencia.codigo_externo` como codigo IBGE de origem e `Municipio.ibge_code` como destino
- matching prioritario por `ibge_code`; fallback apenas por `(UF, nome normalizado)`
- conflitos sao reportados e ignorados individualmente
- `--apply` roda em transacao atomica
- invalida cache de options apos promocao/import/create/update/delete de municipios

## Operacao em producao

Rodar dry-run antes do apply:

```bash
python manage.py promote_municipios_referencia --fonte=ibge --verbose
```

Depois aplicar:

```bash
python manage.py promote_municipios_referencia --fonte=ibge --apply --verbose
```

Fluxo recomendado apos sync/backfill IBGE:

```bash
python manage.py sync_municipios_ibge --apply
python manage.py backfill_municipios_ibge --fonte=ibge --apply --verbose
python manage.py promote_municipios_referencia --fonte=ibge --apply --verbose
```

## Contadores locais

Dry-run local em Docker:

```text
[DRY-RUN] Promote Municipios Referencia
fonte=ibge | uf=ALL
referencias_lidas=0
referencias_codigo_invalido=0
ignored_inactive_refs=0
would_create=0
would_update=0
unchanged=0
conflicts_code_owned_by_other=0
conflicts_ambiguous_existing=0
conflicts_mismatched_existing_code=0
created=0
updated=0
cache_invalidated=0
total_db_target=3
```

Apply local em Docker:

```text
[APPLY] Promote Municipios Referencia
fonte=ibge | uf=ALL
referencias_lidas=0
referencias_codigo_invalido=0
ignored_inactive_refs=0
would_create=0
would_update=0
unchanged=0
conflicts_code_owned_by_other=0
conflicts_ambiguous_existing=0
conflicts_mismatched_existing_code=0
created=0
updated=0
cache_invalidated=0
total_db_target=3
```

## Checklist Tecnico (Code Review Expert - Slim)

- [x] Arquitetura e SOLID: mudancas mantiveram coesao e responsabilidade clara
- [x] Seguranca: sem vazamento de segredo, sem novos vetores obvios de injecao/XSS/SSRF
- [x] Performance: sem regressao relevante (render, queries, loops, payload, N+1)
- [x] Tratamento de erros: falhas tratadas com mensagem/fluxo previsivel
- [x] Condicoes de fronteira: nulos, lista vazia e limites numericos cobertos

## Workflow (Superpowers - Parcial)

- [x] Escopo definido em ate 5 passos objetivos antes da implementacao
- [x] Testes criados/ajustados para comportamento novo ou corrigido
- [x] Evidencias anexadas (logs, screenshots, outputs de teste) quando aplicavel

## Validacoes

- [x] Testes focados de municipios: 16 passed
- [x] Backend full suite: 1999 passed, 43 skipped, 8 warnings
- [x] `python manage.py check`: sem issues
- [x] `python manage.py showmigrations --plan`: todas migrations aplicadas
- [x] Frontend `npm run typecheck`: passed
- [x] Frontend `npm run lint`: passed
- [x] Frontend `npm run build`: passed
- [x] Frontend `npm run deps:check`: passed
- [x] Sem alteracoes fora do escopo combinado

E2E Playwright: tentativa local anterior falhou por login/seed/RBAC `403 PERMISSION_DENIED` (`POST /api/solicitacoes`) e login `dat_matrix@test.com`, nao relacionado ao escopo de municipios. Nao usado como gate deste PR.

## Staging Gate

- [x] `make staging-full` executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR (trecho de log contendo "ALL 8 CHECKS PASSED")

### Evidencia Staging Gate

Executado via Git Bash com `make MAKE=make staging-full` porque o `make` disponivel no host esta em `C:/Program Files (x86)/GnuWin32/bin/make`; sem `MAKE=make`, o path com parenteses quebra o `bash -lc` interno do target. O alvo executado foi `staging-full`.

```text
==============================================
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
==============================================
```
