### PR TITLE
fix(frontend): corrige paginação Admin DAT

### DIFF
--- a/v2/frontend/src/hooks/__tests__/useTableFilters.test.ts
+++ b/v2/frontend/src/hooks/__tests__/useTableFilters.test.ts
@@ -218,6 +218,7 @@ describe('useTableFilters', () => {
 
     await waitFor(() => expect(mockListFn).toHaveBeenCalledTimes(2));
     expect(mockListFn.mock.calls[1][0].page).toBe(3);
+    expect(mockListFn.mock.calls[1][0].page_size).toBe(30);
     expect(result.current.pagination.pageSize).toBe(30);
   });
 

--- a/v2/frontend/src/hooks/useTableFilters.ts
+++ b/v2/frontend/src/hooks/useTableFilters.ts
@@ -66,7 +66,7 @@ export interface UseTableFiltersReturn<F, T, S> {
   setFilters: Dispatch<SetStateAction<F>>;
   pagination: PaginationState;
   setPagination: Dispatch<SetStateAction<PaginationState>>;
-  fetchData: (page?: number) => Promise<void>;
+  fetchData: (page?: number, pageSize?: number) => Promise<void>;
   handleClearFilters: () => void;
   handleTableChange: (page: number, newPageSize?: number) => void;
   refresh: () => Promise<void>;
@@ -109,15 +109,21 @@ export function useTableFilters<F extends object, T, S = unknown>({
   defaultFiltersRef.current = defaultFilters;
 
   const fetchData = useCallback(
-    async (page = 1): Promise<void> => {
+    async (page = 1, pageSizeOverride?: number): Promise<void> => {
       setLoading(true);
       try {
+        const requestPageSize = pageSizeOverride ?? pagination.pageSize;
+        const requestPagination = {
+          ...pagination,
+          current: page,
+          pageSize: requestPageSize,
+        };
         const mapped = buildParams
-          ? buildParams(filters, pagination)
+          ? buildParams(filters, requestPagination)
           : defaultBuildParams(filters);
         const params: TableFilterParams = {
           page,
-          page_size: pagination.pageSize,
+          page_size: requestPageSize,
           ...(defaultOrdering ? { ordering: defaultOrdering } : {}),
           ...mapped,
         };
@@ -133,7 +139,7 @@ export function useTableFilters<F extends object, T, S = unknown>({
         const total = (listResp as PaginatedResponse<T>).count ?? results.length;
 
         setData(results);
-        setPagination((prev) => ({ ...prev, current: page, total }));
+        setPagination((prev) => ({ ...prev, current: page, pageSize: requestPageSize, total }));
 
         if (statsFn) {
           setStats((statsResp as S) ?? null);
@@ -163,17 +169,14 @@ export function useTableFilters<F extends object, T, S = unknown>({
 
   const handleTableChange = useCallback(
     (page: number, newPageSize?: number): void => {
-      if (newPageSize && newPageSize !== pagination.pageSize) {
-        setPagination((prev) => ({ ...prev, current: page, pageSize: newPageSize }));
-      }
-      fetchData(page);
+      fetchData(page, newPageSize);
     },
-    [fetchData, pagination.pageSize],
+    [fetchData],
   );
 
   const refresh = useCallback((): Promise<void> => {
-    return fetchData(pagination.current);
-  }, [fetchData, pagination.current]);
+    return fetchData(pagination.current, pagination.pageSize);
+  }, [fetchData, pagination.current, pagination.pageSize]);
 
   return {
     data,

--- a/v2/frontend/src/pages/AdminDAT/GerenciasPage.tsx
+++ b/v2/frontend/src/pages/AdminDAT/GerenciasPage.tsx
@@ -7,10 +7,12 @@
 import { useState, useEffect } from 'react';
 import { Table, Button, Input, Space, Tag, Typography, Card, message, Modal, Form, Checkbox } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
+import type { TablePaginationConfig } from 'antd/es/table';
 import { ReloadOutlined, EditOutlined, PlusOutlined, DeleteOutlined } from '@ant-design/icons';
 import { Link } from 'react-router-dom';
 import { listGerencias, createGerencia, updateGerencia, deleteGerencia } from '../../api/adminDAT';
 import type { GerenciaRecord, GerenciaPayload } from '../../api/adminDAT';
+import { DEFAULT_PAGE_SIZE } from '../../constants';
 
 const { Title } = Typography;
 const { Search } = Input;
@@ -31,17 +33,33 @@ export default function GerenciasPage(): JSX.Element {
   const [searchText, setSearchText] = useState('');
   const [modalVisible, setModalVisible] = useState(false);
   const [editingGerencia, setEditingGerencia] = useState<GerenciaRecord | null>(null);
+  const [pagination, setPagination] = useState<TablePaginationConfig>({
+    current: 1,
+    pageSize: DEFAULT_PAGE_SIZE,
+    total: 0,
+  });
 
   const [form] = Form.useForm<GerenciaFormValues>();
 
-  const fetchGerencias = async (): Promise<void> => {
+  const fetchGerencias = async (
+    current = pagination.current || 1,
+    pageSize = pagination.pageSize || DEFAULT_PAGE_SIZE,
+  ): Promise<void> => {
     setLoading(true);
     try {
       const data = await listGerencias({
         search: searchText,
         ordering: 'nome',
+        page: current,
+        page_size: pageSize,
       });
       setGerencias(data.results as unknown as GerenciaRecord[]);
+      setPagination((prev) => ({
+        ...prev,
+        current,
+        pageSize,
+        total: data.count,
+      }));
     } catch (error) {
       message.error(`Erro ao carregar gerencias: ${(error as Error).message}`);
     } finally {
@@ -50,8 +68,15 @@ export default function GerenciasPage(): JSX.Element {
   };
 
   useEffect(() => {
-    fetchGerencias();
+    fetchGerencias(1, pagination.pageSize || DEFAULT_PAGE_SIZE);
   }, [searchText]);
+
+  const handleTableChange = (newPagination: TablePaginationConfig): void => {
+    fetchGerencias(
+      newPagination.current || 1,
+      newPagination.pageSize || pagination.pageSize || DEFAULT_PAGE_SIZE,
+    );
+  };
 
   const handleCreate = (): void => {
     setEditingGerencia(null);
@@ -87,7 +112,7 @@ export default function GerenciasPage(): JSX.Element {
       }
       setModalVisible(false);
       form.resetFields();
-      fetchGerencias();
+      fetchGerencias(pagination.current || 1, pagination.pageSize || DEFAULT_PAGE_SIZE);
     } catch (error) {
       message.error(`Erro: ${(error as Error).message}`);
     }
@@ -104,7 +129,7 @@ export default function GerenciasPage(): JSX.Element {
         try {
           await deleteGerencia(gerencia.id);
           message.success('Gerencia excluida com sucesso');
-          fetchGerencias();
+          fetchGerencias(pagination.current || 1, pagination.pageSize || DEFAULT_PAGE_SIZE);
         } catch (error) {
           message.error(`Erro ao excluir: ${(error as Error).message}`);
         }
@@ -168,7 +193,7 @@ export default function GerenciasPage(): JSX.Element {
       <Card>
         <header className="flex justify-between items-center mb-4">
           <Title level={3} className="m-0" id="gerencias-title">
-            Gerencias ({gerencias.length})
+            Gerencias ({pagination.total || 0})
           </Title>
           <Space>
             <Search
@@ -178,7 +203,11 @@ export default function GerenciasPage(): JSX.Element {
               onSearch={setSearchText}
               onChange={(e) => !e.target.value && setSearchText('')}
             />
-            <Button icon={<ReloadOutlined />} onClick={fetchGerencias} loading={loading}>
+            <Button
+              icon={<ReloadOutlined />}
+              onClick={() => fetchGerencias(pagination.current || 1, pagination.pageSize || DEFAULT_PAGE_SIZE)}
+              loading={loading}
+            >
               Atualizar
             </Button>
             <Button type="primary" icon={<PlusOutlined />} onClick={handleCreate}>
@@ -192,7 +221,13 @@ export default function GerenciasPage(): JSX.Element {
           dataSource={gerencias}
           rowKey="id"
           loading={loading}
-          pagination={{ pageSize: 15, showTotal: (total) => `Total: ${total}` }}
+          onChange={handleTableChange}
+          pagination={{
+            ...pagination,
+            showSizeChanger: true,
+            pageSizeOptions: ['15', '30', '50', '100'],
+            showTotal: (total) => `Total: ${total}`,
+          }}
           scroll={{ x: 900 }}
         />
       </Card>

--- a/v2/frontend/src/pages/AdminDAT/MunicipiosPage.tsx
+++ b/v2/frontend/src/pages/AdminDAT/MunicipiosPage.tsx
@@ -8,6 +8,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { Table, Button, Input, Space, Tag, Typography, Card, message, Select, Modal, Form, Checkbox, AutoComplete } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
+import type { TablePaginationConfig } from 'antd/es/table';
 import { ReloadOutlined, EditOutlined, PlusOutlined, DeleteOutlined } from '@ant-design/icons';
 import { Link } from 'react-router-dom';
 import {
@@ -21,7 +22,7 @@ import type { MunicipioAutocompleteItem } from '../../api/adminDAT';
 import { importMunicipios } from '../../api/ops';
 import ImportUploader from '../../components/ImportUploader';
 import type { ValidationResult, ApplyResult } from '../../components/ImportUploader';
-import { UF_NORDESTE_OPTIONS } from '../../constants';
+import { DEFAULT_PAGE_SIZE, UF_NORDESTE_OPTIONS } from '../../constants';
 import type { ID } from '../../types';
 
 const { Title } = Typography;
@@ -91,6 +92,11 @@ export default function MunicipiosPage(): JSX.Element {
   const [lookupOptions, setLookupOptions] = useState<MunicipioAutocompleteItem[]>([]);
   const [lookupLoading, setLookupLoading] = useState(false);
   const [ibgeLocked, setIbgeLocked] = useState(false);
+  const [pagination, setPagination] = useState<TablePaginationConfig>({
+    current: 1,
+    pageSize: DEFAULT_PAGE_SIZE,
+    total: 0,
+  });
 
   const [form] = Form.useForm<MunicipioFormValues>();
   const watchedNome = Form.useWatch('nome', form);
@@ -98,15 +104,26 @@ export default function MunicipiosPage(): JSX.Element {
   const lookupRequestRef = useRef(0);
   const selectingSuggestionRef = useRef(false);
 
-  const fetchMunicipios = async (): Promise<void> => {
+  const fetchMunicipios = async (
+    current = pagination.current || 1,
+    pageSize = pagination.pageSize || DEFAULT_PAGE_SIZE,
+  ): Promise<void> => {
     setLoading(true);
     try {
       const data = await listMunicipios({
         search: searchText,
         uf: ufFilter,
         ordering: 'nome',
+        page: current,
+        page_size: pageSize,
       });
       setMunicipios(data.results as MunicipioRecord[]);
+      setPagination((prev) => ({
+        ...prev,
+        current,
+        pageSize,
+        total: data.count,
+      }));
     } catch (error) {
       message.error(`Erro ao carregar municípios: ${(error as Error).message}`);
     } finally {
@@ -115,8 +132,15 @@ export default function MunicipiosPage(): JSX.Element {
   };
 
   useEffect(() => {
-    fetchMunicipios();
+    fetchMunicipios(1, pagination.pageSize || DEFAULT_PAGE_SIZE);
   }, [searchText, ufFilter]);
+
+  const handleTableChange = (newPagination: TablePaginationConfig): void => {
+    fetchMunicipios(
+      newPagination.current || 1,
+      newPagination.pageSize || pagination.pageSize || DEFAULT_PAGE_SIZE,
+    );
+  };
 
   useEffect(() => {
     if (!modalVisible) {
@@ -230,7 +254,7 @@ export default function MunicipiosPage(): JSX.Element {
       setLookupOptions([]);
       setIbgeLocked(false);
       form.resetFields();
-      fetchMunicipios();
+      fetchMunicipios(pagination.current || 1, pagination.pageSize || DEFAULT_PAGE_SIZE);
     } catch (error) {
       message.error(`Erro: ${(error as Error).message}`);
     }
@@ -289,7 +313,7 @@ export default function MunicipiosPage(): JSX.Element {
         try {
           await deleteMunicipio(municipio.id);
           message.success('Município excluído com sucesso');
-          fetchMunicipios();
+          fetchMunicipios(pagination.current || 1, pagination.pageSize || DEFAULT_PAGE_SIZE);
         } catch (error) {
           message.error(`Erro ao excluir: ${(error as Error).message}`);
         }
@@ -346,7 +370,7 @@ export default function MunicipiosPage(): JSX.Element {
       <Card>
         <header className="flex justify-between items-center mb-4">
           <Title level={3} className="m-0" id="municipios-title">
-            Municípios ({municipios.length})
+            Municípios ({pagination.total || 0})
           </Title>
           <Space>
             <Search
@@ -363,7 +387,11 @@ export default function MunicipiosPage(): JSX.Element {
               onChange={setUfFilter}
               options={UF_NORDESTE_OPTIONS}
             />
-            <Button icon={<ReloadOutlined />} onClick={fetchMunicipios} loading={loading}>
+            <Button
+              icon={<ReloadOutlined />}
+              onClick={() => fetchMunicipios(pagination.current || 1, pagination.pageSize || DEFAULT_PAGE_SIZE)}
+              loading={loading}
+            >
               Atualizar
             </Button>
             <Button type="primary" icon={<PlusOutlined />} onClick={handleCreate}>
@@ -377,7 +405,13 @@ export default function MunicipiosPage(): JSX.Element {
           dataSource={municipios}
           rowKey="id"
           loading={loading}
-          pagination={{ pageSize: 15, showTotal: (total) => `Total: ${total}` }}
+          onChange={handleTableChange}
+          pagination={{
+            ...pagination,
+            showSizeChanger: true,
+            pageSizeOptions: ['15', '30', '50', '100'],
+            showTotal: (total) => `Total: ${total}`,
+          }}
           scroll={{ x: 1000 }}
         />
       </Card>

--- a/v2/frontend/src/pages/AdminDAT/ProdutosPage.tsx
+++ b/v2/frontend/src/pages/AdminDAT/ProdutosPage.tsx
@@ -7,10 +7,12 @@
 import { useState, useEffect } from 'react';
 import { Table, Button, Input, Space, Tag, Typography, Card, message, Modal, Form, Checkbox, Select } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
+import type { TablePaginationConfig } from 'antd/es/table';
 import { ReloadOutlined, EditOutlined, PlusOutlined, DeleteOutlined } from '@ant-design/icons';
 import { Link } from 'react-router-dom';
 import { listProdutos, createProduto, updateProduto, deleteProduto, listProjetos } from '../../api/adminDAT';
 import type { ProdutoRecord, ProdutoPayload } from '../../api/adminDAT';
+import { DEFAULT_PAGE_SIZE } from '../../constants';
 import type { ID, Projeto } from '../../types';
 
 const { Title } = Typography;
@@ -34,17 +36,33 @@ export default function ProdutosPage(): JSX.Element {
   const [searchText, setSearchText] = useState('');
   const [modalVisible, setModalVisible] = useState(false);
   const [editingProduto, setEditingProduto] = useState<ProdutoRecord | null>(null);
+  const [pagination, setPagination] = useState<TablePaginationConfig>({
+    current: 1,
+    pageSize: DEFAULT_PAGE_SIZE,
+    total: 0,
+  });
 
   const [form] = Form.useForm<ProdutoFormValues>();
 
-  const fetchProdutos = async (): Promise<void> => {
+  const fetchProdutos = async (
+    current = pagination.current || 1,
+    pageSize = pagination.pageSize || DEFAULT_PAGE_SIZE,
+  ): Promise<void> => {
     setLoading(true);
     try {
       const data = await listProdutos({
         search: searchText,
         ordering: 'nome',
+        page: current,
+        page_size: pageSize,
       });
       setProdutos(data.results as unknown as ProdutoRecord[]);
+      setPagination((prev) => ({
+        ...prev,
+        current,
+        pageSize,
+        total: data.count,
+      }));
     } catch (error) {
       message.error(`Erro ao carregar produtos: ${(error as Error).message}`);
     } finally {
@@ -62,8 +80,15 @@ export default function ProdutosPage(): JSX.Element {
   };
 
   useEffect(() => {
-    fetchProdutos();
+    fetchProdutos(1, pagination.pageSize || DEFAULT_PAGE_SIZE);
   }, [searchText]);
+
+  const handleTableChange = (newPagination: TablePaginationConfig): void => {
+    fetchProdutos(
+      newPagination.current || 1,
+      newPagination.pageSize || pagination.pageSize || DEFAULT_PAGE_SIZE,
+    );
+  };
 
   useEffect(() => {
     fetchProjetos();
@@ -105,7 +130,7 @@ export default function ProdutosPage(): JSX.Element {
       }
       setModalVisible(false);
       form.resetFields();
-      fetchProdutos();
+      fetchProdutos(pagination.current || 1, pagination.pageSize || DEFAULT_PAGE_SIZE);
     } catch (error) {
       message.error(`Erro: ${(error as Error).message}`);
     }
@@ -122,7 +147,7 @@ export default function ProdutosPage(): JSX.Element {
         try {
           await deleteProduto(produto.id);
           message.success('Produto excluido com sucesso');
-          fetchProdutos();
+          fetchProdutos(pagination.current || 1, pagination.pageSize || DEFAULT_PAGE_SIZE);
         } catch (error) {
           message.error(`Erro ao excluir: ${(error as Error).message}`);
         }
@@ -179,7 +204,7 @@ export default function ProdutosPage(): JSX.Element {
       <Card>
         <header className="flex justify-between items-center mb-4">
           <Title level={3} className="m-0" id="produtos-title">
-            Produtos ({produtos.length})
+            Produtos ({pagination.total || 0})
           </Title>
           <Space>
             <Search
@@ -189,7 +214,11 @@ export default function ProdutosPage(): JSX.Element {
               onSearch={setSearchText}
               onChange={(e) => !e.target.value && setSearchText('')}
             />
-            <Button icon={<ReloadOutlined />} onClick={fetchProdutos} loading={loading}>
+            <Button
+              icon={<ReloadOutlined />}
+              onClick={() => fetchProdutos(pagination.current || 1, pagination.pageSize || DEFAULT_PAGE_SIZE)}
+              loading={loading}
+            >
               Atualizar
             </Button>
             <Button type="primary" icon={<PlusOutlined />} onClick={handleCreate}>
@@ -203,7 +232,13 @@ export default function ProdutosPage(): JSX.Element {
           dataSource={produtos}
           rowKey="id"
           loading={loading}
-          pagination={{ pageSize: 15, showTotal: (total) => `Total: ${total}` }}
+          onChange={handleTableChange}
+          pagination={{
+            ...pagination,
+            showSizeChanger: true,
+            pageSizeOptions: ['15', '30', '50', '100'],
+            showTotal: (total) => `Total: ${total}`,
+          }}
           scroll={{ x: 900 }}
         />
       </Card>

--- a/v2/frontend/src/pages/AdminDAT/ProjetosPage.tsx
+++ b/v2/frontend/src/pages/AdminDAT/ProjetosPage.tsx
@@ -8,9 +8,11 @@
 import { useState, useEffect } from 'react';
 import { Table, Button, Input, Space, Tag, Typography, Card, message, Modal, Form, Radio, Checkbox } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
+import type { TablePaginationConfig } from 'antd/es/table';
 import { ReloadOutlined, EditOutlined, PlusOutlined, DeleteOutlined } from '@ant-design/icons';
 import { Link } from 'react-router-dom';
 import { listProjetos, createProjeto, updateProjeto, deleteProjeto } from '../../api/adminDAT';
+import { DEFAULT_PAGE_SIZE } from '../../constants';
 import type { ID } from '../../types';
 
 const { Title } = Typography;
@@ -43,19 +45,35 @@ export default function ProjetosPage(): JSX.Element {
   const [searchText, setSearchText] = useState('');
   const [modalVisible, setModalVisible] = useState(false);
   const [editingProjeto, setEditingProjeto] = useState<ProjetoRecord | null>(null);
+  const [pagination, setPagination] = useState<TablePaginationConfig>({
+    current: 1,
+    pageSize: DEFAULT_PAGE_SIZE,
+    total: 0,
+  });
 
   const [form] = Form.useForm<ProjetoFormValues>();
 
-  const fetchProjetos = async (): Promise<void> => {
+  const fetchProjetos = async (
+    current = pagination.current || 1,
+    pageSize = pagination.pageSize || DEFAULT_PAGE_SIZE,
+  ): Promise<void> => {
     setLoading(true);
     try {
       const data = await listProjetos({
         search: searchText,
         ordering: 'nome',
+        page: current,
+        page_size: pageSize,
       });
       // Note: API returns Projeto with is_active, but component uses ativo field name
       // This is acceptable during migration - will be unified in strict mode phase
       setProjetos(data.results as unknown as ProjetoRecord[]);
+      setPagination((prev) => ({
+        ...prev,
+        current,
+        pageSize,
+        total: data.count,
+      }));
     } catch (error) {
       message.error(`Erro ao carregar projetos: ${(error as Error).message}`);
     } finally {
@@ -64,8 +82,15 @@ export default function ProjetosPage(): JSX.Element {
   };
 
   useEffect(() => {
-    fetchProjetos();
+    fetchProjetos(1, pagination.pageSize || DEFAULT_PAGE_SIZE);
   }, [searchText]);
+
+  const handleTableChange = (newPagination: TablePaginationConfig): void => {
+    fetchProjetos(
+      newPagination.current || 1,
+      newPagination.pageSize || pagination.pageSize || DEFAULT_PAGE_SIZE,
+    );
+  };
 
   const handleCreate = (): void => {
     setEditingProjeto(null);
@@ -95,7 +120,7 @@ export default function ProjetosPage(): JSX.Element {
       }
       setModalVisible(false);
       form.resetFields();
-      fetchProjetos();
+      fetchProjetos(pagination.current || 1, pagination.pageSize || DEFAULT_PAGE_SIZE);
     } catch (error) {
       message.error(`Erro: ${(error as Error).message}`);
     }
@@ -112,7 +137,7 @@ export default function ProjetosPage(): JSX.Element {
         try {
           await deleteProjeto(projeto.id);
           message.success('Projeto excluído com sucesso');
-          fetchProjetos();
+          fetchProjetos(pagination.current || 1, pagination.pageSize || DEFAULT_PAGE_SIZE);
         } catch (error) {
           message.error(`Erro ao excluir: ${(error as Error).message}`);
         }
@@ -179,7 +204,7 @@ export default function ProjetosPage(): JSX.Element {
       <Card>
         <header className="flex justify-between items-center mb-4">
           <Title level={3} className="m-0" id="projetos-title">
-            Projetos ({projetos.length})
+            Projetos ({pagination.total || 0})
           </Title>
           <Space>
             <Search
@@ -189,7 +214,11 @@ export default function ProjetosPage(): JSX.Element {
               onSearch={setSearchText}
               onChange={(e) => !e.target.value && setSearchText('')}
             />
-            <Button icon={<ReloadOutlined />} onClick={fetchProjetos} loading={loading}>
+            <Button
+              icon={<ReloadOutlined />}
+              onClick={() => fetchProjetos(pagination.current || 1, pagination.pageSize || DEFAULT_PAGE_SIZE)}
+              loading={loading}
+            >
               Atualizar
             </Button>
             <Button type="primary" icon={<PlusOutlined />} onClick={handleCreate}>
@@ -203,7 +232,13 @@ export default function ProjetosPage(): JSX.Element {
           dataSource={projetos}
           rowKey="id"
           loading={loading}
-          pagination={{ pageSize: 15, showTotal: (total) => `Total: ${total}` }}
+          onChange={handleTableChange}
+          pagination={{
+            ...pagination,
+            showSizeChanger: true,
+            pageSizeOptions: ['15', '30', '50', '100'],
+            showTotal: (total) => `Total: ${total}`,
+          }}
           scroll={{ x: 900 }}
         />
       </Card>


### PR DESCRIPTION
## Resumo

Corrige a pagina??o das p?ginas Admin DAT que estavam carregando apenas a primeira p?gina do DRF e paginando client-side. Isso fazia `/dat/admin/municipios` exibir `Total: 100`, limitar a navega??o a 7 p?ginas e ignorar corretamente a troca de quantidade por p?gina, mesmo com 5571 munic?pios promovidos.

Mudan?as principais:
- `Municipios`, `Gerencias`, `Projetos` e `Produtos` agora usam pagina??o server-side com `page`, `page_size` e `count` da API.
- `useTableFilters` agora refaz a busca com o novo `pageSize` imediatamente, sem usar estado antigo.
- Teste do hook cobre envio de `page_size` ap?s troca de pagina??o.

Impacto esperado: listas Admin DAT passam a refletir o total real retornado pelo backend e a sele??o `15/30/50/100 por p?gina` passa a controlar a request, n?o s? a tabela local.

## Causa Raiz

As p?ginas Admin DAT consumiam `data.results` da primeira p?gina da API e deixavam o AntD Table calcular pagina??o localmente. Como o DRF limita a primeira resposta a 100 registros por padr?o, o footer mostrava `Total: 100` e a navega??o n?o tinha acesso ao restante da base.

## Checklist Tecnico (Code Review Expert - Slim)

- [x] Arquitetura e SOLID: mudancas mantiveram coesao e responsabilidade clara
- [x] Seguranca: sem vazamento de segredo, sem novos vetores obvios de injecao/XSS/SSRF
- [x] Performance: sem regressao relevante (render, queries, loops, payload, N+1)
- [x] Tratamento de erros: falhas tratadas com mensagem/fluxo previsivel
- [x] Condicoes de fronteira: nulos, lista vazia e limites numericos cobertos

## Workflow (Superpowers - Parcial)

- [x] Escopo definido em ate 5 passos objetivos antes da implementacao
- [x] Testes criados/ajustados para comportamento novo ou corrigido
- [x] Evidencias anexadas (logs, screenshots, outputs de teste) quando aplicavel

## Staging Gate

- [x] `make staging-full` executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR (trecho de log contendo "ALL 8 CHECKS PASSED")

### Evidencia Staging Gate (obrigatorio para merge)

```text
ALL 8 CHECKS PASSED
```

## Validacoes

- [x] `docker compose --env-file .env.dev -f docker-compose.yml -f docker-compose.override.yml exec -T web pytest apps/core/tests apps/dev_tools/tests -q` -> `2010 passed, 43 skipped`
- [x] `docker compose --env-file .env.dev -f docker-compose.yml -f docker-compose.override.yml exec -T frontend npm run test -- --run` -> `269 passed`
- [x] `python manage.py check` -> sem issues
- [x] `python manage.py showmigrations --plan` -> executado com sucesso
- [x] `npm run typecheck` -> passou
- [x] `npm run lint` -> passou
- [x] `npm run build` -> passou
- [x] `npm run deps:check` -> passou
- [x] Checks `[required]` verdes (somente gates bloqueantes)
- [x] Checks `[info]` revisados quando falharem (sem bloquear merge)
- [x] Sem alteracoes fora do escopo combinado

Observacao: no DB dev local, `showmigrations --plan` ainda listava `core.0080_redistribute_view_all_availability` como nao aplicada, mas o `make staging-full` aplicou essa migration normalmente em staging limpo. Isso nao pertence ao escopo deste PR.
