### PR TITLE
feat(dat): cria página /dat/importacoes (PR-B DAT Imports)

### DIFF
--- a/v2/frontend/src/components/AppRoutes.tsx
+++ b/v2/frontend/src/components/AppRoutes.tsx
@@ -10,6 +10,7 @@ const DisponibilidadeBlocks = lazy(() => import('../pages/Disponibilidade'));
 const MonthlyPage = lazy(() => import('../pages/Disponibilidade/MonthlyPage'));
 const ControlePage = lazy(() => import('../pages/Controle/ControlePage'));
 const DATPage = lazy(() => import('../pages/DAT/DATPage'));
+const DATImportacoesPage = lazy(() => import('../pages/DAT/ImportacoesPage'));
 const NewSolicitacaoWizard = lazy(() => import('../pages/Solicitacoes/NewSolicitacaoWizard'));
 const EditSolicitacaoPage = lazy(() => import('../pages/Solicitacoes/EditSolicitacaoPage'));
 const MySolicitacoesPage = lazy(() => import('../pages/Solicitacoes/MySolicitacoesPage'));
@@ -163,6 +164,7 @@ export function AppRoutes({ user, permissions, policies }: AppRoutesProps): JSX.
         <Route path="/dat/compras-materiais" element={(canControle || canDAT) ? <DATComprasPage /> : <Forbidden />} />
         <Route path="/dat/coordenadores" element={canControle ? <CoordenadoresPage /> : <Forbidden />} />
         <Route path="/dat/importacao" element={canDAT ? <DATPage /> : <Forbidden />} />
+        <Route path="/dat/importacoes" element={canDAT ? <DATImportacoesPage /> : <Forbidden />} />
         <Route path="/dat/registros" element={canDAT ? <DATRegistrosPage /> : <Forbidden />} />
       </Routes>
     </Suspense>

--- a/v2/frontend/src/pages/DAT/ImportacoesPage.tsx
+++ b/v2/frontend/src/pages/DAT/ImportacoesPage.tsx
@@ -1,0 +1,227 @@
+/**
+ * DAT > Importações — página unificada de importações em massa.
+ *
+ * Plano DAT-Imports (2026-04-29) — PR-B (1º).
+ *
+ * Centraliza os 11 fluxos de upload de planilha do projeto em uma única
+ * página, organizados por categoria. Substitui (em passos seguintes — PR-D)
+ * os botões espalhados em ControlePage, ComprasPage, Disponibilidade e
+ * DeslocamentosPage.
+ *
+ * Categorias:
+ * - Cadastros base: Usuários, Municípios, Coleções, Cadastros DAT, Vínculos
+ * - Operacional: Compras, Ações, Eventos, Produtos
+ * - Disponibilidade: Bloqueios, Deslocamentos
+ *
+ * Acesso: DAT/superuser only (guard em AppRoutes via canDAT).
+ *
+ * Reutiliza:
+ * - `ImportUploader` para UI de cada card
+ * - Funções `import*` de `api/ops.ts` (sem alteração)
+ *
+ * Não toca em:
+ * - ASQ-005 async (`/api/imports/bloqueios/`) — Phase 2 separada
+ * - PR municípios IBGE (#1298 já mergeado)
+ * - Lógica interna dos services de import (PR-A1 trata gate backend)
+ */
+
+import { Card, Col, Row, Typography } from 'antd';
+
+import {
+  importAcoes,
+  importBloqueios,
+  importCadastros,
+  importColecoes,
+  importCompras,
+  importDeslocamentos,
+  importEquipeGerencia,
+  importEventos,
+  importMunicipios,
+  importProdutos,
+  importUsuarios,
+} from '../../api/ops';
+import type { ImportResult } from '../../api/ops';
+import ImportUploader from '../../components/ImportUploader';
+import type { ApplyResult, ValidationResult } from '../../components/ImportUploader';
+
+const { Title, Text } = Typography;
+
+/** Helper para converter ImportResult → ValidationResult (mesmo padrão de ControlePage). */
+function toValidationResult(result: ImportResult): ValidationResult {
+  return {
+    stats: {
+      created: result.created,
+      updated: result.updated,
+      unchanged: result.skipped,
+    },
+    errors: result.errors.map((e) => `Linha ${e.row}: ${e.message}`),
+  };
+}
+
+/** Helper para converter ImportResult → ApplyResult. */
+function toApplyResult(result: ImportResult): ApplyResult {
+  return {
+    stats: {
+      created: result.created,
+      updated: result.updated,
+      unchanged: result.skipped,
+    },
+  };
+}
+
+/**
+ * Configuração canônica dos 11 cards de importação.
+ *
+ * Cada card recebe label, description e os callbacks de dry-run/apply ligados
+ * a uma função existente em `api/ops.ts`. Mudar conteúdo de um card não
+ * requer mexer em ImportUploader nem em outras páginas — escopo isolado.
+ */
+interface ImportCard {
+  key: string;
+  label: string;
+  description: string;
+  importFn: (file: File, dryRun?: boolean) => Promise<ImportResult>;
+}
+
+const CADASTROS_BASE: ImportCard[] = [
+  {
+    key: 'usuarios',
+    label: 'Importar USUÁRIOS',
+    description: 'CSV/XLSX: cpf, nome (obrigatórios); email, telefone, cargo, grupos (opcionais)',
+    importFn: importUsuarios,
+  },
+  {
+    key: 'municipios',
+    label: 'Importar MUNICÍPIOS',
+    description: 'CSV/XLSX: nome, uf (obrigatórios); ibge_code, ativo (opcionais)',
+    importFn: importMunicipios,
+  },
+  {
+    key: 'colecoes',
+    label: 'Importar COLEÇÕES',
+    description: 'CSV/XLSX: codigo, nome, projeto (obrigatórios)',
+    importFn: importColecoes,
+  },
+  {
+    key: 'cadastros-dat',
+    label: 'Importar CADASTROS DAT',
+    description: 'CSV/XLSX consolidado de cadastros administrados pelo DAT',
+    importFn: importCadastros,
+  },
+  {
+    key: 'vinculos',
+    label: 'Importar VÍNCULOS (Equipe-Gerência)',
+    description: 'CSV/XLSX: usuario (cpf ou email), gerencia, funcao (obrigatórios)',
+    importFn: importEquipeGerencia,
+  },
+];
+
+const OPERACIONAL: ImportCard[] = [
+  {
+    key: 'compras',
+    label: 'Importar COMPRAS',
+    description: 'CSV/XLSX: codigo, produto, quant, municipio, uf, data, uso',
+    importFn: importCompras,
+  },
+  {
+    key: 'acoes',
+    label: 'Importar AÇÕES',
+    description: 'CSV/XLSX de Ações de Controle (Município, Projeto, Coordenador, Datas, Observação)',
+    importFn: importAcoes,
+  },
+  {
+    key: 'eventos',
+    label: 'Importar EVENTOS',
+    description:
+      'CSV/XLSX: municipio, projeto, tipo_evento, data, hora_inicio, hora_fim, coordenador, formador1-5',
+    importFn: importEventos,
+  },
+  {
+    key: 'produtos',
+    label: 'Importar PRODUTOS',
+    description: 'CSV/XLSX: codigo, nome, projeto (obrigatórios), descricao (opcional)',
+    importFn: importProdutos,
+  },
+];
+
+const DISPONIBILIDADE: ImportCard[] = [
+  {
+    key: 'bloqueios',
+    label: 'Importar BLOQUEIOS',
+    description: 'CSV/XLSX: usuario, inicio, fim, tipo (T/P), motivo',
+    importFn: importBloqueios,
+  },
+  {
+    key: 'deslocamentos',
+    label: 'Importar DESLOCAMENTOS',
+    description: 'CSV/XLSX: usuario, origem, destino, data_inicio, data_fim, observacao',
+    importFn: importDeslocamentos,
+  },
+];
+
+interface ImportSectionProps {
+  title: string;
+  description: string;
+  cards: ImportCard[];
+}
+
+function ImportSection({ title, description, cards }: ImportSectionProps): JSX.Element {
+  return (
+    <section aria-label={title} className="mb-8">
+      <header className="mb-3">
+        <Title level={3} className="!mb-1">
+          {title}
+        </Title>
+        <Text type="secondary">{description}</Text>
+      </header>
+      <Row gutter={[16, 16]}>
+        {cards.map((card) => (
+          <Col key={card.key} xs={24} md={12} lg={8}>
+            <Card variant="outlined">
+              <ImportUploader
+                label={card.label}
+                description={card.description}
+                onDryRun={async (file: File) => toValidationResult(await card.importFn(file, true))}
+                onApply={async (file: File) => toApplyResult(await card.importFn(file, false))}
+              />
+            </Card>
+          </Col>
+        ))}
+      </Row>
+    </section>
+  );
+}
+
+export default function ImportacoesPage(): JSX.Element {
+  return (
+    <main className="p-6 bg-gray-50 min-h-screen" aria-labelledby="importacoes-title">
+      <header className="mb-6">
+        <Title level={2} id="importacoes-title">
+          DAT &gt; Importações
+        </Title>
+        <Text type="secondary">
+          Centralize aqui todas as importações em massa da plataforma. Acesso restrito ao DAT
+          e superusuários.
+        </Text>
+      </header>
+
+      <ImportSection
+        title="Cadastros base"
+        description="Carga inicial e atualização dos cadastros administrados pelo DAT."
+        cards={CADASTROS_BASE}
+      />
+
+      <ImportSection
+        title="Operacional"
+        description="Importações operacionais (compras, ações, eventos, produtos)."
+        cards={OPERACIONAL}
+      />
+
+      <ImportSection
+        title="Disponibilidade"
+        description="Importação em massa de bloqueios e deslocamentos. Lançamento manual permanece nas páginas específicas."
+        cards={DISPONIBILIDADE}
+      />
+    </main>
+  );
+}

--- a/v2/frontend/src/pages/DAT/__tests__/ImportacoesPage.test.tsx
+++ b/v2/frontend/src/pages/DAT/__tests__/ImportacoesPage.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * Tests da página /dat/importacoes (PR-B do plano DAT-Imports, 2026-04-29).
+ *
+ * Cobertura:
+ * - Header com título canônico
+ * - 3 categorias renderizadas (Cadastros base, Operacional, Disponibilidade)
+ * - 11 cards de upload (cada um com label esperado)
+ *
+ * Não cobre (escopo de outros PRs):
+ * - Guard `canDAT` na rota (PR-B só configura — guard é validado em
+ *   testes de AppRoutes, padrão de PR 11/12 do programa hardening RBAC)
+ * - Lógica de upload em si (já coberta pelos testes de `ImportUploader`)
+ * - Backend gate de cada endpoint (PR-A1 cobre)
+ */
+
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+
+import ImportacoesPage from '../ImportacoesPage';
+
+// Mock dos imports — não fazem fetch real durante render
+vi.mock('../../../api/ops', () => ({
+  importAcoes: vi.fn(),
+  importBloqueios: vi.fn(),
+  importCadastros: vi.fn(),
+  importColecoes: vi.fn(),
+  importCompras: vi.fn(),
+  importDeslocamentos: vi.fn(),
+  importEquipeGerencia: vi.fn(),
+  importEventos: vi.fn(),
+  importMunicipios: vi.fn(),
+  importProdutos: vi.fn(),
+  importUsuarios: vi.fn(),
+}));
+
+describe('ImportacoesPage — DAT > Importações (PR-B)', () => {
+  test('renderiza header canônico', () => {
+    render(<ImportacoesPage />);
+    expect(
+      screen.getByRole('heading', { level: 2, name: /DAT.*Importações/i }),
+    ).toBeInTheDocument();
+  });
+
+  test('renderiza 3 categorias com títulos corretos', () => {
+    render(<ImportacoesPage />);
+    expect(screen.getByRole('heading', { level: 3, name: 'Cadastros base' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 3, name: 'Operacional' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 3, name: 'Disponibilidade' })).toBeInTheDocument();
+  });
+
+  test('Cadastros base contém 5 cards (Usuários, Municípios, Coleções, Cadastros DAT, Vínculos)', () => {
+    render(<ImportacoesPage />);
+    const section = screen.getByRole('region', { name: 'Cadastros base' });
+    expect(within(section).getByText(/Importar USUÁRIOS/)).toBeInTheDocument();
+    expect(within(section).getByText(/Importar MUNICÍPIOS/)).toBeInTheDocument();
+    expect(within(section).getByText(/Importar COLEÇÕES/)).toBeInTheDocument();
+    expect(within(section).getByText(/Importar CADASTROS DAT/)).toBeInTheDocument();
+    expect(within(section).getByText(/Importar VÍNCULOS/)).toBeInTheDocument();
+  });
+
+  test('Operacional contém 4 cards (Compras, Ações, Eventos, Produtos)', () => {
+    render(<ImportacoesPage />);
+    const section = screen.getByRole('region', { name: 'Operacional' });
+    expect(within(section).getByText(/Importar COMPRAS/)).toBeInTheDocument();
+    expect(within(section).getByText(/Importar AÇÕES/)).toBeInTheDocument();
+    expect(within(section).getByText(/Importar EVENTOS/)).toBeInTheDocument();
+    expect(within(section).getByText(/Importar PRODUTOS/)).toBeInTheDocument();
+  });
+
+  test('Disponibilidade contém 2 cards (Bloqueios, Deslocamentos)', () => {
+    render(<ImportacoesPage />);
+    const section = screen.getByRole('region', { name: 'Disponibilidade' });
+    expect(within(section).getByText(/Importar BLOQUEIOS/)).toBeInTheDocument();
+    expect(within(section).getByText(/Importar DESLOCAMENTOS/)).toBeInTheDocument();
+  });
+
+  test('total de 11 cards de import (5 + 4 + 2)', () => {
+    render(<ImportacoesPage />);
+    // Cada card tem um label começando com "Importar X".
+    const cardLabels = screen.getAllByText(/^Importar [A-Z]/);
+    expect(cardLabels).toHaveLength(11);
+  });
+});


### PR DESCRIPTION
## O que resolve

PR-B do plano [DAT Imports Centralization](v2/docs/plans/PLAN_dat_imports_centralization.md). Cria página unificada para os 11 fluxos de upload de planilha do projeto.

## Regra de negócio aplicada

Centralizar importações em massa (CSV/XLSX) em **DAT > Importações**. Apenas DAT/superuser têm acesso. Decisões D-1 a D-6 aprovadas em 2026-04-29.

## Mudanças

### Frontend (3 arquivos)

| Arquivo | Tipo | Descrição |
|---------|------|-----------|
| `pages/DAT/ImportacoesPage.tsx` | NEW (~190 LOC) | Página com 11 cards em 3 categorias |
| `pages/DAT/__tests__/ImportacoesPage.test.tsx` | NEW (~80 LOC) | 6 testes de smoke + estrutura |
| `components/AppRoutes.tsx` | +2 LOC | Lazy import + rota `/dat/importacoes` com guard `canDAT` |

### Estrutura da página

3 categorias agrupadas (D-4):

1. **Cadastros base** (5 cards): Usuários, Municípios, Coleções, Cadastros DAT, Vínculos
2. **Operacional** (4 cards): Compras, Ações, Eventos, Produtos
3. **Disponibilidade** (2 cards): Bloqueios, Deslocamentos

Cada card: `<ImportUploader>` (componente reutilizado, sem mudança) ligado a função `import*` de `api/ops.ts` (sem mudança).

### Guard de rota

Mesmo padrão das outras rotas DAT em `AppRoutes.tsx`:
```tsx
<Route path="/dat/importacoes" element={canDAT ? <DATImportacoesPage /> : <Forbidden />} />
```

## Fora de escopo

- **PR-C** (próximo): reorganizar menu DAT + redirect `/dat/importacao` → `/dat/importacoes`
- **PR-A1** (depois): backend DAT-only via `HasPerm("import_spreadsheet")` nos 6 endpoints DAT+Controle
- **PR-D** (último): remover botões duplicados de ControlePage, ComprasPage, Disponibilidade, Deslocamentos + banners informativos
- ASQ-005 async (`/api/imports/bloqueios/`) — Phase 2 separada (#778)
- Pipeline IBGE municípios (#1298 já mergeado)
- RBAC Grade Mensal/Aprovações (programa hardening em curso)
- Fluxo manual de Controle/Assistente Admin lançando bloqueio/deslocamento (issue separada)

## Testes executados

- ✅ `vitest run src/pages/DAT/__tests__/ImportacoesPage.test.tsx` → 6/6 passed
- ✅ Frontend full: `npx vitest run` → 275/275 passed (32 files)
- ✅ TypeScript: `npx tsc --noEmit` → clean
- ✅ Backend não tocado (sem testes a rodar)

### Casos cobertos pelos 6 testes

1. Header canônico ("DAT > Importações")
2. 3 categorias com títulos corretos
3. Cadastros base contém os 5 labels esperados
4. Operacional contém os 4 labels esperados
5. Disponibilidade contém os 2 labels esperados
6. Total de 11 cards (5 + 4 + 2)

## Riscos

🟢 **BAIXO** — só adição. Coexistência com fluxos antigos:

- Página invisível para não-DAT (guard de rota)
- Não remove nem altera botões existentes em ControlePage, ComprasPage, etc.
- Não muda permission backend (próximo PR)
- Não muda menu DAT (próximo PR)

## Como validar manualmente

1. Login como DAT (ex: `dat_e2e@test.com`)
2. Navegar para `/dat/importacoes`
3. Verificar 3 seções com títulos: Cadastros base, Operacional, Disponibilidade
4. Verificar 11 cards de upload
5. Cada card deve ter botão de "Selecione o arquivo" → "Validar Importação" → "Realizar Importação"
6. Login como Controle/Coord/Formador → navegar para `/dat/importacoes` → deve ver Forbidden

## Próximo PR

PR-C: reorganizar menu DAT (Administração + Cadastros + **Importações** + Registros) + redirect `/dat/importacao` (singular) → `/dat/importacoes` (plural).

## Staging Gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR (trecho de log contendo "ALL 8 CHECKS PASSED")

### Evidencia Staging Gate

\`\`\`text
==============================================
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
==============================================
\`\`\`

Pipeline executado: precheck → build → up → smoke (8 checks) → teardown.