### PR TITLE
feat(dat): reorganiza menu DAT + redirect (PR-C DAT Imports)

### DIFF
--- a/v2/frontend/src/components/AppRoutes.tsx
+++ b/v2/frontend/src/components/AppRoutes.tsx
@@ -9,7 +9,10 @@ import type { CurrentUser } from '../types';
 const DisponibilidadeBlocks = lazy(() => import('../pages/Disponibilidade'));
 const MonthlyPage = lazy(() => import('../pages/Disponibilidade/MonthlyPage'));
 const ControlePage = lazy(() => import('../pages/Controle/ControlePage'));
-const DATPage = lazy(() => import('../pages/DAT/DATPage'));
+// DATPage (página antiga de /dat/importacao, Cadastros DAT) deixou de ser
+// usada após PR-C DAT Imports (2026-04-29) — rota agora redireciona para
+// /dat/importacoes. O componente continua existindo para o card "Cadastros
+// DAT" dentro de ImportacoesPage; remoção definitiva fica em PR-D.
 const DATImportacoesPage = lazy(() => import('../pages/DAT/ImportacoesPage'));
 const NewSolicitacaoWizard = lazy(() => import('../pages/Solicitacoes/NewSolicitacaoWizard'));
 const EditSolicitacaoPage = lazy(() => import('../pages/Solicitacoes/EditSolicitacaoPage'));
@@ -163,7 +166,10 @@ export function AppRoutes({ user, permissions, policies }: AppRoutesProps): JSX.
         <Route path="/dat/cadastros" element={canDAT ? <CadastrosPage /> : <Forbidden />} />
         <Route path="/dat/compras-materiais" element={(canControle || canDAT) ? <DATComprasPage /> : <Forbidden />} />
         <Route path="/dat/coordenadores" element={canControle ? <CoordenadoresPage /> : <Forbidden />} />
-        <Route path="/dat/importacao" element={canDAT ? <DATPage /> : <Forbidden />} />
+        {/* PR-C DAT Imports (2026-04-29): /dat/importacao (singular, página antiga
+            de Cadastros DAT) redireciona para /dat/importacoes (plural, página
+            unificada de imports). Evita 404 em links antigos. */}
+        <Route path="/dat/importacao" element={<Navigate to="/dat/importacoes" replace />} />
         <Route path="/dat/importacoes" element={canDAT ? <DATImportacoesPage /> : <Forbidden />} />
         <Route path="/dat/registros" element={canDAT ? <DATRegistrosPage /> : <Forbidden />} />
       </Routes>

--- a/v2/frontend/src/components/AppSidebar.tsx
+++ b/v2/frontend/src/components/AppSidebar.tsx
@@ -58,14 +58,15 @@ const ROUTE_TO_MENU_KEY: Record<string, string> = {
   '/dashboards/gcal': 'gcal-dashboard',
   '/mapa-brasil': 'mapa-brasil',
   '/dat/admin': 'dat-admin',
-  '/dat/admin/colecoes': 'dat-admin-colecoes',
-  '/dat/admin/equipe-gerencia': 'dat-admin-equipe-gerencia',
+  '/dat/admin/colecoes': 'dat-importacoes',
+  '/dat/admin/equipe-gerencia': 'dat-importacoes',
   '/dat/admin/gerencias': 'dat-admin',
   '/dat/admin/produtos': 'dat-admin',
   '/dat/cadastros': 'dat-cadastros',
   '/dat/compras-materiais': 'controle-compras',
   '/dat/coordenadores': 'controle-coordenadores',
-  '/dat/importacao': 'dat-importacao',
+  '/dat/importacao': 'dat-importacoes',
+  '/dat/importacoes': 'dat-importacoes',
   '/dat/registros': 'dat-registros',
 };
 
@@ -86,10 +87,8 @@ const MENU_KEY_TO_PARENT: Record<string, string> = {
   'gcal-dashboard': 'dashboards-submenu',
   'mapa-brasil': 'dashboards-submenu',
   'dat-admin': 'dat-submenu',
-  'dat-admin-colecoes': 'dat-submenu',
-  'dat-admin-equipe-gerencia': 'dat-submenu',
   'dat-cadastros': 'dat-submenu',
-  'dat-importacao': 'dat-submenu',
+  'dat-importacoes': 'dat-submenu',
   'dat-registros': 'dat-submenu',
   'minhas-solicitacoes': 'solicitacoes-submenu',
   'nova-solicitacao': 'solicitacoes-submenu',
@@ -352,10 +351,8 @@ export function AppSidebar({
             {canDAT && (
               <SubMenu key="dat-submenu" icon={<SolutionOutlined />} title="DAT">
                 <Menu.Item key="dat-admin"><Link to="/dat/admin">Administração</Link></Menu.Item>
-                <Menu.Item key="dat-admin-colecoes"><Link to="/dat/admin/colecoes">Importar Coleções</Link></Menu.Item>
-                <Menu.Item key="dat-admin-equipe-gerencia"><Link to="/dat/admin/equipe-gerencia">Importar Vínculos</Link></Menu.Item>
                 <Menu.Item key="dat-cadastros"><Link to="/dat/cadastros">Cadastros</Link></Menu.Item>
-                <Menu.Item key="dat-importacao"><Link to="/dat/importacao">Importação</Link></Menu.Item>
+                <Menu.Item key="dat-importacoes"><Link to="/dat/importacoes">Importações</Link></Menu.Item>
                 <Menu.Item key="dat-registros"><Link to="/dat/registros">Registros de Turmas</Link></Menu.Item>
               </SubMenu>
             )}

--- a/v2/frontend/src/components/__tests__/AppRoutes.dat-imports.test.tsx
+++ b/v2/frontend/src/components/__tests__/AppRoutes.dat-imports.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * Tests do redirect /dat/importacao → /dat/importacoes (PR-C DAT Imports).
+ *
+ * Cobre apenas o redirect. Tests de guard `canDAT` em outras rotas DAT
+ * permanecem responsabilidade dos arquivos próprios de cada página
+ * (PR 11/12 do programa hardening RBAC fazem cobertura ampla por perfil).
+ */
+
+import { MemoryRouter } from 'react-router-dom';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+
+import { AppRoutes } from '../AppRoutes';
+import type { CurrentUser } from '../../types';
+import type { Permissions } from '../../hooks/usePermissions';
+
+// Mock api/ops para evitar fetch real durante render da ImportacoesPage
+vi.mock('../../api/ops', () => ({
+  importAcoes: vi.fn(),
+  importBloqueios: vi.fn(),
+  importCadastros: vi.fn(),
+  importColecoes: vi.fn(),
+  importCompras: vi.fn(),
+  importDeslocamentos: vi.fn(),
+  importEquipeGerencia: vi.fn(),
+  importEventos: vi.fn(),
+  importMunicipios: vi.fn(),
+  importProdutos: vi.fn(),
+  importUsuarios: vi.fn(),
+}));
+
+const DAT_USER: CurrentUser = {
+  id: 1,
+  username: 'dat_user',
+  email: 'dat@test.com',
+  first_name: 'DAT',
+  last_name: 'User',
+  name: 'DAT User',
+  groups: ['DAT'],
+  setores: ['DAT'],
+  funcoes: [],
+  is_superuser: false,
+  is_superintendencia: false,
+  can_approve_super: false,
+  permissions: [],
+};
+
+const DAT_PERMISSIONS: Permissions = {
+  isAdmin: false,
+  isCoordenador: false,
+  isFormador: false,
+  isGerente: false,
+  inSuperintendencia: false,
+  inGerencia: false,
+  inDAT: true,
+  inControle: false,
+  inDiretoria: false,
+  canApproveSuper: false,
+  canCoordenador: false,
+  canControle: false,
+  canDAT: true,
+  canAcoesInternas: false,
+  canDashboardOverview: false,
+  canDashboardEquipe: false,
+  canDashboardGcal: false,
+  canDashboardCompras: false,
+  canMapaBrasil: false,
+  canDashboardsMenu: false,
+  canDisponibilidade: true,
+  canSeeAllSectors: false,
+};
+
+describe('AppRoutes — DAT Imports redirect (PR-C)', () => {
+  test('rota /dat/importacao redireciona para /dat/importacoes', async () => {
+    render(
+      <MemoryRouter initialEntries={['/dat/importacao']}>
+        <AppRoutes user={DAT_USER} permissions={DAT_PERMISSIONS} policies={[]} />
+      </MemoryRouter>,
+    );
+
+    // ImportacoesPage tem heading "DAT > Importações"
+    expect(
+      await screen.findByRole('heading', { level: 2, name: /DAT.*Importações/i }, { timeout: 5000 }),
+    ).toBeInTheDocument();
+  });
+
+  test('rota /dat/importacoes carrega ImportacoesPage diretamente para DAT', async () => {
+    render(
+      <MemoryRouter initialEntries={['/dat/importacoes']}>
+        <AppRoutes user={DAT_USER} permissions={DAT_PERMISSIONS} policies={[]} />
+      </MemoryRouter>,
+    );
+
+    expect(
+      await screen.findByRole('heading', { level: 2, name: /DAT.*Importações/i }, { timeout: 5000 }),
+    ).toBeInTheDocument();
+  });
+
+  test('rota /dat/importacoes mostra Forbidden para não-DAT', async () => {
+    const nonDatPerms: Permissions = { ...DAT_PERMISSIONS, canDAT: false, inDAT: false };
+    const nonDatUser: CurrentUser = { ...DAT_USER, groups: ['Coordenador'], setores: ['Vidas'] };
+    render(
+      <MemoryRouter initialEntries={['/dat/importacoes']}>
+        <AppRoutes user={nonDatUser} permissions={nonDatPerms} policies={[]} />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText(/Recurso indisponível/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## O que resolve

PR-C do plano [DAT Imports Centralization](v2/docs/plans/PLAN_dat_imports_centralization.md). Reorganiza o submenu DAT no AppSidebar e adiciona redirect da rota antiga.

## Regra de negócio aplicada

Decisão D-5 aprovada em 2026-04-29: manter `/dat/importacao` (singular) com redirect para `/dat/importacoes` (plural), evitando 404 em links antigos durante a transição.

## Mudanças

### Frontend (3 arquivos)

| Arquivo | Mudança |
|---------|---------|
| `components/AppSidebar.tsx` | Submenu DAT reduzido para 4 itens canônicos; mappings de path/key atualizados |
| `components/AppRoutes.tsx` | Redirect `/dat/importacao` → `/dat/importacoes`; remoção do lazy import `DATPage` (não mais usado) |
| `components/__tests__/AppRoutes.dat-imports.test.tsx` | NEW — 3 tests: redirect, render direto, Forbidden para não-DAT |

### Sidebar DAT — antes vs depois

**Antes** (6 itens):
1. Administração
2. Importar Coleções
3. Importar Vínculos
4. Cadastros
5. Importação
6. Registros de Turmas

**Depois** (4 itens):
1. Administração
2. Cadastros
3. **Importações** (→ `/dat/importacoes`, criada em PR-B #1303)
4. Registros de Turmas

"Importar Coleções" e "Importar Vínculos" deixam de ter item próprio no menu — passam a ser cards dentro da página unificada `/dat/importacoes`.

## Fora de escopo

- **PR-A1** (próximo): backend DAT-only via `HasPerm("import_spreadsheet")` nos 6 endpoints DAT+Controle
- **PR-D** (último): remover botões duplicados de ControlePage, ComprasPage, Disponibilidade, Deslocamentos + banners informativos
- ASQ-005 async (Phase 2 #778)
- Pipeline IBGE (#1298 mergeado)
- RBAC Grade Mensal/Aprovações (programa hardening em curso)

## Testes executados

- ✅ `vitest run AppRoutes.dat-imports.test.tsx` → 3/3 passed
- ✅ Frontend full: 278/278 passed (33 files)
- ✅ TypeScript: `npx tsc --noEmit` → clean

### Casos cobertos

1. Rota `/dat/importacao` redireciona para `/dat/importacoes`
2. `/dat/importacoes` carrega `ImportacoesPage` para DAT
3. `/dat/importacoes` mostra Forbidden para não-DAT

## Riscos

🟡 **MÉDIO** — UX change para usuários DAT acostumados:

- Usuários DAT que tinham bookmark de "Importar Coleções" ou "Importar Vínculos" no menu vão precisar aprender a página unificada.
- Bookmarks de URL `/dat/admin/colecoes` ou `/dat/admin/equipe-gerencia` continuam funcionando (rotas não foram removidas).
- Bookmarks de `/dat/importacao` continuam via redirect 301.

## Como validar manualmente

1. Login como DAT
2. Sidebar deve mostrar "DAT" como submenu com 4 itens: Administração, Cadastros, **Importações**, Registros de Turmas
3. Clicar em "Importações" → deve abrir `/dat/importacoes` com 11 cards
4. Acessar URL `/dat/importacao` (singular) → deve redirecionar para `/dat/importacoes`
5. Login como Controle/Coord/Formador → sidebar não mostra item "Importações"
6. URL direta `/dat/importacoes` para não-DAT → Forbidden

## Próximo PR

**PR-A1** (3º): restringir 6 endpoints de import a DAT/superuser via `HasPerm("import_spreadsheet")`. Risco mais alto — depende de auditoria operacional do Controle.

## Staging Gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR (trecho de log contendo "ALL 8 CHECKS PASSED")

### Evidencia Staging Gate

\`\`\`text
==============================================
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
==============================================
\`\`\`

Pipeline executado: precheck → build → up → smoke (8 checks) → teardown.