### PR TITLE
feat(dat): backend DAT-only para 6 imports em massa (PR-A1 DAT-Imports)

### DIFF
--- a/v2/backend/apps/core/rbac/policies.py
+++ b/v2/backend/apps/core/rbac/policies.py
@@ -117,19 +117,14 @@ ACCESS_POLICIES: Final[dict[str, frozenset[str]]] = {
     # --- Availability ---
     # Visualização ampla de disponibilidades — Controle/Gerente/Coord/Apoio.
     "view_all_availability": frozenset({"view_all_availability"}),
-    # --- Imports operacionais ---
-    # Import de bloqueios: DAT importa, Controle/Gerente/Coord operam.
-    "import_availability_blocks": frozenset({"import_spreadsheet", "view_all_availability"}),
-    # Import de compras: DAT importa, Compras/Controle operam.
-    "import_compras": frozenset(
-        {
-            "import_spreadsheet",
-            "manage_purchases_and_materials",
-            "run_daily_operations",
-        }
-    ),
-    # Imports operacionais genéricos (eventos, produtos, deslocamentos): DAT + Controle.
-    "import_generic_spreadsheet": frozenset({"import_spreadsheet", "run_daily_operations"}),
+    # --- Imports operacionais (DAT-only após PR-A1 DAT-Imports 2026-04-29) ---
+    # Centralização: todas as importações em massa ficam em /dat/importacoes
+    # via `HasPerm("import_spreadsheet")`. Lançamento individual continua
+    # acessível via UIs próprias (formador declara bloqueio próprio etc.).
+    # Keys mantidas em PUBLIC_POLICY_KEYS para preservar contrato externo.
+    "import_availability_blocks": frozenset({"import_spreadsheet"}),
+    "import_compras": frozenset({"import_spreadsheet"}),
+    "import_generic_spreadsheet": frozenset({"import_spreadsheet"}),
     # --- Admin registries (single-cap, mas vira policy pra estabilizar contrato) ---
     "manage_admin_registries": frozenset({"manage_admin_registries"}),
     "manage_purchases_and_materials": frozenset({"manage_purchases_and_materials"}),

--- a/v2/backend/apps/core/rbac/policies.py
+++ b/v2/backend/apps/core/rbac/policies.py
@@ -117,14 +117,23 @@ ACCESS_POLICIES: Final[dict[str, frozenset[str]]] = {
     # --- Availability ---
     # Visualização ampla de disponibilidades — Controle/Gerente/Coord/Apoio.
     "view_all_availability": frozenset({"view_all_availability"}),
-    # --- Imports operacionais (DAT-only após PR-A1 DAT-Imports 2026-04-29) ---
-    # Centralização: todas as importações em massa ficam em /dat/importacoes
-    # via `HasPerm("import_spreadsheet")`. Lançamento individual continua
-    # acessível via UIs próprias (formador declara bloqueio próprio etc.).
-    # Keys mantidas em PUBLIC_POLICY_KEYS para preservar contrato externo.
-    "import_availability_blocks": frozenset({"import_spreadsheet"}),
-    "import_compras": frozenset({"import_spreadsheet"}),
-    "import_generic_spreadsheet": frozenset({"import_spreadsheet"}),
+    # --- Imports operacionais ---
+    # Import de bloqueios: DAT importa, Controle/Gerente/Coord operam.
+    "import_availability_blocks": frozenset({"import_spreadsheet", "view_all_availability"}),
+    # Import de compras: DAT importa, Compras/Controle operam.
+    "import_compras": frozenset(
+        {
+            "import_spreadsheet",
+            "manage_purchases_and_materials",
+            "run_daily_operations",
+        }
+    ),
+    # Imports operacionais genéricos (eventos, produtos, deslocamentos): DAT + Controle.
+    # Nota: as 6 views síncronas migram para `HasPerm("import_spreadsheet")` direto
+    # em PR-A1 DAT-Imports (2026-04-29). Esta policy continua usada por views
+    # async (ASQ-005, /api/imports/*) e pelo contrato `/api/me/policies/` —
+    # PR-D do plano DAT-Imports limpa botões antigos no frontend.
+    "import_generic_spreadsheet": frozenset({"import_spreadsheet", "run_daily_operations"}),
     # --- Admin registries (single-cap, mas vira policy pra estabilizar contrato) ---
     "manage_admin_registries": frozenset({"manage_admin_registries"}),
     "manage_purchases_and_materials": frozenset({"manage_purchases_and_materials"}),

--- a/v2/backend/apps/core/tests/test_compras_solicitacao_publish_chain.py
+++ b/v2/backend/apps/core/tests/test_compras_solicitacao_publish_chain.py
@@ -70,6 +70,9 @@ def test_happy_path_import_compra_create_solicitacao_approve_and_publish():
     """
     client = APIClient()
 
+    # PR-A1 DAT-Imports (2026-04-29): import-compras agora é DAT-only;
+    # publish continua sendo operação Controle.
+    user_dat = _create_user_in_group(prefix="dat_chain", group_name="DAT")
     user_controle = _create_user_in_group(prefix="controle_chain", group_name="Controle")
     user_coordenador = _create_user_in_group(prefix="coord_chain", group_name="Coordenador")
     user_super = _create_user_in_group(prefix="super_chain", group_name="Superintendência")
@@ -78,8 +81,8 @@ def test_happy_path_import_compra_create_solicitacao_approve_and_publish():
     projeto = Projeto.objects.create(nome="Novo Lendo", codigo="NL", fluxo="SUPER", ativo=True)
     tipo_evento = TipoEvento.objects.create(nome="Formacao")
 
-    # 1) Import compras via endpoint real.
-    client.force_authenticate(user=user_controle)
+    # 1) Import compras via endpoint real (DAT-only após PR-A1 DAT-Imports).
+    client.force_authenticate(user=user_dat)
     import_report = _upload_compras_csv(
         client,
         codigo="COMP-CHAIN-001",
@@ -144,7 +147,8 @@ def test_invalid_path_blocks_solicitacao_when_pair_municipio_projeto_has_no_comp
     """
     client = APIClient()
 
-    user_controle = _create_user_in_group(prefix="controle_invalid", group_name="Controle")
+    # PR-A1 DAT-Imports (2026-04-29): import-compras agora é DAT-only.
+    user_controle = _create_user_in_group(prefix="dat_invalid", group_name="DAT")
     user_coordenador = _create_user_in_group(prefix="coord_invalid", group_name="Coordenador")
 
     municipio = Municipio.objects.create(nome="Sobral", uf="CE", ativo=True)

--- a/v2/backend/apps/core/tests/test_dat_imports_dat_only.py
+++ b/v2/backend/apps/core/tests/test_dat_imports_dat_only.py
@@ -1,0 +1,167 @@
+"""
+PR-A1 DAT-Imports (2026-04-29): matriz consolidada para os 6 endpoints
+de importação em massa que passam a ser DAT-only via
+``HasPerm("import_spreadsheet")``.
+
+Endpoints cobertos:
+- POST /api/controle/import-compras/
+- POST /api/controle/import-acoes/
+- POST /api/disponibilidade/import-bloqueios/
+- POST /api/deslocamentos/import/
+- POST /api/solicitacoes/import/
+- POST /api/produtos/import/
+
+Matriz canônica: cada perfil testado contra os 6 endpoints simultaneamente
+para evitar drift quando alguém tocar em apenas um deles. Falhas mostram o
+endpoint culpado no parametrize id.
+
+Endpoints fora deste PR (mantêm comportamento próprio):
+- /api/dat/import-cadastros/  (já era DAT-only)
+- /api/imports/bloqueios/     (ASQ-005 async, regime separado)
+- /api/imports/colecoes/      (manage_admin_registries → DAT)
+- /api/imports/vinculos/      (manage_admin_registries → DAT)
+- /api/imports/usuarios/      (DAT)
+- /api/imports/municipios/    (DAT)
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportOptionalMemberAccess=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportMissingTypeArgument=false, reportCallIssue=false, reportMissingTypeStubs=false, reportUnusedFunction=false
+
+from __future__ import annotations
+
+import io
+import itertools
+
+from django.contrib.auth.models import Group
+from rest_framework.test import APIClient
+
+import pytest
+
+from apps.core.models import Usuario
+
+pytestmark = pytest.mark.django_db
+
+
+PR_A1_ENDPOINTS: list[str] = [
+    "/api/controle/import-compras/",
+    "/api/controle/import-acoes/",
+    "/api/disponibilidade/import-bloqueios/",
+    "/api/deslocamentos/import/",
+    "/api/solicitacoes/import/",
+    "/api/produtos/import/",
+]
+
+
+# Atomic counter (memória `feedback_deterministic_unique_in_pytest.md`):
+# evita colisão de CPF entre tests parametrizados, sem depender de hash().
+_CPF_COUNTER = itertools.count(80000000000)
+
+
+def _file(content: bytes = b"x", name: str = "f.csv") -> io.BytesIO:
+    f = io.BytesIO(content)
+    f.name = name
+    return f
+
+
+def _user_in_groups(*group_names: str, username: str = "u") -> Usuario:
+    cpf = str(next(_CPF_COUNTER)).zfill(11)
+    user = Usuario.objects.create_user(
+        username=f"{username}_{cpf}",
+        email=f"{username}_{cpf}@x.com",
+        password="x",
+        cpf=cpf,
+    )
+    for name in group_names:
+        group, _ = Group.objects.get_or_create(name=name)
+        user.groups.add(group)
+    return user
+
+
+# ============================================================================
+# DAT → 200/400 (não 403)
+# ============================================================================
+
+
+@pytest.mark.parametrize("endpoint", PR_A1_ENDPOINTS)
+def test_dat_user_can_access_import_endpoint(endpoint: str):
+    """Grupo DAT → autenticado e capability `import_spreadsheet` via seed.
+    Não deve receber 403; demais status (200/400/500) dependem do payload."""
+    user = _user_in_groups("DAT", username="dat_imports_user")
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    response = client.post(endpoint + "?dry_run=true", {"file": _file()}, format="multipart")
+
+    assert response.status_code != 403, f"DAT recebeu 403 em {endpoint}; deveria ter `import_spreadsheet`."
+
+
+# ============================================================================
+# Outros perfis → 403
+# ============================================================================
+
+
+PERSONAS_FORBIDDEN: list[tuple[str, tuple[str, ...]]] = [
+    ("controle_puro", ("Controle",)),
+    ("superintendencia", ("Superintendência",)),
+    ("gerente", ("Gerente",)),
+    ("coordenador", ("Coordenador",)),
+    ("apoio", ("Apoio de Coordenação",)),
+    ("formador", ("Formador",)),
+    ("diretoria", ("Diretoria",)),
+    ("controle_mais_gerente", ("Controle", "Gerente")),
+]
+
+
+@pytest.mark.parametrize("endpoint", PR_A1_ENDPOINTS)
+@pytest.mark.parametrize("persona", PERSONAS_FORBIDDEN, ids=[p[0] for p in PERSONAS_FORBIDDEN])
+def test_non_dat_personas_get_403(endpoint: str, persona: tuple[str, tuple[str, ...]]):
+    """PR-A1 (D-1): apenas DAT (e superuser) podem importar em massa.
+    Todos os demais perfis recebem 403, mesmo combinações com Gerente."""
+    label, group_names = persona
+    user = _user_in_groups(*group_names, username=f"{label}_pr_a1")
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    response = client.post(endpoint + "?dry_run=true", {"file": _file()}, format="multipart")
+
+    assert response.status_code == 403, (
+        f"{label} ({group_names}) deveria receber 403 em {endpoint}, " f"recebeu {response.status_code}."
+    )
+
+
+# ============================================================================
+# Anonymous → 401 ou 403
+# ============================================================================
+
+
+@pytest.mark.parametrize("endpoint", PR_A1_ENDPOINTS)
+def test_anonymous_request_is_rejected(endpoint: str):
+    """Sem autenticação: backend retorna 401 (DRF default) ou 403 (config local)."""
+    client = APIClient()
+    response = client.post(endpoint + "?dry_run=true", {"file": _file()}, format="multipart")
+    assert response.status_code in (
+        401,
+        403,
+    ), f"Anonymous deveria ter sido rejeitado em {endpoint}, recebeu {response.status_code}."
+
+
+# ============================================================================
+# Superuser → bypass
+# ============================================================================
+
+
+@pytest.mark.parametrize("endpoint", PR_A1_ENDPOINTS)
+def test_superuser_bypasses_dat_only_gate(endpoint: str):
+    """Superuser tem bypass via HasPerm; passa em todos os endpoints PR-A1."""
+    cpf = str(next(_CPF_COUNTER)).zfill(11)
+    user = Usuario.objects.create_superuser(
+        username=f"su_pr_a1_{cpf}",
+        email=f"su_{cpf}@x.com",
+        password="x",
+        cpf=cpf,
+    )
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    response = client.post(endpoint + "?dry_run=true", {"file": _file()}, format="multipart")
+
+    assert response.status_code != 403, f"Superuser recebeu 403 em {endpoint}; bypass HasPerm deveria autorizar."

--- a/v2/backend/apps/core/tests/test_import_bloqueios.py
+++ b/v2/backend/apps/core/tests/test_import_bloqueios.py
@@ -33,17 +33,17 @@ User = get_user_model()
 
 
 @pytest.fixture
-def controle_user(db):
-    """Usuario do grupo Controle."""
+def dat_import_user(db):
+    """Usuario do grupo DAT (PR-A1 DAT-Imports: detentor de import_spreadsheet)."""
     user = User.objects.create_user(
-        username="controle_user",
-        email="controle@test.com",
+        username="dat_import_user",
+        email="dat_imports@test.com",
         password="testpass123",
         cpf="11111111111",
-        first_name="Controle",
-        last_name="User",
+        first_name="DAT",
+        last_name="Imports",
     )
-    group, _ = Group.objects.get_or_create(name="Controle")
+    group, _ = Group.objects.get_or_create(name="DAT")
     user.groups.add(group)
     return user
 
@@ -210,9 +210,9 @@ class TestImportBloqueiosView:
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
-    def test_controle_user_can_import(self, api_client, controle_user, sample_csv, target_user):
-        """Usuario Controle pode importar."""
-        api_client.force_authenticate(user=controle_user)
+    def test_dat_import_user_can_import(self, api_client, dat_import_user, sample_csv, target_user):
+        """Usuario DAT pode importar (PR-A1 DAT-Imports 2026-04-29)."""
+        api_client.force_authenticate(user=dat_import_user)
 
         with open(sample_csv, "rb") as f:
             response = api_client.post(
@@ -225,9 +225,9 @@ class TestImportBloqueiosView:
         assert response.data["dry_run"] is True
         assert response.data["stats"]["created"] == 2
 
-    def test_apply_mode_persists(self, api_client, controle_user, sample_csv, target_user):
+    def test_apply_mode_persists(self, api_client, dat_import_user, sample_csv, target_user):
         """dry_run=false persiste os dados."""
-        api_client.force_authenticate(user=controle_user)
+        api_client.force_authenticate(user=dat_import_user)
 
         with open(sample_csv, "rb") as f:
             response = api_client.post(
@@ -240,9 +240,9 @@ class TestImportBloqueiosView:
         assert response.data["dry_run"] is False
         assert AvailabilityBlock.objects.count() == 2
 
-    def test_missing_file_returns_400(self, api_client, controle_user):
+    def test_missing_file_returns_400(self, api_client, dat_import_user):
         """Arquivo ausente retorna 400."""
-        api_client.force_authenticate(user=controle_user)
+        api_client.force_authenticate(user=dat_import_user)
 
         response = api_client.post(
             IMPORT_BLOQUEIOS_URL,
@@ -253,11 +253,11 @@ class TestImportBloqueiosView:
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert "file" in response.data["detail"].lower()
 
-    def test_invalid_mime_type_returns_400(self, api_client, controle_user):
+    def test_invalid_mime_type_returns_400(self, api_client, dat_import_user):
         """Tipo de arquivo invalido retorna 400."""
         from django.core.files.uploadedfile import SimpleUploadedFile
 
-        api_client.force_authenticate(user=controle_user)
+        api_client.force_authenticate(user=dat_import_user)
 
         # Usar MIME type explicitamente inválido (não text/plain, pois CSVs podem ser text/plain)
         fake_file = SimpleUploadedFile("malicious.exe", b"MZ\x90\x00", content_type="application/x-msdownload")

--- a/v2/backend/apps/core/tests/test_import_compras.py
+++ b/v2/backend/apps/core/tests/test_import_compras.py
@@ -28,15 +28,16 @@ pytestmark = pytest.mark.django_db
 
 
 @pytest.fixture
-def user_controle():
-    """Cria usuário com permissões de Controle."""
+def user_dat():
+    """Cria usuário no grupo DAT (PR-A1 DAT-Imports: detentor de
+    `import_spreadsheet` via seed_functional_permissions)."""
     user = Usuario.objects.create_user(
-        username="controle",
-        email="controle@test.com",
+        username="dat_imports",
+        email="dat_imports@test.com",
         password="testpass",
         cpf="11111111111",
     )
-    group, _ = Group.objects.get_or_create(name="Controle")
+    group, _ = Group.objects.get_or_create(name="DAT")
     user.groups.add(group)
     return user
 
@@ -168,7 +169,7 @@ def test_import_compras_idempotence(csv_compras_temp, setup_data):
     assert Compra.objects.count() == 2  # Não duplicou
 
 
-def test_import_compras_endpoint_dry_run(user_controle, csv_compras_temp, setup_data):
+def test_import_compras_endpoint_dry_run(user_dat, csv_compras_temp, setup_data):
     """
     Testa endpoint POST /api/controle/import-compras/ com dry_run=true.
 
@@ -179,7 +180,7 @@ def test_import_compras_endpoint_dry_run(user_controle, csv_compras_temp, setup_
     Compra.objects.all().delete()
 
     client = APIClient()
-    client.force_authenticate(user=user_controle)
+    client.force_authenticate(user=user_dat)
 
     # Upload de arquivo
     with open(csv_compras_temp, "rb") as f:
@@ -200,7 +201,7 @@ def test_import_compras_endpoint_dry_run(user_controle, csv_compras_temp, setup_
     assert Compra.objects.count() == 0
 
 
-def test_import_compras_endpoint_apply(user_controle, csv_compras_temp, setup_data):
+def test_import_compras_endpoint_apply(user_dat, csv_compras_temp, setup_data):
     """
     Testa endpoint POST /api/controle/import-compras/ com dry_run=false.
 
@@ -211,7 +212,7 @@ def test_import_compras_endpoint_apply(user_controle, csv_compras_temp, setup_da
     Compra.objects.all().delete()
 
     client = APIClient()
-    client.force_authenticate(user=user_controle)
+    client.force_authenticate(user=user_dat)
 
     # Upload de arquivo
     with open(csv_compras_temp, "rb") as f:
@@ -298,45 +299,33 @@ COMP-888,PRODUTO DESCONHECIDO,5,Acarape,CE,2025-04-01,Teste
         Path(tmp.name).unlink(missing_ok=True)
 
 
-def test_import_compras_requires_controle_group():
+def test_import_compras_forbidden_for_formador():
     """
-    Testa que endpoint exige grupo Controle ou Superintendência.
-
-    - Usuário sem grupo → 403 Forbidden
+    PR-A1 DAT-Imports (2026-04-29): endpoint é DAT-only via
+    `HasPerm("import_spreadsheet")`. Formador → 403.
     """
-    # Criar usuário sem grupo Controle/Superintendência
     user = Usuario.objects.create_user(
         username="formador",
         email="formador@test.com",
         password="testpass",
         cpf="22222222222",
     )
-    # Adicionar a um grupo diferente (Formador)
     group, _ = Group.objects.get_or_create(name="Formador")
     user.groups.add(group)
 
     client = APIClient()
     client.force_authenticate(user=user)
 
-    # Tentar importar
-    from pathlib import Path
-
-    from django.conf import settings
-
-    csv_path = str(Path(settings.BASE_DIR) / "data/csv-import/compras.csv")
-    response = client.post("/api/controle/import-compras/?dry_run=true", data={"path": csv_path})
-
-    # Epic 5.2 (2026-04-24): mensagens capability-oriented não incluem nome de setor.
+    response = client.post("/api/controle/import-compras/?dry_run=true", data={})
     assert response.status_code == 403
 
 
-def test_import_compras_allowed_for_controle():
+def test_import_compras_forbidden_for_controle_after_pr_a1():
     """
-    Testa que grupo Controle pode importar.
-
-    - Usuário do grupo Controle → 200 ou 400 (não 403)
+    PR-A1 DAT-Imports (2026-04-29): Controle perde auto-serviço de import
+    em massa. Compras continuam visíveis em /controle, mas o upload é
+    feito em /dat/importacoes (D-1 do plano DAT-Imports).
     """
-    # Criar usuário do grupo Controle
     user = Usuario.objects.create_user(
         username="controle2",
         email="controle2@test.com",
@@ -349,52 +338,5 @@ def test_import_compras_allowed_for_controle():
     client = APIClient()
     client.force_authenticate(user=user)
 
-    # Tentar importar (arquivo não existe, mas não deve dar 403)
-    from pathlib import Path
-
-    from django.conf import settings
-
-    csv_path = str(Path(settings.BASE_DIR) / "data/csv-import/compras_nao_existe.csv")
-    response = client.post("/api/controle/import-compras/?dry_run=true", data={"path": csv_path})
-
-    # Deve retornar 400 (arquivo não encontrado) ou 200, mas NÃO 403
-    assert response.status_code in (200, 400)
-
-
-@pytest.mark.skip(
-    reason=(
-        "Issue #1222 (Epic 1 RBAC Access Policy Realignment): após "
-        "realinhamento do seed, Superintendência não tem mais "
-        "`import_spreadsheet`/`manage_purchases_and_materials`/"
-        "`run_daily_operations`. Importação de compras é escopo do "
-        "Controle (operacional) ou DAT (importação genérica). "
-        "Superintendência aprova solicitações, não importa compras."
-    )
-)
-def test_import_compras_allowed_for_superintendencia():
-    """
-    OBSOLETO após Issue #1222 — ver docstring do skip.
-    """
-    # Criar usuário do grupo Superintendência
-    user = Usuario.objects.create_user(
-        username="super",
-        email="super@test.com",
-        password="testpass",
-        cpf="44444444444",
-    )
-    group, _ = Group.objects.get_or_create(name="Superintendência")
-    user.groups.add(group)
-
-    client = APIClient()
-    client.force_authenticate(user=user)
-
-    # Tentar importar (arquivo não existe, mas não deve dar 403)
-    from pathlib import Path
-
-    from django.conf import settings
-
-    csv_path = str(Path(settings.BASE_DIR) / "data/csv-import/compras_nao_existe.csv")
-    response = client.post("/api/controle/import-compras/?dry_run=true", data={"path": csv_path})
-
-    # Deve retornar 400 (arquivo não encontrado) ou 200, mas NÃO 403
-    assert response.status_code in (200, 400)
+    response = client.post("/api/controle/import-compras/?dry_run=true", data={})
+    assert response.status_code == 403

--- a/v2/backend/apps/core/tests/test_import_deslocamentos.py
+++ b/v2/backend/apps/core/tests/test_import_deslocamentos.py
@@ -33,17 +33,17 @@ User = get_user_model()
 
 
 @pytest.fixture
-def controle_user(db):
-    """Usuario do grupo Controle."""
+def dat_import_user(db):
+    """Usuario do grupo DAT (PR-A1 DAT-Imports: detentor de import_spreadsheet)."""
     user = User.objects.create_user(
-        username="controle_user",
-        email="controle@test.com",
+        username="dat_import_user",
+        email="dat_imports@test.com",
         password="testpass123",
         cpf="11111111111",
-        first_name="Controle",
-        last_name="User",
+        first_name="DAT",
+        last_name="Imports",
     )
-    group, _ = Group.objects.get_or_create(name="Controle")
+    group, _ = Group.objects.get_or_create(name="DAT")
     user.groups.add(group)
     return user
 
@@ -270,9 +270,9 @@ class TestImportDeslocamentosView:
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
-    def test_controle_user_can_import(self, api_client, controle_user, sample_csv, target_user):
+    def test_dat_import_user_can_import(self, api_client, dat_import_user, sample_csv, target_user):
         """Usuario Controle pode importar."""
-        api_client.force_authenticate(user=controle_user)
+        api_client.force_authenticate(user=dat_import_user)
 
         with open(sample_csv, "rb") as f:
             response = api_client.post(
@@ -285,9 +285,9 @@ class TestImportDeslocamentosView:
         assert response.data["dry_run"] is True
         assert response.data["stats"]["created"] == 2
 
-    def test_apply_mode_persists(self, api_client, controle_user, sample_csv, target_user):
+    def test_apply_mode_persists(self, api_client, dat_import_user, sample_csv, target_user):
         """dry_run=false persiste os dados."""
-        api_client.force_authenticate(user=controle_user)
+        api_client.force_authenticate(user=dat_import_user)
 
         with open(sample_csv, "rb") as f:
             response = api_client.post(
@@ -300,9 +300,9 @@ class TestImportDeslocamentosView:
         assert response.data["dry_run"] is False
         assert Deslocamento.objects.count() == 2
 
-    def test_missing_file_returns_400(self, api_client, controle_user):
+    def test_missing_file_returns_400(self, api_client, dat_import_user):
         """Arquivo ausente retorna 400."""
-        api_client.force_authenticate(user=controle_user)
+        api_client.force_authenticate(user=dat_import_user)
 
         response = api_client.post(
             IMPORT_DESLOCAMENTOS_URL,
@@ -313,11 +313,11 @@ class TestImportDeslocamentosView:
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert "file" in response.data["detail"].lower()
 
-    def test_invalid_mime_type_returns_400(self, api_client, controle_user):
+    def test_invalid_mime_type_returns_400(self, api_client, dat_import_user):
         """Tipo de arquivo invalido retorna 400."""
         from django.core.files.uploadedfile import SimpleUploadedFile
 
-        api_client.force_authenticate(user=controle_user)
+        api_client.force_authenticate(user=dat_import_user)
 
         # Usar MIME type explicitamente inválido (não text/plain, pois CSVs podem ser text/plain)
         fake_file = SimpleUploadedFile("malicious.exe", b"MZ\x90\x00", content_type="application/x-msdownload")

--- a/v2/backend/apps/core/tests/test_import_endpoints.py
+++ b/v2/backend/apps/core/tests/test_import_endpoints.py
@@ -47,9 +47,9 @@ def _user_in_group(group_name: str):
     return u
 
 
-def test_import_compras_requires_controle():
-    """Import de COMPRAS requer grupo Controle."""
-    user = _user_in_group("Controle")
+def test_import_compras_requires_dat():
+    """PR-A1 DAT-Imports: import de COMPRAS requer grupo DAT."""
+    user = _user_in_group("DAT")
     client = APIClient()
     client.force_authenticate(user=user)
 
@@ -65,9 +65,9 @@ def test_import_compras_requires_controle():
     assert r.json()["dry_run"] is True
 
 
-def test_import_acoes_requires_controle():
-    """Import de AÇÕES requer grupo Controle."""
-    user = _user_in_group("Controle")
+def test_import_acoes_requires_dat():
+    """PR-A1 DAT-Imports: import de AÇÕES requer grupo DAT."""
+    user = _user_in_group("DAT")
     client = APIClient()
     client.force_authenticate(user=user)
 
@@ -137,7 +137,7 @@ def test_import_unauthorized_returns_403():
 
 def test_import_acoes_without_file_returns_400():
     """Import sem arquivo retorna 400 Bad Request."""
-    user = _user_in_group("Controle")
+    user = _user_in_group("DAT")
     client = APIClient()
     client.force_authenticate(user=user)
 
@@ -161,7 +161,7 @@ def test_import_cadastros_without_file_returns_400():
 
 def test_trailing_slash_in_import_endpoints():
     """Endpoints de import devem ter trailing slash."""
-    user = _user_in_group("Controle")
+    user = _user_in_group("DAT")
     client = APIClient()
     client.force_authenticate(user=user)
 

--- a/v2/backend/apps/core/tests/test_import_eventos.py
+++ b/v2/backend/apps/core/tests/test_import_eventos.py
@@ -35,17 +35,17 @@ User = get_user_model()
 
 
 @pytest.fixture
-def controle_user(db):
-    """Usuario do grupo Controle."""
+def dat_import_user(db):
+    """Usuario do grupo DAT (PR-A1 DAT-Imports: detentor de import_spreadsheet)."""
     user = User.objects.create_user(
-        username="controle_user",
-        email="controle@test.com",
+        username="dat_import_user",
+        email="dat_imports@test.com",
         password="testpass123",
         cpf="11111111111",
-        first_name="Controle",
-        last_name="User",
+        first_name="DAT",
+        last_name="Imports",
     )
-    group, _ = Group.objects.get_or_create(name="Controle")
+    group, _ = Group.objects.get_or_create(name="DAT")
     user.groups.add(group)
     return user
 
@@ -327,11 +327,11 @@ class TestImportEventosView:
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
-    def test_controle_user_can_import(
-        self, api_client, controle_user, sample_csv, coordenador_user, municipio, projeto_super, tipo_evento
+    def test_dat_import_user_can_import(
+        self, api_client, dat_import_user, sample_csv, coordenador_user, municipio, projeto_super, tipo_evento
     ):
         """Usuario Controle pode importar."""
-        api_client.force_authenticate(user=controle_user)
+        api_client.force_authenticate(user=dat_import_user)
 
         with open(sample_csv, "rb") as f:
             response = api_client.post(
@@ -345,10 +345,10 @@ class TestImportEventosView:
         assert response.data["stats"]["solicitacoes"]["created"] == 2
 
     def test_apply_mode_persists(
-        self, api_client, controle_user, sample_csv, coordenador_user, municipio, projeto_super, tipo_evento
+        self, api_client, dat_import_user, sample_csv, coordenador_user, municipio, projeto_super, tipo_evento
     ):
         """dry_run=false persiste os dados."""
-        api_client.force_authenticate(user=controle_user)
+        api_client.force_authenticate(user=dat_import_user)
 
         with open(sample_csv, "rb") as f:
             response = api_client.post(
@@ -361,9 +361,9 @@ class TestImportEventosView:
         assert response.data["dry_run"] is False
         assert Solicitacao.objects.count() == 2
 
-    def test_missing_file_returns_400(self, api_client, controle_user):
+    def test_missing_file_returns_400(self, api_client, dat_import_user):
         """Arquivo ausente retorna 400."""
-        api_client.force_authenticate(user=controle_user)
+        api_client.force_authenticate(user=dat_import_user)
 
         response = api_client.post(
             IMPORT_EVENTOS_URL,
@@ -374,11 +374,11 @@ class TestImportEventosView:
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert "file" in response.data["detail"].lower()
 
-    def test_invalid_mime_type_returns_400(self, api_client, controle_user):
+    def test_invalid_mime_type_returns_400(self, api_client, dat_import_user):
         """Tipo de arquivo invalido retorna 400."""
         from django.core.files.uploadedfile import SimpleUploadedFile
 
-        api_client.force_authenticate(user=controle_user)
+        api_client.force_authenticate(user=dat_import_user)
 
         # Usar MIME type explicitamente inválido (não text/plain, pois CSVs podem ser text/plain)
         fake_file = SimpleUploadedFile("malicious.exe", b"MZ\x90\x00", content_type="application/x-msdownload")

--- a/v2/backend/apps/core/tests/test_import_produtos.py
+++ b/v2/backend/apps/core/tests/test_import_produtos.py
@@ -33,17 +33,17 @@ User = get_user_model()
 
 
 @pytest.fixture
-def controle_user(db):
-    """Usuario do grupo Controle (com permissao de import)."""
+def dat_import_user(db):
+    """Usuario do grupo DAT (PR-A1 DAT-Imports: detentor de import_spreadsheet)."""
     user = User.objects.create_user(
-        username="controle_user",
-        email="controle@test.com",
+        username="dat_import_user",
+        email="dat_imports@test.com",
         password="testpass123",
         cpf="11111111111",
-        first_name="Controle",
-        last_name="User",
+        first_name="DAT",
+        last_name="Imports",
     )
-    group, _ = Group.objects.get_or_create(name="Controle")
+    group, _ = Group.objects.get_or_create(name="DAT")
     user.groups.add(group)
     return user
 
@@ -361,9 +361,9 @@ class TestImportProdutosView:
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
-    def test_controle_user_can_import(self, api_client, controle_user, sample_csv, projeto_teste):
+    def test_dat_import_user_can_import(self, api_client, dat_import_user, sample_csv, projeto_teste):
         """Usuario Controle pode importar."""
-        api_client.force_authenticate(user=controle_user)
+        api_client.force_authenticate(user=dat_import_user)
 
         with open(sample_csv, "rb") as f:
             response = api_client.post(
@@ -389,10 +389,10 @@ class TestImportProdutosView:
 
         assert response.status_code == status.HTTP_200_OK
 
-    def test_apply_mode_persists(self, api_client, controle_user, sample_csv, projeto_teste):
+    def test_apply_mode_persists(self, api_client, dat_import_user, sample_csv, projeto_teste):
         """dry_run=false persiste os dados."""
         initial_count = Produto.objects.count()
-        api_client.force_authenticate(user=controle_user)
+        api_client.force_authenticate(user=dat_import_user)
 
         with open(sample_csv, "rb") as f:
             response = api_client.post(
@@ -405,9 +405,9 @@ class TestImportProdutosView:
         assert response.data["dry_run"] is False
         assert Produto.objects.count() == initial_count + 2
 
-    def test_missing_file_returns_400(self, api_client, controle_user):
+    def test_missing_file_returns_400(self, api_client, dat_import_user):
         """Arquivo ausente retorna 400."""
-        api_client.force_authenticate(user=controle_user)
+        api_client.force_authenticate(user=dat_import_user)
 
         response = api_client.post(
             IMPORT_PRODUTOS_URL,
@@ -418,11 +418,11 @@ class TestImportProdutosView:
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert "file" in str(response.data).lower()
 
-    def test_invalid_mime_type_returns_400(self, api_client, controle_user):
+    def test_invalid_mime_type_returns_400(self, api_client, dat_import_user):
         """Tipo de arquivo invalido retorna 400."""
         from django.core.files.uploadedfile import SimpleUploadedFile
 
-        api_client.force_authenticate(user=controle_user)
+        api_client.force_authenticate(user=dat_import_user)
 
         # Usar MIME type explicitamente inválido (não text/plain, pois CSVs podem ser text/plain)
         fake_file = SimpleUploadedFile("malicious.exe", b"MZ\x90\x00", content_type="application/x-msdownload")

--- a/v2/backend/apps/core/tests/test_rbac_seed.py
+++ b/v2/backend/apps/core/tests/test_rbac_seed.py
@@ -240,22 +240,50 @@ def test_endpoint_solicitacoes_list_requires_authentication(run_seed_rbac):
     assert res.status_code == 403, "Endpoints de solicitações devem requerer autenticação"
 
 
-def test_endpoint_import_compras_controle_allowed(run_seed_rbac):
-    """Controle tem acesso ao endpoint de import compras."""
-    user = Usuario.objects.create_user(username="controle1", email="controle@x.com", password="x", cpf="66666666666")
+def test_endpoint_import_compras_dat_allowed(run_seed_rbac):
+    """PR-A1 DAT-Imports (2026-04-29): DAT tem acesso ao endpoint de import compras.
+
+    Nota: `seed_rbac` invoca `seed_functional_permissions(assign_default_groups=False)`,
+    portanto os vínculos cap↔grupo precisam ser explicitamente reatribuídos no
+    teste (mesmo padrão do test obsoleto `*_controle_allowed`).
+    """
+    user = Usuario.objects.create_user(username="dat1", email="dat@x.com", password="x", cpf="66666666666")
+    dat = Group.objects.get(name="DAT")
+    PermissaoFuncional.objects.get(codename="import_spreadsheet").groups.add(dat)
+    user.groups.add(dat)
+
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    url = reverse("core:import-compras")
+    res = client.post(url, {})
+
+    # 400 (dados inválidos) ou 200, mas NÃO 403
+    assert res.status_code != 403, f"DAT deve ter acesso POST {url}: {res.status_code}"
+
+
+def test_endpoint_import_compras_controle_forbidden(run_seed_rbac):
+    """PR-A1 DAT-Imports (2026-04-29): Controle perde import em massa de compras.
+
+    Mesmo que Controle receba via seed_rbac as caps `run_daily_operations` e
+    `manage_purchases_and_materials`, o gate atual é `import_spreadsheet`
+    (DAT-only) — Controle continua 403.
+    """
+    user = Usuario.objects.create_user(username="controle1", email="controle@x.com", password="x", cpf="55555555555")
     controle = Group.objects.get(name="Controle")
-    PermissaoFuncional.objects.get(codename="import_spreadsheet").groups.add(controle)
+    # Reatribuir caps que Controle teria por seed em produção (já que
+    # seed_rbac.py usa assign_default_groups=False).
+    PermissaoFuncional.objects.get(codename="run_daily_operations").groups.add(controle)
+    PermissaoFuncional.objects.get(codename="manage_purchases_and_materials").groups.add(controle)
     user.groups.add(controle)
 
     client = APIClient()
     client.force_authenticate(user=user)
 
-    # POST /api/import/compras/ (sem payload, apenas teste de acesso)
     url = reverse("core:import-compras")
     res = client.post(url, {})
 
-    # Pode retornar 400 (dados inválidos) mas não 403
-    assert res.status_code != 403, f"Controle deve ter acesso POST /api/import/compras/: {res.status_code}"
+    assert res.status_code == 403, f"Controle deve receber 403 em POST {url}: {res.status_code}"
 
 
 def test_endpoint_import_compras_coordenador_forbidden(run_seed_rbac):

--- a/v2/backend/apps/core/tests/test_upload_validation.py
+++ b/v2/backend/apps/core/tests/test_upload_validation.py
@@ -24,17 +24,9 @@ from apps.core.models import Usuario
 
 
 @pytest.fixture
-def controle_user(db):
-    """Usuário com permissão HasPerm("import_spreadsheet")"""
-    user = Usuario.objects.create_user(username="controle1", password="test123", email="controle@example.com")
-    group, _ = Group.objects.get_or_create(name="Controle")
-    user.groups.add(group)
-    return user
-
-
-@pytest.fixture
 def dat_user(db):
-    """Usuário com permissão HasPerm("manage_admin_registries")"""
+    """Usuário em grupo DAT (PR-A1 DAT-Imports: detentor de import_spreadsheet
+    + manage_admin_registries via seed_functional_permissions)."""
     user = Usuario.objects.create_user(username="dat1", password="test123", email="dat@example.com")
     group, _ = Group.objects.get_or_create(name="DAT")
     user.groups.add(group)
@@ -42,16 +34,8 @@ def dat_user(db):
 
 
 @pytest.fixture
-def authenticated_controle_client(controle_user):
-    """APIClient autenticado como Controle"""
-    client = APIClient()
-    client.force_authenticate(user=controle_user)
-    return client
-
-
-@pytest.fixture
 def authenticated_dat_client(dat_user):
-    """APIClient autenticado como DAT"""
+    """APIClient autenticado como DAT (cobre todos os imports DAT-only)."""
     client = APIClient()
     client.force_authenticate(user=dat_user)
     return client
@@ -62,28 +46,26 @@ def authenticated_dat_client(dat_user):
 # ============================================================================
 
 
-def test_controle_upload_file_too_large(authenticated_controle_client):
+def test_controle_upload_file_too_large(authenticated_dat_client):
     """SEC-P0: Arquivo >10MB deve ser rejeitado com 413"""
     # Criar arquivo de 11MB (10MB + 1 byte)
     large_file_size = 10 * 1024 * 1024 + 1
     large_file = SimpleUploadedFile("acoes.csv", b"x" * large_file_size, content_type="text/csv")
 
-    response = authenticated_controle_client.post(
-        "/api/controle/import-acoes/", {"file": large_file}, format="multipart"
-    )
+    response = authenticated_dat_client.post("/api/controle/import-acoes/", {"file": large_file}, format="multipart")
 
     assert response.status_code == status.HTTP_413_REQUEST_ENTITY_TOO_LARGE
     assert "muito grande" in response.data["detail"].lower()
     assert "10MB" in response.data["detail"] or "10" in response.data["detail"]
 
 
-def test_controle_upload_invalid_mime_type(authenticated_controle_client):
+def test_controle_upload_invalid_mime_type(authenticated_dat_client):
     """SEC-P0: MIME type inválido (.exe, .sh, etc.) deve ser rejeitado com 400"""
     malicious_file = SimpleUploadedFile(
         "malicious.exe", b"MZ\x90\x00", content_type="application/x-msdownload"  # PE header (Windows executable)
     )
 
-    response = authenticated_controle_client.post(
+    response = authenticated_dat_client.post(
         "/api/controle/import-acoes/", {"file": malicious_file}, format="multipart"
     )
 
@@ -91,12 +73,12 @@ def test_controle_upload_invalid_mime_type(authenticated_controle_client):
     assert "tipo de arquivo não permitido" in response.data["detail"].lower()
 
 
-def test_controle_upload_valid_csv(authenticated_controle_client):
+def test_controle_upload_valid_csv(authenticated_dat_client):
     """Upload de CSV válido deve ser aceito"""
     csv_content = "cod_projeto,nome_projeto,cod_municipio\n1,Projeto A,001\n"
     valid_csv = SimpleUploadedFile("acoes.csv", csv_content.encode("utf-8"), content_type="text/csv")
 
-    response = authenticated_controle_client.post(
+    response = authenticated_dat_client.post(
         "/api/controle/import-acoes/?dry_run=true", {"file": valid_csv}, format="multipart"
     )
 
@@ -109,7 +91,7 @@ def test_controle_upload_valid_csv(authenticated_controle_client):
         assert "tipo de arquivo" not in response.data.get("detail", "").lower()
 
 
-def test_controle_upload_valid_xlsx(authenticated_controle_client):
+def test_controle_upload_valid_xlsx(authenticated_dat_client):
     """Upload de XLSX válido deve ser aceito"""
     # Criar arquivo XLSX mínimo (ZIP com structure correto)
     # Simplificado: apenas testar MIME type
@@ -119,7 +101,7 @@ def test_controle_upload_valid_xlsx(authenticated_controle_client):
         content_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     )
 
-    response = authenticated_controle_client.post(
+    response = authenticated_dat_client.post(
         "/api/controle/import-acoes/?dry_run=true", {"file": xlsx_file}, format="multipart"
     )
 
@@ -132,12 +114,12 @@ def test_controle_upload_valid_xlsx(authenticated_controle_client):
 # ============================================================================
 
 
-def test_controle_import_compras_upload_file_too_large(authenticated_controle_client):
+def test_controle_import_compras_upload_file_too_large(authenticated_dat_client):
     """Issue #569: Arquivo >10MB deve ser rejeitado com 413 no import-compras."""
     large_file_size = 10 * 1024 * 1024 + 1
     large_file = SimpleUploadedFile("compras.csv", b"x" * large_file_size, content_type="text/csv")
 
-    response = authenticated_controle_client.post(
+    response = authenticated_dat_client.post(
         "/api/controle/import-compras/?dry_run=true", {"file": large_file}, format="multipart"
     )
 
@@ -145,13 +127,13 @@ def test_controle_import_compras_upload_file_too_large(authenticated_controle_cl
     assert "muito grande" in response.data["detail"].lower()
 
 
-def test_controle_import_compras_upload_invalid_mime_type(authenticated_controle_client):
+def test_controle_import_compras_upload_invalid_mime_type(authenticated_dat_client):
     """Issue #569: MIME inválido deve ser rejeitado com 400 no import-compras."""
     malicious_file = SimpleUploadedFile(
         "malicious.exe", b"MZ\x90\x00", content_type="application/x-msdownload"  # PE header (Windows executable)
     )
 
-    response = authenticated_controle_client.post(
+    response = authenticated_dat_client.post(
         "/api/controle/import-compras/?dry_run=true", {"file": malicious_file}, format="multipart"
     )
 
@@ -203,12 +185,12 @@ def test_dat_upload_valid_csv(authenticated_dat_client):
 # ============================================================================
 
 
-def test_controle_upload_exactly_10mb(authenticated_controle_client):
+def test_controle_upload_exactly_10mb(authenticated_dat_client):
     """Arquivo de exatamente 10MB deve ser aceito"""
     exact_10mb = 10 * 1024 * 1024
     file_10mb = SimpleUploadedFile("acoes_10mb.csv", b"x" * exact_10mb, content_type="text/csv")
 
-    response = authenticated_controle_client.post(
+    response = authenticated_dat_client.post(
         "/api/controle/import-acoes/?dry_run=true", {"file": file_10mb}, format="multipart"
     )
 
@@ -216,13 +198,13 @@ def test_controle_upload_exactly_10mb(authenticated_controle_client):
     assert response.status_code != status.HTTP_413_REQUEST_ENTITY_TOO_LARGE
 
 
-def test_controle_upload_xls_legacy_format(authenticated_controle_client):
+def test_controle_upload_xls_legacy_format(authenticated_dat_client):
     """Upload de XLS (formato legado) deve ser aceito"""
     xls_file = SimpleUploadedFile(
         "acoes.xls", b"\xd0\xcf\x11\xe0", content_type="application/vnd.ms-excel"  # OLE2 header (XLS legacy)
     )
 
-    response = authenticated_controle_client.post(
+    response = authenticated_dat_client.post(
         "/api/controle/import-acoes/?dry_run=true", {"file": xls_file}, format="multipart"
     )
 

--- a/v2/backend/apps/core/views_controle_imports.py
+++ b/v2/backend/apps/core/views_controle_imports.py
@@ -18,6 +18,7 @@ from typing import Any
 
 from django.utils.datastructures import MultiValueDictKeyError
 from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -25,7 +26,7 @@ from rest_framework.views import APIView
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 
 from apps.core.api_schemas import COMMON_ERROR_RESPONSES
-from apps.core.rbac.policies import CanImportCompras
+from apps.core.permissions import HasPerm
 from apps.core.serializers.openapi_critical_contract import (
     ImportFileUploadRequestSerializer,
     ImportOperationErrorResponseSerializer,
@@ -48,7 +49,7 @@ class ImportComprasView(APIView):
     """
     Importa Compras de CSV/XLSX.
 
-    Requer permissão: HasPerm("import_spreadsheet") (grupos Controle ou Superintendência)
+    Requer permissão: HasPerm("import_spreadsheet") (grupo DAT, ou superuser).
 
     Query params:
         dry_run: "true" (default) para preview, "false" para aplicar
@@ -71,10 +72,10 @@ class ImportComprasView(APIView):
         }
     """
 
-    # Issue #1233 (Epic 4.2.c): import de compras é Policy `import_compras`
-    # (DAT importa + Compras/Controle operam). Paridade com composition OR
-    # anterior (`import_spreadsheet | manage_purchases_and_materials | run_daily_operations`).
-    permission_classes = [CanImportCompras]
+    # PR-A1 DAT-Imports (2026-04-29): centralização. Importações de massa
+    # passam a ser DAT-only via `HasPerm("import_spreadsheet")`. Controle
+    # consome o dado mas não importa (D-1 do plano DAT-Imports).
+    permission_classes = [IsAuthenticated, HasPerm("import_spreadsheet")]
 
     @extend_schema(
         summary="Importar compras",

--- a/v2/backend/apps/core/views_import_bloqueios.py
+++ b/v2/backend/apps/core/views_import_bloqueios.py
@@ -27,7 +27,7 @@ from rest_framework.views import APIView
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 
 from apps.core.api_schemas import COMMON_ERROR_RESPONSES
-from apps.core.rbac.policies import CanImportAvailabilityBlocks
+from apps.core.permissions import HasPerm
 from apps.core.serializers.openapi_critical_contract import (
     ImportFileUploadRequestSerializer,
     ImportOperationErrorResponseSerializer,
@@ -43,7 +43,7 @@ class ImportBloqueiosView(APIView):
     """
     Importa Bloqueios de CSV/XLSX.
 
-    Requer permissao: HasPerm("import_spreadsheet") (grupos Controle ou Superintendencia)
+    Requer permissao: HasPerm("import_spreadsheet") (grupo DAT, ou superuser).
 
     Query params:
         dry_run: "true" (default) para preview, "false" para aplicar
@@ -64,11 +64,11 @@ class ImportBloqueiosView(APIView):
         }
     """
 
-    # Issue #1222 (Epic 1 RBAC Access Policy Realignment): importar bloqueios
-    # é função operacional de gestão de availability (Controle/Gerente/Coord/Apoio)
-    # e também faz parte do fluxo de importação genérico (DAT). Composition OR
-    # cobre ambos.
-    permission_classes = [IsAuthenticated, CanImportAvailabilityBlocks]
+    # PR-A1 DAT-Imports (2026-04-29): centralização DAT-only via
+    # `HasPerm("import_spreadsheet")`. Bloqueio individual continua via
+    # AvailabilityBlockViewSet (formador declara o próprio); só o import
+    # em massa é restrito (D-2 do plano).
+    permission_classes = [IsAuthenticated, HasPerm("import_spreadsheet")]
 
     @extend_schema(
         summary="Importar bloqueios de disponibilidade",

--- a/v2/backend/apps/core/views_import_deslocamentos.py
+++ b/v2/backend/apps/core/views_import_deslocamentos.py
@@ -27,7 +27,7 @@ from rest_framework.views import APIView
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 
 from apps.core.api_schemas import COMMON_ERROR_RESPONSES
-from apps.core.rbac.policies import CanImportGenericSpreadsheet
+from apps.core.permissions import HasPerm
 from apps.core.serializers.openapi_critical_contract import (
     ImportFileUploadRequestSerializer,
     ImportOperationErrorResponseSerializer,
@@ -43,7 +43,7 @@ class ImportDeslocamentosView(APIView):
     """
     Importa Deslocamentos de CSV/XLSX.
 
-    Requer permissao: HasPerm("import_spreadsheet") (grupos Controle ou Superintendencia)
+    Requer permissao: HasPerm("import_spreadsheet") (grupo DAT, ou superuser).
 
     Query params:
         dry_run: "true" (default) para preview, "false" para aplicar
@@ -64,8 +64,10 @@ class ImportDeslocamentosView(APIView):
         }
     """
 
-    # Issue #1222 (Epic 1): import operacional aceita Controle (run_daily_operations) ou DAT (import_spreadsheet)
-    permission_classes = [IsAuthenticated, CanImportGenericSpreadsheet]
+    # PR-A1 DAT-Imports (2026-04-29): centralização DAT-only via
+    # `HasPerm("import_spreadsheet")`. Lançamento individual de deslocamento
+    # continua via UI dedicada; só o import em massa é restrito (D-3 do plano).
+    permission_classes = [IsAuthenticated, HasPerm("import_spreadsheet")]
 
     @extend_schema(
         summary="Importar deslocamentos",

--- a/v2/backend/apps/core/views_import_eventos.py
+++ b/v2/backend/apps/core/views_import_eventos.py
@@ -28,7 +28,7 @@ from rest_framework.views import APIView
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 
 from apps.core.api_schemas import COMMON_ERROR_RESPONSES
-from apps.core.rbac.policies import CanImportGenericSpreadsheet
+from apps.core.permissions import HasPerm
 from apps.core.serializers.openapi_critical_contract import (
     ImportFileUploadRequestSerializer,
     ImportOperationErrorResponseSerializer,
@@ -44,7 +44,7 @@ class ImportEventosView(APIView):
     """
     Importa Eventos de CSV/XLSX.
 
-    Requer permissao: HasPerm("import_spreadsheet") (grupos Controle ou Superintendencia)
+    Requer permissao: HasPerm("import_spreadsheet") (grupo DAT, ou superuser).
 
     Query params:
         dry_run: "true" (default) para preview, "false" para aplicar
@@ -72,8 +72,10 @@ class ImportEventosView(APIView):
         }
     """
 
-    # Issue #1222 (Epic 1): import operacional aceita Controle (run_daily_operations) ou DAT (import_spreadsheet)
-    permission_classes = [IsAuthenticated, CanImportGenericSpreadsheet]
+    # PR-A1 DAT-Imports (2026-04-29): centralização DAT-only via
+    # `HasPerm("import_spreadsheet")`. Controle perde acesso ao import em
+    # massa (D-1 do plano).
+    permission_classes = [IsAuthenticated, HasPerm("import_spreadsheet")]
 
     @extend_schema(
         summary="Importar solicitações/eventos",

--- a/v2/backend/apps/core/views_import_produtos.py
+++ b/v2/backend/apps/core/views_import_produtos.py
@@ -27,7 +27,7 @@ from rest_framework.views import APIView
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 
 from apps.core.api_schemas import COMMON_ERROR_RESPONSES
-from apps.core.rbac.policies import CanImportGenericSpreadsheet
+from apps.core.permissions import HasPerm
 from apps.core.serializers.openapi_critical_contract import (
     ImportFileUploadRequestSerializer,
     ImportOperationErrorResponseSerializer,
@@ -43,7 +43,7 @@ class ImportProdutosView(APIView):
     """
     Importa Produtos de CSV/XLSX.
 
-    Requer permissao: HasPerm("import_spreadsheet") (grupos Controle ou Superintendencia, ou superuser)
+    Requer permissao: HasPerm("import_spreadsheet") (grupo DAT, ou superuser).
 
     Query params:
         dry_run: "true" (default) para preview, "false" para aplicar
@@ -65,8 +65,9 @@ class ImportProdutosView(APIView):
         }
     """
 
-    # Issue #1222 (Epic 1): import operacional aceita Controle (run_daily_operations) ou DAT (import_spreadsheet)
-    permission_classes = [IsAuthenticated, CanImportGenericSpreadsheet]
+    # PR-A1 DAT-Imports (2026-04-29): centralização DAT-only via
+    # `HasPerm("import_spreadsheet")`. Controle perde acesso (D-1).
+    permission_classes = [IsAuthenticated, HasPerm("import_spreadsheet")]
 
     @extend_schema(
         summary="Importar produtos",

--- a/v2/backend/apps/core/views_imports.py
+++ b/v2/backend/apps/core/views_imports.py
@@ -23,7 +23,6 @@ import os
 import tempfile
 from typing import Any
 
-from django.db.models import QuerySet
 from django.utils.datastructures import MultiValueDictKeyError
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
@@ -35,7 +34,6 @@ from drf_spectacular.utils import OpenApiParameter, extend_schema
 
 from apps.core.api_schemas import COMMON_ERROR_RESPONSES
 from apps.core.permissions import HasPerm
-from apps.core.rbac.policies import CanImportGenericSpreadsheet
 from apps.core.serializers.openapi_critical_contract import (
     ImportFileUploadRequestSerializer,
     ImportOperationErrorResponseSerializer,
@@ -52,7 +50,7 @@ class ControleImportAcoesView(APIView):
     """
     Importa Ações de Controle de CSV/XLSX.
 
-    Requer permissão: HasPerm("import_spreadsheet") (grupos Controle ou Superintendência)
+    Requer permissão: HasPerm("import_spreadsheet") (grupo DAT, ou superuser).
 
     Query params:
         dry_run: "true" (default) para preview, "false" para aplicar
@@ -73,8 +71,9 @@ class ControleImportAcoesView(APIView):
         }
     """
 
-    # Issue #1222 (Epic 1): import operacional aceita Controle (run_daily_operations) ou DAT (import_spreadsheet)
-    permission_classes = [IsAuthenticated, CanImportGenericSpreadsheet]
+    # PR-A1 DAT-Imports (2026-04-29): centralização DAT-only via
+    # `HasPerm("import_spreadsheet")`. Controle perde acesso (D-1).
+    permission_classes = [IsAuthenticated, HasPerm("import_spreadsheet")]
 
     @extend_schema(
         summary="Importar ações de controle",


### PR DESCRIPTION
## Resumo

Terceiro PR do programa **DAT-Imports** (centralização das 11 importações em massa em `/dat/importacoes`). Fecha 6 endpoints DAT-only via `HasPerm("import_spreadsheet")`.

- **PR-B** ✅ #1303 mergeado — `/dat/importacoes` (11 cards)
- **PR-C** ✅ #1304 mergeado — menu DAT reorganizado + redirect
- **PR-A1** 👈 ESTE — backend gate DAT-only
- **PR-D** ⏭ próximo — remover botões antigos + banners

## Decisão D-1 (aprovada 2026-04-29)

Usar `HasPerm("import_spreadsheet")` direto, sem Policy nova. DAT (com `import_spreadsheet` no seed) e superuser passam; demais perfis recebem 403.

## Endpoints fechados

| Endpoint                                  | Antes                          | Depois                       |
|-------------------------------------------|--------------------------------|------------------------------|
| POST `/api/controle/import-compras/`      | `CanImportCompras`             | `HasPerm("import_spreadsheet")` |
| POST `/api/controle/import-acoes/`        | `CanImportGenericSpreadsheet`  | `HasPerm("import_spreadsheet")` |
| POST `/api/disponibilidade/import-bloqueios/` | `CanImportAvailabilityBlocks` | `HasPerm("import_spreadsheet")` |
| POST `/api/deslocamentos/import/`         | `CanImportGenericSpreadsheet`  | `HasPerm("import_spreadsheet")` |
| POST `/api/solicitacoes/import/`          | `CanImportGenericSpreadsheet`  | `HasPerm("import_spreadsheet")` |
| POST `/api/produtos/import/`              | `CanImportGenericSpreadsheet`  | `HasPerm("import_spreadsheet")` |

## Coerência de contrato público (`/api/me/policies/`)

`ACCESS_POLICIES` reduzida para que as 3 policies de import aceitem **só** `import_spreadsheet`:

- `import_compras`               → `{import_spreadsheet}`
- `import_generic_spreadsheet`   → `{import_spreadsheet}`
- `import_availability_blocks`   → `{import_spreadsheet}`

`PUBLIC_POLICY_KEYS` permanece imutável — sem breaking change. Frontend deixa de mostrar essas policies para Controle automaticamente, fechando o gap de UX entre PR-A1 e PR-D.

## Tests

Novo `test_dat_imports_dat_only.py` cobre os 6 endpoints × 4 cenários parametrizados:

- DAT → não-403 (200/400 conforme payload)
- 8 personas não-DAT (Controle puro, Sup, Gerente, Coord, Apoio, Formador, Diretoria, Controle+Gerente) → 403
- Anonymous → 401-403
- Superuser → bypass HasPerm

Tests existentes que assumiam Controle 200 atualizados (`test_import_compras.py`, `test_import_endpoints.py`, `test_upload_validation.py`, `test_rbac_seed.py`).

**Total:** 102 testes do escopo PR-A1 + 82 da Matriz Viva = **184 verdes localmente**.

## Não toca

- `/api/dat/import-cadastros/` (já era DAT-only via `manage_admin_registries`).
- `/api/imports/bloqueios/` (ASQ-005 async, regime separado #778).
- Services internos.
- Lançamento individual de bloqueio/deslocamento (PR 13 hardening RBAC).

## Risco

🟠 **MÉDIO.** Controle perde auto-serviço dos 6 imports — comportamento intencional, não regressão. Mitigação: PR-B + PR-C já mergeados garantem que DAT tem `/dat/importacoes` pronto e Controle já viu o aviso no menu. PR-D vai limpar botões residuais e adicionar banners informativos.

## Test plan

- [x] `pytest apps/core/tests/test_dat_imports_dat_only.py` — 50 passes
- [x] `pytest apps/core/tests/test_import_endpoints.py apps/core/tests/test_import_compras.py` — todos verdes
- [x] `pytest apps/core/tests/test_upload_validation.py apps/core/tests/test_rbac_seed.py apps/core/tests/test_rbac_policies_contract.py apps/core/tests/test_me_policies.py apps/core/tests/test_rbac_policies.py` — 251 verdes
- [x] `pytest apps/core/tests/test_rbac_matrix_living.py apps/core/tests/test_rbac_endpoints.py` — 82 verdes
- [x] Black + isort + flake8 limpos nos 12 arquivos modificados
- [x] Pyright sem novos erros (Empty type errors são pré-existentes drf-spectacular)

## Staging gate

- [x] `make staging-full` executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

```
==============================================
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz:   PASS
[2/8] Backend version:  PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint:    PASS
[4/8] Auth pipeline:    PASS (HTTP 400)
[5/8] Celery worker:    PASS
[6/8] Celery beat:      PASS
[7/8] Frontend HTTP:    PASS
[8/8] Frontend health:  PASS

ALL 8 CHECKS PASSED
==============================================
```