### PR TITLE
docs: organiza inventários e ignora Graphify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -557,6 +557,7 @@ v2/docs/memoria/
 
 # Agent instruction files (local only)
 AGENTS.md
+CLAUDE.md
 v2/docs/AGENTS.md
 
 # Session/handoff notes (local only)
@@ -596,6 +597,16 @@ nul
 # Code Review Graph (development tool)
 .code-review-graph/
 .code-review-graphignore
+
+# Graphify knowledge graph (development tool)
+.graphifyignore
+**/.graphifyignore
+.graphify/
+graphify-out/
+**/graphify-out/
+graphify-out/cache/
+graphify-out/manifest.json
+graphify-out/cost.json
 
 # VS Code Background Shell extension
 .bg-shell/

--- a/v2/docs/analysis/imports_inventory.md
+++ b/v2/docs/analysis/imports_inventory.md
@@ -1,0 +1,134 @@
+# Inventário de Importações — Aprender Sistema v2
+
+**Gerado em**: 2026-04-29
+**Branch**: `main`
+**HEAD**: `8e9e017b76a417e6baaef33ec882b39f6af50aab`
+**Escopo**: read-only — mapeamento estático do estado atual (frontend + backend).
+
+> Pós-PR #1298 (municípios IBGE) e PR #1299 (D9 transversal): `view_all_availability`
+> está em Controle + DAT (não mais Gerente). Mapping confirmado em
+> `apps/core/services/functional_permissions_seed.py` linhas 147–161.
+
+---
+
+## 1. Tabela completa
+
+Todos os endpoints abaixo aceitam `?dry_run=true|false` e payload `multipart/form-data` (campo `file`). Permissions backend são compostas por `IsAuthenticated` + Policy. As Policy classes vivem em `v2/backend/apps/core/rbac/policies.py`. As capabilities elegíveis vêm de `apps/core/rbac/policies.py::ACCESS_POLICIES` e os grupos atribuídos vêm de `apps/core/services/functional_permissions_seed.py`.
+
+| # | Importação | Módulo atual (rota) | Página/rota atual | Componente frontend | Endpoint backend | Método | Permission backend | Capability/policy elegível | Quem acessa hoje | Observações |
+|---|------------|---------------------|--------------------|----------------------|-------------------|--------|--------------------|----------------------------|------------------|-------------|
+| 1 | Compras | **Duplicado** (Controle, AdminDAT/DATModule) | `/controle` (ControlePage.tsx, ImportUploader linhas 110-118) **e** `/controle/compras`, `/compras-materiais`, `/dat/compras-materiais` (DATModule/ComprasPage.tsx, ImportUploader linhas 739-747) | `ImportUploader` em ambas | `POST /api/controle/import-compras/` (alias: `POST /api/import-compras/`) | POST | `[CanImportCompras]` | `import_compras` = `import_spreadsheet \| manage_purchases_and_materials \| run_daily_operations` | DAT, Controle (+ superuser) | View: `ImportComprasView` em `views_controle_imports.py:77`. Note que `permission_classes` aqui é apenas `[CanImportCompras]` (sem `IsAuthenticated` explícito; o policy já requer auth). |
+| 2 | Ações (Controle) | **Duplicado** (Controle, DATModule) | `/controle` (ControlePage.tsx linhas 122-127) **e** `/controle/compras`, `/compras-materiais`, `/dat/compras-materiais` (DATModule/ComprasPage.tsx linhas 750-755) | `ImportUploader` em ambas | `POST /api/controle/import-acoes/` | POST | `[IsAuthenticated, CanImportGenericSpreadsheet]` | `import_generic_spreadsheet` = `import_spreadsheet \| run_daily_operations` | DAT, Controle (+ superuser) | View: `ControleImportAcoesView` em `views_imports.py:77`. |
+| 3 | Cadastros DAT | DAT | `/dat/importacao` (DAT/DATPage.tsx linhas 90-99) | `ImportUploader` | `POST /api/dat/import-cadastros/` | POST | `[IsAuthenticated, HasPerm("manage_admin_registries")]` | capability `manage_admin_registries` (single-cap; existe Policy `CanManageAdminRegistries` mas a view usa `HasPerm` direto) | DAT (+ superuser) | View: `DATImportCadastrosView` em `views_imports.py:173`. Único import com sidebar key `dat-importacao`. |
+| 4 | Bloqueios (AvailabilityBlock) | Outro (Disponibilidade/Solicitações) | `/disponibilidade`, `/solicitacoes/disponibilidade` (Disponibilidade.tsx linhas 190-198) | `ImportUploader` | `POST /api/disponibilidade/import-bloqueios/` | POST | `[IsAuthenticated, CanImportAvailabilityBlocks]` | `import_availability_blocks` = `import_spreadsheet \| view_all_availability` | DAT, Controle (+ superuser). _Comentário no view sugere "Controle/Gerente/Coord/Apoio", mas seed atual só atribui `view_all_availability` a Controle e DAT_ | View: `ImportBloqueiosView` em `views_import_bloqueios.py:71`. Também exposto via async `POST /api/imports/bloqueios/` (ASQ-005, `views/imports.py`). |
+| 5 | Deslocamentos | Outro (Solicitações/Deslocamentos) | `/solicitacoes/deslocamentos` (Deslocamentos/DeslocamentosPage.tsx linhas 607-614) | `ImportUploader` | `POST /api/deslocamentos/import/` | POST | `[IsAuthenticated, CanImportGenericSpreadsheet]` | `import_generic_spreadsheet` = `import_spreadsheet \| run_daily_operations` | DAT, Controle (+ superuser) | View: `ImportDeslocamentosView` em `views_import_deslocamentos.py:68`. |
+| 6 | Eventos (Solicitação) | **Duplicado** (Controle, DATModule) | `/controle` (ControlePage.tsx linhas 130-135) **e** `/controle/compras`, `/compras-materiais`, `/dat/compras-materiais` (DATModule/ComprasPage.tsx linhas 757-762) | `ImportUploader` em ambas | `POST /api/solicitacoes/import/` | POST | `[IsAuthenticated, CanImportGenericSpreadsheet]` | `import_generic_spreadsheet` = `import_spreadsheet \| run_daily_operations` | DAT, Controle (+ superuser) | View: `ImportEventosView` em `views_import_eventos.py:76`. |
+| 7 | Usuários | AdminDAT | `/dat/admin/usuarios` (AdminDAT/UsuariosPage.tsx linhas 550-558) | `ImportUploader` (embutido na página de cadastro) | `POST /api/usuarios/import/` | POST | `[IsAuthenticated, HasPerm("manage_admin_registries")]` | capability `manage_admin_registries` (single-cap) | DAT (+ superuser) | View: `ImportUsuariosView` em `views_import_usuarios.py:67`. Sem entrada própria no sidebar (acessado via página de cadastro). |
+| 8 | Municípios | AdminDAT | `/dat/admin/municipios` (AdminDAT/MunicipiosPage.tsx linhas 423-428) | `ImportUploader` (embutido na página de cadastro) | `POST /api/municipios/import/` | POST | `[IsAuthenticated, HasPerm("manage_admin_registries")]` | capability `manage_admin_registries` (single-cap) | DAT (+ superuser) | View: `ImportMunicipiosView` em `views_import_municipios.py:55`. PR #1298 (mergeado) trata da pipeline IBGE — fora do escopo deste inventário. Sem entrada própria no sidebar. |
+| 9 | Coleções | AdminDAT | `/dat/admin/colecoes` (AdminDAT/ColecoesImportPage.tsx linhas 49-54) | `ImportUploader` | `POST /api/colecoes/import/` | POST | `[IsAuthenticated, HasPerm("manage_admin_registries")]` | capability `manage_admin_registries` (single-cap) | DAT (+ superuser) | View: `ImportColecoesView` em `views_import_colecoes.py:55`. Sidebar: "Importar Coleções". |
+| 10 | Equipe-Gerência | AdminDAT | `/dat/admin/equipe-gerencia` (AdminDAT/EquipeGerenciaImportPage.tsx linhas 50-55) | `ImportUploader` | `POST /api/equipe-gerencia/import/` | POST | `[IsAuthenticated, HasPerm("manage_admin_registries")]` | capability `manage_admin_registries` (single-cap) | DAT (+ superuser) | View: `ImportEquipeGerenciaView` em `views_import_equipe_gerencia.py:55`. Sidebar: "Importar Vínculos". |
+| 11 | Produtos | **Duplicado** (Controle, DATModule) | `/controle` (ControlePage.tsx linhas 138-143) **e** `/controle/compras`, `/compras-materiais`, `/dat/compras-materiais` (DATModule/ComprasPage.tsx linhas 764-769) | `ImportUploader` em ambas | `POST /api/produtos/import/` | POST | `[IsAuthenticated, CanImportGenericSpreadsheet]` | `import_generic_spreadsheet` = `import_spreadsheet \| run_daily_operations` | DAT, Controle (+ superuser) | View: `ImportProdutosView` em `views_import_produtos.py:69`. Comentário no view: "import operacional aceita Controle (run_daily_operations) ou DAT (import_spreadsheet)". |
+| 12 | (Async) Bloqueios via ImportJob | Backend-only (não há botão FE dedicado) | n/a | nenhum | `POST /api/imports/bloqueios/` | POST | (ASQ-005 infra; ver `views/imports.py`) | (job-based) | n/a no FE | View: `ImportJobBloqueiosUploadView`. Endpoints relacionados: `GET /api/imports/`, `GET /api/imports/<id>/`. Phase 2 (FE polling + 9 imports async) ainda aberta em #778 — hoje frontend ainda usa endpoints síncronos da linha 4. |
+
+---
+
+## 2. Resumo
+
+- **Total de importações distintas (FE)**: 11 (sem contar duplicações de UI; `importCompras`, `importAcoes`, `importEventos`, `importProdutos` aparecem em duas páginas cada).
+- **Total de funções `import*` em `api/ops.ts`**: 11 (`importCompras`, `importAcoes`, `importCadastros`, `importBloqueios`, `importDeslocamentos`, `importEventos`, `importUsuarios`, `importMunicipios`, `importColecoes`, `importEquipeGerencia`, `importProdutos`).
+- **Total de endpoints síncronos FE-facing**: 11 paths em `apps/core/urls.py` (linhas 198-267) + 1 alias (`/api/import-compras/`, linha 204) usado apenas em testes RBAC.
+- **Endpoints async (ASQ-005)**: 1 upload (`/api/imports/bloqueios/`) + 2 leitura (`/api/imports/`, `/api/imports/<id>/`).
+
+### Por módulo (rota onde o botão hoje vive)
+
+- **DAT** (`/dat/*`): 1 (Cadastros DAT em `/dat/importacao`).
+- **AdminDAT** (`/dat/admin/*`): 4 (Usuários, Municípios, Coleções, Equipe-Gerência).
+- **Controle** (`/controle*`): 4 (Compras, Ações, Eventos, Produtos) — todos também aparecem em DATModule.
+- **Outro**:
+  - Bloqueios em `/disponibilidade` e `/solicitacoes/disponibilidade` (Disponibilidade.tsx).
+  - Deslocamentos em `/solicitacoes/deslocamentos` (DeslocamentosPage.tsx).
+- **Duplicado** (mesmo `import*` chamado em ≥2 páginas):
+  - `importCompras` → `Controle/ControlePage.tsx` **+** `DATModule/ComprasPage.tsx`.
+  - `importAcoes` → `Controle/ControlePage.tsx` **+** `DATModule/ComprasPage.tsx`.
+  - `importEventos` → `Controle/ControlePage.tsx` **+** `DATModule/ComprasPage.tsx`.
+  - `importProdutos` → `Controle/ControlePage.tsx` **+** `DATModule/ComprasPage.tsx`.
+  - (`DATModule/ComprasPage.tsx` é o componente lazy `DATComprasPage` mapeado em **3 rotas**: `/controle/compras`, `/compras-materiais`, `/dat/compras-materiais`.)
+
+### Endpoints sem botão frontend dedicado
+
+- `POST /api/imports/bloqueios/` (async) — endpoint backend está pronto (`ImportJobBloqueiosUploadView`), mas hoje a UI ainda fala com `POST /api/disponibilidade/import-bloqueios/` (síncrono). Phase 2 do ASQ-005 (#778) trataria a migração FE.
+- `GET /api/imports/`, `GET /api/imports/<id>/` — sem consumidor frontend identificado.
+- `POST /api/import-compras/` — alias declarado em `urls.py:204` apenas para `test_rbac_seed.py`. Sem caller frontend.
+
+### Botões frontend chamando endpoint inexistente
+
+- Nenhum encontrado. Cada função `import*` em `ops.ts` casa 1:1 com um path em `apps/core/urls.py`.
+
+### Importações usando `CanImportGenericSpreadsheet`
+
+- Ações (`/api/controle/import-acoes/`) — `views_imports.py:77`.
+- Eventos (`/api/solicitacoes/import/`) — `views_import_eventos.py:76`.
+- Deslocamentos (`/api/deslocamentos/import/`) — `views_import_deslocamentos.py:68`.
+- Produtos (`/api/produtos/import/`) — `views_import_produtos.py:69`.
+
+### Importações NÃO protegidas por DAT/superuser hoje
+
+Todas as importações exigem ou DAT ou Controle (+ superuser bypass). Não há nenhum endpoint de import com `[IsAuthenticated]` puro nem com permissão a roles fora desse par. Ranking de "amplitude":
+
+- **Mais amplo (DAT + Controle)**: Compras, Ações, Eventos, Produtos, Deslocamentos, Bloqueios.
+- **Mais restrito (DAT only)**: Cadastros DAT, Usuários, Municípios, Coleções, Equipe-Gerência.
+
+---
+
+## 3. Pontos de atenção (sem corrigir)
+
+1. **Importações fora do menu "DAT"**: Compras, Ações, Eventos, Produtos hoje têm botão em `/controle` (ControlePage.tsx) — coerente com a permission `import_generic_spreadsheet | import_compras` que liga DAT+Controle, mas há sobreposição visual com a mesma UI em `/controle/compras` (DATModule/ComprasPage.tsx). Bloqueios e Deslocamentos ficam fora tanto de Controle quanto de DAT (estão em `/disponibilidade` e `/solicitacoes/deslocamentos`).
+2. **Duplicação 4× de UI**: ControlePage.tsx (linhas 110-143) e DATModule/ComprasPage.tsx (linhas 739-769) renderizam **as mesmas 4 importações** (Compras, Ações, Eventos, Produtos). DATModule/ComprasPage.tsx ainda é re-mapeado em **3 rotas** (`/controle/compras`, `/compras-materiais`, `/dat/compras-materiais`), multiplicando o ponto de entrada visual.
+3. **`manage_admin_registries` é single-cap mas a view usa `HasPerm` direto, não a Policy**: Existe `CanManageAdminRegistries` em `policies.py:251`, mas todas as 5 views que protegem registros administrativos (Cadastros DAT, Usuários, Municípios, Coleções, Equipe-Gerência) usam `HasPerm("manage_admin_registries")`. Não é bug — é apenas idioma misto entre Policy class e HasPerm direto para o mesmo predicado.
+4. **`ImportComprasView` quebra padrão de `permission_classes`**: É a única que usa `permission_classes = [CanImportCompras]` sem incluir `IsAuthenticated` explícito (`views_controle_imports.py:77`). Funcionalmente equivalente porque o policy bloqueia anônimos, mas diverge dos outros 10 views.
+5. **Comentário desatualizado em `views_import_bloqueios.py:68-70`**: O comentário diz "função operacional de gestão de availability (Controle/Gerente/Coord/Apoio)", mas a policy `import_availability_blocks` resolve (via seed atual) apenas para **Controle + DAT** — Gerente, Coordenador e Apoio não têm `view_all_availability` nem `import_spreadsheet` desde a Onda 1 / D9. O texto não reflete o seed.
+6. **Endpoint async existe mas FE não consome**: `POST /api/imports/bloqueios/` (ASQ-005 Phase 1 entregue em #1162) está plumbed no backend e tem testes de integração (`test_import_job_integration.py`), mas nenhum chamador frontend. Phase 2 (#778) é o trabalho restante para mover o FE para o modelo job-based.
+7. **Path divergente entre Compras vs resto**: Padrão dominante é `/<dominio>/import/` (deslocamentos, solicitacoes, usuarios, produtos, municipios, colecoes, equipe-gerencia). Compras usa `/controle/import-compras/` (não `/controle/compras/import/`), Ações usa `/controle/import-acoes/`, Cadastros DAT usa `/dat/import-cadastros/`, Bloqueios usa `/disponibilidade/import-bloqueios/`. Endpoint alias `/api/import-compras/` (linha 204) declarado apenas para teste RBAC.
+8. **Registros de Turmas (DAT/registros)**: Sidebar tem `dat-registros` apontando para `/dat/registros` mas **não existe** import correspondente — é página de listagem, não importação. (Mantido fora do inventário, conforme instrução.)
+9. **Municípios IBGE pipeline (#1298)**: Já mergeado. Inventário lista `importMunicipios` apenas como item #8; pipeline IBGE não é reorganização de importação (é qualidade de dados).
+
+---
+
+## 4. Fontes consultadas
+
+### Frontend
+
+- `v2/frontend/src/api/ops.ts` (linhas 1-293) — todas as 11 funções `import*` + `postMultipart` helper.
+- `v2/frontend/src/components/ImportUploader.tsx:67-76` — componente reutilizado.
+- `v2/frontend/src/components/AppRoutes.tsx:115-167` — rotas e gates `canDAT`, `canControle`, `canCoordenador`, `canDisponibilidade`, `access.can('view_all_availability')`.
+- `v2/frontend/src/components/AppSidebar.tsx:26-96` (mappings) e linhas 322-374 (render do menu DAT, Controle, Solicitações, Disponibilidade, Deslocamentos).
+- `v2/frontend/src/hooks/usePermissions.ts:93-122` — definição de `canDAT`, `canControle`, `canCoordenador`, `canDisponibilidade`.
+- `v2/frontend/src/pages/Controle/ControlePage.tsx:12, 14-15, 110-143`.
+- `v2/frontend/src/pages/DATModule/ComprasPage.tsx:54-63, 739-769`.
+- `v2/frontend/src/pages/DAT/DATPage.tsx:10-11, 90-99`.
+- `v2/frontend/src/pages/Disponibilidade.tsx:17-19, 190-198`.
+- `v2/frontend/src/pages/Deslocamentos/DeslocamentosPage.tsx:53-54, 607-614`.
+- `v2/frontend/src/pages/AdminDAT/UsuariosPage.tsx:38, 40-41, 550-558`.
+- `v2/frontend/src/pages/AdminDAT/MunicipiosPage.tsx:22-24, 423-428`.
+- `v2/frontend/src/pages/AdminDAT/ColecoesImportPage.tsx:8-10, 49-54`.
+- `v2/frontend/src/pages/AdminDAT/EquipeGerenciaImportPage.tsx:8-10, 50-55`.
+
+### Backend
+
+- `v2/backend/apps/core/urls.py:198-283` — declaração dos 11 paths síncronos + 1 alias + 3 paths async (ASQ-005).
+- `v2/backend/apps/core/views_controle_imports.py:74-77` — `ImportComprasView` (`CanImportCompras`).
+- `v2/backend/apps/core/views_imports.py:77, 173` — `ControleImportAcoesView` (`CanImportGenericSpreadsheet`), `DATImportCadastrosView` (`HasPerm("manage_admin_registries")`).
+- `v2/backend/apps/core/views_import_bloqueios.py:67-71` — `ImportBloqueiosView` (`CanImportAvailabilityBlocks`).
+- `v2/backend/apps/core/views_import_deslocamentos.py:67-68` — `ImportDeslocamentosView` (`CanImportGenericSpreadsheet`).
+- `v2/backend/apps/core/views_import_eventos.py:75-76` — `ImportEventosView` (`CanImportGenericSpreadsheet`).
+- `v2/backend/apps/core/views_import_usuarios.py:67` — `ImportUsuariosView` (`HasPerm("manage_admin_registries")`).
+- `v2/backend/apps/core/views_import_municipios.py:55` — `ImportMunicipiosView` (`HasPerm("manage_admin_registries")`).
+- `v2/backend/apps/core/views_import_colecoes.py:55` — `ImportColecoesView` (`HasPerm("manage_admin_registries")`).
+- `v2/backend/apps/core/views_import_equipe_gerencia.py:55` — `ImportEquipeGerenciaView` (`HasPerm("manage_admin_registries")`).
+- `v2/backend/apps/core/views_import_produtos.py:68-69` — `ImportProdutosView` (`CanImportGenericSpreadsheet`).
+- `v2/backend/apps/core/views/imports.py:1-200+` — ASQ-005 async (`ImportJobBloqueiosUploadView`, `ImportJobListView`, `ImportJobDetailView`).
+- `v2/backend/apps/core/rbac/policies.py:118-136` — `ACCESS_POLICIES` mapping (`import_availability_blocks`, `import_compras`, `import_generic_spreadsheet`, `manage_admin_registries`).
+- `v2/backend/apps/core/rbac/policies.py:239-252` — classes `CanImportAvailabilityBlocks`, `CanImportCompras`, `CanImportGenericSpreadsheet`, `CanManageAdminRegistries`.
+- `v2/backend/apps/core/rbac/policies.py:294-300` — `PUBLIC_POLICY_KEYS` (inclui as 3 keys de import + `manage_admin_registries`).
+- `v2/backend/apps/core/services/functional_permissions_seed.py:65-160` — capabilities `import_spreadsheet` (DAT), `manage_admin_registries` (DAT), `manage_purchases_and_materials` (DAT, Controle), `run_daily_operations` (Controle), `view_all_availability` (Controle, DAT).
+- `v2/backend/apps/core/services/`: arquivos de serviço `bloqueios_import.py`, `colecoes_import.py`, `controle_acoes_import.py`, `controle_imports.py`, `dat_cadastros_import.py`, `deslocamentos_import.py`, `equipe_gerencia_import.py`, `eventos_import.py`, `municipios_import.py`, `produtos_import.py`, `usuarios_import.py` — implementam a lógica de cada importação (não inspecionados em profundidade neste inventário).

--- a/v2/docs/analysis/rbac_system_inventory.md
+++ b/v2/docs/analysis/rbac_system_inventory.md
@@ -1,0 +1,489 @@
+# Mapa Atual de Permissões — Aprender Sistema v2
+
+**Gerado em**: 2026-04-27
+**Branch**: main (`73cfaa0` — pós-stabilization)
+
+## 0. Estado pós-Stabilization
+
+Sistema pós-**RBAC Access Policy Realignment** (11 PRs, 2026-04-26) + **Stabilization** (6 PRs, 2026-04-27). As "lacunas críticas" C1-C3 e altos A1-A3 listadas em análise anterior **foram corrigidas** pelas Ondas 1-2 (PRs #1250, #1256).
+
+**16 capabilities, 15 policies, 8 atores** mapeados em SSOT canônica. Matriz Viva implementada (PR #1283, 74+ tests).
+
+**Pendência conhecida**: issue #1284 (HomeStats `upcoming_events` fail-safe scope, P0) está coberta pelo PR aberto **#1286** (não mergeado neste momento) — ver §6.
+
+---
+
+## 1. Catálogo de 16 Capabilities Funcionais
+
+**SSOT**: `v2/backend/apps/core/services/functional_permissions_seed.py` (linhas 36-159)
+
+| Codename | Label | Categoria | Grupos | Usado em Policy | Status |
+|----------|-------|-----------|--------|-----------------|--------|
+| `approve_solicitation` | Aprovar solicitações | solicitacao | Superintendência | `access_audit_logs`, `manage_solicitacao_status` | OK — D1 |
+| `approve_solicitation_batch` | Aprovar lote | solicitacao | Gerente, Superintendência | `access_audit_logs`, `manage_solicitacao_status` | OK — D1 |
+| `create_solicitation` | Criar solicitações | solicitacao | Coordenador, Apoio, Gerente | — | OK — Onda 1 A1 |
+| `edit_solicitation_as_owner_or_privileged` | Editar próprias | solicitacao | Gerente, Coordenador, Apoio | — | OK — D5 |
+| `execute_restricted_operations` | Operações restritas | solicitacao | Superintendência | — | Reservado |
+| `import_spreadsheet` | Importar planilhas | importacao | DAT | `import_*` | OK — D2 |
+| `manage_admin_registries` | Administrar cadastros | cadastros_administrativos | DAT | `access_audit_logs`, `view_compras_*` | OK — D2 |
+| `manage_purchases_and_materials` | Administrar compras | cadastros_administrativos | DAT, Controle | `view_compras_stats` | OK — D2 |
+| `operate_preagenda` | Operar pré-agenda | operacao | Controle | `access_audit_logs`, `manage_solicitacao_status` | OK — D1 |
+| `run_daily_operations` | Rotinas operacionais | operacao | Controle | `view_compras_*`, `import_compras` | OK — D1 |
+| `supervise_operations` | Supervisão gerencial | supervisao | Diretoria | — | Reservado |
+| `view_all_availability` | Ver todas disponibilidades | operacao | **Controle, Gerente** | `import_availability_blocks` | OK — Bug 1 fix |
+| `view_compras_dashboard` | Dashboard compras | dashboard | Diretoria | `view_compras_dashboard` | OK — D7 |
+| `view_map_metrics` | Métricas geográficas | dashboard | Diretoria | `view_map_metrics` | OK — D7 |
+| `view_overview_dashboard` | Dashboard geral | dashboard | Diretoria | `view_overview_dashboard` | OK — D7 |
+| `manage_internal_actions` | Ações internas | cadastros_administrativos | **(zero grupos)** | — | OK — Onda 1 C3 |
+
+---
+
+## 2. Catálogo de 15 Policies Públicas
+
+**SSOT**: `v2/backend/apps/core/rbac/policies.py` (`PUBLIC_POLICY_KEYS`)
+
+| Policy Key | Classe | Composição (OR) | Endpoint | Status |
+|-----------|--------|-----------------|---------|--------|
+| `access_audit_logs` | `CanAccessAuditLogs` | `manage_admin_registries \| operate_preagenda \| approve_solicitation \| approve_solicitation_batch` | AuditLogViewSet | OK — D1 |
+| `manage_solicitacao_status` | `CanManageSolicitacaoStatus` | `operate_preagenda \| approve_solicitation` | GCal | OK — D1 |
+| `view_compras_dashboard` | `CanViewComprasDashboard` | `view_compras_dashboard \| manage_admin_registries` | ComprasViewSet | OK — Onda 2 A2 |
+| `view_compras_pendencias` | `CanViewComprasPendencias` | 4 caps | ComprasViewSet.pendencias | OK — D2 |
+| `view_compras_stats` | `CanViewComprasStats` | `manage_purchases_and_materials \| run_daily_operations` | ComprasViewSet.stats | OK — D2 |
+| `view_overview_dashboard` | `CanViewOverviewDashboard` | `view_overview_dashboard` | Frontend | OK — Onda 1 C1 |
+| `view_map_metrics` | `CanViewMapMetrics` | `view_map_metrics` | Frontend | OK — Onda 1 C1 |
+| `view_reports` | `CanViewReports` | 3 caps | Reports | OK — D2 |
+| `use_gcal` | `CanUseGcal` | `operate_preagenda \| approve_solicitation` | GCal | OK — D1 |
+| `view_all_availability` | `CanViewAllAvailability` | `view_all_availability` | MonthlyAvailabilityView | OK — Bug 1, D6 |
+| `import_availability_blocks` | `CanImportAvailabilityBlocks` | `import_spreadsheet \| view_all_availability` | Imports | OK — D2 |
+| `import_compras` | `CanImportCompras` | 3 caps | Compras | OK — D2 |
+| `import_generic_spreadsheet` | `CanImportGenericSpreadsheet` | `import_spreadsheet \| run_daily_operations` | SpreadsheetImportView | OK — D2 |
+| `manage_admin_registries` | `CanManageAdminRegistries` | `manage_admin_registries` | Admin | OK — D2 |
+| `manage_purchases_and_materials` | `CanManagePurchasesAndMaterials` | `manage_purchases_and_materials` | Admin | OK — D2 |
+
+---
+
+## 3. Páginas Frontend (14 principais)
+
+| Página | Rota | Condição Real (pós-fix) | Status |
+|--------|------|------------------------|--------|
+| Home | `/home` | `IsAuthenticated` | OK |
+| Aprovações | `/solicitacoes/aprovacoes` | Estado atual: `useCanAccess` consome capability `approve_solicitation_batch` (não há policy pública dedicada). Futuro ideal: criar policy `access_solicitation_approvals` que componha `approve_solicitation \| approve_solicitation_batch` e expor em `PUBLIC_POLICY_KEYS`. | OK funcional — backlog de hardening |
+| Bloqueios | `/solicitacoes/bloqueios` | `IsAuthenticated` (queryset scoped) | OK — D6 |
+| Deslocamentos | `/solicitacoes/deslocamentos` | `IsAuthenticated` (`get_queryset` scoped) | OK — Onda 1 C2 |
+| Grade Mensal | `/solicitacoes/disponibilidade` | `CanViewAllAvailability \| HasSectorAccess` | OK — Bug 1 |
+| Meus Eventos | `/solicitacoes/meus-eventos` | `IsAuthenticated` | OK |
+| Dashboard Geral | `/dashboards` | `is_superuser \| inDiretoria` | OK — Onda 1 C1 |
+| Dashboard Compras | `/dashboards/compras` | `useCanAccess.can('view_compras_dashboard')` | OK — Onda 2 A2 |
+| Dashboard Equipe | `/dashboards/equipe` | `is_superuser \| inDiretoria \| inDAT` | OK — Onda 1 C1 |
+| Dashboard GCal | `/dashboards/gcal` | `is_superuser \| inDiretoria \| inDAT \| inControle` | OK — Onda 1 C1 |
+| Mapa Brasil | `/mapa-brasil` | `is_superuser \| inDiretoria \| inDAT` | OK — Onda 1 C1 |
+| Ações Internas | `/acoes-internas` | `is_superuser` (capability sem grupos) | OK — Onda 1 C3 |
+| DAT / Admin | `/dat/admin` | `canDAT` | OK — D2 |
+| Controle / Menu | `/controle` | `canControle` | OK — D1 |
+
+---
+
+## 4. Endpoints Backend (principais)
+
+| Endpoint | Método | `permission_classes` | Status |
+|----------|--------|---------------------|--------|
+| `/api/auth/users/` | GET/POST | `HasPerm("manage_admin_registries")` | OK |
+| `/api/audit-logs/` | GET | `CanAccessAuditLogs` | OK — D1 |
+| `/api/ciclos-acoes/` | GET/POST | `HasPerm("manage_internal_actions")` | OK — Onda 1 C3 |
+| `/api/acoes-instancia/` | GET | `HasPerm("manage_internal_actions")` | OK — Onda 1 C3 |
+| `/api/availability/blocks/` | GET/POST | `IsAuthenticated` | OK — D5 |
+| `/api/availability/monthly/` | GET | `IsAuthenticated, CanViewAllAvailability \| HasSectorAccess` | OK — Bug 1, D6 |
+| `/api/deslocamentos/` | GET | `IsAuthenticated` (`get_queryset` scoped) | OK — Onda 1 C2 |
+| `/api/dat-area/` | GET/POST | `HasPerm("manage_admin_registries")` | OK — D2 |
+| `/api/dat-compra/dashboard/` | GET | `CanViewComprasDashboard` | OK — Onda 2 A2 |
+| `/api/dat-compra/stats/` | GET | `CanViewComprasStats` | OK — D2 |
+| `/api/solicitacoes/` | POST | `HasPerm("create_solicitation")` via `get_permissions` | OK — Onda 1 A1 |
+| `/api/solicitacoes/{id}/approve/` | POST | `CanManageSolicitacaoStatus` | OK — D1 |
+| `/api/me/events/` | GET | `IsAuthenticated` | OK — Epic 2 |
+| `/api/me/policies/` | GET | `IsAuthenticated` | OK — Epic 4.4 |
+
+> Endpoints críticos mapeados e sem lacunas críticas conhecidas; backlog de hardening ainda aberto (ver §7).
+
+---
+
+## 5. Matriz Ator → Permissions (8 atores)
+
+| Ator | Capabilities | Policies | Status |
+|------|--------------|----------|--------|
+| **Superuser** | **(todas — bypass)** | **(todas)** | Escape hatch |
+| **DAT** | `manage_admin_registries`, `import_spreadsheet`, `manage_purchases_and_materials` | 9/15 | OK — D2 (transversal) |
+| **Controle** | `manage_purchases_and_materials`, `operate_preagenda`, `run_daily_operations`, `view_all_availability` | 8/15 | OK — D1 (transversal) |
+| **Diretoria** | `view_compras_dashboard`, `supervise_operations`, `view_overview_dashboard`, `view_map_metrics` | 5/15 | OK — D7 |
+| **Gerente** | `approve_solicitation_batch`, `create_solicitation`, `edit_solicitation_as_owner_or_privileged`, `view_all_availability` | 4/15 | OK — D1 |
+| **Coordenador** | `create_solicitation`, `edit_solicitation_as_owner_or_privileged` | 0/15 | OK — D6 (EquipeGerencia) |
+| **Apoio Coord** | `create_solicitation`, `edit_solicitation_as_owner_or_privileged` | 0/15 | OK — D6 |
+| **Formador** | **(zero)** | 0/15 | OK — caso especial |
+
+---
+
+## 6. Lacunas REAIS (validadas em código)
+
+Todas as divergências C1-C3/A1-A3 foram corrigidas:
+
+- **C1 (Dashboards hardcoded)** ✅ Onda 1 PR #1250
+- **C2 (Deslocamentos scope)** ✅ Onda 1 PR #1250
+- **C3 (Ações Internas IsAdminUser)** ✅ Onda 1 PR #1250
+- **A1 (SolicitacaoViewSet.create)** ✅ Onda 1 PR #1250
+- **A2 (Dashboard Compras)** ✅ Onda 2 PR #1256
+- **A3 (Queryset-only)** ✅ Por design D6
+
+**Lacuna crítica em PR aberto (não mergeado neste momento)**:
+
+- **#1284 — HomeStats `upcoming_events` fail-safe scope (P0)** → corrigido no PR **#1286** (`OPEN`, base `main`). Endereça também #1260 (HomeStatsView remove hardcode de grupos). Quando #1286 mergear, esta entrada migra para "histórico".
+
+---
+
+## 7. Backlog de hardening ainda aberto
+
+Itens identificados durante a Stabilization que **não bloqueiam produção** mas estão registrados para hardening incremental:
+
+| Issue | Tipo | Tema | Estado |
+|-------|------|------|--------|
+| **#1258** | A1 — backend gate | `ProdutoViewSet.list` exige capability operacional explícita (hoje só `IsAuthenticated`) | OPEN |
+| **#1259** | A2 — backend gate | `UsuarioLookup` exige capability (hoje só `IsAuthenticated`) | OPEN |
+| **#1260** | A4 — frontend cleanup | `HomeStatsView` remove hardcode de grupos | OPEN (coberta por PR #1286) |
+| **#1261** | A5 — test meta | Test sentinela meta para `SolicitacaoViewSet` permission resolution | OPEN |
+| **#1276** | governança | Gerar Markdown a partir de `apps/core/rbac/matrix.py` (doc auto-sync) | OPEN |
+| **#1284** | A6 — P0 fix | `HomeStats upcoming_events` fail-safe scope | OPEN (coberta por PR #1286) |
+
+> Backlog conservador: priorizar #1284/#1260 (já em PR #1286), depois #1258/#1259 (capability gates faltando) numa onda 4 e #1261/#1276 em governança contínua.
+
+---
+
+## 8. Matriz Página × Funcionalidade × Acesso
+
+Esta seção aprofunda o mapeamento do §3 (Páginas), descendo ao nível de funcionalidades internas (botões, formulários, ações) e mapeando quais endpoints backend cada uma invoca. Diferencia-se do §3 por não apenas registrar visibilidade de rota, mas detalhar o contrato API funcional em nível de UI.
+
+**Nota sobre Status**: `INCERTO` indica que não foi possível confirmar 100% via leitura estática de código — recomenda-se validação manual. A quantidade limitada de `INCERTO` reflete a maturidade do RBAC pós-Realignment + Stabilization.
+
+---
+
+### 8.1 Home — `/home`
+
+**Componente**: [HomePage.tsx](../frontend/src/pages/Home/HomePage.tsx)
+**Visibilidade**: `IsAuthenticated` (cards renderizados condicionalmente conforme `usePermissions` / `useCanAccess`)
+
+| Funcionalidade | UI | Endpoint | `permission_classes` | Quem acessa | Scope | Status |
+|---|---|---|---|---|---|---|
+| Listar KPIs (stats) | Cards com badges | `GET /api/stats/home/` | `IsAuthenticated` | Todos | self via `request.user` | OK |
+| Link "Meu Painel" | Card | — (navegação) | — | Todos autenticados | — | OK |
+| Link "Enviar Solicitação" | Card | — (navegação) | `canCoordenador` (condicional) | Coord, Apoio, Gerente | — | OK |
+| Link "Minhas Solicitações" | Card com badge | — (navegação) | `canCoordenador` | Coord, Apoio, Gerente | — | OK |
+| Link "Aprovações" | Card | — (navegação) | `canApproveSuper` | Superintendência, DAT | — | OK |
+| Link "Dashboard Geral" | Card "Análises" | — (navegação) | `isAdmin` | DAT, Superuser | — | OK |
+| Link "Dashboard Equipe" | Card | — (navegação) | `isManager` | Gerente | — | OK |
+| Exibir "Aprovações Pendentes" | KPI Card (red) | `GET /api/stats/home/` | `IsAuthenticated` | Se `canApproveSuper` | self | INCERTO — issue #1284 (HomeStats `upcoming_events` fail-safe scope) coberta por PR #1286 |
+
+---
+
+### 8.2 Solicitações (Minhas) — `/solicitacoes/minhas`
+
+**Componente**: [MySolicitacoesPage.tsx](../frontend/src/pages/Solicitacoes/MySolicitacoesPage.tsx)
+**Visibilidade**: `IsAuthenticated` (queryset scoped a `request.user`)
+
+| Funcionalidade | UI | Endpoint | `permission_classes` | Quem acessa | Scope | Status |
+|---|---|---|---|---|---|---|
+| Listar próprias solicitações | Tabela | `GET /api/solicitacoes/?mine=true` | `IsAuthenticated` | Todos | `usuario=request.user` em queryset | OK |
+| Filtrar por status | Select | — (client-side) | — | Todos | — | OK |
+| Buscar por município/projeto | `Input.Search` | `GET /api/solicitacoes/?mine=true&q=...` | `IsAuthenticated` | Todos | `usuario=request.user` | OK |
+| Botão "Nova Solicitação" | Button primária | navega `/solicitacoes/nova` | `canCoordenador` (frontend) | Coord, Apoio, Gerente | — | OK |
+| Editar solicitação | `EditOutlined` por linha | `PATCH /api/solicitacoes/{id}/` | `IsOwnerOrPrivileged` | Owner ou DAT/Super | owner check | OK |
+| Excluir solicitação | `DeleteOutlined` + `Popconfirm` | `DELETE /api/solicitacoes/{id}/` | `IsOwnerOrPrivileged` | Owner ou DAT/Super | owner check + state validation | OK |
+| Ver Google Meet | Hyperlink | — (URL externa) | — | Todos (se aprovado) | — | OK |
+
+---
+
+### 8.3 Aprovações — `/solicitacoes/aprovacoes`
+
+**Componente**: [ApprovalsPage.tsx](../frontend/src/pages/Aprovacoes/ApprovalsPage.tsx)
+**Visibilidade**: `useCanAccess` consome capability `approve_solicitation_batch` (não há policy pública dedicada — ver §3 e §9 sobre `access_solicitation_approvals` ideal)
+
+| Funcionalidade | UI | Endpoint | `permission_classes` | Quem acessa | Scope | Status |
+|---|---|---|---|---|---|---|
+| Listar SUPER pendentes | Tabela | `GET /api/solicitacoes/?flow=SUPER&status=pendente` | `IsAuthenticated` | Todos (filtrado por backend) | — | OK |
+| Filtrar por status | Select | — (query param) | — | Todos | — | OK |
+| Buscar por município/projeto/autor | `Input.Search` | `GET /api/solicitacoes/?q=...&flow=SUPER` | `IsAuthenticated` | Todos | — | OK |
+| Preview payload GCal | `EyeOutlined` | `POST /api/solicitacoes/{id}/preview-gcal/` | `CanUseGcal` | Controle, Superintendência | — | OK |
+| Aprovar (individual) | `CheckOutlined` | `PATCH /api/solicitacoes/{id}/approve/` | `HasPerm("approve_solicitation")` | Superintendência | — | OK |
+| Reprovar (individual) | `CloseOutlined` (danger) | `PATCH /api/solicitacoes/{id}/reject/` | `HasPerm("approve_solicitation")` | Superintendência | — | OK |
+| Selecionar múltiplas | Checkbox table selection | — (state) | — | Approvers | — | OK |
+| Aprovar em lote | Button "Aprovar Selecionadas" | `POST /api/solicitacoes/batch-approve/` | `HasPerm("approve_solicitation")` (via `@action permission_classes`) | Superintendência (+ superuser via bypass) | Service usa `select_for_update(skip_locked)`; limite 100 IDs | OK |
+| Reprovar em lote | Button "Reprovar Selecionadas" | `POST /api/solicitacoes/batch-reject/` | `HasPerm("approve_solicitation")` (via `@action permission_classes`) | Superintendência (+ superuser via bypass) | Idem batch-approve | OK |
+
+> **Observação registrada (não bloqueante)**: a capability `approve_solicitation_batch` existe no seed e está atribuída a Gerente + Superintendência, mas os endpoints `batch-approve` / `batch-reject` exigem a capability `approve_solicitation` (mais restrita, hoje só Superintendência). Em consequência, **Gerente não consegue usar batch endpoints com a configuração atual**. Pode ser intent (batch = paridade com aprovação individual) ou divergência semântica de naming. Decisão de negócio fica para issue futura `RBAC: decidir semântica de approve_solicitation_batch nos endpoints batch` — não mexer no código sem essa decisão.
+
+---
+
+### 8.4 Bloqueios — `/solicitacoes/bloqueios`
+
+**Componente**: [Solicitacoes.tsx](../frontend/src/pages/Solicitacoes.tsx) → painel "Bloqueios"
+**Visibilidade**: `IsAuthenticated` (queryset scoped; privilegiados veem todos; ver D6)
+
+| Funcionalidade | UI | Endpoint | `permission_classes` | Quem acessa | Scope | Status |
+|---|---|---|---|---|---|---|
+| Listar bloqueios | `MyBlocksTable` | `GET /api/solicitacoes/bloqueios/` | `IsAuthenticated` | Todos | owner=`request.user` ou gerência | OK |
+| Criar novo bloqueio | `BlockForm` + Button | `POST /api/solicitacoes/bloqueios/` | `IsAuthenticated` | Todos (Formador, Coord) | auto `usuario=request.user` | OK — RD-02/RD-03 |
+| Preencher datas/tipo | Form inputs | — (state) | — | — | — | OK |
+| Excluir bloqueio | Delete por linha | `DELETE /api/solicitacoes/bloqueios/{id}/` | `IsAuthenticated` (owner check) | Owner ou privilegiados | owner via `get_queryset` | OK |
+| Importar bloqueios CSV/XLSX | `ImportUploader` | `POST /api/imports/bloqueios/` | `CanImportAvailabilityBlocks` | DAT, Controle | — | OK |
+
+---
+
+### 8.5 Grade Mensal (Disponibilidade) — `/solicitacoes/disponibilidade`
+
+**Componente**: [Disponibilidade.tsx](../frontend/src/pages/Disponibilidade.tsx) + [MonthlyPage.tsx](../frontend/src/pages/Disponibilidade/MonthlyPage.tsx)
+**Visibilidade**: `IsAuthenticated, CanViewAllAvailability | HasSectorAccess` (Bug 1 fix, D6)
+
+| Funcionalidade | UI | Endpoint | `permission_classes` | Quem acessa | Scope | Status |
+|---|---|---|---|---|---|---|
+| Visualizar grade mensal | Grid interativo | `GET /api/availability/monthly/?year=...&month=...` | `CanViewAllAvailability \| HasSectorAccess` | Todos (scope por gerência) | gerência do user ou todos se privilegiado | OK |
+| Filtro por usuário | Dropdown | — (query param) | — | Gerente, Coord | filtra por `EquipeGerencia` | OK |
+| Filtro por projeto/setor | Select | — (query param) | — | Todos | — | OK |
+| Detalhes em célula | `DetailsDrawer` | — (modal client-side) | — | — | — | OK |
+| Criar bloqueio | Form interno | `POST /api/availability-blocks/` | `IsAuthenticated` | Todos (Formador) | auto `usuario=request.user` | OK |
+| Listar próprios bloqueios | Seção "Meus Bloqueios" | `GET /api/availability-blocks/?owner=me` | `IsAuthenticated` | Todos | self | OK |
+| Excluir bloqueio próprio | Delete em lista | `DELETE /api/availability-blocks/{id}/` | `IsAuthenticated` (owner check) | Owner | self via `get_queryset` | OK |
+| Importar disponibilidades | `ImportUploader` | `POST /api/imports/bloqueios/` | `CanImportAvailabilityBlocks` | DAT, Controle | — | OK |
+
+---
+
+### 8.6 Deslocamentos — `/solicitacoes/deslocamentos`
+
+**Componente**: [DeslocamentosPage.tsx](../frontend/src/pages/Deslocamentos/DeslocamentosPage.tsx)
+**Visibilidade**: `IsAuthenticated` (queryset scoped, Onda 1 C2)
+
+| Funcionalidade | UI | Endpoint | `permission_classes` | Quem acessa | Scope | Status |
+|---|---|---|---|---|---|---|
+| Listar deslocamentos | Tabela paginada | `GET /api/deslocamentos/` | `IsAuthenticated` | Todos (Controle, DAT, Coord) | filtro por usuário/gerência (Onda 1 C2 — `EquipeGerencia`) | OK |
+| Filtro por usuário | Select | `?usuario_id=...` | `IsAuthenticated` | Coord, Controle, DAT | filtra por `EquipeGerencia` ou todos se privilegiado | OK |
+| Filtro por data range | RangePicker | `?data_inicio=...&data_fim=...` | `IsAuthenticated` | Todos | — | OK |
+| Filtro origem/destino | Input | `?origem=...&destino=...` | `IsAuthenticated` | Todos | — | OK |
+| Criar deslocamento | Modal form + `PlusOutlined` | `POST /api/deslocamentos/` | `IsAuthenticated` | Controle, Coord | auto `usuario=request.user` ou selecionado | OK |
+| Editar | `EditOutlined` | `PUT /api/deslocamentos/{id}/` | `IsAuthenticated` (owner check) | Owner ou privilegiados | owner via `get_queryset` | OK |
+| Excluir | `DeleteOutlined` + `Popconfirm` | `DELETE /api/deslocamentos/{id}/` | `IsAuthenticated` (owner check) | Owner ou privilegiados | owner via `get_queryset` | OK |
+| Importar deslocamentos | `ImportUploader` | `POST /api/imports/deslocamentos/` | `HasPerm("import_spreadsheet")` | Controle, DAT | — | OK |
+
+---
+
+### 8.7 Meus Eventos — `/solicitacoes/meus-eventos`
+
+**Componente**: [MeusEventosPage.tsx](../frontend/src/pages/MeusEventos/MeusEventosPage.tsx)
+**Visibilidade**: `IsAuthenticated` (Epic 2 — feature criada no Realignment)
+
+| Funcionalidade | UI | Endpoint | `permission_classes` | Quem acessa | Scope | Status |
+|---|---|---|---|---|---|---|
+| Listar eventos como participante | Tabela paginada | `GET /api/me/events/?page=...` | `IsAuthenticated` | Todos (Formador primário) | `request.user` em `Solicitacao.aprovado` | OK |
+| Paginação | Pagination | — (query param) | — | — | — | OK |
+| Colunas (data, horário, município, projeto, tipo, local, Meet) | denormalized | — | — | — | — | OK |
+| Link Google Meet | Hyperlink | — (URL externa) | — | Todos | — | OK |
+
+---
+
+### 8.8 Dashboard Geral — `/dashboards`
+
+**Componente**: [DashboardsPage.tsx](../frontend/src/pages/Dashboards/DashboardsPage.tsx)
+**Visibilidade**: `is_superuser \| inDiretoria` (Onda 1 C1, alinhado com D7)
+
+| Funcionalidade | UI | Endpoint | `permission_classes` | Quem acessa | Scope | Status |
+|---|---|---|---|---|---|---|
+| KPIs (Eventos Futuros, Aprovados, Participantes, Pendentes) | Cards `Statistic` | `GET /api/dashboard/overview/` | `HasPerm("view_overview_dashboard")` | Diretoria, Superuser | — | OK |
+| Gráfico eventos por fluxo | Bar chart | — (denormalized) | — | Diretoria | — | OK |
+| Gráfico eventos por gerência | Pie/Bar | — (denormalized) | — | Diretoria | — | OK |
+| Top coordenadores | Lista/tabela | — (denormalized) | — | Diretoria | — | OK |
+| Recarregar | `ReloadOutlined` | `GET /api/dashboard/overview/` (refetch) | `HasPerm("view_overview_dashboard")` | Diretoria | — | OK |
+| Exportar CSV (stub) | `DownloadOutlined` | — (não implementado) | — | Diretoria | — | pendente |
+
+---
+
+### 8.9 Dashboard Compras — `/dashboards/compras`
+
+**Componente**: [ComprasDashboardPage.tsx](../frontend/src/pages/Dashboards/ComprasDashboardPage.tsx)
+**Visibilidade**: `useCanAccess.can('view_compras_dashboard')` (Onda 2 A2)
+
+| Funcionalidade | UI | Endpoint | `permission_classes` | Quem acessa | Scope | Status |
+|---|---|---|---|---|---|---|
+| Métricas agregadas | Cards com `Progress` | `GET /api/dat-compra/dashboard/` | `CanViewComprasDashboard` | Diretoria, DAT | — | OK |
+| Filtro por projeto | Select | — (query param) | — | Diretoria, DAT | — | OK |
+| Filtro por UF | Select | — (query param) | — | Diretoria, DAT | — | OK |
+| Rankings (Top produtos, municípios) | Tabelas | — (denormalized) | — | Diretoria, DAT | — | OK |
+| Painel de pendências | Tabela | `GET /api/dat-compra/pendencias/` | `CanViewComprasPendencias` | DAT, Controle, Diretoria | — | OK |
+| Recarregar | `ReloadOutlined` | refetch dashboard | `CanViewComprasDashboard` | Diretoria, DAT | — | OK |
+
+---
+
+### 8.10 Dashboard Equipe — `/dashboards/equipe`
+
+**Componente**: [EquipeDashboardPage.tsx](../frontend/src/pages/Dashboards/EquipeDashboardPage.tsx)
+**Visibilidade**: `is_superuser \| inDiretoria \| inDAT` (Onda 1 C1)
+**API consumida**: 3 endpoints distintos de [teamMetrics.ts](../frontend/src/api/teamMetrics.ts) — não há `/api/dashboard/equipe/` único.
+
+| Funcionalidade | UI | Endpoint | `permission_classes` | Quem acessa | Scope | Status |
+|---|---|---|---|---|---|---|
+| Métricas de produtividade (eventos criados, tempo médio aprovação, taxa erro GCal) | Cards `Statistic` | `GET /api/metrics/team/productivity/?days=N` | composition β `run_daily_operations \| supervise_operations \| manage_admin_registries` | Controle, Diretoria, DAT | filtro `days` (7/15/30) | OK — Onda 2 A3 (β preserva Lote 4.2.b2) |
+| Ranking de formadores | Bar chart + tabela com export CSV | `GET /api/metrics/team/formadores/?days=N` | composition β (idem) | Controle, Diretoria, DAT | filtro `days` | OK — Onda 2 A3 |
+| Métricas de qualidade (rejeição, conflitos, re-trabalho, tempo publicação) | Cards `Statistic` com Progress | `GET /api/metrics/team/quality/?days=N` | composition β (idem) | Controle, Diretoria, DAT | filtro `days` | OK — Onda 2 A3 |
+| Filtro de período (7/15/30 dias) | `Select` | aplicado nos 3 endpoints como `?days=N` | — | — | — | OK |
+| Exportar CSV | `DownloadOutlined` | client-side (gera CSV a partir de `formadoresData`) | — | Controle, Diretoria, DAT | — | OK |
+
+> Tests RBAC: [test_metrics_team_rbac.py](../backend/apps/core/tests/test_metrics_team_rbac.py) cobre os 3 endpoints com a composition β.
+
+---
+
+### 8.11 Dashboard GCal — `/dashboards/gcal`
+
+**Componente**: [GCalDashboardPage.tsx](../frontend/src/pages/Dashboards/GCalDashboardPage.tsx)
+**Visibilidade**: `is_superuser \| inDiretoria \| inDAT \| inControle` (Onda 1 C1)
+
+| Funcionalidade | UI | Endpoint | `permission_classes` | Quem acessa | Scope | Status |
+|---|---|---|---|---|---|---|
+| Métricas GCal (success rate, drift, erros) | Cards/charts | `GET /api/gcal/dashboard/` | `CanUseGcal \| IsAdmin` | Controle, Diretoria, DAT | — | OK |
+| Alertas de erro | `Alert` | — (denormalized) | — | Controle, Diretoria | — | OK |
+| Retry batch failed | Button | `POST /api/gcal/dashboard/batch/reapply/` | `IsAuthenticated, CanUseGcal` (`operate_preagenda \| approve_solicitation`) | Controle, Superintendência | throttle `gcal_write` 10/min; OAuth check (sem `GoogleOAuthCredential` → 403 `google_not_connected` quando `GCAL_AUTH_MODE=oauth`); limite 500 IDs | OK |
+
+---
+
+### 8.12 Mapa Brasil — `/mapa-brasil`
+
+**Componente**: [MapaBrasilPage.tsx](../frontend/src/pages/MapaBrasil/MapaBrasilPage.tsx)
+**Visibilidade**: `CanViewMapMetrics` (Diretoria, alinhado com D7)
+
+| Funcionalidade | UI | Endpoint | `permission_classes` | Quem acessa | Scope | Status |
+|---|---|---|---|---|---|---|
+| Mapa com municípios e eventos | Leaflet + GeoJSON | `GET /api/metrics/map/?...` | `CanViewMapMetrics` | Diretoria | — | OK |
+| Filtro por projeto | Select | `?projeto=...` | — | Diretoria | — | OK |
+| Filtro por data range | DatePicker | `?date_from=...&date_to=...` | — | Diretoria | — | OK |
+| Toggle Map/List | Radio | — (client-side) | — | Diretoria | — | OK |
+| Tabela de estados | `Table` | — (denormalized) | — | Diretoria | — | OK |
+| Collapse por município | `Collapse` | — (client-side) | — | Diretoria | — | OK |
+| Detalhes de coordenador | List | — (nested) | — | Diretoria | — | OK |
+
+---
+
+### 8.13 Ações Internas — `/acoes-internas`
+
+**Componente**: [DATModule/AcoesPage.tsx](../frontend/src/pages/DATModule/AcoesPage.tsx)
+**Visibilidade**: `HasPerm("manage_internal_actions")` — capability **zero-groups** (apenas Superuser bypassa hoje; pattern documentado em `feedback_capability_zero_groups_dev_feature.md`)
+
+| Funcionalidade | UI | Endpoint | `permission_classes` | Quem acessa | Scope | Status |
+|---|---|---|---|---|---|---|
+| Listar ciclos de ação | Tabela com filtros | `GET /api/ciclos-acoes/` | `HasPerm("manage_internal_actions")` | Superuser | — | OK |
+| Filtro por município | Select | `?municipio=...` | — | Superuser | — | OK |
+| Filtro por projeto | Select | `?projeto=...` | — | Superuser | — | OK |
+| Filtro por status (Carta/Contato/Reunião/Entrega) | Select | `?status=...` | — | Superuser | — | OK |
+| Busca textual | `Input.Search` | `?q=...` | — | Superuser | — | OK |
+| Criar nova ação | Modal + `PlusOutlined` | `POST /api/ciclos-acoes/` | `HasPerm("manage_internal_actions")` | Superuser | — | OK |
+| Editar ação | `EditOutlined` | `PUT /api/ciclos-acoes/{id}/` | `HasPerm("manage_internal_actions")` | Superuser | — | OK |
+| Excluir ação | `DeleteOutlined` + `Popconfirm` | `DELETE /api/ciclos-acoes/{id}/` | `HasPerm("manage_internal_actions")` | Superuser | — | OK |
+| Exportar lista (stub) | `DownloadOutlined` | — (não implementado) | — | Superuser | — | pendente |
+
+---
+
+### 8.14 DAT / Admin — `/dat/admin`
+
+**Componente**: [AdminDATHomePage.tsx](../frontend/src/pages/AdminDAT/AdminDATHomePage.tsx)
+**Visibilidade**: `HasPerm("manage_admin_registries")` (DAT, Superuser; D2 — DAT é ator transversal)
+
+| Funcionalidade | UI | Endpoint | `permission_classes` | Quem acessa | Scope | Status |
+|---|---|---|---|---|---|---|
+| Cartão "Usuários" | Card + link | navega `/dat/admin/usuarios` | `CanManageAdminRegistries` | DAT | — | OK |
+| Cartão "Municípios" | Card | — (navegação) | `CanManageAdminRegistries` | DAT | — | OK |
+| Cartão "Setores" | Card | — (navegação) | `CanManageAdminRegistries` | DAT | — | OK |
+| Cartão "Funções" | Card | — (navegação) | `CanManageAdminRegistries` | DAT | — | OK |
+| Cartão "Gerências" | Card | — (navegação) | `CanManageAdminRegistries` | DAT | — | OK |
+| Cartão "Produtos" | Card | — (navegação) | `CanManageAdminRegistries` | DAT | — | OK |
+| Cartão "Projetos" | Card | — (navegação) | `CanManageAdminRegistries` | DAT | — | OK |
+| Cartão "Configurações" | Card | — (navegação) | `CanManageAdminRegistries` | DAT | — | OK |
+| Sub-CRUD Usuários | Tabela + Form modal | `GET/POST/PUT/DELETE /api/users/` | `HasPerm("manage_admin_registries")` | DAT | — | OK — CPF write-only LGPD (Bug 3 PR #1285) |
+| Sub-CRUD Municípios | Tabela + Form modal | `GET/POST/PUT/DELETE /api/municipios/` | `HasPerm("manage_admin_registries")` | DAT | — | OK |
+| Sub-CRUD Projetos | Tabela + Form modal | `GET/POST/PUT/DELETE /api/projetos/` | `HasPerm("manage_admin_registries")` | DAT | — | OK |
+| Sub-CRUD Cadastros (Ações, Compras, …) | Tabelas + importers | `GET/POST /api/cadastros/...` + `POST /api/imports/...` | `HasPerm("manage_admin_registries")` | DAT | — | OK |
+| Listagem `ProdutoViewSet.list` | Tabela | `GET /api/produtos/` | `IsAuthenticated` | Todos autenticados | — | revisar — issue #1258 (capability operacional faltando) |
+| Lookup `UsuarioLookup` | Autocomplete | `GET /api/lookup/usuario/` | `IsAuthenticated` | Todos autenticados | — | revisar — issue #1259 |
+
+---
+
+### 8.15 Controle — `/controle`
+
+**Componente**: [ControlePage.tsx](../frontend/src/pages/Controle/ControlePage.tsx)
+**Visibilidade**: `HasPerm("operate_preagenda")` (Controle, Superuser; D1)
+
+| Funcionalidade | UI | Endpoint | `permission_classes` | Quem acessa | Scope | Status |
+|---|---|---|---|---|---|---|
+| Upload Compras | `ImportUploader` | `POST /api/imports/compras/` (validate + apply) | `CanImportCompras` | Controle, DAT | — | OK |
+| Upload Ações | `ImportUploader` | `POST /api/imports/acoes/` (validate + apply) | `CanImportGenericSpreadsheet` | Controle, DAT | — | OK |
+| Upload Eventos | `ImportUploader` | `POST /api/solicitacoes/import/` (validate + apply) | `IsAuthenticated, CanImportGenericSpreadsheet` (`import_spreadsheet \| run_daily_operations`) | Controle, DAT | — | OK |
+| Upload Produtos | `ImportUploader` | `POST /api/produtos/import/` (validate + apply) | `IsAuthenticated, CanImportGenericSpreadsheet` (idem) | Controle, DAT | — | OK |
+| Listar compras (pós-import) | Tabela com filtros | `GET /api/controle/compras/?...` | `HasPerm("run_daily_operations")` | Controle | — | OK |
+| Filtro município/projeto/UF | Select dropdowns | query params | — | Controle | — | OK |
+| Filtro data range | DatePicker | `?from=...&to=...` | — | Controle | — | OK |
+| Busca por código/uso | `Input.Search` | `?q=...` | — | Controle | — | OK |
+
+---
+
+### 8.16 Resumo da Matriz
+
+**Páginas mapeadas**: 15/15 (100%)
+**Funcionalidades total**: ~100
+
+**Distribuição de status** (após verificação cirúrgica dos INCERTO em 2026-04-27):
+
+| Status | Aprox. | Observações |
+|--------|--------|-------------|
+| OK | ~93% | Alinhado com decisões D1-D7 |
+| INCERTO | 0% | Todos os 5 INCERTO da varredura inicial foram resolvidos: 3 eram bugs de doc (paths errados), 2 viraram OK com permission corrigida (Aprovações batch — ver observação inline em §8.3) |
+| revisar | ~3% | Issues #1258 (`ProdutoViewSet.list`), #1259 (`UsuarioLookup`) — backlog §7 |
+| pendente | ~4% | Stubs de export CSV (Dashboard Geral, Ações Internas) |
+
+**Top-3 páginas com mais funcionalidades**:
+1. **DAT/Admin** — 14+ (cards + sub-CRUDs)
+2. **Controle** — 8 (uploads + listagem)
+3. **Aprovações** — 9 (preview, aprovar/reprovar individual e batch)
+
+**INCERTO resolvidos** (verificação cirúrgica 2026-04-27):
+
+| Item | Resultado |
+|------|-----------|
+| `/api/solicitacoes/batch-approve/` e `/batch-reject/` | Existem em [views_solicitacao.py:812-882](../backend/apps/core/views_solicitacao.py#L812-L882). Permission é `HasPerm("approve_solicitation")` (não `_batch`). Sub-finding: Gerente pode não ter acesso — registrado como observação em §8.3, decisão de produto pendente |
+| `/api/dashboard/equipe/` | Não existe — frontend chama 3 endpoints `/api/metrics/team/{productivity,formadores,quality}/` com composition β (Onda 2 A3) |
+| `/api/gcal/batch-reapply/` | Path real: `/api/gcal/dashboard/batch/reapply/` em [views_gcal/batch.py:154](../backend/apps/core/views_gcal/batch.py#L154); permission `IsAuthenticated, CanUseGcal` |
+| `/api/imports/eventos/` | Path real: `/api/solicitacoes/import/` em [views_import_eventos.py:43](../backend/apps/core/views_import_eventos.py#L43); permission `CanImportGenericSpreadsheet` |
+| `/api/imports/produtos/` | Path real: `/api/produtos/import/` em [views_import_produtos.py:42](../backend/apps/core/views_import_produtos.py#L42); permission `CanImportGenericSpreadsheet` |
+
+---
+
+## 9. Recomendações Finais
+
+**Pode usar hoje sem código**: criar grupos via admin + atribuir capabilities + validar via `GET /api/me/policies/`.
+
+**Exige cuidado**:
+- Não misturar Coordenador com capabilities transversais (rompe D6 — escopo via `EquipeGerencia`).
+- Não atribuir grupo a `manage_internal_actions` antes da feature estar madura (pattern capability-zero-groups documentado).
+- Linha "Aprovações" usa capability como flag: aceitável tatícamente, mas backlog ideal é criar policy pública `access_solicitation_approvals` (composição `approve_solicitation \| approve_solicitation_batch`) e expor em `PUBLIC_POLICY_KEYS` — alinha contrato externo com a regra real (Gerente OR Superintendência).
+
+**Exige PR futuro**:
+- Onda 4 (capability gates faltando: #1258, #1259).
+- Onda 5 governança (#1261 sentinela, #1276 doc auto-sync).
+- Expansão da Matriz Viva para scope cases (não apenas autorização binária).
+
+---
+
+## Estatísticas
+
+| Métrica | Contagem | Status |
+|---------|----------|--------|
+| Capabilities | 16 | ✅ Todas validadas no seed |
+| Policies | 15 | ✅ Todas em `PUBLIC_POLICY_KEYS` |
+| Endpoints | 50+ | Críticos mapeados; sem lacunas críticas conhecidas; backlog aberto |
+| Páginas | 14 | ✅ Funcional; 1 com pendência de policy dedicada (Aprovações) |
+| Atores | 8 | ✅ SSOT completo |
+| Lacunas críticas mergeadas | 6/6 | ✅ Ondas 1-2 (PRs #1250, #1256) |
+| Lacunas críticas em PR aberto | 1 | PR #1286 (cobre #1284 + #1260) |
+| Backlog de hardening aberto | 6 issues | #1258, #1259, #1260, #1261, #1276, #1284 |
+| Tests Matriz Viva | 74+ | ✅ PR #1283 |
+
+**Validação**: Leitura de código contra seed, policies, 5+ views, 2 hooks. Findings cross-referenciadas contra memórias do projeto e decision matrix (D1-D7).

--- a/v2/docs/plans/PLAN_dat_imports_centralization.md
+++ b/v2/docs/plans/PLAN_dat_imports_centralization.md
@@ -1,0 +1,346 @@
+# Plano: Centralização de Importações no Módulo DAT
+
+**Data**: 2026-04-29
+**Status**: ✅ **decisões aprovadas** — pronto para iniciar PR-B
+**Base**: [`v2/docs/analysis/imports_inventory.md`](../analysis/imports_inventory.md)
+**Branch atual**: `main` em `530fbe7`
+
+> **Escopo**: este plano cobre **apenas import em massa/planilha** (upload de CSV/XLSX).
+> O fluxo manual de Controle/Assistente Administrativo lançando bloqueio/deslocamento em
+> nome de outro usuário é **issue separada** (programa hardening RBAC, PR 13).
+
+## 1. Regra de negócio final
+
+- Todas as importações administrativas/base ficam no módulo DAT
+- Rota canônica: **`/dat/importacoes`** (plural)
+- Apenas DAT e superuser podem realizar importações (frontend + backend)
+- Controle pode usar dados importados, mas **não tem botões nem acesso aos endpoints**
+- Compras: dado em Controle, mas importação fica em DAT > Importações
+- Registros de Turmas: **fora** desta reorganização
+- ASQ-005 async (`/api/imports/bloqueios/`): **fora** — Phase 2 trata
+- PR municípios IBGE: **fora** — não tocar pipeline
+- RBAC Grade Mensal/Aprovações: **fora**
+
+## 2. Mapeamento (do inventário)
+
+11 importações ativas hoje:
+
+| # | Importação | Endpoint | Hoje em (rota frontend) | Permission backend hoje |
+|---|------------|----------|-------------------------|--------------------------|
+| 1 | Compras | `POST /api/controle/import-compras/` | `/controle` + `/controle/compras` + `/compras-materiais` + `/dat/compras-materiais` (4×) | `CanImportCompras` (DAT, Controle) |
+| 2 | Ações | `POST /api/controle/import-acoes/` | `/controle` + ComprasPage (4 rotas) | `CanImportGenericSpreadsheet` (DAT, Controle) |
+| 3 | Cadastros DAT | `POST /api/dat/import-cadastros/` | `/dat/importacao` | `HasPerm("manage_admin_registries")` (DAT) |
+| 4 | Bloqueios | `POST /api/disponibilidade/import-bloqueios/` | `/disponibilidade` + `/solicitacoes/disponibilidade` | `CanImportAvailabilityBlocks` (DAT, Controle) |
+| 5 | Deslocamentos | `POST /api/deslocamentos/import/` | `/solicitacoes/deslocamentos` | `CanImportGenericSpreadsheet` (DAT, Controle) |
+| 6 | Eventos/Solicitações | `POST /api/solicitacoes/import/` | `/controle` + ComprasPage (4 rotas) | `CanImportGenericSpreadsheet` (DAT, Controle) |
+| 7 | Usuários | `POST /api/usuarios/import/` | `/dat/admin/usuarios` (embutido no CRUD) | `HasPerm("manage_admin_registries")` (DAT) |
+| 8 | Municípios | `POST /api/municipios/import/` | `/dat/admin/municipios` (embutido no CRUD) | `HasPerm("manage_admin_registries")` (DAT) |
+| 9 | Coleções | `POST /api/colecoes/import/` | `/dat/admin/colecoes` | `HasPerm("manage_admin_registries")` (DAT) |
+| 10 | Vínculos (Equipe-Gerência) | `POST /api/equipe-gerencia/import/` | `/dat/admin/equipe-gerencia` | `HasPerm("manage_admin_registries")` (DAT) |
+| 11 | Produtos | `POST /api/produtos/import/` | `/controle` + ComprasPage (4 rotas) | `CanImportGenericSpreadsheet` (DAT, Controle) |
+
+**Já DAT-only (5)**: Cadastros, Usuários, Municípios, Coleções, Vínculos
+**Hoje DAT+Controle (6)**: Compras, Ações, Bloqueios, Deslocamentos, Eventos, Produtos
+
+## 3. Decisões de produto — APROVADAS (2026-04-29)
+
+### D-1 ✅ Reusar `HasPerm("import_spreadsheet")`
+
+Usar `HasPerm("import_spreadsheet")` direto. Não criar `CanUseDatImports` agora.
+Motivo: `import_spreadsheet` já é DAT-only no seed atual e resolve o escopo sem nova abstração.
+
+### D-2 ✅ Bloqueios via planilha = DAT-only
+
+Importação em massa de bloqueios → DAT-only.
+**Não decide** o fluxo manual de lançamento de bloqueio por Controle/Assistente Administrativo
+em nome de outro usuário — esse é tratado em **issue separada** (programa hardening RBAC, PR 13).
+
+### D-3 ✅ Deslocamentos via planilha = DAT-only
+
+Importação em massa de deslocamentos → DAT-only.
+**Não decide** o fluxo manual de lançamento de deslocamento por Controle/Assistente Administrativo
+em nome de outro usuário — esse é tratado em **issue separada** (programa hardening RBAC, PR 13).
+
+### D-4 ✅ Layout agrupado por categoria
+
+Página `/dat/importacoes` com 3 grupos:
+
+- **Cadastros base**: Usuários, Municípios, Coleções, Cadastros DAT, Vínculos
+- **Operacional**: Compras, Ações, Eventos, Produtos
+- **Disponibilidade**: Bloqueios, Deslocamentos
+
+### D-5 ✅ Manter rota antiga com redirect
+
+Manter `/dat/importacao` com redirect 301 → `/dat/importacoes`.
+
+### D-6 ✅ Banner informativo com link condicional
+
+Banner explica que importações foram centralizadas em **DAT > Importações**.
+Link clicável `/dat/importacoes` **apenas para DAT/superuser**.
+Para outros perfis: texto informativo sem link (não dar link para área proibida).
+
+---
+
+## 4. Plano em PRs pequenos (ordem aprovada: B → C → A1 → D)
+
+A ordem foi invertida em relação ao rascunho original. Razão: criar a alternativa visual
+**antes** de fechar os endpoints reduz risco operacional. Quando PR-A1 entrar em prod,
+DAT já tem `/dat/importacoes` pronta e Controle já viu o aviso no menu.
+
+---
+
+### PR-B (1º): Frontend — criar página `/dat/importacoes`
+
+**Escopo**:
+
+- Nova rota `/dat/importacoes` no `AppRoutes.tsx`
+- Nova página `pages/DAT/ImportacoesPage.tsx`
+- 11 cards de `ImportUploader` agrupados por 3 categorias (D-4):
+  - **Cadastros base**: Usuários, Municípios, Coleções, Cadastros DAT, Vínculos
+  - **Operacional**: Compras, Ações, Eventos, Produtos
+  - **Disponibilidade**: Bloqueios, Deslocamentos
+- **Não remove nada ainda** — coexiste com botões antigos
+- Reutiliza funções `importCompras`, `importAcoes`, etc. do `api/ops.ts`
+- Guard de rota: `canDAT` ou `is_superuser` (não-DAT recebe `<Forbidden>`)
+
+**Arquivos prováveis**:
+
+- NEW: `v2/frontend/src/pages/DAT/ImportacoesPage.tsx`
+- `v2/frontend/src/components/AppRoutes.tsx` (rota nova com gate)
+- NEW: `v2/frontend/src/pages/DAT/__tests__/ImportacoesPage.test.tsx`
+
+**Testes**:
+
+- Página carrega com 11 cards agrupados (smoke)
+- Não-DAT recebe Forbidden via guard
+- Cards renderizam `ImportUploader` com `onDryRun`/`onApply` corretos
+
+**Riscos**: 🟢 **BAIXO** — só adição. Coexistência com fluxos antigos.
+
+**Ordem**: **PRIMEIRO**.
+
+---
+
+### PR-C (2º): Reorganizar menu lateral DAT + redirect
+
+**Escopo**:
+
+- `AppSidebar.tsx`: substituir submenu DAT atual:
+  - **Antes**: Administração, Importar Coleções, Importar Vínculos, Cadastros, Importação, Registros de Turmas
+  - **Depois**: Administração, Cadastros, **Importações** (→ `/dat/importacoes`), Registros de Turmas
+- Remover "Importar Coleções" e "Importar Vínculos" do menu (passam a ser cards dentro de Importações)
+- Renomear "Importação" (singular) → "Importações" (plural)
+- Redirect 301 de `/dat/importacao` → `/dat/importacoes` (D-5)
+
+**Arquivos prováveis**:
+
+- `v2/frontend/src/components/AppSidebar.tsx`
+- `v2/frontend/src/components/AppRoutes.tsx` (redirect)
+
+**Testes**:
+
+- Sidebar para `canDAT` mostra exatamente: Administração + Cadastros + Importações + Registros de Turmas
+- Sidebar para Controle/Coord/Formador NÃO mostra "Importações"
+- `/dat/importacao` (singular) redireciona para `/dat/importacoes`
+
+**Riscos**: 🟡 **MÉDIO** — UX change para DAT acostumado.
+
+**Ordem**: **SEGUNDO** (depois de PR-B).
+
+---
+
+### PR-A1 (3º): Backend — endpoints DAT-only via `import_spreadsheet`
+
+**Escopo**:
+
+- Trocar `permission_classes` em 6 endpoints hoje DAT+Controle para
+  `[IsAuthenticated, HasPerm("import_spreadsheet")]` (D-1):
+  - `views_controle_imports.py` — Compras
+  - `views_imports.py` — Ações
+  - `views_import_bloqueios.py` — Bloqueios (D-2 — apenas import em massa)
+  - `views_import_deslocamentos.py` — Deslocamentos (D-3 — apenas import em massa)
+  - `views_import_eventos.py` — Eventos
+  - `views_import_produtos.py` — Produtos
+- Manter os 5 já DAT-only inalterados (`HasPerm("manage_admin_registries")`)
+- **Não alterar lógica interna** dos imports, só o gate
+- **Não tocar** em ASQ-005 (`/api/imports/bloqueios/` async)
+- **Não tocar** em fluxo manual de Controle lançando bloqueio/deslocamento — issue separada
+- Tests novos: `test_dat_imports_dat_only.py`
+
+**Arquivos prováveis**:
+
+- 6 arquivos `views_*_imports*.py` listados acima
+- NEW: `v2/backend/apps/core/tests/test_dat_imports_dat_only.py`
+
+**Testes**:
+
+- DAT → 200 em todos 11 endpoints
+- Controle → 403 nos 6 reorganizados
+- Coord, Apoio, Gerente, Diretoria, Formador → 403 em todos
+- Anonymous → 401/403
+- Smoke: ASQ-005 async (`POST /api/imports/bloqueios/`) NÃO foi tocado
+
+**Riscos**:
+
+- 🔴 **ALTO** — Se Controle hoje usa endpoints em produção, vai parar imediatamente.
+- **Mitigação**: PR-B + PR-C já mergeados antes deste, então DAT já tem alternativa pronta.
+- **Auditoria recomendada**: pesquisar logs ou perguntar time Controle se houve upload de planilha em Compras/Ações/Eventos/Produtos no último mês.
+
+**Impacto operacional**:
+
+- Controle perde auto-serviço para os 6 imports.
+- Fluxo novo: solicitar ao DAT.
+
+**Ordem**: **TERCEIRO** (depois de PR-B + PR-C).
+
+---
+
+### PR-D (4º): Remover botões de importação fora do DAT + banners
+
+**Escopo**:
+
+- `ControlePage.tsx`: remover seção "Importação de dados" (4 cards)
+- `DATModule/ComprasPage.tsx`: remover seção equivalente (4 cards)
+- `Disponibilidade.tsx`: remover botão "Importar bloqueios"
+- `Deslocamentos/DeslocamentosPage.tsx`: remover botão "Importar deslocamentos"
+- Adicionar **banner informativo** em cada uma das 4 páginas:
+  - Texto: "Importações foram centralizadas em **DAT > Importações**."
+  - **Para DAT/superuser**: link clicável `/dat/importacoes`
+  - **Para outros perfis**: texto sem link (não dar link para área proibida — D-6)
+
+**Arquivos prováveis**:
+
+- `v2/frontend/src/pages/Controle/ControlePage.tsx`
+- `v2/frontend/src/pages/DATModule/ComprasPage.tsx`
+- `v2/frontend/src/pages/Disponibilidade.tsx`
+- `v2/frontend/src/pages/Deslocamentos/DeslocamentosPage.tsx`
+- NEW (opcional): `v2/frontend/src/components/ImportsMigratedBanner.tsx` (componente reutilizável)
+- Tests ajustados (snapshot/render)
+
+**Testes**:
+
+- Cada uma das 4 páginas NÃO tem cards/botões de import
+- Banner presente em todas com texto correto
+- Banner mostra link clicável apenas para DAT/superuser
+- Banner para Controle/Coord/Formador é texto puro (sem `<a>`)
+- DATModule/ComprasPage continua funcional para listagem
+
+**Riscos**: 🟠 **MÉDIO-ALTO** — remove caminhos de UX existentes.
+
+**Pré-requisitos** (todos mergeados):
+
+1. PR-B (página `/dat/importacoes` existe)
+2. PR-C (menu DAT aponta para nova página)
+3. PR-A1 (endpoints já fechados — sem regressão de UX exposta a 403)
+
+**Ordem**: **ÚLTIMO**.
+
+---
+
+### PR-E (opcional): Tests adicionais por perfil
+
+Se PR-B, PR-C, PR-A1, PR-D já incluem testes próprios, este pode ser desnecessário.
+Caso contrário:
+
+- `test_dat_imports_e2e.py` (backend): 8 perfis × 11 endpoints
+- Testes de integração frontend: AppSidebar para 8 perfis, AppRoutes para 8 perfis
+
+**Riscos**: 🟢 **BAIXO** — só testes.
+
+---
+
+## 5. Ordem recomendada (aprovada)
+
+```text
+1. PR-B  — criar /dat/importacoes (nova página, sem remoção)         [primeiro]
+2. PR-C  — reorganizar menu DAT + redirect /dat/importacao            [segundo]
+3. PR-A1 — backend DAT-only nos 6 endpoints (Controle perde acesso)   [terceiro]
+4. PR-D  — remover botões antigos + banners informativos              [último]
+5. PR-E  — testes adicionais (opcional)
+```
+
+Razão da ordem: criar alternativa visual e menu **antes** de fechar endpoints garante que
+DAT já tem fluxo novo pronto e Controle já tem aviso no menu quando o backend deixar de
+responder. Reduz janela de regressão operacional para zero.
+
+## 6. Mapa "fluxo Controle hoje → fluxo Controle depois"
+
+| Antes (Controle clica) | Depois (Controle clica) |
+|------------------------|--------------------------|
+| `/controle` → "Importar COMPRAS" | banner: "Importação migrada para DAT" |
+| `/controle` → "Importar AÇÕES" | banner: idem |
+| `/controle` → "Importar EVENTOS" | banner: idem |
+| `/controle` → "Importar PRODUTOS" | banner: idem |
+| `/controle/compras` → tab "Importar" | banner: idem |
+| `/disponibilidade` → "Importar bloqueios" | depende de D-2 |
+| `/solicitacoes/deslocamentos` → "Importar" | depende de D-3 |
+
+**Caminho novo único** (DAT/superuser): `/dat/importacoes` — 1 página, 11 cards.
+
+## 7. Riscos cross-PR
+
+- **Risco operacional**: Se Controle estava operando imports em prod, PR-A1 quebra. **Mitigação**: auditoria de logs ou pesquisa qualitativa antes do PR.
+- **Risco de UX**: usuários DAT acostumados com submenus específicos (Importar Coleções, Importar Vínculos) vão ter que aprender página unificada. **Mitigação**: comunicação prévia + onboarding interno.
+- **Risco de coexistência**: PR-A1 (backend) sem PR-B (frontend) deixa Controle sem alternativa visual. **Mitigação**: sequenciar corretamente — se PR-A1 mergeado primeiro, comunicar imediatamente que PR-B vem em sequência.
+- **Risco de regressão de import async**: PR-D não toca em ASQ-005 (`/api/imports/bloqueios/`). Se Phase 2 do ASQ-005 (#778) entrar em paralelo, alinhar com plano.
+- **Risco de RBAC dependente**: PR-A1 não aprofunda em RBAC de Bloqueios/Deslocamentos. Se decisão D-2/D-3 disser "manter Controle", a regra "DAT-only" tem exceções explícitas.
+
+## 8. Checklist de validação por PR (decisões já aprovadas)
+
+### PR-B (1º)
+- [x] D-4 (layout agrupado por categoria) ✅ aprovado
+- [x] D-5 (redirect) ✅ aprovado
+- [ ] Página renderiza com 11 cards em 3 grupos (smoke)
+- [ ] Guard de rota: não-DAT → Forbidden
+- [ ] CI verde, staging gate verde
+
+### PR-C (2º)
+- [ ] PR-B mergeado
+- [ ] Sidebar DAT: 4 itens (Administração, Cadastros, Importações, Registros)
+- [ ] Outros perfis: sem item Importações
+- [ ] Redirect 301 `/dat/importacao` → `/dat/importacoes`
+- [ ] Tests por perfil
+- [ ] CI verde, staging gate verde
+
+### PR-A1 (3º)
+- [x] D-1 (`HasPerm("import_spreadsheet")` direto) ✅ aprovado
+- [x] D-2 (bloqueios import-em-massa = DAT-only) ✅ aprovado
+- [x] D-3 (deslocamentos import-em-massa = DAT-only) ✅ aprovado
+- [ ] Auditoria operacional Controle imports (recomendada antes do merge)
+- [ ] Tests: DAT 200 + Controle 403 + outros 403 em todos 6 endpoints
+- [ ] Smoke: ASQ-005 async não foi tocado
+- [ ] Smoke: views de bloqueio/deslocamento manual (não-import) não foram tocadas
+- [ ] CI verde, staging gate verde
+
+### PR-D (4º)
+- [ ] PR-B + PR-C + PR-A1 todos mergeados
+- [x] D-6 (banner com link condicional) ✅ aprovado
+- [ ] Tests confirmando ausência dos cards antigos em ControlePage, ComprasPage, Disponibilidade, DeslocamentosPage
+- [ ] Tests do banner com link clicável apenas para DAT/superuser
+- [ ] CI verde, staging gate verde
+
+## 9. Itens fora deste plano (não tocar)
+
+- Importação async ASQ-005 (`/api/imports/bloqueios/`) — Phase 2 separada (#778)
+- PR municípios IBGE (#1298 mergeado; pipeline IBGE pode evoluir em outro PR)
+- RBAC Grade Mensal / Aprovações (programa hardening em curso, PRs separados)
+- `seed_produtos` management command (não relacionado)
+- Registros de Turmas (`/dat/registros`) — fora desta reorganização
+
+## 10. Próximo passo
+
+Decisões D-1 a D-6 ✅ aprovadas em 2026-04-29. Pronto para iniciar:
+
+**PR-B**: criar página `/dat/importacoes` com 11 cards agrupados em 3 categorias.
+
+Branch sugerida: `feat/dat-importacoes-page`.
+
+Quando PR-B mergear, seguir: PR-C → PR-A1 → PR-D.
+
+**Não tocar**:
+- ASQ-005 async (`/api/imports/bloqueios/`) — Phase 2 separada (#778)
+- Pipeline IBGE (PR #1298 já mergeado)
+- RBAC Grade Mensal/Aprovações (programa hardening em curso)
+- Registros de Turmas (`/dat/registros`)
+- Fluxo manual de Controle/Assistente Administrativo lançando bloqueio/deslocamento em
+  nome de outro usuário (issue separada do programa hardening RBAC, PR 13)


### PR DESCRIPTION
## Resumo

Organiza documenta??o local que estava aparecendo no VS Code e fecha a pol?tica de ignore para Graphify/integra??es locais.

Mudan?as:
- adiciona regras no `.gitignore` para manter Graphify, `CLAUDE.md`, `AGENTS.md`, `.codex/`, `.claude/` e `graphify-out/` fora do Git;
- move o invent?rio de imports para `v2/docs/analysis/imports_inventory.md`;
- move o invent?rio RBAC para `v2/docs/analysis/rbac_system_inventory.md`;
- mant?m o plano de centraliza??o em `v2/docs/plans/PLAN_dat_imports_centralization.md` e ajusta o link base para o novo caminho do invent?rio.

## Checklist Tecnico (Code Review Expert - Slim)

- [x] Arquitetura e SOLID: mudancas mantiveram coesao e responsabilidade clara
- [x] Seguranca: sem vazamento de segredo, sem novos vetores obvios de injecao/XSS/SSRF
- [x] Performance: sem regressao relevante (render, queries, loops, payload, N+1)
- [x] Tratamento de erros: falhas tratadas com mensagem/fluxo previsivel
- [x] Condicoes de fronteira: nulos, lista vazia e limites numericos cobertos

## Workflow (Superpowers - Parcial)

- [x] Escopo definido em ate 5 passos objetivos antes da implementacao
- [x] Testes criados/ajustados para comportamento novo ou corrigido
- [x] Evidencias anexadas (logs, screenshots, outputs de teste) quando aplicavel

## Staging Gate

- [x] N/A - PR somente docs/gitignore, sem impacto runtime em `v2/backend`, `v2/frontend` ou `v2/infra`

### Evidencia Staging Gate (obrigatorio para merge)

```text
N/A - docs/gitignore only
```

## Validacoes

- [x] `git diff --check -- .gitignore v2/docs/plans/PLAN_dat_imports_centralization.md`
- [x] `git status -sb` revisado antes do commit
- [x] Sem alteracoes fora do escopo combinado
