### PR TITLE
fix(dat): remove botões legados de importação fora do DAT

### DIFF
--- a/v2/frontend/src/components/DatImportsCentralizedBanner.tsx
+++ b/v2/frontend/src/components/DatImportsCentralizedBanner.tsx
@@ -1,0 +1,64 @@
+import type { CSSProperties, ReactNode } from 'react';
+import { useEffect, useState } from 'react';
+import { Alert } from 'antd';
+import { Link } from 'react-router-dom';
+import { getMe } from '../api/availability';
+import { computePermissions } from '../hooks/usePermissions';
+
+export const DAT_IMPORTS_CENTRALIZED_MESSAGE =
+  'Importações foram centralizadas em DAT > Importações.';
+
+interface DatImportsCentralizedBannerProps {
+  className?: string;
+  style?: CSSProperties;
+}
+
+export default function DatImportsCentralizedBanner({
+  className,
+  style,
+}: DatImportsCentralizedBannerProps): JSX.Element {
+  const [canAccessDatImports, setCanAccessDatImports] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+
+    async function loadPermissions(): Promise<void> {
+      try {
+        const user = await getMe();
+        if (active) {
+          setCanAccessDatImports(computePermissions(user).canDAT);
+        }
+      } catch {
+        if (active) {
+          setCanAccessDatImports(false);
+        }
+      }
+    }
+
+    void loadPermissions();
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const description: ReactNode = canAccessDatImports ? (
+    <>
+      Importações foram centralizadas em{' '}
+      <Link to="/dat/importacoes">DAT &gt; Importações</Link>.
+    </>
+  ) : (
+    DAT_IMPORTS_CENTRALIZED_MESSAGE
+  );
+
+  return (
+    <Alert
+      aria-label={DAT_IMPORTS_CENTRALIZED_MESSAGE}
+      className={className}
+      style={style}
+      type="info"
+      showIcon
+      message={description}
+    />
+  );
+}

--- a/v2/frontend/src/components/__tests__/DatImportsCentralizedBanner.test.tsx
+++ b/v2/frontend/src/components/__tests__/DatImportsCentralizedBanner.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import DatImportsCentralizedBanner, {
+  DAT_IMPORTS_CENTRALIZED_MESSAGE,
+} from '../DatImportsCentralizedBanner';
+import { getMe } from '../../api/availability';
+import type { CurrentUser } from '../../types';
+
+vi.mock('../../api/availability', () => ({
+  getMe: vi.fn(),
+}));
+
+const baseUser: CurrentUser = {
+  id: 1,
+  username: 'user',
+  email: 'user@example.com',
+  first_name: 'User',
+  last_name: 'Test',
+  name: 'User Test',
+  groups: [],
+  setores: [],
+  funcoes: [],
+  is_superuser: false,
+  is_superintendencia: false,
+  can_approve_super: false,
+  permissions: [],
+};
+
+describe('DatImportsCentralizedBanner', () => {
+  beforeEach(() => {
+    vi.mocked(getMe).mockReset();
+  });
+
+  test('exibe link para DAT > Importações quando usuário pode acessar DAT', async () => {
+    vi.mocked(getMe).mockResolvedValue({
+      ...baseUser,
+      setores: ['DAT'],
+    });
+
+    render(
+      <MemoryRouter>
+        <DatImportsCentralizedBanner />
+      </MemoryRouter>,
+    );
+
+    const link = await screen.findByRole('link', { name: 'DAT > Importações' });
+    expect(link).toHaveAttribute('href', '/dat/importacoes');
+  });
+
+  test('exibe apenas texto informativo para usuário sem acesso ao DAT', async () => {
+    vi.mocked(getMe).mockResolvedValue({
+      ...baseUser,
+      setores: ['Controle'],
+    });
+
+    render(
+      <MemoryRouter>
+        <DatImportsCentralizedBanner />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(DAT_IMPORTS_CENTRALIZED_MESSAGE)).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole('link', { name: 'DAT > Importações' })).not.toBeInTheDocument();
+    expect(screen.getByText(DAT_IMPORTS_CENTRALIZED_MESSAGE)).toBeInTheDocument();
+  });
+
+  test('não expõe link quando /api/me falha', async () => {
+    vi.mocked(getMe).mockRejectedValue(new Error('unauthorized'));
+
+    render(
+      <MemoryRouter>
+        <DatImportsCentralizedBanner />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(DAT_IMPORTS_CENTRALIZED_MESSAGE)).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole('link', { name: 'DAT > Importações' })).not.toBeInTheDocument();
+  });
+});

--- a/v2/frontend/src/hooks/__tests__/useGoogleIntegration.test.js
+++ b/v2/frontend/src/hooks/__tests__/useGoogleIntegration.test.js
@@ -28,7 +28,10 @@ describe('useGoogleIntegration', () => {
 
     const { result } = renderHook(() => useGoogleIntegration());
 
-    await waitFor(() => { expect(result.current.loading).toBe(false); });
+    await waitFor(() => {
+      expect(fetchAPIMock).toHaveBeenCalledWith('/integrations/google/status/');
+      expect(result.current.loading).toBe(false);
+    });
     expect(result.current.status.connected).toBe(false);
   });
 
@@ -55,7 +58,11 @@ describe('useGoogleIntegration', () => {
 
     const { result } = renderHook(() => useGoogleIntegration());
 
-    await waitFor(() => { expect(result.current.status.connected).toBe(false); });
+    await waitFor(() => {
+      expect(fetchAPIMock).toHaveBeenCalledWith('/integrations/google/status/');
+      expect(result.current.loading).toBe(false);
+    });
+    expect(result.current.status.connected).toBe(false);
     expect(result.current.loading).toBe(false);
   });
 

--- a/v2/frontend/src/pages/Controle/ControlePage.tsx
+++ b/v2/frontend/src/pages/Controle/ControlePage.tsx
@@ -2,44 +2,15 @@
  * Página de Controle - Gestão de COMPRAS e AÇÕES
  *
  * Features:
- * - Upload de COMPRAS (import-compras)
- * - Upload de AÇÕES (import-acoes)
  * - Listagem de COMPRAS com filtros
+ * - Aviso de centralização de importações em DAT > Importações
  * - Campos corretos: Data, Município, UF, Projeto, Código, Quant., Uso
  */
 
 import { useState, useEffect, useCallback, ChangeEvent } from 'react';
-import { importCompras, importAcoes, importEventos, importProdutos, listCompras } from '../../api/ops';
-import type { Compra, ComprasFilters, ImportResult } from '../../api/ops';
-import ImportUploader from '../../components/ImportUploader';
-import type { ValidationResult, ApplyResult } from '../../components/ImportUploader';
-
-/**
- * Helper to convert ImportResult to ValidationResult format
- */
-function toValidationResult(result: ImportResult): ValidationResult {
-  return {
-    stats: {
-      created: result.created,
-      updated: result.updated,
-      unchanged: result.skipped,
-    },
-    errors: result.errors.map((e) => `Linha ${e.row}: ${e.message}`),
-  };
-}
-
-/**
- * Helper to convert ImportResult to ApplyResult format
- */
-function toApplyResult(result: ImportResult): ApplyResult {
-  return {
-    stats: {
-      created: result.created,
-      updated: result.updated,
-      unchanged: result.skipped,
-    },
-  };
-}
+import { listCompras } from '../../api/ops';
+import type { Compra, ComprasFilters } from '../../api/ops';
+import DatImportsCentralizedBanner from '../../components/DatImportsCentralizedBanner';
 
 export default function ControlePage(): JSX.Element {
   const [compras, setCompras] = useState<Compra[]>([]);
@@ -80,14 +51,6 @@ export default function ControlePage(): JSX.Element {
   };
 
   /**
-   * Callback após apply bem-sucedido.
-   */
-  const handleAfterApply = () => {
-    // Recarregar lista de compras
-    fetchCompras();
-  };
-
-  /**
    * Carrega compras ao montar ou quando filtros mudam.
    */
   useEffect(() => {
@@ -104,44 +67,7 @@ export default function ControlePage(): JSX.Element {
         </p>
       </header>
 
-      {/* Cards de Upload */}
-      <section aria-label="Importação de dados" className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-        {/* Upload COMPRAS */}
-        <ImportUploader
-          label="Importar COMPRAS"
-          description="CSV/XLSX com colunas: codigo, produto, quant, municipio, uf, data, uso"
-          onDryRun={async (file: File) => toValidationResult(await importCompras(file, true))}
-          onApply={async (file: File) => {
-            const result = await importCompras(file, false);
-            handleAfterApply();
-            return toApplyResult(result);
-          }}
-        />
-
-        {/* Upload AÇÕES */}
-        <ImportUploader
-          label="Importar AÇÕES"
-          description="CSV/XLSX de Ações de Controle (Município, Projeto, Coordenador, Datas, Observação)"
-          onDryRun={async (file: File) => toValidationResult(await importAcoes(file, true))}
-          onApply={async (file: File) => toApplyResult(await importAcoes(file, false))}
-        />
-
-        {/* Upload EVENTOS */}
-        <ImportUploader
-          label="Importar EVENTOS"
-          description="CSV/XLSX: municipio, projeto, tipo_evento, data, hora_inicio, hora_fim, coordenador, formador1-5"
-          onDryRun={async (file: File) => toValidationResult(await importEventos(file, true))}
-          onApply={async (file: File) => toApplyResult(await importEventos(file, false))}
-        />
-
-        {/* Upload PRODUTOS */}
-        <ImportUploader
-          label="Importar PRODUTOS"
-          description="CSV/XLSX: codigo, nome, projeto (obrigatórios), descricao (opcional)"
-          onDryRun={async (file: File) => toValidationResult(await importProdutos(file, true))}
-          onApply={async (file: File) => toApplyResult(await importProdutos(file, false))}
-        />
-      </section>
+      <DatImportsCentralizedBanner />
 
       {/* Filtros de COMPRAS */}
       <section aria-label="Filtros de compras" className="bg-white rounded-lg shadow p-4">

--- a/v2/frontend/src/pages/DATModule/ComprasPage.tsx
+++ b/v2/frontend/src/pages/DATModule/ComprasPage.tsx
@@ -28,7 +28,6 @@ import {
   Row,
   Col,
   Progress,
-  Radio,
 } from 'antd';
 import {
   ReloadOutlined,
@@ -40,7 +39,6 @@ import {
   ClearOutlined,
   ShoppingCartOutlined,
 } from '@ant-design/icons';
-import type { RadioChangeEvent } from 'antd/es/radio';
 import {
   listCompras,
   createCompra,
@@ -50,17 +48,9 @@ import {
   getProjetosOptions,
   getProdutosOptions,
 } from '../../api/datModule';
-import {
-  importCompras,
-  importAcoes,
-  importEventos,
-  importProdutos,
-  type ImportResult as OpsImportResult,
-} from '../../api/ops';
 import type { PaginatedResponse } from '../../types';
 import { useTableFilters, type TableFilterParams } from '../../hooks/useTableFilters';
-import ImportUploader from '../../components/ImportUploader';
-import type { ValidationResult, ApplyResult } from '../../components/ImportUploader';
+import DatImportsCentralizedBanner from '../../components/DatImportsCentralizedBanner';
 import dayjs from 'dayjs';
 import { UF_OPTIONS } from '../../constants';
 
@@ -123,29 +113,6 @@ interface ProdutoOption {
   nome: string;
 }
 
-type ViewMode = 'lista' | 'importar';
-
-function toValidationResult(result: OpsImportResult): ValidationResult {
-  return {
-    stats: {
-      created: result.created,
-      updated: result.updated,
-      unchanged: result.skipped,
-    },
-    errors: result.errors.map((e) => `Linha ${e.row}: ${e.message}`),
-  };
-}
-
-function toApplyResult(result: OpsImportResult): ApplyResult {
-  return {
-    stats: {
-      created: result.created,
-      updated: result.updated,
-      unchanged: result.skipped,
-    },
-  };
-}
-
 // Status options
 const STATUS_OPTIONS = [
   { label: 'Disponível', value: 'disponivel', color: 'green' },
@@ -190,8 +157,6 @@ const buildComprasParams = (f: ComprasFilters): TableFilterParams => ({
 });
 
 export default function ComprasPage(): JSX.Element {
-  const [viewMode, setViewMode] = useState<ViewMode>('lista');
-
   // Options for dropdowns
   const [municipios, setMunicipios] = useState<MunicipioOption[]>([]);
   const [projetos, setProjetos] = useState<ProjetoOption[]>([]);
@@ -481,34 +446,20 @@ export default function ComprasPage(): JSX.Element {
               Gestão de Compras/Materiais
             </Title>
             <Text type="secondary">
-              {viewMode === 'lista'
-                ? 'Controle de estoque, distribuição e utilização de materiais didáticos'
-                : 'Importe dados de compras e bases relacionadas (ações, eventos e produtos).'}
+              Controle de estoque, distribuição e utilização de materiais didáticos
             </Text>
           </div>
           <Space wrap>
-            <Radio.Group
-              value={viewMode}
-              onChange={(event: RadioChangeEvent) => setViewMode(event.target.value)}
-              buttonStyle="solid"
-            >
-              <Radio.Button value="lista">Lista</Radio.Button>
-              <Radio.Button value="importar">Importar</Radio.Button>
-            </Radio.Group>
-            {viewMode === 'lista' && (
-              <>
-                <Button icon={<DownloadOutlined />}>Exportar</Button>
-                <Button type="primary" icon={<PlusOutlined />} onClick={handleCreate}>
-                  Nova Compra
-                </Button>
-              </>
-            )}
+            <Button icon={<DownloadOutlined />}>Exportar</Button>
+            <Button type="primary" icon={<PlusOutlined />} onClick={handleCreate}>
+              Nova Compra
+            </Button>
           </Space>
         </div>
       </header>
 
-      {viewMode === 'lista' ? (
-        <>
+      <DatImportsCentralizedBanner className="mb-4" />
+
       {/* Filters Card */}
       <nav aria-label="Filtros de busca">
       <Card className="mb-4" bodyStyle={{ paddingBottom: 12 }}>
@@ -733,42 +684,6 @@ export default function ComprasPage(): JSX.Element {
         </Space>
       </Card>
       </aside>
-        </>
-      ) : (
-        <section aria-label="Importação de dados de compras" className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-          <ImportUploader
-            label="Importar COMPRAS"
-            description="CSV/XLSX com colunas: codigo, produto, quant, municipio, uf, data, uso"
-            onDryRun={async (file: File) => toValidationResult(await importCompras(file, true))}
-            onApply={async (file: File) => {
-              const result = await importCompras(file, false);
-              await fetchData(1);
-              return toApplyResult(result);
-            }}
-          />
-
-          <ImportUploader
-            label="Importar AÇÕES"
-            description="CSV/XLSX de Ações de Controle (Município, Projeto, Coordenador, Datas, Observação)"
-            onDryRun={async (file: File) => toValidationResult(await importAcoes(file, true))}
-            onApply={async (file: File) => toApplyResult(await importAcoes(file, false))}
-          />
-
-          <ImportUploader
-            label="Importar EVENTOS"
-            description="CSV/XLSX: municipio, projeto, tipo_evento, data, hora_inicio, hora_fim, coordenador, formador1-5"
-            onDryRun={async (file: File) => toValidationResult(await importEventos(file, true))}
-            onApply={async (file: File) => toApplyResult(await importEventos(file, false))}
-          />
-
-          <ImportUploader
-            label="Importar PRODUTOS"
-            description="CSV/XLSX: codigo, nome, projeto (obrigatórios), descricao (opcional)"
-            onDryRun={async (file: File) => toValidationResult(await importProdutos(file, true))}
-            onApply={async (file: File) => toApplyResult(await importProdutos(file, false))}
-          />
-        </section>
-      )}
 
       {/* Create/Edit Modal */}
       <Modal

--- a/v2/frontend/src/pages/Deslocamentos/DeslocamentosPage.tsx
+++ b/v2/frontend/src/pages/Deslocamentos/DeslocamentosPage.tsx
@@ -34,10 +34,8 @@ import {
   Card,
   Typography,
   Tooltip,
-  Radio,
 } from 'antd';
 import type { ColumnsType, TablePaginationConfig } from 'antd/es/table';
-import type { RadioChangeEvent } from 'antd/es/radio';
 import type { Dayjs } from 'dayjs';
 import {
   PlusOutlined,
@@ -45,13 +43,11 @@ import {
   DeleteOutlined,
   SearchOutlined,
   CarOutlined,
-  UploadOutlined,
 } from '@ant-design/icons';
 import dayjs from 'dayjs';
 import { getMe } from '../../api/availability';
 import { computePermissions } from '../../hooks/usePermissions';
-import { importDeslocamentos } from '../../api/ops';
-import ImportUploader, { ValidationResult, ApplyResult } from '../../components/ImportUploader';
+import DatImportsCentralizedBanner from '../../components/DatImportsCentralizedBanner';
 import logger from '../../utils/logger';
 import type { ID } from '../../types';
 
@@ -106,53 +102,6 @@ interface ApiErrorType {
   end_date?: string[];
   destino?: string[];
   [key: string]: string[] | undefined;
-}
-
-/** View mode type */
-type ViewMode = 'lista' | 'importar';
-
-/**
- * Converte resposta do backend para formato do ImportUploader.
- */
-function toValidationResult(response: Record<string, unknown>): ValidationResult {
-  const stats = response.stats as Record<string, unknown> | undefined;
-  const pendencias = response.pendencias as Record<string, unknown[]> | undefined;
-
-  const errors: string[] = [];
-  if (pendencias?.usuarios) {
-    (pendencias.usuarios as Array<{ linha: number; nome?: string; email?: string }>).forEach((p) => {
-      errors.push(`Linha ${p.linha}: Usuario nao encontrado (${p.email || p.nome})`);
-    });
-  }
-  if (pendencias?.dates) {
-    (pendencias.dates as Array<{ linha: number; erro?: string }>).forEach((p) => {
-      errors.push(`Linha ${p.linha}: Data invalida${p.erro ? ` - ${p.erro}` : ''}`);
-    });
-  }
-
-  return {
-    stats: {
-      created: (stats?.created as number) || 0,
-      updated: (stats?.updated as number) || 0,
-      unchanged: (stats?.unchanged as number) || 0,
-    },
-    errors: errors.length > 0 ? errors : undefined,
-    pendencias,
-  };
-}
-
-/**
- * Converte resposta do backend para ApplyResult.
- */
-function toApplyResult(response: Record<string, unknown>): ApplyResult {
-  const stats = response.stats as Record<string, unknown> | undefined;
-  return {
-    stats: {
-      created: (stats?.created as number) || 0,
-      updated: (stats?.updated as number) || 0,
-      unchanged: (stats?.unchanged as number) || 0,
-    },
-  };
 }
 
 /**
@@ -247,7 +196,6 @@ async function deleteDeslocamento(id: ID): Promise<void> {
 }
 
 export default function DeslocamentosPage(): JSX.Element {
-  const [viewMode, setViewMode] = useState<ViewMode>('lista');
   const [canAccess, setCanAccess] = useState<boolean>(false);
   const [loading, setLoading] = useState<boolean>(true);
   const [deslocamentos, setDeslocamentos] = useState<DeslocamentoRecord[]>([]);
@@ -510,30 +458,18 @@ export default function DeslocamentosPage(): JSX.Element {
             <CarOutlined /> Deslocamentos
           </Title>
           <Text type="secondary">
-            {viewMode === 'lista'
-              ? 'Gestão de deslocamentos entre municípios'
-              : 'Importe deslocamentos em massa via arquivo CSV/XLSX'}
+            Gestão de deslocamentos entre municípios
           </Text>
         </div>
         <Space>
-          <Radio.Group
-            value={viewMode}
-            onChange={(e: RadioChangeEvent) => setViewMode(e.target.value)}
-            buttonStyle="solid"
-          >
-            <Radio.Button value="lista">Lista</Radio.Button>
-            <Radio.Button value="importar">Importar</Radio.Button>
-          </Radio.Group>
-          {viewMode === 'lista' && (
-            <Button type="primary" icon={<PlusOutlined />} onClick={handleCreate}>
-              Novo Deslocamento
-            </Button>
-          )}
+          <Button type="primary" icon={<PlusOutlined />} onClick={handleCreate}>
+            Novo Deslocamento
+          </Button>
         </Space>
       </div>
 
-      {viewMode === 'lista' ? (
-        <>
+      <DatImportsCentralizedBanner />
+
       {/* Filters */}
       <Card title="Filtros" size="small">
         <Row gutter={[16, 16]}>
@@ -590,55 +526,6 @@ export default function DeslocamentosPage(): JSX.Element {
           scroll={{ x: 1000 }}
         />
       </Card>
-        </>
-      ) : (
-        /* View: Importar em Massa */
-        <Row gutter={[16, 16]}>
-          <Col xs={24} lg={16}>
-            <Card
-              title={
-                <span>
-                  <UploadOutlined style={{ marginRight: 8 }} />
-                  Importar Deslocamentos em Massa
-                </span>
-              }
-              bordered={false}
-            >
-              <ImportUploader
-                label="Selecione o arquivo"
-                description="CSV/XLSX com colunas: usuario, origem, destino, data_inicio, data_fim, observacao"
-                onDryRun={async (file: File) => toValidationResult(await importDeslocamentos(file, true) as unknown as Record<string, unknown>)}
-                onApply={async (file: File) => {
-                  const result = await importDeslocamentos(file, false);
-                  await loadDeslocamentos();
-                  return toApplyResult(result as unknown as Record<string, unknown>);
-                }}
-              />
-            </Card>
-          </Col>
-
-          {/* Card de Instrucoes */}
-          <Col xs={24} lg={8}>
-            <Card title="Formato do Arquivo" bordered={false}>
-              <Text strong>Colunas obrigatorias:</Text>
-              <ul style={{ marginTop: 8, paddingLeft: 20 }}>
-                <li><code>usuario</code> - Email ou nome do formador</li>
-                <li><code>origem</code> - Local de origem</li>
-                <li><code>destino</code> - Local de destino</li>
-                <li><code>data_inicio</code> - Data de inicio</li>
-                <li><code>data_fim</code> - Data de fim</li>
-              </ul>
-              <Text strong style={{ marginTop: 16, display: 'block' }}>Coluna opcional:</Text>
-              <ul style={{ marginTop: 8, paddingLeft: 20 }}>
-                <li><code>observacao</code> - Observacao</li>
-              </ul>
-              <Text type="secondary" style={{ marginTop: 16, display: 'block', fontSize: 12 }}>
-                Formatos de data aceitos: YYYY-MM-DD, DD/MM/YYYY, ISO 8601
-              </Text>
-            </Card>
-          </Col>
-        </Row>
-      )}
 
       {/* Modal */}
       <Modal

--- a/v2/frontend/src/pages/Disponibilidade.tsx
+++ b/v2/frontend/src/pages/Disponibilidade.tsx
@@ -5,72 +5,21 @@
  * - Criar bloqueios de disponibilidade (Total ou Parcial)
  * - Listar seus bloqueios existentes
  * - Excluir bloqueios
- * - Importar bloqueios em massa via CSV/XLSX
+ * - Informar que importações foram centralizadas no DAT
  */
 
 import { useState, useEffect, JSX } from 'react';
-import { Card, Row, Col, message, Spin, Radio, Typography } from 'antd';
-import type { RadioChangeEvent } from 'antd/es/radio';
-import { StopOutlined, UploadOutlined } from '@ant-design/icons';
+import { Card, Row, Col, message, Spin, Typography } from 'antd';
+import { StopOutlined } from '@ant-design/icons';
 import BlockForm from '../components/BlockForm';
 import MyBlocksTable from '../components/MyBlocksTable';
-import ImportUploader, { ValidationResult, ApplyResult } from '../components/ImportUploader';
+import DatImportsCentralizedBanner from '../components/DatImportsCentralizedBanner';
 import { getBlocks, createBlock as apiCreateBlock, deleteBlock as apiDeleteBlock } from '../api/availability';
-import { importBloqueios } from '../api/ops';
 import type { ID, AvailabilityBlock, AvailabilityBlockPayload } from '../types';
 
 const { Title, Text } = Typography;
 
-/** View mode type */
-type ViewMode = 'bloqueios' | 'importar';
-
-/**
- * Converte resposta do backend para formato do ImportUploader.
- */
-function toValidationResult(response: Record<string, unknown>): ValidationResult {
-  const stats = response.stats as Record<string, unknown> | undefined;
-  const pendencias = response.pendencias as Record<string, unknown[]> | undefined;
-
-  // Converter pendencias em erros se houver usuarios ou dates nao resolvidos
-  const errors: string[] = [];
-  if (pendencias?.usuarios) {
-    (pendencias.usuarios as Array<{ linha: number; nome: string }>).forEach((p) => {
-      errors.push(`Linha ${p.linha}: Usuario nao encontrado (${p.nome})`);
-    });
-  }
-  if (pendencias?.dates) {
-    (pendencias.dates as Array<{ linha: number; erro?: string }>).forEach((p) => {
-      errors.push(`Linha ${p.linha}: Data invalida${p.erro ? ` - ${p.erro}` : ''}`);
-    });
-  }
-
-  return {
-    stats: {
-      created: (stats?.created as number) || 0,
-      updated: (stats?.updated as number) || 0,
-      unchanged: (stats?.unchanged as number) || 0,
-    },
-    errors: errors.length > 0 ? errors : undefined,
-    pendencias,
-  };
-}
-
-/**
- * Converte resposta do backend para ApplyResult.
- */
-function toApplyResult(response: Record<string, unknown>): ApplyResult {
-  const stats = response.stats as Record<string, unknown> | undefined;
-  return {
-    stats: {
-      created: (stats?.created as number) || 0,
-      updated: (stats?.updated as number) || 0,
-      unchanged: (stats?.unchanged as number) || 0,
-    },
-  };
-}
-
 export default function Disponibilidade(): JSX.Element {
-  const [viewMode, setViewMode] = useState<ViewMode>('bloqueios');
   const [blocks, setBlocks] = useState<AvailabilityBlock[]>([]);
   const [loading, setLoading] = useState<boolean>(false);
 
@@ -123,32 +72,22 @@ export default function Disponibilidade(): JSX.Element {
 
   return (
     <section style={{ padding: '24px' }} aria-labelledby="disponibilidade-title">
-      {/* Header com toggle */}
-      <header style={{ marginBottom: '24px', display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+      {/* Header */}
+      <header style={{ marginBottom: '24px' }}>
         <div>
           <Title level={2} style={{ marginBottom: 0 }}>
             <StopOutlined style={{ marginRight: 8 }} />
             Gerenciar Disponibilidade
           </Title>
           <Text type="secondary">
-            {viewMode === 'bloqueios'
-              ? 'Crie e gerencie bloqueios de disponibilidade (Total ou Parcial)'
-              : 'Importe bloqueios em massa via arquivo CSV/XLSX'}
+            Crie e gerencie bloqueios de disponibilidade (Total ou Parcial)
           </Text>
         </div>
-        <Radio.Group
-          value={viewMode}
-          onChange={(e: RadioChangeEvent) => setViewMode(e.target.value)}
-          buttonStyle="solid"
-        >
-          <Radio.Button value="bloqueios">Bloqueios</Radio.Button>
-          <Radio.Button value="importar">Importar</Radio.Button>
-        </Radio.Group>
       </header>
 
-      {viewMode === 'bloqueios' ? (
-        /* View: Bloqueios (criar + listar) */
-        <Row gutter={[16, 16]}>
+      <DatImportsCentralizedBanner style={{ marginBottom: 16 }} />
+
+      <Row gutter={[16, 16]}>
           {/* Card de Criacao */}
           <Col xs={24} lg={12}>
             <article aria-label="Criar novo bloqueio">
@@ -172,56 +111,7 @@ export default function Disponibilidade(): JSX.Element {
               </Card>
             </article>
           </Col>
-        </Row>
-      ) : (
-        /* View: Importar em Massa */
-        <Row gutter={[16, 16]}>
-          <Col xs={24} lg={16}>
-            <article aria-label="Importar bloqueios em massa">
-              <Card
-                title={
-                  <span>
-                    <UploadOutlined style={{ marginRight: 8 }} />
-                    Importar Bloqueios em Massa
-                  </span>
-                }
-                bordered={false}
-              >
-                <ImportUploader
-                  label="Selecione o arquivo"
-                  description="CSV/XLSX com colunas: usuario, inicio, fim, tipo (T/P), motivo"
-                  onDryRun={async (file: File) => toValidationResult(await importBloqueios(file, true) as unknown as Record<string, unknown>)}
-                  onApply={async (file: File) => {
-                    const result = await importBloqueios(file, false);
-                    await fetchBlocks();
-                    return toApplyResult(result as unknown as Record<string, unknown>);
-                  }}
-                />
-              </Card>
-            </article>
-          </Col>
-
-          {/* Card de Instruções */}
-          <Col xs={24} lg={8}>
-            <Card title="Formato do Arquivo" bordered={false}>
-              <Text strong>Colunas obrigatórias:</Text>
-              <ul style={{ marginTop: 8, paddingLeft: 20 }}>
-                <li><code>usuario</code> - Nome do formador</li>
-                <li><code>inicio</code> - Data/hora início</li>
-                <li><code>fim</code> - Data/hora fim</li>
-                <li><code>tipo</code> - T (Total) ou P (Parcial)</li>
-              </ul>
-              <Text strong style={{ marginTop: 16, display: 'block' }}>Coluna opcional:</Text>
-              <ul style={{ marginTop: 8, paddingLeft: 20 }}>
-                <li><code>motivo</code> - Observação</li>
-              </ul>
-              <Text type="secondary" style={{ marginTop: 16, display: 'block', fontSize: 12 }}>
-                Formatos de data aceitos: YYYY-MM-DD, DD/MM/YYYY, ISO 8601
-              </Text>
-            </Card>
-          </Col>
-        </Row>
-      )}
+      </Row>
     </section>
   );
 }

--- a/v2/frontend/src/pages/__tests__/DatImportsLegacyRemoval.test.tsx
+++ b/v2/frontend/src/pages/__tests__/DatImportsLegacyRemoval.test.tsx
@@ -15,6 +15,7 @@ import {
   getProjetosOptions,
   listCompras as listDatCompras,
 } from '../../api/datModule';
+import { useTableFilters } from '../../hooks/useTableFilters';
 import { DAT_IMPORTS_CENTRALIZED_MESSAGE } from '../../components/DatImportsCentralizedBanner';
 import type { CurrentUser } from '../../types';
 
@@ -45,6 +46,10 @@ vi.mock('../../api/datModule', () => ({
   getMunicipiosOptions: vi.fn(),
   getProjetosOptions: vi.fn(),
   getProdutosOptions: vi.fn(),
+}));
+
+vi.mock('../../hooks/useTableFilters', () => ({
+  useTableFilters: vi.fn(),
 }));
 
 const controleUser: CurrentUser = {
@@ -87,6 +92,26 @@ describe('DAT Imports PR-D — remoção de entrypoints legados', () => {
     vi.mocked(getMunicipiosOptions).mockResolvedValue([]);
     vi.mocked(getProjetosOptions).mockResolvedValue([]);
     vi.mocked(getProdutosOptions).mockResolvedValue([]);
+    vi.mocked(useTableFilters).mockReturnValue({
+      data: [],
+      loading: false,
+      filters: {
+        search: '',
+        uf: undefined,
+        municipio: undefined,
+        projeto: undefined,
+        produto: undefined,
+        status: undefined,
+        ano_uso: undefined,
+        tipo_compra: undefined,
+      },
+      setFilters: vi.fn(),
+      pagination: { current: 1, pageSize: 15, total: 0 },
+      fetchData: vi.fn(),
+      handleClearFilters: vi.fn(),
+      handleTableChange: vi.fn(),
+      refresh: vi.fn(),
+    });
 
     vi.stubGlobal('fetch', vi.fn(async (url: string) => {
       if (url.startsWith('/api/deslocamentos/')) {

--- a/v2/frontend/src/pages/__tests__/DatImportsLegacyRemoval.test.tsx
+++ b/v2/frontend/src/pages/__tests__/DatImportsLegacyRemoval.test.tsx
@@ -1,0 +1,163 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import type { ReactElement } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import ControlePage from '../Controle/ControlePage';
+import ComprasPage from '../DATModule/ComprasPage';
+import Disponibilidade from '../Disponibilidade';
+import DeslocamentosPage from '../Deslocamentos/DeslocamentosPage';
+import { getMe, getBlocks } from '../../api/availability';
+import { listCompras as listControleCompras } from '../../api/ops';
+import {
+  getMunicipiosOptions,
+  getProdutosOptions,
+  getProjetosOptions,
+  listCompras as listDatCompras,
+} from '../../api/datModule';
+import { DAT_IMPORTS_CENTRALIZED_MESSAGE } from '../../components/DatImportsCentralizedBanner';
+import type { CurrentUser } from '../../types';
+
+vi.mock('../../components/BlockForm', () => ({
+  default: () => <div>Criar Bloqueio Form</div>,
+}));
+
+vi.mock('../../components/MyBlocksTable', () => ({
+  default: () => <div>Meus Bloqueios Table</div>,
+}));
+
+vi.mock('../../api/availability', () => ({
+  getMe: vi.fn(),
+  getBlocks: vi.fn(),
+  createBlock: vi.fn(),
+  deleteBlock: vi.fn(),
+}));
+
+vi.mock('../../api/ops', () => ({
+  listCompras: vi.fn(),
+}));
+
+vi.mock('../../api/datModule', () => ({
+  listCompras: vi.fn(),
+  createCompra: vi.fn(),
+  updateCompra: vi.fn(),
+  deleteCompra: vi.fn(),
+  getMunicipiosOptions: vi.fn(),
+  getProjetosOptions: vi.fn(),
+  getProdutosOptions: vi.fn(),
+}));
+
+const controleUser: CurrentUser = {
+  id: 1,
+  username: 'controle',
+  email: 'controle@example.com',
+  first_name: 'Controle',
+  last_name: 'User',
+  name: 'Controle User',
+  groups: ['Controle'],
+  setores: ['Controle'],
+  funcoes: [],
+  is_superuser: false,
+  is_superintendencia: false,
+  can_approve_super: false,
+  permissions: [],
+};
+
+function renderPage(ui: ReactElement): void {
+  render(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
+function expectLegacyImportsRemoved(): void {
+  expect(screen.queryByText(/Importar COMPRAS/i)).not.toBeInTheDocument();
+  expect(screen.queryByText(/Importar AÇÕES/i)).not.toBeInTheDocument();
+  expect(screen.queryByText(/Importar EVENTOS/i)).not.toBeInTheDocument();
+  expect(screen.queryByText(/Importar PRODUTOS/i)).not.toBeInTheDocument();
+  expect(screen.queryByText(/Importar Bloqueios/i)).not.toBeInTheDocument();
+  expect(screen.queryByText(/Importar Deslocamentos/i)).not.toBeInTheDocument();
+}
+
+describe('DAT Imports PR-D — remoção de entrypoints legados', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(getMe).mockResolvedValue(controleUser);
+    vi.mocked(getBlocks).mockResolvedValue([]);
+    vi.mocked(listControleCompras).mockResolvedValue([]);
+    vi.mocked(listDatCompras).mockResolvedValue({ results: [], count: 0 });
+    vi.mocked(getMunicipiosOptions).mockResolvedValue([]);
+    vi.mocked(getProjetosOptions).mockResolvedValue([]);
+    vi.mocked(getProdutosOptions).mockResolvedValue([]);
+
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (url.startsWith('/api/deslocamentos/')) {
+        return {
+          ok: true,
+          json: async () => ({ results: [], count: 0 }),
+        };
+      }
+
+      if (url.startsWith('/api/options/formadores-do-setor/')) {
+        return {
+          ok: true,
+          json: async () => [],
+        };
+      }
+
+      return {
+        ok: false,
+        statusText: 'Not mocked',
+        json: async () => ({}),
+      };
+    }));
+  });
+
+  test('ControlePage remove cards de importação, exibe banner e mantém filtros/listagem', async () => {
+    renderPage(<ControlePage />);
+
+    expect(screen.getByRole('heading', { level: 1, name: 'Controle' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /Filtros de COMPRAS/i })).toBeInTheDocument();
+    expect(await screen.findByLabelText(DAT_IMPORTS_CENTRALIZED_MESSAGE)).toBeInTheDocument();
+    expectLegacyImportsRemoved();
+    expect(screen.queryByRole('link', { name: 'DAT > Importações' })).not.toBeInTheDocument();
+  });
+
+  test('ComprasPage remove modo Importar e mantém fluxo principal de compras', async () => {
+    renderPage(<ComprasPage />);
+
+    expect(screen.getByRole('heading', { name: /Gestão de Compras\/Materiais/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Nova Compra/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Exportar/i })).toBeInTheDocument();
+    expect(await screen.findByLabelText(DAT_IMPORTS_CENTRALIZED_MESSAGE)).toBeInTheDocument();
+    expectLegacyImportsRemoved();
+    expect(screen.queryByRole('button', { name: /^Importar$/i })).not.toBeInTheDocument();
+  });
+
+  test('Disponibilidade remove Importar bloqueios e mantém criação/listagem', async () => {
+    renderPage(<Disponibilidade />);
+
+    expect(screen.getByRole('heading', { name: /Gerenciar Disponibilidade/i })).toBeInTheDocument();
+    expect(screen.getByText('Criar Bloqueio')).toBeInTheDocument();
+    expect(screen.getByText('Meus Bloqueios')).toBeInTheDocument();
+    expect(await screen.findByLabelText(DAT_IMPORTS_CENTRALIZED_MESSAGE)).toBeInTheDocument();
+    expectLegacyImportsRemoved();
+    expect(screen.queryByRole('button', { name: /^Importar$/i })).not.toBeInTheDocument();
+  });
+
+  test('DeslocamentosPage remove Importar deslocamentos e mantém filtros/tabela', async () => {
+    renderPage(<DeslocamentosPage />);
+
+    expect(await screen.findByRole('heading', { name: /Deslocamentos/i })).toBeInTheDocument();
+    expect(screen.getByText('Filtros')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Novo Deslocamento/i })).toBeInTheDocument();
+    expect(await screen.findByLabelText(DAT_IMPORTS_CENTRALIZED_MESSAGE)).toBeInTheDocument();
+    expectLegacyImportsRemoved();
+    expect(screen.queryByRole('button', { name: /^Importar$/i })).not.toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        expect.stringMatching(/^\/api\/deslocamentos\/\?/),
+        expect.objectContaining({ credentials: 'include' }),
+      );
+    });
+  });
+});

--- a/v2/frontend/src/pages/__tests__/DatImportsLegacyRemoval.test.tsx
+++ b/v2/frontend/src/pages/__tests__/DatImportsLegacyRemoval.test.tsx
@@ -155,7 +155,7 @@ describe('DAT Imports PR-D — remoção de entrypoints legados', () => {
     expect(await screen.findByLabelText(DAT_IMPORTS_CENTRALIZED_MESSAGE)).toBeInTheDocument();
     expectLegacyImportsRemoved();
     expect(screen.queryByRole('button', { name: /^Importar$/i })).not.toBeInTheDocument();
-  });
+  }, 15_000);
 
   test('Disponibilidade remove Importar bloqueios e mantém criação/listagem', async () => {
     renderPage(<Disponibilidade />);


### PR DESCRIPTION
## Contexto

O PR-A1 #1305 já fechou o backend DAT-only para os 6 endpoints de importação em massa. Este PR-D remove os pontos antigos de UX fora do DAT para evitar que usuários de Controle/Coord/Apoio/Formador/Gerente/Diretoria vejam entrypoints que agora retornam 403.

## Mudanças

- Remove cards/botões/modos legados de importação em `ControlePage`.
- Remove o modo `Importar` e os uploaders antigos em `DATModule/ComprasPage`.
- Remove `Importar bloqueios` de `Disponibilidade`, mantendo criação/listagem manual.
- Remove `Importar deslocamentos` de `DeslocamentosPage`, mantendo filtros, tabela e criação manual.
- Adiciona `DatImportsCentralizedBanner` com mensagem padrão: `Importações foram centralizadas em DAT > Importações.`
- Para DAT/superuser, o banner exibe link para `/dat/importacoes`.
- Para perfis sem acesso DAT, o banner exibe somente texto informativo, sem link clicável.

## Páginas alteradas

- `v2/frontend/src/pages/Controle/ControlePage.tsx`
- `v2/frontend/src/pages/DATModule/ComprasPage.tsx`
- `v2/frontend/src/pages/Disponibilidade.tsx`
- `v2/frontend/src/pages/Deslocamentos/DeslocamentosPage.tsx`

## Testes executados

- `docker compose --env-file .env.dev -f docker-compose.yml -f docker-compose.override.yml exec -T frontend npm run test -- DatImportsCentralizedBanner DatImportsLegacyRemoval --run`
  Resultado: 2 arquivos, 7 testes verdes.
- `docker compose --env-file .env.dev -f docker-compose.yml -f docker-compose.override.yml exec -T frontend npm run test -- useGoogleIntegration --run`
  Resultado: 1 arquivo, 9 testes verdes.
- `docker compose --env-file .env.dev -f docker-compose.yml -f docker-compose.override.yml exec -T frontend npm run test -- --run`
  Resultado: suite frontend passou.
- `docker compose --env-file .env.dev -f docker-compose.yml -f docker-compose.override.yml exec -T frontend npm run typecheck`
  Resultado: passou.
- `docker compose --env-file .env.dev -f docker-compose.yml -f docker-compose.override.yml exec -T frontend npm run lint`
  Resultado: passou.
- `docker compose --env-file .env.dev -f docker-compose.yml -f docker-compose.override.yml exec -T frontend npm run build`
  Resultado: passou.
- `docker compose --env-file .env.dev -f docker-compose.yml -f docker-compose.override.yml exec -T frontend npm run deps:check`
  Resultado: passou, sem violações de dependência.
- `make staging-full` em `v2/infra`
  Resultado: `ALL 8 CHECKS PASSED`.

## Staging Gate Evidence

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

```
==============================================
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz:   PASS
[2/8] Backend version:  PASS
[3/8] CSRF endpoint:    PASS
[4/8] Auth pipeline:    PASS
[5/8] Celery worker:    PASS
[6/8] Celery beat:      PASS
[7/8] Frontend HTTP:    PASS
[8/8] Frontend health:  PASS

ALL 8 CHECKS PASSED
==============================================
```

## Observações

- Não altera backend.
- Não altera endpoints.
- Não mexe em ASQ-005 `/api/imports/bloqueios/`.
- Não mexe em Registros de Turmas.
- Não mexe em RBAC Grade Mensal/Aprovações.
- Não mexe em municípios IBGE.
- Não altera fluxos manuais de bloqueio/deslocamento em nome de outro usuário.