### PR TITLE
fix(rbac): exige capability para listar produtos (#1258)

### DIFF
--- a/v2/backend/apps/core/tests/test_pr4_produto_viewset_cap_gate.py
+++ b/v2/backend/apps/core/tests/test_pr4_produto_viewset_cap_gate.py
@@ -1,0 +1,219 @@
+"""
+PR 4 hardening RBAC (2026-04-30, #1258): matriz consolidada para
+`ProdutoViewSet`. Endpoint deixa de ser `IsAuthenticated` puro e passa a
+exigir capability operacional/admin.
+
+Endpoint: `GET/POST/PATCH/DELETE /api/produtos/`
+
+Capabilities permitidas (OR):
+- `manage_admin_registries` (DAT)
+- `manage_purchases_and_materials` (DAT/Controle)
+- `run_daily_operations` (Controle)
+
+Personas:
+- ✅ DAT, Controle, superuser → 200
+- ❌ Formador, Coordenador, Apoio, Gerente pedagógico, Diretoria → 403
+- Anonymous → 401/403
+
+Para dropdowns de formulários (Coordenador/Apoio criando solicitação
+ou Diretoria em dashboards), o endpoint paralelo `/api/options/produtos/`
+permanece `IsAuthenticated` (cobertura existente em test_views_options.py).
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportOptionalMemberAccess=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportMissingTypeArgument=false, reportCallIssue=false, reportMissingTypeStubs=false, reportUnusedFunction=false
+
+from __future__ import annotations
+
+import itertools
+
+from django.contrib.auth.models import Group
+from rest_framework.test import APIClient
+
+import pytest
+
+from apps.core.models import Produto, Projeto, Usuario
+
+pytestmark = pytest.mark.django_db
+
+
+_CPF_COUNTER = itertools.count(60000000000)
+
+
+def _user_in_groups(*group_names: str, label: str = "user") -> Usuario:
+    cpf = str(next(_CPF_COUNTER)).zfill(11)
+    user = Usuario.objects.create_user(
+        username=f"{label}_{cpf}",
+        email=f"{label}_{cpf}@example.com",
+        password="testpass",
+        cpf=cpf,
+    )
+    for name in group_names:
+        group, _ = Group.objects.get_or_create(name=name)
+        user.groups.add(group)
+    return user
+
+
+@pytest.fixture
+def produto():
+    projeto = Projeto.objects.create(nome="Projeto Test", codigo="PT", ativo=True)
+    return Produto.objects.create(codigo="P001", nome="Produto Teste", projeto=projeto, ativo=True)
+
+
+# =============================================================================
+# ✅ Allowed personas (DAT, Controle, superuser)
+# =============================================================================
+
+
+ALLOWED_PERSONAS: list[tuple[str, tuple[str, ...]]] = [
+    ("dat", ("DAT",)),
+    ("controle", ("Controle",)),
+]
+
+
+@pytest.mark.parametrize("persona", ALLOWED_PERSONAS, ids=[p[0] for p in ALLOWED_PERSONAS])
+def test_allowed_personas_can_list_produtos(persona, produto):
+    label, group_names = persona
+    user = _user_in_groups(*group_names, label=label)
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    response = client.get("/api/produtos/")
+
+    assert (
+        response.status_code == 200
+    ), f"{label} ({group_names}) deveria listar produtos; recebeu {response.status_code}"
+
+
+@pytest.mark.parametrize("persona", ALLOWED_PERSONAS, ids=[p[0] for p in ALLOWED_PERSONAS])
+def test_allowed_personas_can_retrieve_produto(persona, produto):
+    label, group_names = persona
+    user = _user_in_groups(*group_names, label=label)
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    response = client.get(f"/api/produtos/{produto.id}/")
+
+    assert response.status_code == 200, f"{label} deveria fazer retrieve; recebeu {response.status_code}"
+
+
+def test_superuser_can_list_produtos(produto):
+    cpf = str(next(_CPF_COUNTER)).zfill(11)
+    user = Usuario.objects.create_superuser(
+        username=f"super_pr4_{cpf}",
+        email=f"super_pr4_{cpf}@example.com",
+        password="testpass",
+        cpf=cpf,
+    )
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    response = client.get("/api/produtos/")
+    assert response.status_code == 200
+
+
+# =============================================================================
+# ❌ Forbidden personas
+# =============================================================================
+
+
+FORBIDDEN_PERSONAS: list[tuple[str, tuple[str, ...]]] = [
+    ("formador", ("Formador",)),
+    ("coordenador", ("Coordenador",)),
+    ("apoio", ("Apoio de Coordenação",)),
+    ("gerente_pedagogico", ("Vidas", "Gerente")),
+    ("diretoria", ("Diretoria",)),
+]
+
+
+@pytest.mark.parametrize("persona", FORBIDDEN_PERSONAS, ids=[p[0] for p in FORBIDDEN_PERSONAS])
+def test_forbidden_personas_get_403_on_list(persona, produto):
+    label, group_names = persona
+    user = _user_in_groups(*group_names, label=label)
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    response = client.get("/api/produtos/")
+
+    assert (
+        response.status_code == 403
+    ), f"{label} ({group_names}) deveria receber 403 em list; recebeu {response.status_code}"
+
+
+@pytest.mark.parametrize("persona", FORBIDDEN_PERSONAS, ids=[p[0] for p in FORBIDDEN_PERSONAS])
+def test_forbidden_personas_get_403_on_retrieve(persona, produto):
+    label, group_names = persona
+    user = _user_in_groups(*group_names, label=label)
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    response = client.get(f"/api/produtos/{produto.id}/")
+
+    assert response.status_code == 403
+
+
+def test_anonymous_blocked_on_list():
+    client = APIClient()
+    response = client.get("/api/produtos/")
+    assert response.status_code in (401, 403)
+
+
+# =============================================================================
+# Write operations (POST/PATCH/DELETE) também restritos
+# =============================================================================
+
+
+def test_dat_can_create_produto():
+    user = _user_in_groups("DAT", label="dat_writer")
+    projeto = Projeto.objects.create(nome="Proj W", codigo="PW", ativo=True)
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    response = client.post(
+        "/api/produtos/",
+        {"codigo": "PNEW", "nome": "Novo", "projeto": projeto.id, "ativo": True},
+        format="json",
+    )
+    assert response.status_code in (200, 201), response.data
+
+
+def test_coordenador_cannot_create_produto():
+    user = _user_in_groups("Coordenador", label="coord_writer")
+    projeto = Projeto.objects.create(nome="Proj W2", codigo="PW2", ativo=True)
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    response = client.post(
+        "/api/produtos/",
+        {"codigo": "PCOO", "nome": "X", "projeto": projeto.id, "ativo": True},
+        format="json",
+    )
+    assert response.status_code == 403
+
+
+# =============================================================================
+# Endpoint paralelo /api/options/produtos/ permanece IsAuthenticated
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "persona",
+    [
+        ("coordenador_options", ("Coordenador",)),
+        ("apoio_options", ("Apoio de Coordenação",)),
+        ("formador_options", ("Formador",)),
+    ],
+    ids=lambda p: p[0],
+)
+def test_options_produtos_remains_open_to_authenticated(persona, produto):
+    """Endpoint paralelo `/api/options/produtos/` continua autenticado puro
+    para suportar selects/dropdowns sem precisar de capability."""
+    label, group_names = persona
+    user = _user_in_groups(*group_names, label=label)
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    response = client.get("/api/options/produtos/")
+
+    assert (
+        response.status_code == 200
+    ), f"{label} deveria acessar /api/options/produtos/; recebeu {response.status_code}"

--- a/v2/backend/apps/core/views/admin.py
+++ b/v2/backend/apps/core/views/admin.py
@@ -239,7 +239,17 @@ class ProdutoViewSet(viewsets.ModelViewSet):  # type: ignore[misc]
 
     queryset = Produto.objects.select_related("projeto").order_by("codigo")
     serializer_class = ProdutoSerializer
-    permission_classes = [IsAuthenticated]
+    # PR 4 hardening RBAC (2026-04-30, #1258): list/retrieve/CRUD são
+    # operações admin/operacionais — não devem ficar abertas a qualquer
+    # usuário autenticado. Composition cobre os 3 motivos legítimos:
+    #   - manage_admin_registries (DAT — admin de cadastros)
+    #   - manage_purchases_and_materials (DAT/Controle — gestão de materiais)
+    #   - run_daily_operations (Controle — operação diária)
+    # Dropdowns/selects de formulário continuam via /api/options/produtos/
+    # (IsAuthenticated) para Coordenador/Apoio/Diretoria.
+    permission_classes = [
+        HasPerm("manage_admin_registries") | HasPerm("manage_purchases_and_materials") | HasPerm("run_daily_operations")
+    ]
     filter_backends = [DjangoFilterBackend, SearchFilter, OrderingFilter]
     filterset_fields = ["ativo", "projeto"]
     search_fields = ["codigo", "nome"]
@@ -247,10 +257,19 @@ class ProdutoViewSet(viewsets.ModelViewSet):  # type: ignore[misc]
     ordering = ["codigo"]
 
     def get_permissions(self) -> list:  # type: ignore[type-arg]
-        """DAT pode criar/editar/deletar. Outros apenas leitura."""
+        """
+        PR 4 hardening RBAC (2026-04-30, #1258): list/retrieve/CRUD admin
+        compartilham o mesmo gate (capability operacional/admin). Dropdowns
+        públicos ficam em /api/options/produtos/.
+
+        Antes deste PR o override aceitava qualquer usuário autenticado em
+        list/retrieve, contornando `permission_classes` da classe.
+        """
         if self.action in ["create", "update", "partial_update", "destroy"]:
+            # Escrita exige a cap específica de gestão de materiais (DAT/Controle).
             return [IsAuthenticated(), HasPerm("manage_purchases_and_materials")()]
-        return [IsAuthenticated()]
+        # Leitura: composition das 3 caps via permission_classes da classe.
+        return [permission() for permission in self.permission_classes]
 
 
 class GerenciaViewSet(viewsets.ModelViewSet):  # type: ignore[misc]


### PR DESCRIPTION
## Resumo

PR 4 do programa hardening RBAC. Fecha o gap em `ProdutoViewSet`
(`/api/produtos/`), que aceitava qualquer usuário autenticado em
list/retrieve por causa de um `get_permissions()` override que retornava
`[IsAuthenticated()]` para leitura — contornando silenciosamente o
`permission_classes` da classe.

Pitfall já documentado em memória `feedback_drf_get_permissions_override.md`.

## Regra de negócio (matriz aprovada)

Leitura (`list`/`retrieve`) e escrita (`create`/`update`/`partial_update`/
`destroy`) compartilham agora o gate composite OR:

- `manage_admin_registries` (DAT)
- `manage_purchases_and_materials` (DAT/Controle)
- `run_daily_operations` (Controle)

Escrita preserva o gate adicional `manage_purchases_and_materials`
(DAT/Controle).

| Persona | Antes | Depois |
|---------|-------|--------|
| DAT | 200 | ✅ 200 |
| Controle | 200 | ✅ 200 |
| Superuser | 200 | ✅ 200 |
| Formador | 200 | ❌ 403 |
| Coordenador | 200 | ❌ 403 |
| Apoio de Coordenação | 200 | ❌ 403 |
| Gerente pedagógico | 200 | ❌ 403 |
| Diretoria | 200 | ❌ 403 |
| Anonymous | 401/403 | 401/403 |

## Verificação cross-stack (consumidores frontend)

`/api/produtos/` é consumido **apenas** por:
- `pages/AdminDAT/ProdutosPage.tsx` (DAT puro)
- `api/datModule.ts::listProdutosDAT` (DAT)
- `api/adminDAT.ts::listProdutos` (DAT)

**Nenhum** consumidor fora de DAT/Controle: `pages/Solicitacoes/Nova` não
usa esse endpoint, dropdowns/selects de Coordenador/Apoio/Diretoria
consomem o endpoint paralelo `/api/options/produtos/` (`IsAuthenticated`,
intocado por este PR).

Conclusão da auditoria: é seguro restringir sem quebrar fluxo Coord/Apoio.

## Mudanças

- `apps/core/views/admin.py::ProdutoViewSet`:
  - `permission_classes` agora declara o gate composite OR.
  - `get_permissions()` ajustado: list/retrieve consomem
    `permission_classes` da classe; escrita preserva gate específico.

## Tests

Novo `test_pr4_produto_viewset_cap_gate.py` — **21 testes parametrizados**:

- 2 personas allowed × 3 endpoints (list/retrieve/superuser) — 5 testes
- 5 personas forbidden × 2 endpoints (list/retrieve) — 10 testes
- Anonymous — 1 teste
- Write: DAT pode criar / Coord não pode — 2 testes
- Endpoint paralelo `/api/options/produtos/` open para 3 personas — 3 testes

Resultados:
- `test_pr4_produto_viewset_cap_gate.py` — **21/21 passes**
- Regression check: `apps/core/tests/` (full suite, exceto novo arquivo) — **2093 passes**, 0 falhas
- `python scripts/rbac_lint.py apps/core/` — 0 violações
- Black/isort/flake8 limpos
- `make staging-full` em `v2/infra` → ALL 8 CHECKS PASSED

## Não toca

- model `Produto`
- `apps/core/views_import_produtos.py` (importação — já restrita por PR-A1)
- frontend (gate é só backend)
- `ProdutoOptionViewSet` / `/api/options/produtos/`
- DAT Imports, municípios, RBAC Aprovações

## Test plan

- [x] `pytest apps/core/tests/test_pr4_produto_viewset_cap_gate.py` — 21/21
- [x] `pytest apps/core/tests/ -k "produto or Produto"` — 55/55
- [x] `pytest apps/core/tests/` (full minus PR 4) — 2093/2093 passes
- [x] `python scripts/rbac_lint.py apps/core/` — 0 violações
- [x] Black + isort + flake8 — limpos
- [x] `make staging-full` em `v2/infra` → 8/8 PASS

## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

```
==============================================
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz:   PASS
[2/8] Backend version:  PASS (v=staging-local)
[3/8] CSRF endpoint:    PASS
[4/8] Auth pipeline:    PASS (HTTP 400)
[5/8] Celery worker:    PASS
[6/8] Celery beat:      PASS
[7/8] Frontend HTTP:    PASS
[8/8] Frontend health:  PASS

ALL 8 CHECKS PASSED
==============================================
```

Closes #1258.