### PR TITLE
fix(rbac): exige capability para lookup de usuários (PR 5 hardening RBAC)

### DIFF
--- a/v2/backend/apps/core/tests/test_pr5_usuario_lookup_cap_gate.py
+++ b/v2/backend/apps/core/tests/test_pr5_usuario_lookup_cap_gate.py
@@ -1,0 +1,208 @@
+"""
+PR 5 hardening RBAC (2026-04-30): matriz consolidada para `UsuarioLookup`.
+
+Endpoint: `GET /api/lookup/usuarios/`
+
+Mudanças:
+- Antes: `permission_classes = [IsAuthenticated]` — qualquer user autenticado.
+- Depois: composite `HasPerm("create_solicitation") |
+  HasPerm("manage_admin_registries")` (motivos legítimos confirmados em
+  auditoria cross-stack).
+
+Consumidores legítimos (auditoria 2026-04-30):
+- `NewSolicitacaoWizard` / `EditSolicitacaoPage` → `create_solicitation`
+- `AdminDAT` / suporte → `manage_admin_registries`
+
+Aprovações, Controle/operação e dashboards executivos NÃO consomem
+o endpoint — portanto `approve_solicitation_batch` e `operate_preagenda`
+ficam fora do gate.
+
+SEC-ENUM-01: email permanece fora do payload (anti-enumeração).
+SEC-ENUM-02: busca por email/username é cap-gated (mesma matriz),
+sem hardcode de group names.
+
+Personas:
+- ✅ DAT, Coordenador, Apoio, Gerente, superuser → 200
+- ❌ Controle puro, Formador, Diretoria, Sup pura sem Função → 403
+- Anonymous → 401/403
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportOptionalMemberAccess=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportMissingTypeArgument=false, reportCallIssue=false, reportMissingTypeStubs=false, reportUnusedFunction=false
+
+from __future__ import annotations
+
+import itertools
+
+from django.contrib.auth.models import Group
+from rest_framework.test import APIClient
+
+import pytest
+
+from apps.core.models import Usuario
+
+pytestmark = pytest.mark.django_db
+
+
+_CPF_COUNTER = itertools.count(50000000000)
+
+
+def _user_in_groups(*group_names: str, label: str = "user") -> Usuario:
+    cpf = str(next(_CPF_COUNTER)).zfill(11)
+    user = Usuario.objects.create_user(
+        username=f"{label}_{cpf}",
+        email=f"{label}_{cpf}@example.com",
+        password="testpass",
+        cpf=cpf,
+        first_name=label.capitalize(),
+        last_name="User",
+    )
+    for name in group_names:
+        group, _ = Group.objects.get_or_create(name=name)
+        user.groups.add(group)
+    return user
+
+
+@pytest.fixture
+def target_formador():
+    """Usuário-alvo para a busca."""
+    cpf = str(next(_CPF_COUNTER)).zfill(11)
+    user = Usuario.objects.create_user(
+        username=f"target_{cpf}",
+        email=f"maria_alvo_{cpf}@example.com",
+        password="testpass",
+        cpf=cpf,
+        first_name="Maria",
+        last_name="Silva",
+    )
+    formador, _ = Group.objects.get_or_create(name="Formador")
+    user.groups.add(formador)
+    return user
+
+
+# =============================================================================
+# Capability gate
+# =============================================================================
+
+
+ALLOWED_PERSONAS: list[tuple[str, tuple[str, ...]]] = [
+    ("dat", ("DAT",)),
+    ("coordenador", ("Coordenador",)),
+    ("apoio", ("Apoio de Coordenação",)),
+    ("gerente_pedagogico", ("Vidas", "Gerente")),
+    ("gerente_super", ("Superintendência", "Gerente")),
+]
+
+
+@pytest.mark.parametrize("persona", ALLOWED_PERSONAS, ids=[p[0] for p in ALLOWED_PERSONAS])
+def test_allowed_personas_can_lookup(persona, target_formador):
+    label, group_names = persona
+    user = _user_in_groups(*group_names, label=label)
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    response = client.get("/api/lookup/usuarios/?q=Maria")
+
+    assert response.status_code == 200, f"{label} ({group_names}) deveria ter acesso; recebeu {response.status_code}"
+
+
+def test_superuser_can_lookup(target_formador):
+    cpf = str(next(_CPF_COUNTER)).zfill(11)
+    user = Usuario.objects.create_superuser(
+        username=f"super_pr5_{cpf}",
+        email=f"super_pr5_{cpf}@example.com",
+        password="testpass",
+        cpf=cpf,
+    )
+    client = APIClient()
+    client.force_authenticate(user=user)
+    response = client.get("/api/lookup/usuarios/?q=Maria")
+    assert response.status_code == 200
+
+
+FORBIDDEN_PERSONAS: list[tuple[str, tuple[str, ...]]] = [
+    ("controle_puro", ("Controle",)),
+    ("formador", ("Formador",)),
+    ("diretoria", ("Diretoria",)),
+    ("sup_pura", ("Superintendência",)),  # Sem Função: sem create_solicitation
+]
+
+
+@pytest.mark.parametrize("persona", FORBIDDEN_PERSONAS, ids=[p[0] for p in FORBIDDEN_PERSONAS])
+def test_forbidden_personas_get_403(persona, target_formador):
+    label, group_names = persona
+    user = _user_in_groups(*group_names, label=label)
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    response = client.get("/api/lookup/usuarios/?q=Maria")
+
+    assert response.status_code == 403, f"{label} ({group_names}) deveria receber 403; recebeu {response.status_code}"
+
+
+def test_anonymous_blocked():
+    client = APIClient()
+    response = client.get("/api/lookup/usuarios/?q=Maria")
+    assert response.status_code in (401, 403)
+
+
+# =============================================================================
+# SEC-ENUM-02: busca por email é cap-gated (sem hardcode de grupo)
+# =============================================================================
+
+
+EMAIL_SEARCH_ALLOWED: list[tuple[str, tuple[str, ...]]] = [
+    ("dat_email", ("DAT",)),
+    ("coordenador_email", ("Coordenador",)),
+    ("apoio_email", ("Apoio de Coordenação",)),
+    ("gerente_pedagogico_email", ("Vidas", "Gerente")),
+]
+
+
+@pytest.mark.parametrize("persona", EMAIL_SEARCH_ALLOWED, ids=[p[0] for p in EMAIL_SEARCH_ALLOWED])
+def test_email_search_finds_user_for_allowed_personas(persona, target_formador):
+    label, group_names = persona
+    user = _user_in_groups(*group_names, label=label)
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    # Buscar pelo prefixo do email (não usa nome).
+    response = client.get(f"/api/lookup/usuarios/?q=maria_alvo_{target_formador.cpf}")
+    assert response.status_code == 200
+    body = response.json()
+    ids = [item["id"] for item in body]
+    assert target_formador.id in ids, f"{label} deveria encontrar usuário por email; payload={body}"
+
+
+# =============================================================================
+# SEC-ENUM-01: email NUNCA aparece no payload, mesmo para perfis privilegiados
+# =============================================================================
+
+
+def test_payload_never_exposes_email(target_formador):
+    user = _user_in_groups("DAT", label="dat_payload")
+    client = APIClient()
+    client.force_authenticate(user=user)
+    response = client.get("/api/lookup/usuarios/?q=Maria")
+    assert response.status_code == 200
+    body = response.json()
+    assert body, "Esperava ao menos 1 resultado para Maria"
+    for item in body:
+        assert "email" not in item, f"SEC-ENUM-01 violado: payload exposes email: {item}"
+
+
+# =============================================================================
+# Role filter continua funcionando (regression)
+# =============================================================================
+
+
+def test_role_filter_returns_only_role(target_formador):
+    """Garantir que `?role=Formador` continua filtrando por grupo."""
+    user = _user_in_groups("Coordenador", label="coord_role")
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    response = client.get("/api/lookup/usuarios/?q=Maria&role=Formador")
+    assert response.status_code == 200
+    body = response.json()
+    ids = [item["id"] for item in body]
+    assert target_formador.id in ids

--- a/v2/backend/apps/core/tests/test_sec_enum_audit.py
+++ b/v2/backend/apps/core/tests/test_sec_enum_audit.py
@@ -56,10 +56,17 @@ class TestUsuarioOptionsNoEmail(TestCase):
 
 
 class TestUsuarioLookupNoEmail(TestCase):
-    """SEC-ENUM-01: /api/lookup/usuarios/ must not return email field."""
+    """SEC-ENUM-01: /api/lookup/usuarios/ must not return email field.
+
+    PR 5 hardening RBAC (2026-04-30): endpoint deixou de ser
+    `IsAuthenticated`. User precisa ter cap legítima — usamos Coordenador
+    (cap `create_solicitation`) para validar SEC-ENUM-01.
+    """
 
     def setUp(self):
+        coord_group, _ = Group.objects.get_or_create(name="Coordenador")
         self.user = User.objects.create_user("lookup_test", "lookup@test.com", "pass1234", cpf=_next_cpf())
+        self.user.groups.add(coord_group)
         User.objects.create_user(
             "lookup_target", "target@secret.com", "pass1234", first_name="Maria", last_name="Silva", cpf=_next_cpf()
         )
@@ -116,13 +123,13 @@ class TestEmailSearchRestriction(TestCase):
 
         self.client = APIClient()
 
-    def test_formador_cannot_search_by_email(self):
-        """Formador searching by email should not find the user."""
+    def test_formador_cannot_lookup_at_all(self):
+        """PR 5 hardening RBAC: Formador NÃO acessa o endpoint
+        (regra anterior — busca por email retornar lista vazia — foi
+        substituída por capability gate; Formador recebe 403)."""
         self.client.force_authenticate(user=self.formador)
         response = self.client.get("/api/lookup/usuarios/?q=distinct.email")
-        data = response.json()
-        # Should not find user by email
-        assert len(data) == 0, f"Formador should not find users by email search: {data}"
+        assert response.status_code == 403, f"Formador deveria receber 403 após PR 5, recebeu {response.status_code}"
 
     def test_coordenador_can_search_by_email(self):
         """Coordenador searching by email should find the user."""
@@ -131,12 +138,12 @@ class TestEmailSearchRestriction(TestCase):
         data = response.json()
         assert len(data) > 0, "Coordenador should find users by email search"
 
-    def test_formador_can_search_by_name(self):
-        """Formador can still search by name."""
+    def test_formador_cannot_search_by_name_either(self):
+        """PR 5 hardening RBAC: Formador também perde a busca por nome
+        (gate é no endpoint inteiro, não só na coluna de email)."""
         self.client.force_authenticate(user=self.formador)
         response = self.client.get("/api/lookup/usuarios/?q=Ana")
-        data = response.json()
-        assert len(data) > 0, "Formador should find users by name search"
+        assert response.status_code == 403
 
 
 # ================================================================

--- a/v2/backend/apps/core/views_lookup.py
+++ b/v2/backend/apps/core/views_lookup.py
@@ -22,6 +22,8 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from apps.core.permissions import HasPerm
+from apps.core.rbac.helpers import user_has_any_perm
 from apps.core.services.normalize import norm_text
 
 from .models import Municipio, Projeto, TipoEvento, Usuario
@@ -183,14 +185,36 @@ class UsuarioLookup(APIView):
     GET /api/lookup/usuarios/?q=maria&role=formador
     Retorna: [{id, label, kind: "usuario"}]
 
-    SEC-ENUM-01: email removed from response to prevent user enumeration.
-    SEC-ENUM-02: email search restricted to Coordenador+ roles.
+    PR 5 hardening RBAC (2026-04-30):
+    - Capability gate: somente perfis com motivo legítimo (criar
+      solicitação OU administrar cadastros) listam usuários.
+    - Não usa hardcode de grupos.
+
+    SEC-ENUM-01: email permanece fora do payload (anti-enumeração).
+    SEC-ENUM-02: busca por email/username é cap-gated, mantendo a matriz
+    via `user_has_any_perm`.
+
+    Consumidores legítimos confirmados (auditoria 2026-04-30):
+    - `NewSolicitacaoWizard` (Coord/Apoio/Gerente cria) →
+      `create_solicitation`
+    - `EditSolicitacaoPage` (owner ou privileged edita) →
+      `create_solicitation`
+    - DAT admin (admin geral / suporte) → `manage_admin_registries`
+
+    Aprovações, Controle/Operação e dashboards executivos não consomem
+    este endpoint, portanto `approve_solicitation_batch` e
+    `operate_preagenda` ficam fora do gate.
     """
 
-    permission_classes = [IsAuthenticated]
+    permission_classes = [HasPerm("create_solicitation") | HasPerm("manage_admin_registries")]
 
-    # Roles allowed to search by email (SEC-ENUM-02)
-    _EMAIL_SEARCH_ROLES = {"Coordenador", "Gerente", "Superintendência", "Apoio"}
+    # Capabilities habilitadas a buscar por email/username (SEC-ENUM-02).
+    # Idêntico ao gate de leitura: quem tem motivo legítimo para usar o
+    # picker no fluxo de solicitação ou para admin de cadastros.
+    _EMAIL_SEARCH_CAPS: tuple[str, ...] = (
+        "create_solicitation",
+        "manage_admin_registries",
+    )
 
     def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         q = request.GET.get("q", "").strip()
@@ -199,9 +223,8 @@ class UsuarioLookup(APIView):
         # Começar com queryset base
         qs = Usuario.objects.filter(is_active=True)
 
-        # SEC-ENUM-02: only Coordenador+ can search by email/username
-        user_groups = set(request.user.groups.values_list("name", flat=True))
-        can_search_email = bool(request.user.is_superuser or user_groups & self._EMAIL_SEARCH_ROLES)
+        # SEC-ENUM-02 (cap-based, sem hardcode de grupo).
+        can_search_email = bool(request.user.is_superuser or user_has_any_perm(request.user, *self._EMAIL_SEARCH_CAPS))
 
         # Aplicar filtro de busca
         if q:


### PR DESCRIPTION
## Resumo

PR 5 do programa hardening RBAC. Fecha o gap em `UsuarioLookup`
(`/api/lookup/usuarios/`), que aceitava qualquer usuário autenticado em
list/search por causa de `permission_classes = [IsAuthenticated]` puro.

Também corrige o anti-pattern de hardcode de group names em SEC-ENUM-02
(`_EMAIL_SEARCH_ROLES = {"Coordenador", "Gerente", ...}`), substituindo
por helper baseado em capability via `user_has_any_perm`.

## Auditoria cross-stack (decisiva pré-implementação)

Consumidores reais de `/api/lookup/usuarios/` no frontend:

- `pages/Solicitacoes/NewSolicitacaoWizard.tsx` (Coord/Apoio/Gerente)
- `pages/Solicitacoes/EditSolicitacaoPage.tsx` (owner ou privileged)
- `components/CoordenadoresPicker.tsx` (consumido por ambos acima)
- `components/FormadoresPicker.tsx` (idem)

Aprovações, Controle/operação e dashboards executivos NÃO consomem o
endpoint. Portanto `approve_solicitation_batch` e `operate_preagenda`
ficam fora do gate (mais conservador, evita over-permission).

## Mudanças

### `apps/core/views_lookup.py::UsuarioLookup`

**Antes:**
```python
permission_classes = [IsAuthenticated]
_EMAIL_SEARCH_ROLES = {"Coordenador", "Gerente", "Superintendência", "Apoio"}
user_groups = set(request.user.groups.values_list("name", flat=True))
can_search_email = bool(request.user.is_superuser or user_groups & self._EMAIL_SEARCH_ROLES)
```

**Depois:**
```python
permission_classes = [
    HasPerm("create_solicitation") | HasPerm("manage_admin_registries")
]
_EMAIL_SEARCH_CAPS: tuple[str, ...] = ("create_solicitation", "manage_admin_registries")
can_search_email = bool(
    request.user.is_superuser
    or user_has_any_perm(request.user, *self._EMAIL_SEARCH_CAPS)
)
```

## Acesso resultante

| Persona | list/search | search por email |
|---------|-------------|------------------|
| DAT (`manage_admin_registries`) | ✅ 200 | ✅ |
| Coordenador (`create_solicitation`) | ✅ 200 | ✅ |
| Apoio de Coordenação (`create_solicitation`) | ✅ 200 | ✅ |
| Gerente (pedagógico ou Sup) (`create_solicitation`) | ✅ 200 | ✅ |
| Superuser | ✅ 200 (bypass) | ✅ |
| Controle puro | ❌ 403 | n/a |
| Sup pura sem Função | ❌ 403 | n/a |
| Formador | ❌ 403 | n/a |
| Diretoria | ❌ 403 | n/a |
| Anonymous | 401/403 | n/a |

SEC-ENUM-01 preservado: email permanece **fora** do payload (validado por test
`test_payload_never_exposes_email`).

## Tests

### Novo `test_pr5_usuario_lookup_cap_gate.py` — 17 testes

- 5 personas allowed × list/search → 200
- Superuser bypass → 200
- 4 personas forbidden × search → 403 (inclui Sup pura sem Função e Controle puro)
- Anonymous → 401/403
- 4 personas com cap × email search → encontra alvo
- Payload audit (SEC-ENUM-01)
- Role filter regression

### Tests existentes ajustados (`test_sec_enum_audit.py`)

- `TestUsuarioLookupNoEmail`: fixture agora atribui Função `Coordenador`
  (necessária após PR 5 para passar pelo gate). SEC-ENUM-01 continua
  validado.
- `test_formador_cannot_search_by_email` → `test_formador_cannot_lookup_at_all`:
  agora valida 403 (mais restritivo que filtro vazio antes).
- `test_formador_can_search_by_name` → `test_formador_cannot_search_by_name_either`:
  invertido (gate é no endpoint inteiro, não só na coluna de email).

### Resultados locais

- `pytest test_pr5_usuario_lookup_cap_gate.py` — **17/17 passes**
- `pytest test_sec_enum_audit.py test_lookup_validate.py` — verde
- `pytest apps/core/tests/` (full) — **2131 passes, 42 skipped, 0 falhas**
- `python scripts/rbac_lint.py apps/core/` — 0 violações
- Black + isort + flake8 limpos
- `make staging-full` em `v2/infra` → ALL 8 CHECKS PASSED

## Não toca

- Outros lookups (`MunicipioLookup`, `ProjetoLookup`, `TipoEventoLookup`)
  permanecem `IsAuthenticated` — escopo separado se houver onda futura.
- ProdutoViewSet (já endurecido em PR 4 #1309).
- RBAC Aprovações (já endurecido em PR 3 #1308).
- Frontend (gate é só backend; pickers continuam funcionando para Coord/Apoio/Gerente).

## Test plan

- [x] `pytest apps/core/tests/test_pr5_usuario_lookup_cap_gate.py` — 17/17
- [x] `pytest apps/core/tests/test_sec_enum_audit.py apps/core/tests/test_lookup_validate.py` — verde
- [x] `pytest apps/core/tests/` (full suite) — 2131 passes
- [x] `python scripts/rbac_lint.py apps/core/` — 0 violações
- [x] Black + isort + flake8 limpos
- [x] `make staging-full` em `v2/infra` → 8/8 PASS

## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

```
==============================================
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz:   PASS
[2/8] Backend version:  PASS (v=staging-local)
[3/8] CSRF endpoint:    PASS
[4/8] Auth pipeline:    PASS (HTTP 400)
[5/8] Celery worker:    PASS
[6/8] Celery beat:      PASS
[7/8] Frontend HTTP:    PASS
[8/8] Frontend health:  PASS

ALL 8 CHECKS PASSED
==============================================
```

## Nota sobre Gerente (registro pré-merge)

- **Gerente recebe 200** porque a capability `create_solicitation` é
  atribuída ao grupo Função `Gerente` no seed canonical
  (`functional_permissions_seed.py`: `("Coordenador", "Apoio de Coordenação", "Gerente")`).
- **Este PR não expande acesso de Gerente** — apenas substitui o gate
  permissivo `IsAuthenticated` por `HasPerm`. Quem entrava antes (todos)
  inclui Gerente; o que muda é que agora Gerente entra **por capability
  declarada**, não por autenticação genérica.
- **Se a decisão final for retirar `create_solicitation` de Gerente
  pedagógico**, isso é tratamento da Matriz Viva / revisão de Funções
  (fora do escopo deste PR). O endpoint segue automaticamente a matriz
  via `HasPerm("create_solicitation")`.
