### PR TITLE
fix(rbac): restringe access_audit_logs a DAT e Controle (PR 6 hardening RBAC)

### DIFF
--- a/v2/backend/apps/core/rbac/matrix.py
+++ b/v2/backend/apps/core/rbac/matrix.py
@@ -192,16 +192,18 @@ ACCESS_MATRIX: Final[dict[str, dict[str, int]]] = {
         FORMADOR: DENY,
     },
     #
-    # AuditLog: `[CanAccessAuditLogs]` (Epic 4.2.a).
-    # Capabilities: manage_admin_registries | operate_preagenda |
-    #               approve_solicitation | approve_solicitation_batch.
-    # 4 motivos legítimos: auditar/operar/suportar.
+    # AuditLog: `[CanAccessAuditLogs]` (Epic 4.2.a + PR 6 hardening RBAC 2026-04-30).
+    # Capabilities: manage_admin_registries | operate_preagenda.
+    # PR 6 (2026-04-30): removidos `approve_solicitation` e
+    # `approve_solicitation_batch` para evitar liberação indevida a
+    # Gerente pedagógico, Sup pura e Gerente da Sup. Auditoria por
+    # aprovador volta como escopo isolado se necessário em onda futura.
     "audit_logs": {
         SUPERUSER: ALLOW,
         DAT: ALLOW,  # manage_admin_registries (suportar)
         CONTROLE: ALLOW,  # operate_preagenda (operar)
-        DIRETORIA: DENY,  # sem nenhuma das 4 capabilities elegíveis
-        GERENTE: ALLOW,  # approve_solicitation_batch (auditar batch)
+        DIRETORIA: DENY,
+        GERENTE: DENY,  # PR 6: removido approve_solicitation_batch do gate
         COORDENADOR: DENY,
         APOIO: DENY,
         FORMADOR: DENY,

--- a/v2/backend/apps/core/rbac/policies.py
+++ b/v2/backend/apps/core/rbac/policies.py
@@ -77,14 +77,15 @@ COMPOSITE_POLICY_KEYS: Final[frozenset[str]] = frozenset({"access_solicitation_a
 
 ACCESS_POLICIES: Final[dict[str, frozenset[str]]] = {
     # --- Solicitação / Audit ---
-    # AuditLog tem 4 motivos legítimos: auditar (Super/Gerente próprias e
-    # batch), operar (Controle), suportar (DAT). Confirmado Epic 1.6.
+    # PR 6 hardening RBAC (2026-04-30): policy reduzida a DAT (admin) +
+    # Controle (operação). Antes incluía `approve_solicitation` e
+    # `approve_solicitation_batch` (Sup, Gerente) — removidos para evitar
+    # liberação indevida a Gerente pedagógico e Sup pura. Auditoria por
+    # aprovador volta a ser escopo isolado se necessário em onda futura.
     "access_audit_logs": frozenset(
         {
             "manage_admin_registries",
             "operate_preagenda",
-            "approve_solicitation",
-            "approve_solicitation_batch",
         }
     ),
     # Transições GCal (publish/cancel/resync) — Controle (operação) +

--- a/v2/backend/apps/core/tests/test_pr6_audit_logs_policy.py
+++ b/v2/backend/apps/core/tests/test_pr6_audit_logs_policy.py
@@ -1,0 +1,230 @@
+"""
+PR 6 hardening RBAC (2026-04-30): matriz consolidada para
+`access_audit_logs`. Policy reduzida a DAT (admin) + Controle (operação)
++ superuser. `approve_solicitation` e `approve_solicitation_batch`
+removidos do gate para evitar liberação indevida a Gerente pedagógico,
+Sup pura e Gerente da Sup.
+
+Endpoint: `GET /api/audit-logs/`
+
+Personas:
+- ✅ DAT (`manage_admin_registries`) → 200
+- ✅ Controle (`operate_preagenda`) → 200
+- ✅ Superuser → 200
+- ❌ Sup pura, Gerente Sup, Gerente pedagógico, Coord, Apoio, Formador, Diretoria → 403
+- Anonymous → 401/403
+
+SEC-AUDIT-01 (`_mask_email` / `_mask_ip` / `_redact_details`) preservado:
+testes específicos em test_sec_enum_audit.py continuam validando para
+DAT, Controle e superuser.
+
+Cobre tanto o gate dos endpoints quanto o contrato `/api/me/policies/`.
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportOptionalMemberAccess=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportMissingTypeArgument=false, reportCallIssue=false, reportMissingTypeStubs=false, reportUnusedFunction=false
+
+from __future__ import annotations
+
+import itertools
+
+from django.contrib.auth.models import Group
+from rest_framework.test import APIClient
+
+import pytest
+
+from apps.core.models import AuditLog, Usuario
+
+pytestmark = pytest.mark.django_db
+
+
+_CPF_COUNTER = itertools.count(40000000000)
+
+
+def _user_in_groups(*group_names: str, label: str = "user") -> Usuario:
+    cpf = str(next(_CPF_COUNTER)).zfill(11)
+    user = Usuario.objects.create_user(
+        username=f"{label}_{cpf}",
+        email=f"{label}_{cpf}@example.com",
+        password="testpass",
+        cpf=cpf,
+    )
+    for name in group_names:
+        group, _ = Group.objects.get_or_create(name=name)
+        user.groups.add(group)
+    return user
+
+
+@pytest.fixture
+def audit_log_record():
+    """Cria um AuditLog para o teste poder consultar via list endpoint."""
+    return AuditLog.objects.create(
+        usuario=None,
+        action="LOGIN",
+        model_name="Usuario",
+        details={
+            "ip_address": "203.0.113.50",
+            "google_email": "user@gmail.com",
+            "reason": "success",
+        },
+    )
+
+
+# =============================================================================
+# Allowed personas (DAT, Controle, superuser)
+# =============================================================================
+
+
+ALLOWED_PERSONAS: list[tuple[str, tuple[str, ...]]] = [
+    ("dat", ("DAT",)),
+    ("controle", ("Controle",)),
+]
+
+
+@pytest.mark.parametrize("persona", ALLOWED_PERSONAS, ids=[p[0] for p in ALLOWED_PERSONAS])
+def test_allowed_personas_can_list_audit_logs(persona, audit_log_record):
+    label, group_names = persona
+    user = _user_in_groups(*group_names, label=label)
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    response = client.get("/api/audit-logs/")
+    assert (
+        response.status_code == 200
+    ), f"{label} ({group_names}) deveria listar audit logs; recebeu {response.status_code}"
+
+
+def test_superuser_can_list_audit_logs(audit_log_record):
+    cpf = str(next(_CPF_COUNTER)).zfill(11)
+    user = Usuario.objects.create_superuser(
+        username=f"super_pr6_{cpf}",
+        email=f"super_pr6_{cpf}@example.com",
+        password="testpass",
+        cpf=cpf,
+    )
+    client = APIClient()
+    client.force_authenticate(user=user)
+    response = client.get("/api/audit-logs/")
+    assert response.status_code == 200
+
+
+# =============================================================================
+# Forbidden personas
+# =============================================================================
+
+
+FORBIDDEN_PERSONAS: list[tuple[str, tuple[str, ...]]] = [
+    ("sup_pura", ("Superintendência",)),
+    ("gerente_sup", ("Superintendência", "Gerente")),
+    ("gerente_pedagogico", ("Vidas", "Gerente")),
+    ("coordenador", ("Coordenador",)),
+    ("apoio", ("Apoio de Coordenação",)),
+    ("formador", ("Formador",)),
+    ("diretoria", ("Diretoria",)),
+]
+
+
+@pytest.mark.parametrize("persona", FORBIDDEN_PERSONAS, ids=[p[0] for p in FORBIDDEN_PERSONAS])
+def test_forbidden_personas_get_403(persona, audit_log_record):
+    label, group_names = persona
+    user = _user_in_groups(*group_names, label=label)
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    response = client.get("/api/audit-logs/")
+    assert response.status_code == 403, f"{label} ({group_names}) deveria receber 403; recebeu {response.status_code}"
+
+
+def test_anonymous_blocked():
+    client = APIClient()
+    response = client.get("/api/audit-logs/")
+    assert response.status_code in (401, 403)
+
+
+# =============================================================================
+# SEC-AUDIT-01: masking continua funcionando para personas autorizadas
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "persona",
+    ALLOWED_PERSONAS + [("superuser_redaction", ())],
+    ids=[p[0] for p in ALLOWED_PERSONAS] + ["superuser_redaction"],
+)
+def test_redaction_works_for_allowed_personas(persona, audit_log_record):
+    """SEC-AUDIT-01: details PII redigidos exceto para superuser."""
+    label, group_names = persona
+
+    if label == "superuser_redaction":
+        cpf = str(next(_CPF_COUNTER)).zfill(11)
+        user = Usuario.objects.create_superuser(
+            username=f"super_red_{cpf}",
+            email=f"super_red_{cpf}@example.com",
+            password="testpass",
+            cpf=cpf,
+        )
+        expected_full_payload = True
+    else:
+        user = _user_in_groups(*group_names, label=label)
+        expected_full_payload = False
+
+    client = APIClient()
+    client.force_authenticate(user=user)
+    response = client.get("/api/audit-logs/")
+    assert response.status_code == 200
+
+    data = response.json()
+    results = data.get("results", data) if isinstance(data, dict) else data
+    if isinstance(results, dict):
+        results = results.get("results", [])
+    assert len(results) > 0, f"{label}: esperava ao menos 1 audit log no payload"
+
+    details = results[0]["details"]
+    if expected_full_payload:
+        # Superuser: vê detalhes completos (sem masking).
+        assert details["ip_address"] == "203.0.113.50"
+        assert details["google_email"] == "user@gmail.com"
+    else:
+        # Não-superuser: SEC-AUDIT-01 redige PII.
+        assert details["ip_address"] == "203.0.113.***", f"{label}: ip mascarado esperado, got={details}"
+        assert details["google_email"] == "u***@gmail.com", f"{label}: email mascarado esperado, got={details}"
+        # Não-PII preservado.
+        assert details["reason"] == "success"
+
+
+# =============================================================================
+# /api/me/policies — exposição de access_audit_logs
+# =============================================================================
+
+
+@pytest.mark.parametrize("persona", ALLOWED_PERSONAS, ids=[p[0] for p in ALLOWED_PERSONAS])
+def test_me_policies_exposes_access_audit_logs_for_allowed(persona):
+    label, group_names = persona
+    user = _user_in_groups(*group_names, label=f"{label}_policy")
+    client = APIClient()
+    client.force_authenticate(user=user)
+    response = client.get("/api/me/policies/")
+    assert response.status_code == 200
+    body = response.json()
+    assert "access_audit_logs" in body, f"{label} deveria receber a policy access_audit_logs; payload={body}"
+
+
+@pytest.mark.parametrize(
+    "persona",
+    [
+        ("sup_pura_policy", ("Superintendência",)),
+        ("gerente_sup_policy", ("Superintendência", "Gerente")),
+        ("gerente_pedagogico_policy", ("Vidas", "Gerente")),
+        ("formador_policy", ("Formador",)),
+        ("diretoria_policy", ("Diretoria",)),
+    ],
+    ids=lambda p: p[0],
+)
+def test_me_policies_does_not_expose_access_audit_logs_for_forbidden(persona):
+    label, group_names = persona
+    user = _user_in_groups(*group_names, label=label)
+    client = APIClient()
+    client.force_authenticate(user=user)
+    response = client.get("/api/me/policies/")
+    assert response.status_code == 200
+    body = response.json()
+    assert "access_audit_logs" not in body, f"{label} NÃO deveria receber a policy access_audit_logs; payload={body}"

--- a/v2/frontend/e2e/journeys/j04-reprovacao.spec.ts
+++ b/v2/frontend/e2e/journeys/j04-reprovacao.spec.ts
@@ -59,10 +59,16 @@ test.describe(
       const check = await superApi.get(`/api/solicitacoes/${solicitacao.id}/`);
       expect(((await check.json()) as { status: string }).status).toBe('reprovado');
 
-      // PA-05: AuditLog registra justificativa
-      const logsRes = await superApi.get(
-        `/api/audit-logs/?action=REJECT&model_name=Solicitacao`
-      );
+      // PA-05: AuditLog registra justificativa.
+      // PR 6 hardening RBAC (2026-04-30): `access_audit_logs` reduzida a
+      // DAT/Controle. Usa contexto DAT para ler o log (super_geral perdeu
+      // a cap mas ainda é o ator que reprova — o audit é gravado igual).
+      const datApi = await createApiContext({
+        baseURL: baseURL!,
+        username: ROLE_CREDENTIALS.dat_e2e.username,
+        password: ROLE_CREDENTIALS.dat_e2e.password,
+      });
+      const logsRes = await datApi.get(`/api/audit-logs/?action=REJECT&model_name=Solicitacao`);
       expect(logsRes.ok()).toBeTruthy();
       const logsData = (await logsRes.json()) as
         | { results?: Array<{ details: Record<string, unknown> }> }

--- a/v2/frontend/e2e/journeys/j08-approval-race.spec.ts
+++ b/v2/frontend/e2e/journeys/j08-approval-race.spec.ts
@@ -132,7 +132,16 @@ test.describe(
         superApi2.patch(`/api/solicitacoes/${solicitacao.id}/approve/`, { data: {} }),
       ]);
 
-      const logsRes = await superApi1.get(`/api/audit-logs/?action=APPROVE&model_name=Solicitacao`);
+      // PR 6 hardening RBAC (2026-04-30): `access_audit_logs` reduzida a
+      // DAT/Controle. Usa contexto DAT para a leitura — atores
+      // aprovadores (super_geral / super_e2e) perderam a cap mas o
+      // AuditLog continua gravado normalmente pelo backend.
+      const datApi = await createApiContext({
+        baseURL: baseURL!,
+        username: ROLE_CREDENTIALS.dat_e2e.username,
+        password: ROLE_CREDENTIALS.dat_e2e.password,
+      });
+      const logsRes = await datApi.get(`/api/audit-logs/?action=APPROVE&model_name=Solicitacao`);
       expect(logsRes.ok()).toBeTruthy();
       const logsData = (await logsRes.json()) as
         | { results?: Array<{ details: Record<string, unknown> }> }


### PR DESCRIPTION
## Resumo

PR 6 do programa hardening RBAC. Reduz a Policy `access_audit_logs` ao
escopo essencial (DAT admin + Controle operação + superuser), removendo
capabilities que liberavam audit logs a perfis sem motivo legítimo claro.

## Regra de negócio (aprovada)

Audit Logs devem ser acessíveis **apenas** a:
- DAT (admin/suporte transversal)
- Controle (operação)
- Superuser

NÃO devem acessar:
- Sup pura
- Gerente da Sup (por enquanto)
- Gerente pedagógico
- Coordenador, Apoio, Formador, Diretoria

## Mudança técnica

`apps/core/rbac/policies.py::ACCESS_POLICIES["access_audit_logs"]`:

| Antes | Depois |
|-------|--------|
| `manage_admin_registries` | `manage_admin_registries` |
| `operate_preagenda` | `operate_preagenda` |
| `approve_solicitation` | _(removido)_ |
| `approve_solicitation_batch` | _(removido)_ |

`apps/core/rbac/matrix.py::audit_logs`:
- `GERENTE: ALLOW` → `GERENTE: DENY` (refletindo remoção da cap `approve_solicitation_batch` do gate)

Auditoria por aprovador volta como escopo isolado se necessário em
onda futura — fora do escopo deste PR.

## Acesso resultante

| Persona | Antes | Depois |
|---------|-------|--------|
| DAT | ✅ 200 | ✅ 200 |
| Controle | ✅ 200 | ✅ 200 |
| Superuser | ✅ 200 | ✅ 200 |
| Sup pura | ✅ 200 (`approve_solicitation`) | ❌ 403 |
| Gerente da Sup | ✅ 200 | ❌ 403 |
| Gerente pedagógico | ✅ 200 (`approve_solicitation_batch`) | ❌ 403 |
| Coordenador, Apoio, Formador, Diretoria | ❌ 403 | ❌ 403 |
| Anonymous | 401/403 | 401/403 |

## SEC-AUDIT-01 preservado

Masking/redaction continua funcionando:
- `_mask_email` (`u***@gmail.com`)
- `_mask_ip` (`203.0.113.***`)
- `_redact_details` (remove `user_agent`, etc.)

Superuser continua vendo detalhes completos. DAT/Controle veem PII
redigida. Validado por testes específicos.

## Tests

### Novo `test_pr6_audit_logs_policy.py` — 21 testes

- 2 personas allowed × list → 200 (DAT, Controle)
- Superuser bypass → 200
- 7 personas forbidden → 403 (Sup pura, Gerente Sup, Gerente pedagógico, Coord, Apoio, Formador, Diretoria)
- Anonymous → 401/403
- 3 cenários SEC-AUDIT-01 (DAT, Controle, superuser) — masking comportamento correto por persona
- 7 cenários `/api/me/policies/` (2 expostos, 5 não expostos)

### Tests existentes ajustados

- `test_rbac_matrix_living.py::test_actor_can_or_cannot_access_resource[Gerente::audit_logs]` — agora espera DENY (atualizado via `matrix.py`).

### Resultados locais

- `pytest test_pr6_audit_logs_policy.py` — **21/21 passes**
- `pytest test_rbac_*.py test_me_policies.py test_sec_enum_audit.py test_rbac_endpoints.py test_rbac_seed.py test_rbac_matrix_living.py` — verde
- `pytest apps/core/tests/` (full) — **2152 passes, 42 skipped, 0 falhas**
- `python scripts/rbac_lint.py apps/core/` — 0 violações
- Black + isort + flake8 limpos
- `make staging-full` em `v2/infra` → ALL 8 CHECKS PASSED

## Não toca

- UI de Audit Logs (não há frontend consumindo `/api/audit-logs/` no `src/`)
- Scope object-level (filtro por gerência/aprovador) — escopo isolado de futura onda
- Rate limit / janela temporal
- Aprovações (RBAC PR 3 já endurecido)
- delegated bloqueio/deslocamento (PR 13 hardening)
- ProdutoViewSet, UsuarioLookup (PRs 4 e 5 já mergeados)

## Test plan

- [x] `pytest apps/core/tests/test_pr6_audit_logs_policy.py` — 21/21
- [x] `pytest apps/core/tests/test_rbac_matrix_living.py` — verde após ajuste
- [x] `pytest apps/core/tests/` (full) — 2152 passes
- [x] `python scripts/rbac_lint.py apps/core/` — 0 violações
- [x] Black + isort + flake8 limpos
- [x] `make staging-full` em `v2/infra` → 8/8 PASS

## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

```
==============================================
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz:   PASS
[2/8] Backend version:  PASS (v=staging-local)
[3/8] CSRF endpoint:    PASS
[4/8] Auth pipeline:    PASS (HTTP 400)
[5/8] Celery worker:    PASS
[6/8] Celery beat:      PASS
[7/8] Frontend HTTP:    PASS
[8/8] Frontend health:  PASS

ALL 8 CHECKS PASSED
==============================================
```