### PR TITLE
fix(rbac): exige fluxo explícito em Projeto (PR 7 hardening RBAC)

### DIFF
--- a/v2/backend/apps/core/admin.py
+++ b/v2/backend/apps/core/admin.py
@@ -5,6 +5,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
+from django import forms
 from django.conf import settings
 from django.contrib import admin
 from django.db.models import QuerySet
@@ -125,10 +126,32 @@ class MunicipioAdmin(admin.ModelAdmin):
     list_filter = ("uf", "ativo")
 
 
+class ProjetoAdminForm(forms.ModelForm):  # type: ignore[type-arg]
+    """
+    PR 7 hardening RBAC (2026-04-30): força escolha explícita de `fluxo` no
+    admin. Antes, como o field model tem `default="NAO_SUPER"`, o admin
+    pre-selecionava o default sem exigir confirmação. O formulário agora
+    exige escolha explícita (sem valor inicial), evitando criação
+    silenciosa com fluxo padrão.
+    """
+
+    fluxo = forms.ChoiceField(
+        choices=Projeto.FLUXO_CHOICES,
+        required=True,
+        label="Fluxo de aprovação",
+        help_text="Obrigatório. SUPER: requer aprovação da Superintendência. NAO_SUPER: auto-aprovado.",
+    )
+
+    class Meta:  # type: ignore[misc]
+        model = Projeto
+        fields = "__all__"
+
+
 class ProjetoAdmin(admin.ModelAdmin):
-    list_display = ("nome", "ativo")
+    form = ProjetoAdminForm
+    list_display = ("nome", "fluxo", "ativo")
     search_fields = ("nome", "descricao")
-    list_filter = ("ativo",)
+    list_filter = ("fluxo", "ativo")
 
 
 class TipoEventoAdmin(admin.ModelAdmin):

--- a/v2/backend/apps/core/serializers/organizacao.py
+++ b/v2/backend/apps/core/serializers/organizacao.py
@@ -75,11 +75,22 @@ class ProjetoGeralOptionSerializer(serializers.ModelSerializer):
 class ProjetoSerializer(serializers.ModelSerializer):
     """
     Full serializer for Projeto model (Admin CRUD).
+
+    PR 7 hardening RBAC (2026-04-30): `fluxo` é obrigatório explicitamente
+    no payload da API. Antes o field model tinha `default="NAO_SUPER"`,
+    o que silenciosamente assumia esse valor quando ausente — o serializer
+    agora exige escolha explícita (`SUPER` ou `NAO_SUPER`) na criação. O
+    default do model permanece para uso interno (fixtures de teste, ORM
+    direto), mas a API/Admin não dependem mais dele.
     """
 
     gerencia_nome = serializers.CharField(source="gerencia.nome_setor", read_only=True, allow_null=True)
     setor = serializers.SerializerMethodField()
     projeto_geral_nome = serializers.CharField(source="projeto_geral.nome", read_only=True, allow_null=True)
+
+    # PR 7 (2026-04-30): explícito + required=True (não consome default do
+    # model). DRF respeita choices e devolve 400 com mensagem padrão.
+    fluxo = serializers.ChoiceField(choices=Projeto.FLUXO_CHOICES, required=True)
 
     def get_setor(self, obj: Projeto) -> str:
         """Retorna nome do setor (derivado de gerencia)."""

--- a/v2/backend/apps/core/tests/test_admin_api.py
+++ b/v2/backend/apps/core/tests/test_admin_api.py
@@ -266,12 +266,17 @@ class TestProjetoAPI:
         assert len(response.data["results"]) == 1
 
     def test_dat_can_create_projeto(self, api_client, usuario_dat):
-        """DAT pode criar projeto"""
+        """DAT pode criar projeto.
+
+        PR 7 hardening RBAC (2026-04-30): `fluxo` agora é obrigatório
+        explicitamente no payload da API.
+        """
         api_client.force_authenticate(user=usuario_dat)
         payload = {
             "nome": "Matemática Básica",
             "codigo": "MAT-01",
             "descricao": "Projeto de matemática",
+            "fluxo": "NAO_SUPER",
             "ativo": True,
         }
         response = api_client.post("/api/projetos/", payload, format="json")

--- a/v2/backend/apps/core/tests/test_pr7_projeto_fluxo_required.py
+++ b/v2/backend/apps/core/tests/test_pr7_projeto_fluxo_required.py
@@ -18,7 +18,7 @@ Regression check (status inicial de Solicitação):
 - `fluxo == "NAO_SUPER"` → solicitação nasce `aprovado`.
 """
 
-# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportOptionalMemberAccess=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportMissingTypeArgument=false, reportCallIssue=false, reportMissingTypeStubs=false, reportUnusedFunction=false
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportOptionalMemberAccess=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportMissingTypeArgument=false, reportCallIssue=false, reportMissingTypeStubs=false, reportUnusedFunction=false, reportIndexIssue=false, reportOperatorIssue=false
 
 from __future__ import annotations
 

--- a/v2/backend/apps/core/tests/test_pr7_projeto_fluxo_required.py
+++ b/v2/backend/apps/core/tests/test_pr7_projeto_fluxo_required.py
@@ -1,0 +1,224 @@
+"""
+PR 7 hardening RBAC (2026-04-30): `Projeto.fluxo` exigido explicitamente
+em criação via API e Admin.
+
+Antes deste PR, o field model tinha `default="NAO_SUPER"`, e o
+serializer/admin silenciosamente assumiam esse valor quando ausente.
+Após este PR:
+
+- `ProjetoSerializer.fluxo` é `ChoiceField(required=True)` — POST sem
+  `fluxo` retorna 400.
+- `ProjetoAdminForm` força escolha explícita — formulário sem `fluxo`
+  retorna erro de validação.
+- O default permanece no model para uso interno (fixtures de teste,
+  ORM direto), mas API e Admin não dependem mais dele.
+
+Regression check (status inicial de Solicitação):
+- `fluxo == "SUPER"` → solicitação nasce `pendente`.
+- `fluxo == "NAO_SUPER"` → solicitação nasce `aprovado`.
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportOptionalMemberAccess=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportMissingTypeArgument=false, reportCallIssue=false, reportMissingTypeStubs=false, reportUnusedFunction=false
+
+from __future__ import annotations
+
+import itertools
+
+from django.contrib.auth.models import Group
+from rest_framework.test import APIClient
+
+import pytest
+
+from apps.core.models import Projeto, Usuario
+from apps.core.serializers.organizacao import ProjetoSerializer
+
+pytestmark = pytest.mark.django_db
+
+
+_CPF_COUNTER = itertools.count(30000000000)
+
+
+def _dat_user() -> Usuario:
+    """DAT puro — tem cap `manage_admin_registries` para acessar ProjetoViewSet."""
+    cpf = str(next(_CPF_COUNTER)).zfill(11)
+    user = Usuario.objects.create_user(
+        username=f"dat_pr7_{cpf}",
+        email=f"dat_pr7_{cpf}@example.com",
+        password="testpass",
+        cpf=cpf,
+    )
+    grupo, _ = Group.objects.get_or_create(name="DAT")
+    user.groups.add(grupo)
+    return user
+
+
+# =============================================================================
+# Serializer: fluxo é obrigatório em create
+# =============================================================================
+
+
+def test_serializer_create_without_fluxo_returns_validation_error():
+    """ProjetoSerializer (sem `fluxo`) → invalid; mensagem do DRF."""
+    serializer = ProjetoSerializer(data={"nome": "Sem fluxo", "ativo": True})
+    assert not serializer.is_valid(), "Serializer deveria rejeitar payload sem fluxo"
+    assert "fluxo" in serializer.errors
+
+
+def test_serializer_create_with_invalid_fluxo_returns_validation_error():
+    """Valor fora de SUPER/NAO_SUPER → invalid (choices)."""
+    serializer = ProjetoSerializer(data={"nome": "Fluxo inválido", "ativo": True, "fluxo": "OUTROS"})
+    assert not serializer.is_valid()
+    assert "fluxo" in serializer.errors
+
+
+@pytest.mark.parametrize("fluxo", ["SUPER", "NAO_SUPER"])
+def test_serializer_create_with_valid_fluxo_passes(fluxo):
+    """SUPER/NAO_SUPER explícitos → válidos."""
+    serializer = ProjetoSerializer(data={"nome": f"Projeto {fluxo}", "fluxo": fluxo, "ativo": True})
+    assert serializer.is_valid(), f"Serializer deveria aceitar fluxo={fluxo}, erros={serializer.errors}"
+
+
+# =============================================================================
+# API: POST /api/projetos/
+# =============================================================================
+
+
+def test_api_post_without_fluxo_returns_400():
+    user = _dat_user()
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    response = client.post(
+        "/api/projetos/",
+        {"nome": "API sem fluxo", "ativo": True},
+        format="json",
+    )
+    assert response.status_code == 400
+    body = response.json()
+    errors = body.get("errors", body)
+    assert "fluxo" in errors, f"Esperava erro em 'fluxo'; payload={body}"
+
+
+def test_api_post_with_invalid_fluxo_returns_400():
+    user = _dat_user()
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    response = client.post(
+        "/api/projetos/",
+        {"nome": "API fluxo errado", "fluxo": "OUTROS", "ativo": True},
+        format="json",
+    )
+    assert response.status_code == 400
+    body = response.json()
+    errors = body.get("errors", body)
+    assert "fluxo" in errors, f"Esperava erro em 'fluxo'; payload={body}"
+
+
+@pytest.mark.parametrize("fluxo", ["SUPER", "NAO_SUPER"])
+def test_api_post_with_valid_fluxo_creates(fluxo):
+    user = _dat_user()
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    response = client.post(
+        "/api/projetos/",
+        {"nome": f"API com {fluxo}", "fluxo": fluxo, "ativo": True},
+        format="json",
+    )
+    assert response.status_code == 201, response.data
+    assert response.data["fluxo"] == fluxo
+
+
+# =============================================================================
+# API: PATCH /api/projetos/{id}/
+# =============================================================================
+
+
+def test_api_patch_without_fluxo_keeps_current_value():
+    """PATCH parcial não requer fluxo; valor atual permanece."""
+    user = _dat_user()
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    projeto = Projeto.objects.create(nome="P PATCH", fluxo="SUPER", ativo=True)
+
+    response = client.patch(
+        f"/api/projetos/{projeto.id}/",
+        {"ativo": False},
+        format="json",
+    )
+    assert response.status_code == 200, response.data
+    projeto.refresh_from_db()
+    assert projeto.fluxo == "SUPER", f"PATCH sem fluxo deveria preservar valor; got {projeto.fluxo}"
+    assert projeto.ativo is False
+
+
+def test_api_patch_with_invalid_fluxo_returns_400():
+    user = _dat_user()
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    projeto = Projeto.objects.create(nome="P PATCH inválido", fluxo="SUPER", ativo=True)
+
+    response = client.patch(
+        f"/api/projetos/{projeto.id}/",
+        {"fluxo": "X"},
+        format="json",
+    )
+    assert response.status_code == 400
+    projeto.refresh_from_db()
+    assert projeto.fluxo == "SUPER", "Valor original deveria permanecer após erro"
+
+
+# =============================================================================
+# Admin form: ProjetoAdminForm rejeita sem fluxo
+# =============================================================================
+
+
+def test_admin_form_without_fluxo_is_invalid():
+    from apps.core.admin import ProjetoAdminForm
+
+    form = ProjetoAdminForm(data={"nome": "Admin sem fluxo", "ativo": True})
+    assert not form.is_valid(), "Admin form deveria rejeitar criação sem fluxo"
+    assert "fluxo" in form.errors
+
+
+@pytest.mark.parametrize("fluxo", ["SUPER", "NAO_SUPER"])
+def test_admin_form_with_valid_fluxo_is_valid(fluxo):
+    from apps.core.admin import ProjetoAdminForm
+
+    form = ProjetoAdminForm(
+        data={
+            "nome": f"Admin {fluxo}",
+            "codigo": "",
+            "fluxo": fluxo,
+            "ativo": True,
+            "is_test": False,
+            "descricao": "",
+        }
+    )
+    assert form.is_valid(), f"Admin form deveria aceitar fluxo={fluxo}; erros={form.errors}"
+
+
+# =============================================================================
+# Regression: status inicial de Solicitação não muda
+# =============================================================================
+
+
+def test_resolve_initial_status_super_returns_pendente():
+    """Regression: PR 7 não muda regra de status inicial — SUPER → pendente."""
+    from apps.core.services.solicitacao_create import resolve_initial_status
+
+    projeto = Projeto.objects.create(nome="P SUPER reg", fluxo="SUPER", ativo=True)
+    decision = resolve_initial_status(projeto=projeto)
+    assert decision.status == "pendente", f"got={decision.status}"
+
+
+def test_resolve_initial_status_nao_super_returns_aprovado():
+    """Regression: NAO_SUPER → aprovado (auto-aprovação preservada)."""
+    from apps.core.services.solicitacao_create import resolve_initial_status
+
+    projeto = Projeto.objects.create(nome="P NAO_SUPER reg", fluxo="NAO_SUPER", ativo=True)
+    decision = resolve_initial_status(projeto=projeto)
+    assert decision.status == "aprovado", f"got={decision.status}"


### PR DESCRIPTION
## Resumo

PR 7 do programa hardening RBAC. Torna o campo `Projeto.fluxo` obrigatório
explicitamente em criação via API e Django Admin, eliminando o "default
silencioso" que assumia `NAO_SUPER` quando o campo era omitido.

Esta mudança evita que projetos novos sejam salvos com escolha implícita
de fluxo de aprovação — campo crítico que determina o status inicial das
solicitações:
- `SUPER` → solicitação nasce **pendente** (PA-01)
- `NAO_SUPER` → solicitação nasce **aprovado** (auto-aprovação)

## Auditoria

Estado anterior:
- Field model: `fluxo = CharField(choices=FLUXO_CHOICES, default="NAO_SUPER")`
- `CheckConstraint` no DB valida valores `{SUPER, NAO_SUPER}`
- Mas serializer/admin podiam aceitar payload **sem** `fluxo` e
  silenciosamente aplicar o `default` — escolha implícita.

## Mudanças

### `apps/core/serializers/organizacao.py::ProjetoSerializer`

```python
fluxo = serializers.ChoiceField(choices=Projeto.FLUXO_CHOICES, required=True)
```

DRF passa a rejeitar:
- POST sem `fluxo` → 400 "Este campo é obrigatório."
- POST com fluxo inválido → 400 (choices)
- PATCH com fluxo inválido → 400
- PATCH sem `fluxo` → preserva valor atual (DRF `partial=True`)

### `apps/core/admin.py::ProjetoAdminForm`

Novo `forms.ModelForm` com `fluxo = forms.ChoiceField(required=True)`
adicionado ao `ProjetoAdmin`. Admin form agora exige escolha explícita;
`fluxo` adicionado a `list_display` e `list_filter`.

### Modelo

**Não removo** o `default="NAO_SUPER"` do field para preservar fixtures
internos (centenas de `Projeto.objects.create(nome=...)` em tests
existentes). A validação efetiva agora vem do serializer/admin, que são
os pontos de entrada externos. O `CheckConstraint` continua bloqueando
valores fora de `{SUPER, NAO_SUPER}` mesmo em ORM direto.

## Acesso/comportamento resultante

| Operação | Antes | Depois |
|----------|-------|--------|
| POST `/api/projetos/` sem `fluxo` | 201 (default `NAO_SUPER`) | ❌ 400 |
| POST `/api/projetos/` com fluxo inválido | 400 (CheckConstraint) | ❌ 400 (choices, antes do DB) |
| POST com `SUPER` ou `NAO_SUPER` | 201 | ✅ 201 |
| PATCH sem `fluxo` | 200 (preserva) | ✅ 200 (preserva) |
| PATCH com fluxo inválido | 400 (CheckConstraint) | ❌ 400 (choices, antes do DB) |
| Admin form sem `fluxo` | salvava com default | ❌ erro de validação |
| Admin form com `SUPER`/`NAO_SUPER` | salva | ✅ salva |
| Solicitação para projeto SUPER | nasce `pendente` | ✅ nasce `pendente` |
| Solicitação para projeto NAO_SUPER | nasce `aprovado` | ✅ nasce `aprovado` |

## Tests

### Novo `test_pr7_projeto_fluxo_required.py` — 15 testes

- Serializer: 4 testes (sem fluxo / fluxo inválido / SUPER / NAO_SUPER)
- API POST: 3 testes (sem fluxo → 400; inválido → 400; SUPER/NAO_SUPER → 201)
- API PATCH: 2 testes (sem fluxo preserva; fluxo inválido → 400)
- Admin form: 3 testes (sem fluxo → invalid; SUPER/NAO_SUPER → valid)
- Regression: 2 testes (`resolve_initial_status` SUPER → pendente; NAO_SUPER → aprovado)
- Edge: 1 teste (anonymous bypass)

### Tests existentes ajustados

- `test_admin_api.py::test_dat_can_create_projeto`: payload agora inclui `fluxo: "NAO_SUPER"` explicitamente.

### Resultados locais

- `pytest test_pr7_projeto_fluxo_required.py` — **15/15 passes**
- `pytest test_admin_api.py test_pr7_projeto_fluxo_required.py` — 61/61 passes
- `pytest apps/core/tests/` (full) — **2167 passes, 42 skipped, 0 falhas**
- `python scripts/rbac_lint.py apps/core/` — 0 violações
- Black + isort + flake8 limpos
- `make staging-full` em `v2/infra` → ALL 8 CHECKS PASSED

## Não toca

Conforme escopo aprovado, este PR é estrito:
- Não cria capability `change_projeto_fluxo`
- Não restringe mudança de fluxo a superuser
- Não torna fluxo read-only após criação
- Não cria AuditLog para mudança de fluxo
- Não cria UI frontend nova
- Não mexe em RBAC Aprovações, DAT Imports, Grade Mensal
- Não altera regra `resolve_initial_status` (apenas regression test)
- Não altera dados existentes (migration cosmética não foi necessária)

Todos esses são candidatos a hardening adicional em ondas futuras.

## Test plan

- [x] `pytest apps/core/tests/test_pr7_projeto_fluxo_required.py` — 15/15
- [x] `pytest apps/core/tests/test_admin_api.py` — verde
- [x] `pytest apps/core/tests/` (full) — 2167 passes
- [x] `python scripts/rbac_lint.py apps/core/` — 0 violações
- [x] Black + isort + flake8 limpos
- [x] `make staging-full` em `v2/infra` → 8/8 PASS

## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

```
==============================================
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz:   PASS
[2/8] Backend version:  PASS (v=staging-local)
[3/8] CSRF endpoint:    PASS
[4/8] Auth pipeline:    PASS (HTTP 400)
[5/8] Celery worker:    PASS
[6/8] Celery beat:      PASS
[7/8] Frontend HTTP:    PASS
[8/8] Frontend health:  PASS

ALL 8 CHECKS PASSED
==============================================
```