### PR TITLE
test(rbac): expande matriz viva para aprovações, produtos e lookup

### DIFF
--- a/v2/backend/apps/core/rbac/matrix.py
+++ b/v2/backend/apps/core/rbac/matrix.py
@@ -43,10 +43,15 @@ SUPERUSER: Final = "Superuser"
 DAT: Final = "DAT"
 CONTROLE: Final = "Controle"
 DIRETORIA: Final = "Diretoria"
-GERENTE: Final = "Gerente"
+GERENTE: Final = "Gerente"  # legacy — Setor Vidas + Função Gerente (Gerente pedagógico)
 COORDENADOR: Final = "Coordenador"
 APOIO: Final = "Apoio de Coordenação"
 FORMADOR: Final = "Formador"
+
+# PR 8 hardening RBAC (2026-04-30): atores compostos para distinguir
+# regras endurecidas em PRs 3-6 (Aprovações + Audit Logs).
+GERENTE_SUPER: Final = "Gerente da Superintendência"  # Setor Sup + Função Gerente
+ASST_ADMIN_CONTROLE: Final = "Assistente Administrativo do Controle"  # Setor Controle + Função Asst Admin
 
 ACTORS: Final[tuple[str, ...]] = (
     SUPERUSER,
@@ -54,18 +59,23 @@ ACTORS: Final[tuple[str, ...]] = (
     CONTROLE,
     DIRETORIA,
     GERENTE,
+    GERENTE_SUPER,
+    ASST_ADMIN_CONTROLE,
     COORDENADOR,
     APOIO,
     FORMADOR,
 )
 
 # Mapping ator → group_names usados em `_make_user`. Superuser é caso especial.
+# Atores compostos têm múltiplos grupos (Setor + Função).
 ACTOR_GROUPS: Final[dict[str, list[str]]] = {
     SUPERUSER: [],  # is_superuser=True (não usa grupos)
     DAT: ["DAT"],
     CONTROLE: ["Controle"],
     DIRETORIA: ["Diretoria"],
     GERENTE: ["Gerente"],
+    GERENTE_SUPER: ["Superintendência", "Gerente"],
+    ASST_ADMIN_CONTROLE: ["Controle", "Assistente Administrativo"],
     COORDENADOR: ["Coordenador"],
     APOIO: ["Apoio de Coordenação"],
     FORMADOR: ["Formador"],
@@ -79,12 +89,17 @@ ACTOR_GROUPS: Final[dict[str, list[str]]] = {
 
 @dataclass(frozen=True)
 class ResourceCase:
-    """Endpoint a auditar. `query` adicionado à URL via querystring."""
+    """Endpoint a auditar. `query` adicionado à URL via querystring.
+
+    `body` permite payload válido em POST (ex: `{"ids": []}` para
+    batch-approve evitar 400 por ids_required quando o gate aprova).
+    """
 
     name: str
     method: str
     url: str
     query: dict[str, str] = field(default_factory=dict)
+    body: dict[str, object] = field(default_factory=dict)
 
     def full_url(self) -> str:
         if not self.query:
@@ -96,6 +111,13 @@ class ResourceCase:
 # Status codes canônicos. Manter como int para que pytest exiba diff legível.
 ALLOW = 200
 DENY = 403
+# PR 8 hardening RBAC (2026-04-30): para endpoints POST cujo gate de
+# autorização passa antes da validação de payload, o test runner usa
+# `ALLOW_PAYLOAD_INVALID` — significa "gate aprovou; serviço rejeitou
+# payload por motivo não-RBAC". Útil para batch-approve com `ids: []`
+# (gate aprova; serviço retorna 400 ids_required). Permanece distinto
+# de DENY (403) para garantir que o gate diferenciou o ator.
+ALLOW_PAYLOAD_INVALID = 400
 
 
 RESOURCES: Final[tuple[ResourceCase, ...]] = (
@@ -112,6 +134,20 @@ RESOURCES: Final[tuple[ResourceCase, ...]] = (
     ResourceCase("audit_logs", "GET", "/api/audit-logs/"),
     ResourceCase("me_events", "GET", "/api/me/events/"),
     ResourceCase("solicitacoes_list", "GET", "/api/solicitacoes/"),
+    # PR 8 hardening RBAC (2026-04-30): cobre regras endurecidas em PRs 3-6.
+    # Aprovação composite (PR 3 #1308): batch-approve representa os 4 endpoints
+    # de aprovação (mesmo gate `CanAccessSolicitationApprovals`). approve/reject
+    # individuais e batch-reject têm cobertura dedicada em test_pr3_approvals_policy.
+    ResourceCase(
+        "solicitacoes_batch_approve",
+        "POST",
+        "/api/solicitacoes/batch-approve/",
+        body={"ids": []},  # lista vazia é no-op (200 com approved=0); evita 400 por ids_required
+    ),
+    # ProdutoViewSet (PR 4 #1309): list restrito a DAT/Controle.
+    ResourceCase("produtos_list", "GET", "/api/produtos/"),
+    # UsuarioLookup (PR 5 #1310): cap-gated, sem hardcode de grupos.
+    ResourceCase("usuario_lookup", "GET", "/api/lookup/usuarios/"),
 )
 
 
@@ -140,6 +176,8 @@ ACCESS_MATRIX: Final[dict[str, dict[str, int]]] = {
         CONTROLE: ALLOW,  # view_all_availability via seed 0080 (mantém de D6)
         DIRETORIA: DENY,  # D8: decisão executiva, não consulta operacional
         GERENTE: ALLOW,  # D9: scoped via EquipeGerencia (perdeu cap global) — fixture cria vínculo
+        GERENTE_SUPER: ALLOW,  # PR 8: composite Sup+Gerente — fixture cria EquipeGerencia
+        ASST_ADMIN_CONTROLE: ALLOW,  # PR 8: setor Controle herda view_all_availability via seed 0080
         COORDENADOR: ALLOW,  # scoped via EquipeGerencia (D6) — fixture cria vínculo
         APOIO: ALLOW,  # scoped via EquipeGerencia (D6) — fixture cria vínculo
         FORMADOR: DENY,  # D8: caso especial; só Meus Eventos + Bloqueios próprios
@@ -159,6 +197,8 @@ ACCESS_MATRIX: Final[dict[str, dict[str, int]]] = {
         CONTROLE: DENY,
         DIRETORIA: ALLOW,  # view_compras_dashboard
         GERENTE: DENY,
+        GERENTE_SUPER: DENY,
+        ASST_ADMIN_CONTROLE: DENY,
         COORDENADOR: DENY,
         APOIO: DENY,
         FORMADOR: DENY,
@@ -173,6 +213,8 @@ ACCESS_MATRIX: Final[dict[str, dict[str, int]]] = {
         CONTROLE: ALLOW,  # run_daily_operations
         DIRETORIA: ALLOW,  # supervise_operations
         GERENTE: DENY,
+        GERENTE_SUPER: DENY,
+        ASST_ADMIN_CONTROLE: ALLOW,  # herda Controle (run_daily_operations)
         COORDENADOR: DENY,
         APOIO: DENY,
         FORMADOR: DENY,
@@ -187,6 +229,8 @@ ACCESS_MATRIX: Final[dict[str, dict[str, int]]] = {
         CONTROLE: DENY,
         DIRETORIA: DENY,
         GERENTE: DENY,
+        GERENTE_SUPER: DENY,
+        ASST_ADMIN_CONTROLE: DENY,
         COORDENADOR: DENY,
         APOIO: DENY,
         FORMADOR: DENY,
@@ -196,14 +240,15 @@ ACCESS_MATRIX: Final[dict[str, dict[str, int]]] = {
     # Capabilities: manage_admin_registries | operate_preagenda.
     # PR 6 (2026-04-30): removidos `approve_solicitation` e
     # `approve_solicitation_batch` para evitar liberação indevida a
-    # Gerente pedagógico, Sup pura e Gerente da Sup. Auditoria por
-    # aprovador volta como escopo isolado se necessário em onda futura.
+    # Gerente pedagógico, Sup pura e Gerente da Sup.
     "audit_logs": {
         SUPERUSER: ALLOW,
         DAT: ALLOW,  # manage_admin_registries (suportar)
         CONTROLE: ALLOW,  # operate_preagenda (operar)
         DIRETORIA: DENY,
         GERENTE: DENY,  # PR 6: removido approve_solicitation_batch do gate
+        GERENTE_SUPER: DENY,  # PR 6: idem (já não tem mais approve_solicitation no gate)
+        ASST_ADMIN_CONTROLE: ALLOW,  # herda Controle (operate_preagenda)
         COORDENADOR: DENY,
         APOIO: DENY,
         FORMADOR: DENY,
@@ -216,6 +261,67 @@ ACCESS_MATRIX: Final[dict[str, dict[str, int]]] = {
     # /api/solicitacoes/ list: `[IsAuthenticated]` via get_permissions (sem create).
     # Queryset filtra por permissions de quem pode ver tudo vs próprias.
     "solicitacoes_list": _ALL_AUTH,
+    #
+    # PR 8 (2026-04-30): consolida regras dos PRs 3, 4, 5 na matriz.
+    #
+    # Aprovação de solicitação (PR 3 #1308): policy composta
+    # `CanAccessSolicitationApprovals` = Gerente Sup OR Asst Admin Controle.
+    # Os 4 endpoints (approve/reject individual + batch) compartilham o mesmo
+    # gate; batch-approve representa todos. Cobertura granular fica em
+    # `test_pr3_approvals_policy.py`.
+    # Status code esperado para POST sem ids = 200 (lista vazia → no-op) para
+    # personas allowed; demais perfis recebem 403 antes do payload.
+    "solicitacoes_batch_approve": {
+        # ALLOW_PAYLOAD_INVALID (400) = gate aprovou; serviço rejeita payload
+        # `ids: []` por ids_required. Cobertura granular dos 4 endpoints com
+        # solicitação pendente real está em test_pr3_approvals_policy.py.
+        SUPERUSER: ALLOW_PAYLOAD_INVALID,
+        DAT: DENY,
+        CONTROLE: DENY,  # Controle puro não aprova (precisa Função Asst Admin)
+        DIRETORIA: DENY,
+        GERENTE: DENY,  # Gerente pedagógico (Vidas + Gerente) NÃO aprova
+        GERENTE_SUPER: ALLOW_PAYLOAD_INVALID,  # composite Setor Sup + Função Gerente
+        ASST_ADMIN_CONTROLE: ALLOW_PAYLOAD_INVALID,  # composite Setor Controle + Função Asst Admin
+        COORDENADOR: DENY,
+        APOIO: DENY,
+        FORMADOR: DENY,
+    },
+    #
+    # ProdutoViewSet list (PR 4 #1309): list/retrieve restrito a operação/admin.
+    # Composition: `manage_admin_registries | manage_purchases_and_materials | run_daily_operations`.
+    # DAT (admin) + Controle (operação). Dropdowns/selects de Coord/Apoio
+    # consomem `/api/options/produtos/` (IsAuthenticated, intocado).
+    "produtos_list": {
+        SUPERUSER: ALLOW,
+        DAT: ALLOW,  # manage_admin_registries
+        CONTROLE: ALLOW,  # run_daily_operations + manage_purchases_and_materials
+        DIRETORIA: DENY,
+        GERENTE: DENY,
+        GERENTE_SUPER: DENY,
+        ASST_ADMIN_CONTROLE: ALLOW,  # herda Controle
+        COORDENADOR: DENY,
+        APOIO: DENY,
+        FORMADOR: DENY,
+    },
+    #
+    # UsuarioLookup (PR 5 #1310): cap-gated, sem hardcode de grupos.
+    # Composition: `create_solicitation | manage_admin_registries`.
+    # Coord/Apoio/Gerente (pedagógico ou Sup) usam `create_solicitation` para
+    # popular pickers em NewSolicitacaoWizard. DAT usa manage_admin_registries.
+    # Asst Admin Controle puro não tem create_solicitation no seed; só passa
+    # se também tiver Função Coord/Apoio/Gerente — não esse ator.
+    "usuario_lookup": {
+        SUPERUSER: ALLOW,
+        DAT: ALLOW,  # manage_admin_registries
+        CONTROLE: DENY,  # PR 5: sem create_solicitation nem manage_admin_registries
+        DIRETORIA: DENY,
+        GERENTE: ALLOW,  # create_solicitation (seed atribui a Função Gerente)
+        GERENTE_SUPER: ALLOW,  # idem (composite tem Função Gerente)
+        ASST_ADMIN_CONTROLE: DENY,  # composite Asst Admin não tem create_solicitation
+        COORDENADOR: ALLOW,  # create_solicitation
+        APOIO: ALLOW,  # create_solicitation
+        FORMADOR: DENY,
+    },
 }
 
 

--- a/v2/backend/apps/core/tests/test_rbac_matrix_living.py
+++ b/v2/backend/apps/core/tests/test_rbac_matrix_living.py
@@ -25,8 +25,10 @@ from apps.core.rbac.matrix import (
     ACTOR_GROUPS,
     ACTORS,
     APOIO,
+    ASST_ADMIN_CONTROLE,
     COORDENADOR,
     GERENTE,
+    GERENTE_SUPER,
     RESOURCES,
     SUPERUSER,
     ResourceCase,
@@ -77,11 +79,15 @@ def _make_user_for_actor(actor: str) -> Usuario:
         group, _ = Group.objects.get_or_create(name=gname)
         user.groups.add(group)
 
-    # D8 + D9: Coord/Apoio/Gerente precisam de vínculo organizacional para passar HasSectorAccess.
-    if actor in (COORDENADOR, APOIO, GERENTE):
+    # D8 + D9 + PR 8: Coord/Apoio/Gerente* precisam de vínculo organizacional
+    # para passar HasSectorAccess na grade mensal.
+    if actor in (COORDENADOR, APOIO, GERENTE, GERENTE_SUPER):
+        # Setor da gerência segue o ator (Vidas para pedagógico, Sup para
+        # GERENTE_SUPER) — diferenciação importante para tests de scope.
+        nome_setor = "Superintendência" if actor == GERENTE_SUPER else "Vidas"
         gerencia, _ = Gerencia.objects.get_or_create(
             nome=f"GERENCIA MATRIX {_USER_COUNTER['i']:06d}",
-            defaults={"nome_setor": "Vidas"},
+            defaults={"nome_setor": nome_setor},
         )
         if actor == COORDENADOR:
             # Coordenador: papel direto, sem supervisor.
@@ -91,8 +97,8 @@ def _make_user_for_actor(actor: str) -> Usuario:
                 papel="COORDENADOR",
                 ativo=True,
             )
-        elif actor == GERENTE:
-            # Gerente: papel direto, sem supervisor (D9 — perdeu cap global).
+        elif actor in (GERENTE, GERENTE_SUPER):
+            # Gerente (pedagógico ou Sup): papel direto, sem supervisor.
             EquipeGerencia.objects.create(
                 gerencia=gerencia,
                 usuario=user,
@@ -160,7 +166,7 @@ def test_actor_can_or_cannot_access_resource(actor: str, resource: ResourceCase,
     if resource.method == "GET":
         res = client.get(resource.full_url())
     elif resource.method == "POST":
-        res = client.post(resource.full_url(), data={}, format="json")
+        res = client.post(resource.full_url(), data=resource.body or {}, format="json")
     else:
         raise ValueError(f"Method {resource.method} não suportado pela matriz viva")
 
@@ -216,9 +222,10 @@ def test_matrix_covers_all_actor_resource_combinations():
 
 
 def test_matrix_status_codes_are_valid():
-    """Toda célula deve ser ALLOW (200) ou DENY (403). Detecta typos tipo 200 vs 201."""
+    """Toda célula deve ser ALLOW (200), ALLOW_PAYLOAD_INVALID (400) ou DENY (403)."""
     for resource_name, actor_map in ACCESS_MATRIX.items():
         for actor, status in actor_map.items():
-            assert status in (200, 403), (
-                f"ACCESS_MATRIX['{resource_name}']['{actor}'] = {status} é inválido. " f"Use 200 (ALLOW) ou 403 (DENY)."
+            assert status in (200, 400, 403), (
+                f"ACCESS_MATRIX['{resource_name}']['{actor}'] = {status} é inválido. "
+                "Use 200 (ALLOW), 400 (ALLOW_PAYLOAD_INVALID) ou 403 (DENY)."
             )

--- a/v2/backend/apps/core/tests/test_rbac_matrix_scope.py
+++ b/v2/backend/apps/core/tests/test_rbac_matrix_scope.py
@@ -1,0 +1,203 @@
+"""
+PR 8 hardening RBAC (2026-04-30): testes de **escopo** discriminante na
+Grade Mensal — complementa a Matriz Viva (que valida apenas ALLOW/DENY)
+distinguindo o que cada subtipo de Gerente realmente vê.
+
+Foco discriminante (não está coberto pela Matriz Viva ALLOW/DENY):
+- Gerente pedagógico (Setor `Vidas` + Função `Gerente`) vê grade
+  filtrada por Vidas; **não** vê dados de Fluir.
+- Gerente da Superintendência vê grade filtrada por Superintendência.
+- Coordenador / Apoio: scope via `EquipeGerencia` ativa.
+- Controle / DAT: cap global via `view_all_availability` (D9).
+
+Tests aqui são focados; cobertura de ALLOW/DENY por endpoint segue na
+Matriz Viva (`test_rbac_matrix_living.py`).
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportOptionalMemberAccess=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportMissingTypeArgument=false, reportCallIssue=false, reportMissingTypeStubs=false, reportUnusedFunction=false, reportIndexIssue=false, reportOperatorIssue=false
+
+from __future__ import annotations
+
+import itertools
+
+from django.contrib.auth.models import Group
+from rest_framework.test import APIClient
+
+import pytest
+
+from apps.core.models import EquipeGerencia, Gerencia, Usuario
+
+pytestmark = pytest.mark.django_db
+
+
+_CPF_COUNTER = itertools.count(20000000000)
+
+
+def _user_in_groups(*group_names: str, label: str = "user") -> Usuario:
+    cpf = str(next(_CPF_COUNTER)).zfill(11)
+    user = Usuario.objects.create_user(
+        username=f"{label}_{cpf}",
+        email=f"{label}_{cpf}@example.com",
+        password="testpass",
+        cpf=cpf,
+    )
+    for name in group_names:
+        group, _ = Group.objects.get_or_create(name=name)
+        user.groups.add(group)
+    return user
+
+
+def _attach_equipe(user: Usuario, gerencia: Gerencia, papel: str = "GERENTE") -> EquipeGerencia:
+    return EquipeGerencia.objects.create(gerencia=gerencia, usuario=user, papel=papel, ativo=True)
+
+
+@pytest.fixture
+def gerencia_vidas() -> Gerencia:
+    g, _ = Gerencia.objects.get_or_create(
+        nome="VIDAS SCOPE TEST",
+        defaults={"nome_setor": "Vidas"},
+    )
+    return g
+
+
+@pytest.fixture
+def gerencia_fluir() -> Gerencia:
+    g, _ = Gerencia.objects.get_or_create(
+        nome="FLUIR SCOPE TEST",
+        defaults={"nome_setor": "Fluir"},
+    )
+    return g
+
+
+@pytest.fixture
+def gerencia_super() -> Gerencia:
+    g, _ = Gerencia.objects.get_or_create(
+        nome="SUP SCOPE TEST",
+        defaults={"nome_setor": "Superintendência"},
+    )
+    return g
+
+
+# =============================================================================
+# Grade Mensal — scope discriminante por Gerente pedagógico vs Gerente Sup
+# =============================================================================
+
+
+def test_gerente_pedagogico_vidas_acessa_propria_gerencia_mas_nao_fluir(gerencia_vidas, gerencia_fluir):
+    """Gerente pedagógico em Vidas: 200 com `gerencia_id=Vidas`; 403 com `gerencia_id=Fluir`.
+
+    PR 8: Gerente pedagógico perdeu cap global em D9 — só vê via vínculo
+    `EquipeGerencia` ativo. Não tem vínculo em Fluir → bloqueado.
+    """
+    user = _user_in_groups("Vidas", "Gerente", label="gerente_vidas_scope")
+    _attach_equipe(user, gerencia_vidas, papel="GERENTE")
+
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    # Vidas — vínculo presente → 200
+    response_vidas = client.get(
+        f"/api/availability/monthly/?year=2026&month=5&role=FORMADOR&gerencia_id={gerencia_vidas.id}"
+    )
+    assert response_vidas.status_code == 200, response_vidas.json()
+
+    # Fluir — sem vínculo → 403
+    response_fluir = client.get(
+        f"/api/availability/monthly/?year=2026&month=5&role=FORMADOR&gerencia_id={gerencia_fluir.id}"
+    )
+    assert (
+        response_fluir.status_code == 403
+    ), f"Gerente pedagógico Vidas NÃO deveria ver Fluir; recebeu {response_fluir.status_code}"
+
+
+def test_gerente_superintendencia_acessa_propria_gerencia(gerencia_super, gerencia_vidas):
+    """Gerente da Superintendência: vê Sup, não vê Vidas (sem cap global)."""
+    user = _user_in_groups("Superintendência", "Gerente", label="gerente_sup_scope")
+    _attach_equipe(user, gerencia_super, papel="GERENTE")
+
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    # Sup — vínculo presente → 200
+    response_sup = client.get(
+        f"/api/availability/monthly/?year=2026&month=5&role=FORMADOR&gerencia_id={gerencia_super.id}"
+    )
+    assert response_sup.status_code == 200, response_sup.json()
+
+    # Vidas — sem vínculo → 403
+    response_vidas = client.get(
+        f"/api/availability/monthly/?year=2026&month=5&role=FORMADOR&gerencia_id={gerencia_vidas.id}"
+    )
+    assert (
+        response_vidas.status_code == 403
+    ), f"Gerente da Sup NÃO deveria ver Vidas; recebeu {response_vidas.status_code}"
+
+
+def test_coordenador_scope_via_equipe_gerencia(gerencia_vidas, gerencia_fluir):
+    """Coordenador vê apenas a própria EquipeGerencia ativa."""
+    user = _user_in_groups("Coordenador", label="coord_scope")
+    _attach_equipe(user, gerencia_vidas, papel="COORDENADOR")
+
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    response_vidas = client.get(
+        f"/api/availability/monthly/?year=2026&month=5&role=FORMADOR&gerencia_id={gerencia_vidas.id}"
+    )
+    assert response_vidas.status_code == 200
+
+    response_fluir = client.get(
+        f"/api/availability/monthly/?year=2026&month=5&role=FORMADOR&gerencia_id={gerencia_fluir.id}"
+    )
+    assert response_fluir.status_code == 403
+
+
+def test_apoio_scope_via_equipe_gerencia(gerencia_vidas, gerencia_fluir):
+    """Apoio de Coordenação: mesma regra do Coord."""
+    coord = _user_in_groups("Coordenador", label="coord_apoio_supervisor")
+    EquipeGerencia.objects.create(gerencia=gerencia_vidas, usuario=coord, papel="COORDENADOR", ativo=True)
+
+    user = _user_in_groups("Apoio de Coordenação", label="apoio_scope")
+    EquipeGerencia.objects.create(
+        gerencia=gerencia_vidas,
+        usuario=user,
+        papel="APOIO",
+        ativo=True,
+        coordenador_supervisor=coord,
+    )
+
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    response_vidas = client.get(
+        f"/api/availability/monthly/?year=2026&month=5&role=FORMADOR&gerencia_id={gerencia_vidas.id}"
+    )
+    assert response_vidas.status_code == 200
+
+    response_fluir = client.get(
+        f"/api/availability/monthly/?year=2026&month=5&role=FORMADOR&gerencia_id={gerencia_fluir.id}"
+    )
+    assert response_fluir.status_code == 403
+
+
+def test_controle_e_dat_mantem_acesso_global(gerencia_vidas, gerencia_fluir):
+    """Controle e DAT têm cap `view_all_availability` (seed 0080) — bypass scope."""
+    controle = _user_in_groups("Controle", label="controle_global")
+    dat = _user_in_groups("DAT", label="dat_global")
+
+    client_c = APIClient()
+    client_c.force_authenticate(user=controle)
+
+    client_d = APIClient()
+    client_d.force_authenticate(user=dat)
+
+    # Ambos acessam Vidas e Fluir sem vínculo de gerência (cap global cobre).
+    for gerencia in (gerencia_vidas, gerencia_fluir):
+        for client in (client_c, client_d):
+            response = client.get(
+                f"/api/availability/monthly/?year=2026&month=5&role=FORMADOR&gerencia_id={gerencia.id}"
+            )
+            assert response.status_code == 200, (
+                f"Controle/DAT deveriam acessar gerência {gerencia.nome_setor} via cap global; "
+                f"got {response.status_code}"
+            )

--- a/v2/docs/rbac_authorization_matrix.md
+++ b/v2/docs/rbac_authorization_matrix.md
@@ -44,7 +44,16 @@ Ver `RBAC_NAMING.md` para convenção de nomes (verbos canônicos, classe ↔ ke
 | Gerente | Supervisão, aprovação composta com Superintendência | Cross-sector (transversal) |
 | Coordenador | Cria solicitações, gerencia bloqueios próprios | Setor vinculado via `EquipeGerencia` |
 | Apoio de Coordenação | Mesma regra do Coordenador | Setor vinculado |
+| Assistente Administrativo | Função formal criada em PR 3 hardening RBAC (#1308). Combinada com Setor `Controle` libera aprovação de solicitações via `CanAccessSolicitationApprovals`. | Setor vinculado |
 | Formador | Declara próprio bloqueio (RD-02/03), participa de eventos | Próprios dados |
+
+### Composites Setor × Função (PR 3 hardening RBAC, 2026-04-29)
+
+| Composite | Setor | Função | Capacidade ganha |
+|-----------|-------|--------|------------------|
+| **Gerente da Superintendência** | `Superintendência` | `Gerente` | Aprovação de solicitações (individual + lote) |
+| **Assistente Administrativo do Controle** | `Controle` | `Assistente Administrativo` | Aprovação de solicitações (individual + lote) |
+| **Gerente pedagógico** | `Vidas` / `Fluir` / etc. (não-Sup) | `Gerente` | Cria/edita solicitação (`create_solicitation`); **não aprova** |
 
 ### Princípio "ator transversal"
 
@@ -68,12 +77,16 @@ Legenda:
 | **Dashboard GCal** (`/dashboards/gcal`) | 🔧 | ✅ (suportar) | ✅ (decidir) | ✅ (operar) | 🔒 | 🔒 | 🔒 |
 | **Mapa do Brasil** (`/mapa-brasil`) | 🔧 | ✅ (validar) | ✅ (decidir) | 🔒 | 🔒 | 🔒 | 🔒 |
 | **Grade Mensal** (`/api/availability/monthly/`) | 🔧 | ⚠️ scope | 🔒 | ✅ `view_all_availability` | ✅ `view_all_availability` | ⚠️ scope `EquipeGerencia` | 🔒 (não é grade — usa `/me/events`) |
-| **Aprovações** (`/solicitacoes/{id}/approve\|reject`) | 🔧 | 🔒 | ✅ Superintendência | 🔒 | ✅ batch (composite) | 🔒 | 🔒 |
+| **Aprovações** (`/solicitacoes/{id}/approve\|reject`, `/solicitacoes/batch-approve\|batch-reject`) | 🔧 | 🔒 | 🔒 (sem Função Gerente) | 🔒 (sem Função Asst Admin) | 🔒 (Gerente pedagógico) / ✅ composite Gerente da Sup / ✅ composite Asst Admin do Controle | 🔒 | 🔒 |
 | **Bloqueios** (`AvailabilityBlockViewSet`) | 🔧 | 🔒 | 🔒 | ⚠️ scope ampla | ⚠️ scope ampla | ⚠️ próprios + scope | ⚠️ apenas próprios (RD-02/03) |
 | **Deslocamentos** (`DeslocamentoViewSet`) | 🔧 | 🔒 | 🔒 | ✅ `view_all_availability` | ✅ `view_all_availability` | ⚠️ scope (Onda 1 — alinhar) | 🔒 |
 | **DAT Compras** (`DATCompraViewSet`) | 🔧 | ✅ `manage_purchases_and_materials` | ✅ dashboard | ✅ `manage_purchases_and_materials` | 🔒 | 🔒 | 🔒 |
 | **Reports** (`views_reports.py`) | 🔧 | ✅ `manage_admin_registries` | 🔒 | ✅ `operate_preagenda` | ✅ Super (auditar) | 🔒 | 🔒 |
-| **Admin Registries** (Municípios, Projetos, Produtos, etc.) | 🔧 | ✅ `manage_admin_registries` | 🔒 | 🔒 | 🔒 | 🔒 | 🔒 |
+| **Admin Registries** (Municípios) | 🔧 | ✅ `manage_admin_registries` | 🔒 | 🔒 | 🔒 | 🔒 | 🔒 |
+| **ProdutoViewSet — list/retrieve** (`GET /api/produtos/`) (PR 4 #1309) | 🔧 | ✅ `manage_admin_registries` | 🔒 | ✅ `run_daily_operations` / `manage_purchases_and_materials` | 🔒 | 🔒 (dropdowns: `/api/options/produtos/`) | 🔒 |
+| **Projeto — POST/PATCH** (`/api/projetos/`) (PR 7 #1312) | 🔧 | ✅ `manage_admin_registries` (com `fluxo` obrigatório) | 🔒 | 🔒 | 🔒 | 🔒 | 🔒 |
+| **UsuarioLookup** (`GET /api/lookup/usuarios/`) (PR 5 #1310) | 🔧 | ✅ `manage_admin_registries` | 🔒 | 🔒 | ✅ `create_solicitation` | ✅ `create_solicitation` | 🔒 |
+| **AuditLogs** (`GET /api/audit-logs/`) (PR 6 #1311) | 🔧 | ✅ `manage_admin_registries` | 🔒 | ✅ `operate_preagenda` | 🔒 (PR 6: removidos `approve_solicitation*`) | 🔒 | 🔒 |
 | **Imports** (planilhas) | 🔧 | ✅ `import_spreadsheet` | 🔒 | 🔒 | 🔒 | 🔒 | 🔒 |
 | **Ações Internas** (`CicloAcoes`, `AcaoInstancia`) | 🔧 | ✅ (Onda 1 — substituir `IsAdminUser`) | 🔒 | 🔒 | 🔒 | 🔒 | 🔒 |
 | **Solicitações — Criar** (`POST /solicitacoes/`) | 🔧 | 🔒 (não é função de DAT) | 🔒 | 🔒 | ✅ `create_solicitation` | ✅ `create_solicitation` | 🔒 |
@@ -158,6 +171,12 @@ permission_classes = [IsAdminUser]                    # ❌ DRF built-in fora da
 | D7 | Dashboards = Diretoria + DAT + superuser only | 2026-04-26 | `project_rbac_invariants.md` — Controle não vê Dashboards (Onda 1 corrige `usePermissions` hardcoded) |
 | D8 | Formador, DAT e Diretoria **não acessam** Grade Mensal; Coord/Apoio só com `EquipeGerencia` ativa | 2026-04-28 (issue #1287) | Formador é caso especial RD-02/RD-03 (acessa só Meus Eventos + Bloqueios). DAT/Diretoria não têm motivo legítimo de consultar grade. Antes do fix, frontend `canDisponibilidade=!inControle` (lógica invertida) e backend `HasSectorAccess` retornava True sem `gerencia_id` — Formador via menu e abria página com 200. Reescrita como lista positiva no frontend + endurecimento no backend (sem `gerencia_id` exige vínculo de gerência) |
 | D9 | Grade Mensal — **DAT recebe** `view_all_availability` global; **Gerente perde** cap global e cai em scope via `EquipeGerencia` (igual Coord/Apoio) | 2026-04-28 (PR 2 RBAC hardening) | Refina D8: DAT é ator transversal admin (suporte/validação cross-setor) — motivo legítimo para grade global. Gerente pedagógico (ACerta, Vidas, Fluir, Brincando, Sou da Paz, Gestão Escolar) e Gerente da Superintendência devem ver apenas a própria gerência via `EquipeGerencia` — não devem receber visão global apenas por ter função "Gerente". Migration 0080 redistribui `view_all_availability` de `[Controle, Gerente]` para `[Controle, DAT]`. Diretoria mantém DENY (D8). Formador mantém DENY (D8). Distinção semântica entre subtipos de Gerente (pedagógico vs Sup vs DAT) fica em PR 8 (Matriz Viva escopo) |
+| D10 | Aprovação de solicitações = composite Setor × Função (Gerente da Sup OU Asst Admin do Controle) | 2026-04-29 (PR 3 #1308) | Consolidação da regra: PA-02 Adaptada (Sup OR DAT aprovavam) descontinuada. Após PR 3, `CanAccessSolicitationApprovals` exige composite Setor × Função. DAT/Sup pura/Gerente pedagógico não aprovam mais. Função formal `Assistente Administrativo` adicionada a `FUNCAO_GROUPS`. Policy nova `access_solicitation_approvals` em `PUBLIC_POLICY_KEYS`. |
+| D11 | ProdutoViewSet list/retrieve = capability gate (DAT/Controle) | 2026-04-30 (PR 4 #1309) | Endpoint estava em `IsAuthenticated` puro por bug em `get_permissions()` override. Composite `manage_admin_registries OR manage_purchases_and_materials OR run_daily_operations`. Dropdowns/selects de Coord/Apoio/Diretoria continuam via `/api/options/produtos/`. |
+| D12 | UsuarioLookup = capability gate, sem hardcode de grupos | 2026-04-30 (PR 5 #1310) | Endpoint era `IsAuthenticated` puro; SEC-ENUM-02 usava hardcode `_EMAIL_SEARCH_ROLES` (anti-pattern). Composition `create_solicitation OR manage_admin_registries`. SEC-ENUM-01 (email fora do payload) preservado. |
+| D13 | AuditLog policy reduzida a DAT (admin) + Controle (operação) | 2026-04-30 (PR 6 #1311) | Antes incluía `approve_solicitation` e `approve_solicitation_batch` (Sup, Gerente). Removidos: Gerente pedagógico, Sup pura e Gerente da Sup não acessam mais. Auditoria por aprovador volta como escopo isolado se necessário em onda futura. SEC-AUDIT-01 (PII redaction) preservado. |
+| D14 | Projeto.fluxo obrigatório explicitamente em criação | 2026-04-30 (PR 7 #1312) | Field tinha `default="NAO_SUPER"` que era aplicado silenciosamente quando ausente. Serializer + Admin form agora exigem `ChoiceField(required=True)` antes do DB. CheckConstraint preservado. Default no model preservado para fixtures internos. |
+| D15 | Matriz Viva expandida com atores composite e novos recursos | 2026-04-30 (PR 8 #TBD) | Atores `Gerente da Superintendência` e `Assistente Administrativo do Controle` adicionados ao `ACTOR_GROUPS`. Recursos `solicitacoes_batch_approve`, `produtos_list`, `usuario_lookup` adicionados a `RESOURCES`. Constante `ALLOW_PAYLOAD_INVALID = 400` adicionada para POSTs onde gate aprova mas payload é rejeitado por validação de serviço (não-RBAC). |
 
 ---
 


### PR DESCRIPTION
## Resumo

PR 8 do programa hardening RBAC. Consolida na Matriz Viva as regras endurecidas em PRs 3-6 e distingue subtipos de Gerente que ficavam ambíguos (pedagógico vs Sup vs DAT). Mudança 100% test+matriz+doc — não toca lógica de produção.

## Atores adicionados

| Ator | Composite |
|------|-----------|
| `Gerente da Superintendência` | Setor `Superintendência` + Função `Gerente` |
| `Assistente Administrativo do Controle` | Setor `Controle` + Função `Assistente Administrativo` |

`Gerente` legado continua representando "Gerente pedagógico" (Setor não-Sup + Função Gerente). DAT/Controle representam motivos transversais — sem necessidade de `Gerente DAT`.

## Recursos adicionados

| Recurso | Endpoint | PR origem |
|---------|----------|-----------|
| `solicitacoes_batch_approve` | `POST /api/solicitacoes/batch-approve/` | #1308 (PR 3) |
| `produtos_list` | `GET /api/produtos/` | #1309 (PR 4) |
| `usuario_lookup` | `GET /api/lookup/usuarios/` | #1310 (PR 5) |

`solicitacoes_batch_approve` representa os 4 endpoints de aprovação (compartilham mesmo gate `CanAccessSolicitationApprovals`). Cobertura granular dos individuais segue em `test_pr3_approvals_policy.py`.

## Constante nova

`ALLOW_PAYLOAD_INVALID = 400`: usado para POSTs onde gate aprova mas serviço rejeita payload por motivo não-RBAC. Aplicado a `solicitacoes_batch_approve` (gate aprova; serviço retorna 400 por `ids_required` em lista vazia). Permanece distinto de `DENY (403)` para garantir que o gate diferenciou o ator.

## Acesso resultante (cells novas)

| Recurso | DAT | Controle | Gerente Sup | Asst Admin Controle | Gerente pedagógico | Demais |
|---------|-----|----------|-------------|---------------------|--------------------|--------|
| `solicitacoes_batch_approve` | DENY | DENY | ✅ ALLOW | ✅ ALLOW | DENY | DENY |
| `produtos_list` | ✅ | ✅ | DENY | ✅ (herda Controle) | DENY | DENY |
| `usuario_lookup` | ✅ | DENY | ✅ (`create_solicitation`) | DENY | ✅ (`create_solicitation`) | Coord/Apoio ✅; Formador/Diretoria DENY |
| `audit_logs` | ✅ | ✅ | DENY | ✅ (herda Controle) | DENY | DENY |

## Testes de scope

`test_rbac_matrix_scope.py` adiciona 5 cenários discriminantes (Matriz Viva valida apenas ALLOW/DENY; scope precisa de tests dedicados):

- Gerente pedagógico Vidas: 200 em Vidas; **403 em Fluir**
- Gerente da Superintendência: 200 em Sup; **403 em Vidas**
- Coordenador: scope via `EquipeGerencia` ativa
- Apoio de Coordenação: idem (com supervisor)
- Controle/DAT: cap global via `view_all_availability` — bypass scope

## Documentação

`v2/docs/rbac_authorization_matrix.md` atualizado:
- §2: novos composites (`Gerente da Superintendência` + `Assistente Administrativo do Controle`)
- §3: linhas Aprovações/Produtos/UsuarioLookup/AuditLogs/Projeto-fluxo refletem PRs 3-7
- §6: decisões D10-D15 documentando consolidação

## Resultados locais

- Matriz: **8 atores → 10 atores; 8 recursos → 11 recursos; 64 cases → 123 cases**
- `pytest test_rbac_matrix_living.py` — 123/123 verde
- `pytest test_rbac_matrix_scope.py` — 5/5 verde
- `pytest apps/core/tests/` (full) — **2221 passes, 42 skipped, 0 falhas**
- `python scripts/rbac_lint.py apps/core/` — 0 violações
- Black + isort + flake8 limpos
- `make staging-full` em `v2/infra` → ALL 8 CHECKS PASSED

## Não toca (escopo deliberadamente fora)

- Snapshot literal da matriz (Hipótese B → PR 9 — Sentinela)
- Sentinela automática para endpoint novo sem entrada (Hipótese E → PR 9)
- Auto-sync `matrix.py` ↔ Markdown
- Refactor de Matrix Runner
- UI nova
- Capability/policy nova
- Mudança em `permission_classes` de produção
- Projeto fluxo, DAT Imports, delegated bloqueio/deslocamento

## Test plan

- [x] `pytest apps/core/tests/test_rbac_matrix_living.py` — 123/123
- [x] `pytest apps/core/tests/test_rbac_matrix_scope.py` — 5/5
- [x] `pytest apps/core/tests/` (full suite) — 2221 passes
- [x] `python scripts/rbac_lint.py apps/core/` — 0 violações
- [x] Black + isort + flake8 limpos
- [x] `make staging-full` em `v2/infra` → 8/8 PASS

## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

```
==============================================
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz:   PASS
[2/8] Backend version:  PASS (v=staging-local)
[3/8] CSRF endpoint:    PASS
[4/8] Auth pipeline:    PASS (HTTP 400)
[5/8] Celery worker:    PASS
[6/8] Celery beat:      PASS
[7/8] Frontend HTTP:    PASS
[8/8] Frontend health:  PASS

ALL 8 CHECKS PASSED
==============================================
```