### PR TITLE
refactor(rbac): usa policy pública para Aprovações no frontend (PR 10 hardening RBAC)

### DIFF
--- a/v2/frontend/src/components/AppRoutes.tsx
+++ b/v2/frontend/src/components/AppRoutes.tsx
@@ -86,16 +86,17 @@ interface AppRoutesProps {
 
 export function AppRoutes({ user, permissions, policies }: AppRoutesProps): JSX.Element {
   const {
-    canApproveSuper, canCoordenador, canControle, canDAT, canAcoesInternas,
+    canCoordenador, canControle, canDAT, canAcoesInternas,
     canDashboardOverview, canDashboardEquipe, canDashboardGcal, canDashboardCompras,
     canMapaBrasil, canDisponibilidade, isFormador,
   } = permissions;
 
   // Camada de tradução semântica (Epic 3): derived flags a partir de policies + legacy.
-  // Componentes consomem `access.canAccessApprovals` em vez de `canApproveSuper` direto.
-  // Quando Epic 4.6 introduzir policy `approve_*` pública, a fonte muda no hook sem ripple.
+  // Componentes consomem `access.canAccessApprovals` direto.
+  // PR 10 hardening RBAC (2026-04-30): aprovações dependem exclusivamente
+  // da policy `access_solicitation_approvals`; legacy `canApproveSuper`
+  // saiu do contrato deste hook.
   const access = useCanAccess(policies, {
-    canApproveSuper,
     canBloqueios: canControle || canCoordenador || isFormador,
     canCoordenador,
     canDashboardCompras,

--- a/v2/frontend/src/components/AppSidebar.tsx
+++ b/v2/frontend/src/components/AppSidebar.tsx
@@ -195,15 +195,17 @@ export function AppSidebar({
   const { openKeys, onOpenChange, closeAllSubmenus } = useMenuOpenKeys();
 
   const {
-    canApproveSuper, canCoordenador, canControle, canDAT, canAcoesInternas, isFormador,
+    canCoordenador, canControle, canDAT, canAcoesInternas, isFormador,
     canDashboardOverview, canDashboardEquipe, canDashboardGcal, canDashboardCompras,
     canMapaBrasil, canDashboardsMenu, canDisponibilidade,
   } = permissions;
 
   // Camada de tradução semântica (Epic 3, Issue #1228): derived flags do policy layer.
   // Itens de menu consomem `access.canAccessApprovals` etc. — origem (policy vs legacy) é detalhe.
+  // PR 10 hardening RBAC (2026-04-30): Aprovações depende exclusivamente da
+  // policy `access_solicitation_approvals`. Legacy `canApproveSuper` não é
+  // mais passado ao hook (campo segue na API, mas não decide acesso aqui).
   const access = useCanAccess(policies, {
-    canApproveSuper,
     canBloqueios: canControle || canCoordenador || isFormador,
     canDashboardCompras,
     canCoordenador,

--- a/v2/frontend/src/components/__tests__/AppRoutes.approvals.test.tsx
+++ b/v2/frontend/src/components/__tests__/AppRoutes.approvals.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * AppRoutes — gate da rota /solicitacoes/aprovacoes.
+ *
+ * PR 10 hardening RBAC (2026-04-30): a rota Aprovações depende exclusivamente
+ * da policy pública `access_solicitation_approvals`. Sem a policy, o
+ * componente <Forbidden /> é renderizado — mesmo que o user tenha legacy
+ * `can_approve_super=true` ou pertença a Superintendência/Controle por
+ * setor sem a Função correta.
+ */
+
+import { MemoryRouter } from 'react-router-dom';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+
+import { AppRoutes } from '../AppRoutes';
+import type { CurrentUser } from '../../types';
+import type { Permissions } from '../../hooks/usePermissions';
+
+// ApprovalsPage faz fetch de policies/solicitações dentro do effect; mockamos
+// as APIs envolvidas para evitar 404 / fetch real durante o render do teste.
+vi.mock('../../api/solicitacoes', () => ({
+  listSolicitacoes: vi.fn().mockResolvedValue({ results: [], count: 0 }),
+  approveSolicitacao: vi.fn(),
+  rejectSolicitacao: vi.fn(),
+  previewSolicitacao: vi.fn(),
+  approveSolicitacoesBatch: vi.fn(),
+  rejectSolicitacoesBatch: vi.fn(),
+}));
+vi.mock('../../api/me', () => ({
+  getMyPolicies: vi.fn().mockResolvedValue([]),
+}));
+
+const BASE_USER: CurrentUser = {
+  id: 1,
+  username: 'tester',
+  email: 'tester@test.com',
+  first_name: 'Test',
+  last_name: 'User',
+  name: 'Test User',
+  groups: [],
+  setores: [],
+  funcoes: [],
+  is_superuser: false,
+  is_superintendencia: false,
+  can_approve_super: false,
+  permissions: [],
+};
+
+const EMPTY_PERMISSIONS: Permissions = {
+  isAdmin: false,
+  isCoordenador: false,
+  isFormador: false,
+  isGerente: false,
+  inSuperintendencia: false,
+  inGerencia: false,
+  inDAT: false,
+  inControle: false,
+  inDiretoria: false,
+  canApproveSuper: false,
+  canCoordenador: false,
+  canControle: false,
+  canDAT: false,
+  canAcoesInternas: false,
+  canDashboardOverview: false,
+  canDashboardEquipe: false,
+  canDashboardGcal: false,
+  canDashboardCompras: false,
+  canMapaBrasil: false,
+  canDashboardsMenu: false,
+  canDisponibilidade: false,
+  canSeeAllSectors: false,
+};
+
+describe('AppRoutes — /solicitacoes/aprovacoes depende de access_solicitation_approvals', () => {
+  test('user com a policy → renderiza ApprovalsPage', async () => {
+    render(
+      <MemoryRouter initialEntries={['/solicitacoes/aprovacoes']}>
+        <AppRoutes
+          user={BASE_USER}
+          permissions={{ ...EMPTY_PERMISSIONS, isGerente: true, inSuperintendencia: true }}
+          policies={['access_solicitation_approvals']}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(
+      await screen.findByRole('heading', { level: 2, name: /Aprovações/i }, { timeout: 5000 }),
+    ).toBeInTheDocument();
+  });
+
+  test('user sem a policy → Forbidden mesmo com legacy canApproveSuper=true', async () => {
+    render(
+      <MemoryRouter initialEntries={['/solicitacoes/aprovacoes']}>
+        <AppRoutes
+          user={{ ...BASE_USER, can_approve_super: true }}
+          permissions={{
+            ...EMPTY_PERMISSIONS,
+            canApproveSuper: true,
+            inSuperintendencia: true,
+            isGerente: true,
+          }}
+          policies={[]}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText(/Recurso indisponível/i)).toBeInTheDocument();
+  });
+
+  test('Controle puro sem a policy → Forbidden', async () => {
+    render(
+      <MemoryRouter initialEntries={['/solicitacoes/aprovacoes']}>
+        <AppRoutes
+          user={{ ...BASE_USER, groups: ['Controle'], setores: ['Controle'] }}
+          permissions={{ ...EMPTY_PERMISSIONS, inControle: true, canControle: true }}
+          policies={[]}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText(/Recurso indisponível/i)).toBeInTheDocument();
+  });
+
+  test('DAT sem a policy → Forbidden', async () => {
+    render(
+      <MemoryRouter initialEntries={['/solicitacoes/aprovacoes']}>
+        <AppRoutes
+          user={{ ...BASE_USER, groups: ['DAT'], setores: ['DAT'] }}
+          permissions={{ ...EMPTY_PERMISSIONS, inDAT: true, canDAT: true, canCoordenador: true }}
+          policies={[]}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText(/Recurso indisponível/i)).toBeInTheDocument();
+  });
+
+  test('Gerente pedagógico (Vidas) sem a policy → Forbidden', async () => {
+    render(
+      <MemoryRouter initialEntries={['/solicitacoes/aprovacoes']}>
+        <AppRoutes
+          user={{ ...BASE_USER, groups: ['Gerente', 'Vidas'], setores: ['Vidas'], funcoes: ['Gerente'] }}
+          permissions={{ ...EMPTY_PERMISSIONS, isGerente: true, inGerencia: true }}
+          policies={[]}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText(/Recurso indisponível/i)).toBeInTheDocument();
+  });
+});

--- a/v2/frontend/src/components/__tests__/AppSidebar.approvals.test.tsx
+++ b/v2/frontend/src/components/__tests__/AppSidebar.approvals.test.tsx
@@ -1,0 +1,147 @@
+/**
+ * AppSidebar — visibilidade do item "Aprovações" por perfil.
+ *
+ * PR 10 hardening RBAC (2026-04-30): a fonte exclusiva de autorização para
+ * Aprovações no frontend é a policy pública `access_solicitation_approvals`
+ * (Gerente da Superintendência OU Assistente Administrativo do Controle).
+ * Legacy `can_approve_super` deixou de ser consultado.
+ *
+ * Cada cenário monta `permissions` e `policies` espelhando o que
+ * `usePermissions(user)` + `GET /api/me/policies/` retornariam para o ator.
+ */
+
+import { MemoryRouter } from 'react-router-dom';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+
+import { AppSidebar } from '../AppSidebar';
+import type { Permissions } from '../../hooks/usePermissions';
+
+const COLORS = { sidebarBackground: '#001529', borderLight: '#303030' };
+
+const SIDEBAR_PROPS = {
+  gcalErrorCount: 0,
+  unreadNotifications: 0,
+  isMobile: false,
+  sidebarCollapsed: false,
+  toggleSidebar: () => {},
+  colors: COLORS,
+};
+
+const EMPTY_PERMISSIONS: Permissions = {
+  isAdmin: false,
+  isCoordenador: false,
+  isFormador: false,
+  isGerente: false,
+  inSuperintendencia: false,
+  inGerencia: false,
+  inDAT: false,
+  inControle: false,
+  inDiretoria: false,
+  canApproveSuper: false,
+  canCoordenador: false,
+  canControle: false,
+  canDAT: false,
+  canAcoesInternas: false,
+  canDashboardOverview: false,
+  canDashboardEquipe: false,
+  canDashboardGcal: false,
+  canDashboardCompras: false,
+  canMapaBrasil: false,
+  canDashboardsMenu: false,
+  canDisponibilidade: false,
+  canSeeAllSectors: false,
+};
+
+function renderSidebar(permissions: Permissions, policies: readonly string[]): void {
+  render(
+    <MemoryRouter>
+      <AppSidebar permissions={permissions} policies={policies} {...SIDEBAR_PROPS} />
+    </MemoryRouter>,
+  );
+}
+
+describe('AppSidebar — item "Aprovações" depende exclusivamente de access_solicitation_approvals', () => {
+  test('Gerente da Superintendência (policy presente) → mostra Aprovações', () => {
+    renderSidebar(
+      { ...EMPTY_PERMISSIONS, isGerente: true, inSuperintendencia: true, canSeeAllSectors: true },
+      ['access_solicitation_approvals'],
+    );
+    expect(screen.getByRole('link', { name: /Aprovações/i })).toBeInTheDocument();
+  });
+
+  test('Assistente Administrativo do Controle (policy presente) → mostra Aprovações', () => {
+    renderSidebar(
+      { ...EMPTY_PERMISSIONS, inControle: true, canControle: true },
+      ['access_solicitation_approvals'],
+    );
+    expect(screen.getByRole('link', { name: /Aprovações/i })).toBeInTheDocument();
+  });
+
+  test('Controle puro (sem policy) → NÃO mostra Aprovações', () => {
+    renderSidebar(
+      { ...EMPTY_PERMISSIONS, inControle: true, canControle: true },
+      [],
+    );
+    expect(screen.queryByRole('link', { name: /Aprovações/i })).not.toBeInTheDocument();
+  });
+
+  test('DAT (sem policy) → NÃO mostra Aprovações', () => {
+    renderSidebar(
+      { ...EMPTY_PERMISSIONS, inDAT: true, canDAT: true, canCoordenador: true },
+      [],
+    );
+    expect(screen.queryByRole('link', { name: /Aprovações/i })).not.toBeInTheDocument();
+  });
+
+  test('Gerente pedagógico (Vidas/Fluir, sem policy) → NÃO mostra Aprovações', () => {
+    renderSidebar(
+      { ...EMPTY_PERMISSIONS, isGerente: true, inGerencia: true },
+      [],
+    );
+    expect(screen.queryByRole('link', { name: /Aprovações/i })).not.toBeInTheDocument();
+  });
+
+  test('Coordenador → NÃO mostra Aprovações', () => {
+    renderSidebar(
+      { ...EMPTY_PERMISSIONS, isCoordenador: true, canCoordenador: true },
+      [],
+    );
+    expect(screen.queryByRole('link', { name: /Aprovações/i })).not.toBeInTheDocument();
+  });
+
+  test('Apoio de Coordenação → NÃO mostra Aprovações', () => {
+    renderSidebar(
+      // Apoio é tratado como isCoordenador no usePermissions.
+      { ...EMPTY_PERMISSIONS, isCoordenador: true, canCoordenador: true },
+      [],
+    );
+    expect(screen.queryByRole('link', { name: /Aprovações/i })).not.toBeInTheDocument();
+  });
+
+  test('Formador → NÃO mostra Aprovações', () => {
+    renderSidebar(
+      { ...EMPTY_PERMISSIONS, isFormador: true },
+      [],
+    );
+    expect(screen.queryByRole('link', { name: /Aprovações/i })).not.toBeInTheDocument();
+  });
+
+  test('Diretoria → NÃO mostra Aprovações', () => {
+    renderSidebar(
+      { ...EMPTY_PERMISSIONS, inDiretoria: true, canDashboardOverview: true, canDashboardsMenu: true },
+      ['view_overview_dashboard', 'view_compras_dashboard', 'view_map_metrics'],
+    );
+    expect(screen.queryByRole('link', { name: /Aprovações/i })).not.toBeInTheDocument();
+  });
+
+  test('legacy canApproveSuper=true em Permissions → NÃO basta sem a policy', () => {
+    // Garante que o frontend não consulta mais `permissions.canApproveSuper`.
+    // Mesmo com a flag legacy true, sem a policy o item não renderiza.
+    renderSidebar(
+      { ...EMPTY_PERMISSIONS, canApproveSuper: true, inSuperintendencia: true, isGerente: true, canSeeAllSectors: true },
+      [], // policy ausente
+    );
+    expect(screen.queryByRole('link', { name: /Aprovações/i })).not.toBeInTheDocument();
+  });
+});

--- a/v2/frontend/src/hooks/__tests__/rbac_matrix.test.ts
+++ b/v2/frontend/src/hooks/__tests__/rbac_matrix.test.ts
@@ -61,7 +61,6 @@ const ACTORS: ActorSnapshot[] = [
       'view_reports',
     ],
     legacy: {
-      canApproveSuper: true,
       canBloqueios: true,
       canCoordenador: true,
       canDashboardCompras: true,
@@ -90,7 +89,6 @@ const ACTORS: ActorSnapshot[] = [
     legacy: {
       // canDashboardCompras vem do usePermissions: inDAT → true
       canDashboardCompras: true,
-      canApproveSuper: false,
       canCoordenador: true, // canCoordenador inclui inDAT no usePermissions
     },
     expected: {
@@ -111,7 +109,6 @@ const ACTORS: ActorSnapshot[] = [
       'view_reports',
     ],
     legacy: {
-      canApproveSuper: false,
       canBloqueios: true, // canControle (true) || canCoordenador || isFormador
       canCoordenador: false,
       canDashboardCompras: false, // Controle não vê dashboard compras
@@ -127,7 +124,6 @@ const ACTORS: ActorSnapshot[] = [
     actor: 'Diretoria',
     policies: ['view_compras_dashboard', 'view_overview_dashboard', 'view_map_metrics'],
     legacy: {
-      canApproveSuper: false,
       canBloqueios: false,
       canCoordenador: false,
       canDashboardCompras: true, // inDiretoria
@@ -152,7 +148,9 @@ const ACTORS: ActorSnapshot[] = [
       'view_reports',
     ],
     legacy: {
-      canApproveSuper: true, // can_approve_super=true para Gerente da Super
+      // PR 10 hardening RBAC (2026-04-30): canApproveSuper saiu do contrato
+      // de useCanAccess. Decisão de Aprovações vem da policy
+      // `access_solicitation_approvals` listada acima.
       canBloqueios: true,
       canCoordenador: false,
       canDashboardCompras: false,
@@ -169,7 +167,6 @@ const ACTORS: ActorSnapshot[] = [
     // Coord/Apoio são SCOPED — sem view_all_availability após 0078
     policies: [],
     legacy: {
-      canApproveSuper: false,
       canBloqueios: true, // canCoordenador(=true) → canBloqueios true
       canCoordenador: true,
       canDashboardCompras: false,
@@ -186,7 +183,6 @@ const ACTORS: ActorSnapshot[] = [
     // Apoio segue regra de Coordenador — sem view_all_availability
     policies: [],
     legacy: {
-      canApproveSuper: false,
       canBloqueios: true,
       canCoordenador: true,
       canDashboardCompras: false,
@@ -203,7 +199,6 @@ const ACTORS: ActorSnapshot[] = [
     // Formador: nenhuma capability pública; só /me/events e bloqueio próprio (RD-02/03)
     policies: [],
     legacy: {
-      canApproveSuper: false,
       canBloqueios: true, // isFormador → canBloqueios true (RD-02/03 — declara próprio)
       canCoordenador: false,
       canDashboardCompras: false,

--- a/v2/frontend/src/hooks/__tests__/useCanAccess.test.ts
+++ b/v2/frontend/src/hooks/__tests__/useCanAccess.test.ts
@@ -36,29 +36,27 @@ describe('computeAccess.can()', () => {
   });
 });
 
-describe('computeAccess.canAccessApprovals — semantic translation layer', () => {
-  test('no policy + no legacy → false', () => {
-    const access = computeAccess([], {});
+describe('computeAccess.canAccessApprovals — policy-only (PR 10 hardening RBAC, 2026-04-30)', () => {
+  test('sem policy → false', () => {
+    const access = computeAccess([]);
     expect(access.canAccessApprovals).toBe(false);
   });
 
-  test('legacy canApproveSuper=true → true (current path)', () => {
-    const access = computeAccess([], { canApproveSuper: true });
+  test('policy access_solicitation_approvals presente → true', () => {
+    const access = computeAccess(['access_solicitation_approvals']);
     expect(access.canAccessApprovals).toBe(true);
   });
 
-  test('public policy access_solicitation_approvals present → true (PR 3 hardening RBAC)', () => {
-    const access = computeAccess(['access_solicitation_approvals'], {});
-    expect(access.canAccessApprovals).toBe(true);
+  test('policy unrelated → false', () => {
+    const access = computeAccess(['view_compras_dashboard']);
+    expect(access.canAccessApprovals).toBe(false);
   });
 
-  test('public policy access_solicitation_approvals overrides legacy=false', () => {
-    const access = computeAccess(['access_solicitation_approvals'], { canApproveSuper: false });
-    expect(access.canAccessApprovals).toBe(true);
-  });
-
-  test('legacy false + unrelated policy → false', () => {
-    const access = computeAccess(['view_compras_dashboard'], { canApproveSuper: false });
+  test('canAccessApprovals não depende de legacy can_approve_super', () => {
+    // Backend continua expondo `can_approve_super` no payload de /api/me/,
+    // mas o hook não consulta mais essa flag. Decisão é exclusivamente da
+    // policy pública — `LegacyAccessFlags` removeu o campo.
+    const access = computeAccess([], { canBloqueios: true, canCoordenador: true });
     expect(access.canAccessApprovals).toBe(false);
   });
 });

--- a/v2/frontend/src/hooks/useCanAccess.ts
+++ b/v2/frontend/src/hooks/useCanAccess.ts
@@ -19,8 +19,6 @@ import { useMemo } from 'react';
  * cada derived flag abaixo.
  */
 export interface LegacyAccessFlags {
-  /** Composite Gerente+Superintendência. Migrar quando Epic 4.6 criar policy `approve_*` pública. */
-  canApproveSuper?: boolean;
   /** `canControle || canCoordenador || isFormador`. Formador owns own bloqueio (RD-02/RD-03). */
   canBloqueios?: boolean;
   /** Hoje 100% legacy. Sem policy pública pra "criar solicitação" (apenas auth + role). */
@@ -47,9 +45,8 @@ export interface AccessState {
    * Pode acessar fila de aprovações.
    * Composite Setor × Função aprovado em PR 3 hardening RBAC (2026-04-29):
    * Gerente da Superintendência OU Assistente Administrativo do Controle.
-   * Fonte de verdade: policy pública `access_solicitation_approvals`.
-   * `legacy.canApproveSuper` permanece como fallback compat durante a
-   * transição para clientes que ainda não consomem `/api/me/policies/`.
+   * Fonte de verdade: policy pública `access_solicitation_approvals` (PR 10
+   * hardening RBAC, 2026-04-30 — fallback `can_approve_super` removido).
    */
   canAccessApprovals: boolean;
 
@@ -84,9 +81,10 @@ export function computeAccess(
   const policySet = new Set(policies);
   const can = (key: string): boolean => policySet.has(key);
 
-  const canAccessApprovals =
-    can('access_solicitation_approvals') ||   // PR 3 hardening RBAC (2026-04-29)
-    legacy.canApproveSuper === true;
+  // PR 10 hardening RBAC (2026-04-30): fonte exclusiva é a policy pública.
+  // Legacy `can_approve_super` foi removido — backend continua expondo o
+  // campo no payload de /api/me/, mas o frontend não decide por ele.
+  const canAccessApprovals = can('access_solicitation_approvals');
 
   const canAccessBlocks =
     can('view_all_availability') ||
@@ -123,7 +121,6 @@ export function useCanAccess(
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       policies,
-      legacy.canApproveSuper,
       legacy.canBloqueios,
       legacy.canCoordenador,
       legacy.canDashboardCompras,

--- a/v2/frontend/src/pages/Aprovacoes/ApprovalsPage.tsx
+++ b/v2/frontend/src/pages/Aprovacoes/ApprovalsPage.tsx
@@ -51,7 +51,6 @@ import {
   approveSolicitacoesBatch,
   rejectSolicitacoesBatch,
 } from '../../api/solicitacoes';
-import { getMe } from '../../api/availability';
 import { getMyPolicies } from '../../api/me';
 import { computeAccess } from '../../hooks/useCanAccess';
 import { TIMING } from '../../constants/timing';
@@ -148,22 +147,19 @@ export default function ApprovalsPage(): JSX.Element {
     return () => { unsub1(); unsub2(); };
   }, [loadData]);
 
-  // PA-06 + PR 3 hardening RBAC (2026-04-29): preferir policy pública
-  // `access_solicitation_approvals` (Gerente Sup OU Asst Admin Controle).
-  // Mantém `can_approve_super` como fallback compat durante a transição.
+  // PA-06 + PR 3 hardening RBAC (#1308) + PR 10 hardening RBAC (2026-04-30):
+  // a fonte exclusiva de autorização passou a ser a policy pública
+  // `access_solicitation_approvals` (Gerente da Superintendência OU
+  // Assistente Administrativo do Controle). Legacy `can_approve_super`
+  // deixou de ser consultado pelo frontend.
   useEffect(() => {
     const loadAccess = async (): Promise<void> => {
       try {
-        const [userData, policies] = await Promise.all([
-          getMe(),
-          getMyPolicies().catch(() => [] as string[]),
-        ]);
-        const access = computeAccess(policies, {
-          canApproveSuper: userData?.can_approve_super || false,
-        });
+        const policies = await getMyPolicies().catch(() => [] as string[]);
+        const access = computeAccess(policies);
         setCanApprove(access.canAccessApprovals);
       } catch (error) {
-        logger.error('Erro ao carregar usuário:', error);
+        logger.error('Erro ao carregar policies:', error);
         setCanApprove(false);
       }
     };

--- a/v2/frontend/src/pages/Home/HomePage.tsx
+++ b/v2/frontend/src/pages/Home/HomePage.tsx
@@ -21,8 +21,10 @@ import {
   SafetyOutlined,
 } from '@ant-design/icons';
 import { getMe } from '../../api/availability';
+import { getMyPolicies } from '../../api/me';
 import { getHomeStats } from '../../api/stats';
 import { computePermissions } from '../../hooks/usePermissions';
+import { computeAccess } from '../../hooks/useCanAccess';
 import logger from '../../utils/logger';
 import type { CurrentUser } from '../../types';
 
@@ -91,6 +93,7 @@ function AccessCard({ icon, title, description, link, badge, disabled = false }:
 
 export default function HomePage(): JSX.Element {
   const [user, setUser] = useState<CurrentUser | null>(null);
+  const [policies, setPolicies] = useState<readonly string[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [stats, setStats] = useState<StatsType>({
     pendingApprovals: 0,
@@ -101,13 +104,18 @@ export default function HomePage(): JSX.Element {
   useEffect(() => {
     const loadUserAndStats = async (): Promise<void> => {
       try {
-        // Carregar dados do usuário e estatísticas em paralelo
-        const [userData, statsData] = await Promise.all([
+        // Carregar dados do usuário, policies e estatísticas em paralelo.
+        // PR 10 hardening RBAC (2026-04-30): policies viraram fonte oficial
+        // para gating de Aprovações no frontend (campo `can_approve_super`
+        // continua na API mas não é consumido aqui).
+        const [userData, userPolicies, statsData] = await Promise.all([
           getMe(),
+          getMyPolicies().catch(() => [] as string[]),
           getHomeStats() as Promise<HomeStatsResponse>,
         ]);
 
         setUser(userData);
+        setPolicies(userPolicies);
         setStats({
           pendingApprovals: statsData.pending_approvals ?? 0,
           myRequests: statsData.my_requests ?? 0,
@@ -135,7 +143,11 @@ export default function HomePage(): JSX.Element {
   // Epic 3.3 cleanup: usa computePermissions (SSOT) em vez de hardcodes inline.
   const perms = computePermissions(user);
   const isAdmin = perms.isAdmin;
-  const canApproveSuper = perms.canApproveSuper;
+  // PR 10 hardening RBAC (2026-04-30): Aprovações depende exclusivamente da
+  // policy `access_solicitation_approvals`. Legacy `can_approve_super` não
+  // é mais consultado pelo frontend.
+  const access = computeAccess(policies);
+  const canAccessApprovals = access.canAccessApprovals;
   const isManager = perms.isGerente && (perms.inGerencia || perms.isAdmin);
   const isCoordenador = perms.canCoordenador;
   const canDAT = perms.canDAT;
@@ -179,7 +191,7 @@ export default function HomePage(): JSX.Element {
       )}
 
       {/* Aprovações (Superintendência/DAT) */}
-      {canApproveSuper && (
+      {canAccessApprovals && (
         <>
           <Title level={4} className="mt-6 mb-4">
             Aprovações
@@ -275,7 +287,7 @@ export default function HomePage(): JSX.Element {
               />
             </Col>
           )}
-          {canApproveSuper && (
+          {canAccessApprovals && (
             <Col xs={24} sm={8}>
               <Statistic
                 title="Aprovações Pendentes"


### PR DESCRIPTION
## Programa Hardening RBAC — PR 10/16

Backend (PR 3 hardening RBAC, #1308) tornou `access_solicitation_approvals` o contrato oficial para autorização de Aprovações. O frontend ainda mantinha `can_approve_super` como fallback no hook `useCanAccess`. Este PR remove esse fallback — Aprovações passa a depender exclusivamente da policy pública.

## Regra de negócio

- Gerente da **Superintendência** acessa Aprovações.
- **Assistente Administrativo** do **Controle** acessa Aprovações.
- Controle puro **NÃO** acessa.
- DAT **NÃO** acessa.
- Gerente pedagógico (Vidas/Fluir/Brincando…) **NÃO** acessa.
- Coordenador / Apoio / Formador / Diretoria **NÃO** acessam.

Fonte de verdade: policy pública `access_solicitation_approvals`.

## Mudanças

| Arquivo | Mudança |
|---------|---------|
| `useCanAccess.ts` | remove `canApproveSuper` de `LegacyAccessFlags`; `canAccessApprovals = can('access_solicitation_approvals')` |
| `AppSidebar.tsx` / `AppRoutes.tsx` | deixam de passar `canApproveSuper` para `useCanAccess` |
| `ApprovalsPage.tsx` | troca `getMe() + can_approve_super` por `getMyPolicies()` puro |
| `HomePage.tsx` | passa a buscar `getMyPolicies()` e usa `access.canAccessApprovals` |

`usePermissions.ts` mantém `canApproveSuper` por contrato legado (não é mais consumido para autorização). Backend continua expondo `can_approve_super` em `/api/me/` para retrocompat com clientes externos; frontend deixa de consultá-lo. Depreciação do campo no backend fica para onda posterior.

## Tests

- `useCanAccess.test.ts`: cenários de fallback legacy reescritos para comportamento policy-only.
- `rbac_matrix.test.ts`: remove `canApproveSuper` dos snapshots por ator (não é mais campo aceito em `LegacyAccessFlags`).
- `AppSidebar.approvals.test.tsx` **(novo)**: 10 cenários de visibilidade do item "Aprovações" por perfil. Inclui assert explícito de que legacy `canApproveSuper=true` em `Permissions` **não** basta sem a policy.
- `AppRoutes.approvals.test.tsx` **(novo)**: 5 cenários do gate da rota `/solicitacoes/aprovacoes`. Inclui assert de que `<Forbidden />` renderiza mesmo para user com legacy `can_approve_super=true`.

## Validação

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR (ver bloco abaixo)
- [x] vitest run: 299/299 passing (37 files)
- [x] tsc --noEmit: limpo
- [x] vite build: limpo

```text
==============================================
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS
ALL 8 CHECKS PASSED
==============================================
```

## Fora de escopo

- Não remove `can_approve_super` do backend.
- Não altera `/api/me/` payload.
- Não altera policies backend.
- Não altera endpoints de aprovação.
- Não mexe em Audit Logs, Projeto.fluxo, ProdutoViewSet, UsuarioLookup, DAT Imports, delegated bloqueio/deslocamento.
- Não faz refactor amplo de `usePermissions` além do necessário.

## Programa Hardening RBAC

10/16 PRs concluídos. Decisão D17 — frontend Aprovações 100% policy-driven.