### PR TITLE
feat(rbac): permite delegar criação de bloqueio com auditoria (PR 13 hardening RBAC)

### DIFF
--- a/v2/backend/apps/core/migrations/0082_availability_block_created_by.py
+++ b/v2/backend/apps/core/migrations/0082_availability_block_created_by.py
@@ -1,0 +1,50 @@
+"""PR 13 hardening RBAC (2026-05-04): adiciona `created_by` em AvailabilityBlock.
+
+Contexto
+--------
+
+O fluxo atual permite apenas que o owner crie seu próprio bloqueio
+(`usuario=request.user`). PR 13 introduz delegação: Asst Admin Controle,
+DAT e Superuser podem criar bloqueio em nome de um Formador.
+
+Para auditoria, separamos `usuario` (target — quem está bloqueado) de
+`created_by` (quem digitou). `created_by != usuario` indica delegação.
+
+- Registros antigos ficam com `created_by = NULL` (não há identidade
+  histórica retroativa; o owner já é `usuario`).
+- Novos registros próprios salvam `created_by = request.user` (== usuario).
+- Bloqueios delegados salvam `created_by = request.user`, `usuario = target`.
+
+`on_delete=SET_NULL` preserva o histórico de bloqueios mesmo se o
+delegate for desativado/excluído (auditoria sobrevive ao usuário).
+"""
+
+# pyright: reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false
+from __future__ import annotations
+
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0081_create_assistente_administrativo_group"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="availabilityblock",
+            name="created_by",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="availability_blocks_created",
+                to=settings.AUTH_USER_MODEL,
+                help_text=(
+                    "Usuario que criou o bloqueio. Quando != usuario, " "indica delegação (PR 13 hardening RBAC)."
+                ),
+            ),
+        ),
+    ]

--- a/v2/backend/apps/core/models/agenda.py
+++ b/v2/backend/apps/core/models/agenda.py
@@ -41,6 +41,18 @@ class AvailabilityBlock(models.Model):
     usuario = models.ForeignKey(  # type: ignore[misc]
         "core.Usuario", on_delete=models.PROTECT, related_name="availability_blocks"
     )
+    # PR 13 hardening RBAC (2026-05-04): separa `usuario` (target) de
+    # `created_by` (delegate). Quando `created_by != usuario`, indica
+    # bloqueio delegado por Asst Admin Controle / DAT / Superuser.
+    # Registros antigos: NULL (owner é o próprio `usuario`).
+    created_by = models.ForeignKey(  # type: ignore[misc]
+        "core.Usuario",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="availability_blocks_created",
+        help_text=("Usuario que criou o bloqueio. Quando != usuario, indica " "delegação (PR 13 hardening RBAC)."),
+    )
     inicio = models.DateTimeField(help_text="Inicio do bloqueio (UTC)")
     fim = models.DateTimeField(help_text="Fim do bloqueio (UTC)")
     tipo = models.CharField(max_length=1, choices=TIPO_CHOICES, default="T")

--- a/v2/backend/apps/core/rbac/helpers.py
+++ b/v2/backend/apps/core/rbac/helpers.py
@@ -12,7 +12,7 @@ Filtros de data scope por nome de grupo (ex: "quem é formador?") vivem em
 Ver v2/docs/RBAC_NAMING.md §4 e master-plan §4.
 """
 
-# pyright: reportUnknownMemberType=false, reportAttributeAccessIssue=false
+# pyright: reportUnknownMemberType=false, reportAttributeAccessIssue=false, reportUnknownArgumentType=false
 
 from __future__ import annotations
 

--- a/v2/backend/apps/core/rbac/helpers.py
+++ b/v2/backend/apps/core/rbac/helpers.py
@@ -47,6 +47,30 @@ def user_has_any_perm(
     return any(code in user_perms for code in codenames)
 
 
+def user_is_assistente_administrativo_controle(
+    user: AbstractBaseUser | AnonymousUser | None,
+) -> bool:
+    """
+    True se o usuário é Assistente Administrativo do Controle (composite
+    Setor `Controle` + Função `Assistente Administrativo`).
+
+    SSOT extraído em PR 13 hardening RBAC (2026-05-04). Antes a checagem
+    vivia inline em `IsAssistenteAdministrativoControle` (permissions.py);
+    este helper é reutilizado pela classe DRF E pelo helper de delegação
+    de bloqueios (`_user_can_delegate_availability_block`).
+
+    - user None ou anônimo → False
+    - is_superuser → False (bypass é decidido por quem chama)
+    - caso geral → exige AMBOS os grupos
+    """
+    if not user or not user.is_authenticated:
+        return False
+    return bool(
+        user.groups.filter(name="Controle").exists()  # noqa: RBAC-composite-allowed
+        and user.groups.filter(name="Assistente Administrativo").exists()  # noqa: RBAC-composite-allowed
+    )
+
+
 def user_has_all_perms(
     user: AbstractBaseUser | AnonymousUser | None,
     *codenames: str,

--- a/v2/backend/apps/core/rbac/permissions.py
+++ b/v2/backend/apps/core/rbac/permissions.py
@@ -176,15 +176,17 @@ class IsAssistenteAdministrativoControle(permissions.BasePermission):  # type: i
     message = "Apenas Assistente Administrativo do Controle pode realizar esta ação."
 
     def has_permission(self, request: Request, view: APIView) -> bool:
+        # PR 13 hardening RBAC (2026-05-04): a checagem composite virou
+        # helper reutilizável em `apps.core.rbac.helpers` para que o gate
+        # de delegação de bloqueios consuma o mesmo SSOT.
+        from apps.core.rbac.helpers import user_is_assistente_administrativo_controle
+
         user = request.user
         if not user or not user.is_authenticated:
             return False
         if getattr(user, "is_superuser", False):
             return True
-        return bool(
-            user.groups.filter(name="Controle").exists()  # noqa: RBAC-composite-allowed
-            and user.groups.filter(name="Assistente Administrativo").exists()  # noqa: RBAC-composite-allowed
-        )
+        return user_is_assistente_administrativo_controle(user)
 
 
 class IsOwnerOrPrivileged(HasFunctionalPermission):  # type: ignore[misc]

--- a/v2/backend/apps/core/rbac/policies.py
+++ b/v2/backend/apps/core/rbac/policies.py
@@ -45,7 +45,7 @@ from rest_framework.views import APIView
 # em `permission_classes`). Não usamos HasPerm aqui, mas precisamos que o
 # patch esteja ativo antes do primeiro uso de composition.
 from apps.core.rbac import permissions as _rbac_permissions  # noqa: F401
-from apps.core.rbac.helpers import user_has_any_perm
+from apps.core.rbac.helpers import user_has_any_perm, user_is_assistente_administrativo_controle
 
 # ============================================================================
 # SSOT: matriz declarativa Policy → capabilities elegíveis (OR semantics)
@@ -357,6 +357,10 @@ def _user_has_solicitation_approvals(user: AbstractBaseUser | AnonymousUser | No
     SSOT chamado tanto pela Policy class `CanAccessSolicitationApprovals`
     quanto por `user_has_policy("access_solicitation_approvals")`. Mudar
     a regra = mudar aqui e atualizar tests da matriz.
+
+    PR 13 (2026-05-04): a checagem do composite Asst Admin Controle migrou
+    para `helpers.user_is_assistente_administrativo_controle` (SSOT
+    compartilhado com o gate de delegação de bloqueios).
     """
     if not user or not getattr(user, "is_authenticated", False):
         return False
@@ -367,11 +371,34 @@ def _user_has_solicitation_approvals(user: AbstractBaseUser | AnonymousUser | No
         groups.filter(name="Gerente").exists()  # noqa: RBAC-composite-allowed
         and groups.filter(name="Superintendência").exists()  # noqa: RBAC-composite-allowed
     )
-    is_asst_admin_controle = (
-        groups.filter(name="Assistente Administrativo").exists()  # noqa: RBAC-composite-allowed
-        and groups.filter(name="Controle").exists()  # noqa: RBAC-composite-allowed
-    )
-    return bool(is_gerente_super or is_asst_admin_controle)
+    if is_gerente_super:
+        return True
+    return user_is_assistente_administrativo_controle(user)
+
+
+def user_can_delegate_availability_block(user: AbstractBaseUser | AnonymousUser | None) -> bool:
+    """
+    Composite check (PR 13 hardening RBAC, 2026-05-04): autoriza criar
+    bloqueio em nome de outro Formador.
+
+    Habilitado para:
+    - Superuser (bypass)
+    - Assistente Administrativo do Controle (composite Setor × Função)
+    - DAT (via capability `manage_admin_registries` — exclusiva de DAT
+      e superuser no seed atual)
+
+    Outros perfis (Coord, Apoio, Gerente Sup, Gerente pedagógico,
+    Diretoria, Controle puro, Formador) → False.
+
+    Não cria capability nova: composição de helpers SSOT existentes.
+    """
+    if not user or not getattr(user, "is_authenticated", False):
+        return False
+    if getattr(user, "is_superuser", False):
+        return True
+    if user_is_assistente_administrativo_controle(user):
+        return True
+    return user_has_any_perm(user, "manage_admin_registries")
 
 
 def user_has_policy(user: AbstractBaseUser | AnonymousUser | None, key: str) -> bool:
@@ -424,6 +451,7 @@ __all__ = [
     "ACCESS_POLICIES",
     "PUBLIC_POLICY_KEYS",
     "_PolicyPermission",
+    "user_can_delegate_availability_block",
     "user_has_policy",
     "resolve_public_policies",
     "CanAccessAuditLogs",

--- a/v2/backend/apps/core/serializers/agenda.py
+++ b/v2/backend/apps/core/serializers/agenda.py
@@ -22,14 +22,24 @@ class AvailabilityBlockSerializer(serializers.ModelSerializer):
     Serializer for AvailabilityBlock model.
 
     Status é auto-aprovado no ViewSet.perform_create().
-    Usuario é preenchido automaticamente com request.user no ViewSet.
+    Usuario é preenchido automaticamente com request.user no ViewSet,
+    salvo se o requester delegar via `usuario_id` (PR 13 hardening RBAC,
+    2026-05-04). Validação de permissão de delegar fica no ViewSet
+    (`perform_create`), não aqui — anti-enumeração: requester não
+    autorizado recebe 403 ANTES de qualquer lookup do target.
     """
+
+    # PR 13: write-only opcional para delegação. IntegerField (não
+    # PrimaryKeyRelatedField) para evitar lookup de Usuario antes da
+    # validação de permissão — vazaria enumeração de IDs por 400 vs 403.
+    usuario_id = serializers.IntegerField(required=False, write_only=True)
 
     class Meta:
         model = AvailabilityBlock
         fields = [
             "id",
             "usuario",
+            "usuario_id",
             "inicio",
             "fim",
             "tipo",

--- a/v2/backend/apps/core/tests/test_pr13_delegated_availability_blocks.py
+++ b/v2/backend/apps/core/tests/test_pr13_delegated_availability_blocks.py
@@ -1,0 +1,310 @@
+"""
+PR 13 hardening RBAC (2026-05-04): delegated AvailabilityBlock creation.
+
+Endpoint coberto:
+- POST /api/availability-blocks/
+
+Regra de negócio:
+- Sem `usuario_id` (ou == request.user.id): comportamento atual (próprio).
+- Com `usuario_id` diferente: requer permissão de delegar.
+  - ✅ Superuser
+  - ✅ Assistente Administrativo do Controle (composite Setor × Função)
+  - ✅ DAT (via capability `manage_admin_registries`)
+  - ❌ Coordenador, Apoio, Gerente Sup, Gerente pedagógico, Diretoria,
+       Controle puro, Formador
+- Target precisa ser Formador ativo (após autorizar requester).
+- Anti-enumeração: requester não autorizado recebe 403 ANTES de qualquer
+  lookup do target. ID inexistente vs existente vs inativo é
+  indistinguível para requester sem permissão.
+- AuditLog `DELEGATE_BLOCK_CREATE` registra delegate_user_id e
+  target_formador_id quando delegação ocorre.
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportOptionalMemberAccess=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportMissingTypeArgument=false, reportCallIssue=false, reportMissingTypeStubs=false, reportUnusedFunction=false, reportIndexIssue=false
+
+from __future__ import annotations
+
+import itertools
+from datetime import timedelta
+
+from django.contrib.auth.models import Group
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+import pytest
+
+from apps.core.models import AuditLog, AvailabilityBlock, Usuario
+
+pytestmark = pytest.mark.django_db
+
+
+_CPF_COUNTER = itertools.count(72000000000)
+
+
+def _user_in_groups(*group_names: str, label: str = "user", is_active: bool = True) -> Usuario:
+    cpf = str(next(_CPF_COUNTER)).zfill(11)
+    user = Usuario.objects.create_user(
+        username=f"{label}_{cpf}",
+        email=f"{label}_{cpf}@example.com",
+        password="testpass",
+        cpf=cpf,
+    )
+    user.is_active = is_active
+    user.save()
+    for name in group_names:
+        group, _ = Group.objects.get_or_create(name=name)
+        user.groups.add(group)
+    return user
+
+
+def _formador(label: str = "formador", is_active: bool = True) -> Usuario:
+    return _user_in_groups("Formador", label=label, is_active=is_active)
+
+
+def _make_block_payload(usuario_id: int | None = None) -> dict:
+    inicio = timezone.now() + timedelta(days=1)
+    fim = inicio + timedelta(hours=2)
+    payload: dict = {
+        "tipo": "T",
+        "inicio": inicio.isoformat(),
+        "fim": fim.isoformat(),
+        "motivo": "Teste delegação",
+    }
+    if usuario_id is not None:
+        payload["usuario_id"] = usuario_id
+    return payload
+
+
+def _post(client: APIClient, payload: dict):
+    return client.post("/api/availability-blocks/", payload, format="json")
+
+
+# ============================================================================
+# Comportamento original (sem usuario_id)
+# ============================================================================
+
+
+class TestSelfCreate:
+    def test_formador_cria_bloqueio_proprio_sem_usuario_id(self):
+        formador = _formador()
+        client = APIClient()
+        client.force_authenticate(formador)
+        response = _post(client, _make_block_payload())
+        assert response.status_code == 201
+        block = AvailabilityBlock.objects.get(pk=response.data["id"])
+        assert block.usuario_id == formador.id
+        assert block.created_by_id == formador.id
+
+    def test_formador_self_target_com_proprio_id_funciona(self):
+        formador = _formador()
+        client = APIClient()
+        client.force_authenticate(formador)
+        response = _post(client, _make_block_payload(usuario_id=formador.id))
+        assert response.status_code == 201
+        block = AvailabilityBlock.objects.get(pk=response.data["id"])
+        assert block.usuario_id == formador.id
+        assert block.created_by_id == formador.id
+
+
+# ============================================================================
+# Delegação autorizada
+# ============================================================================
+
+
+class TestDelegationAllowed:
+    def test_assistente_administrativo_controle_delega_para_formador(self):
+        delegate = _user_in_groups("Controle", "Assistente Administrativo", label="asst")
+        target = _formador(label="target_asst")
+        client = APIClient()
+        client.force_authenticate(delegate)
+        response = _post(client, _make_block_payload(usuario_id=target.id))
+        assert response.status_code == 201
+        block = AvailabilityBlock.objects.get(pk=response.data["id"])
+        assert block.usuario_id == target.id
+        assert block.created_by_id == delegate.id
+
+    def test_dat_delega_para_formador(self):
+        # DAT possui capability `manage_admin_registries` atribuída via seed
+        # de migrations (`0077_realign_funcperm_groups.py` + descendentes).
+        delegate = _user_in_groups("DAT", label="dat")
+        target = _formador(label="target_dat")
+        client = APIClient()
+        client.force_authenticate(delegate)
+        response = _post(client, _make_block_payload(usuario_id=target.id))
+        assert response.status_code == 201
+        block = AvailabilityBlock.objects.get(pk=response.data["id"])
+        assert block.usuario_id == target.id
+        assert block.created_by_id == delegate.id
+
+    def test_superuser_delega_para_formador(self):
+        delegate = Usuario.objects.create_superuser(
+            username="su_pr13",
+            email="su_pr13@example.com",
+            password="x",
+            cpf="72099999999",
+        )
+        target = _formador(label="target_su")
+        client = APIClient()
+        client.force_authenticate(delegate)
+        response = _post(client, _make_block_payload(usuario_id=target.id))
+        assert response.status_code == 201
+        block = AvailabilityBlock.objects.get(pk=response.data["id"])
+        assert block.usuario_id == target.id
+        assert block.created_by_id == delegate.id
+
+
+# ============================================================================
+# Delegação NÃO autorizada (anti-enumeração: 403 antes de lookup)
+# ============================================================================
+
+
+class TestDelegationDenied:
+    @pytest.mark.parametrize(
+        "groups,label",
+        [
+            (("Controle",), "controle_puro"),  # Controle SEM Asst Admin
+            (("Coordenador",), "coord"),
+            (("Apoio de Coordenação",), "apoio"),
+            (("Gerente", "Superintendência"), "gerente_sup"),
+            (("Gerente", "Vidas"), "gerente_pedagogico"),
+            (("Diretoria",), "diretoria"),
+            (("Formador",), "formador_outro"),
+        ],
+    )
+    def test_perfil_nao_autorizado_recebe_403(self, groups, label):
+        delegate = _user_in_groups(*groups, label=label)
+        target = _formador(label=f"target_{label}")
+        client = APIClient()
+        client.force_authenticate(delegate)
+        response = _post(client, _make_block_payload(usuario_id=target.id))
+        assert response.status_code == 403, f"Perfil {label} deveria receber 403 mas obteve {response.status_code}"
+
+    def test_assistente_administrativo_fora_do_controle_recebe_403(self):
+        # Função sem o Setor — composite não passa.
+        delegate = _user_in_groups("Vidas", "Assistente Administrativo", label="asst_vidas")
+        target = _formador(label="target_asst_vidas")
+        client = APIClient()
+        client.force_authenticate(delegate)
+        response = _post(client, _make_block_payload(usuario_id=target.id))
+        assert response.status_code == 403
+
+    def test_anti_enumeracao_target_inexistente_para_nao_autorizado(self):
+        # Anti-enumeração: 403 mesmo com ID inexistente.
+        delegate = _user_in_groups("Coordenador", label="coord_anti_enum")
+        client = APIClient()
+        client.force_authenticate(delegate)
+        response = _post(client, _make_block_payload(usuario_id=99999999))
+        assert response.status_code == 403, (
+            "Não autorizado deve receber 403 antes de qualquer lookup — "
+            "ID inexistente NÃO pode vazar enumeração via 400/404."
+        )
+
+
+# ============================================================================
+# Validação de target (apenas para requester autorizado)
+# ============================================================================
+
+
+class TestTargetValidation:
+    def test_target_inexistente_recebe_400_para_autorizado(self):
+        delegate = _user_in_groups("Controle", "Assistente Administrativo", label="asst_inex")
+        client = APIClient()
+        client.force_authenticate(delegate)
+        response = _post(client, _make_block_payload(usuario_id=99999999))
+        assert response.status_code == 400
+        # Project-wide error envelope: {code, detail, errors: {field: msg}}.
+        errors = response.data.get("errors", response.data)
+        assert "usuario_id" in errors
+
+    def test_target_nao_formador_recebe_400(self):
+        delegate = _user_in_groups("Controle", "Assistente Administrativo", label="asst_nf")
+        non_formador = _user_in_groups("Coordenador", label="non_formador_target")
+        client = APIClient()
+        client.force_authenticate(delegate)
+        response = _post(client, _make_block_payload(usuario_id=non_formador.id))
+        assert response.status_code == 400
+        # Project-wide error envelope: {code, detail, errors: {field: msg}}.
+        errors = response.data.get("errors", response.data)
+        assert "usuario_id" in errors
+
+    def test_target_inativo_recebe_400(self):
+        delegate = _user_in_groups("Controle", "Assistente Administrativo", label="asst_inativo")
+        target = _formador(label="target_inativo", is_active=False)
+        client = APIClient()
+        client.force_authenticate(delegate)
+        response = _post(client, _make_block_payload(usuario_id=target.id))
+        assert response.status_code == 400
+        # Project-wide error envelope: {code, detail, errors: {field: msg}}.
+        errors = response.data.get("errors", response.data)
+        assert "usuario_id" in errors
+
+
+# ============================================================================
+# AuditLog
+# ============================================================================
+
+
+class TestAuditLog:
+    def test_delegacao_cria_auditlog_com_ids(self):
+        delegate = _user_in_groups("Controle", "Assistente Administrativo", label="asst_audit")
+        target = _formador(label="target_audit")
+        client = APIClient()
+        client.force_authenticate(delegate)
+        response = _post(client, _make_block_payload(usuario_id=target.id))
+        assert response.status_code == 201
+        block_id = response.data["id"]
+
+        log = AuditLog.objects.filter(action="DELEGATE_BLOCK_CREATE").latest("created_at")
+        assert log.usuario_id == delegate.id
+        assert log.model_name == "AvailabilityBlock"
+        assert log.details["delegate_user_id"] == delegate.id
+        assert log.details["target_formador_id"] == target.id
+        assert log.details["block_id"] == block_id
+        assert log.details["origem"] == "delegated"
+        assert "inicio" in log.details
+        assert "fim" in log.details
+        # Anti-PII: motivo não deve estar no AuditLog.
+        assert "motivo" not in log.details
+
+    def test_self_create_nao_cria_auditlog_de_delegacao(self):
+        formador = _formador(label="self_no_audit")
+        client = APIClient()
+        client.force_authenticate(formador)
+        response = _post(client, _make_block_payload())
+        assert response.status_code == 201
+        assert not AuditLog.objects.filter(action="DELEGATE_BLOCK_CREATE").exists()
+
+
+# ============================================================================
+# Queryset não vaza bloqueios
+# ============================================================================
+
+
+class TestQuerysetIsolation:
+    def test_formador_lista_apenas_proprio_bloqueio_apos_delegacao(self):
+        delegate = _user_in_groups("Controle", "Assistente Administrativo", label="asst_ql")
+        formador_a = _formador(label="form_a")
+        formador_b = _formador(label="form_b")
+
+        # Asst Admin cria bloqueio em nome de A.
+        client_admin = APIClient()
+        client_admin.force_authenticate(delegate)
+        resp = _post(client_admin, _make_block_payload(usuario_id=formador_a.id))
+        assert resp.status_code == 201
+
+        # Formador A vê o próprio bloqueio.
+        client_a = APIClient()
+        client_a.force_authenticate(formador_a)
+        resp_a = client_a.get("/api/availability-blocks/")
+        assert resp_a.status_code == 200
+        # DRF paginated ou lista direta — checagem agnóstica.
+        results_a = resp_a.data.get("results", resp_a.data)
+        assert len(results_a) == 1
+
+        # Formador B NÃO vê o bloqueio do A.
+        client_b = APIClient()
+        client_b.force_authenticate(formador_b)
+        resp_b = client_b.get("/api/availability-blocks/")
+        assert resp_b.status_code == 200
+        results_b = resp_b.data.get("results", resp_b.data)
+        assert len(results_b) == 0

--- a/v2/backend/apps/core/views_availability.py
+++ b/v2/backend/apps/core/views_availability.py
@@ -126,14 +126,67 @@ class AvailabilityBlockViewSet(viewsets.ModelViewSet):
 
     def perform_create(self, serializer):
         """
-        Cria bloqueio e auto-aprova.
+        Cria bloqueio para o owner ou para um Formador delegado.
 
         Bloqueios são informações factuais (formador sabe quando está indisponível)
-        e não requerem aprovação de terceiros. O status é definido como 'aprovado'
-        automaticamente para que o bloqueio seja considerado imediatamente nas
-        verificações de conflito (RD-02, RD-03).
+        e não requerem aprovação de terceiros. Status='aprovado' automático para
+        que o bloqueio entre nas verificações de conflito (RD-02, RD-03).
+
+        PR 13 hardening RBAC (2026-05-04):
+        - Sem `usuario_id` (ou == request.user.id): comportamento original.
+          `usuario = created_by = request.user`.
+        - Com `usuario_id != request.user.id`: requer permissão de delegar
+          (`user_can_delegate_availability_block`). Anti-enumeração: 403
+          é avaliado ANTES de qualquer lookup do target.
+          Após autorizar: valida que target é Formador ativo (400 caso
+          contrário), salva `usuario=target, created_by=request.user` e
+          registra AuditLog `DELEGATE_BLOCK_CREATE`.
         """
-        serializer.save(usuario=self.request.user, status="aprovado")
+        from rest_framework.exceptions import PermissionDenied, ValidationError
+
+        from apps.core.models import AuditLog, Usuario
+        from apps.core.rbac.policies import user_can_delegate_availability_block
+
+        request_user = self.request.user
+        target_id = serializer.validated_data.pop("usuario_id", None)
+
+        # Caso 1: sem usuario_id ou self-target → fluxo original.
+        if target_id is None or target_id == request_user.id:
+            serializer.save(usuario=request_user, created_by=request_user, status="aprovado")
+            return
+
+        # Caso 2: delegação. Anti-enumeração: 403 ANTES de qualquer lookup.
+        if not user_can_delegate_availability_block(request_user):
+            raise PermissionDenied("Você não tem permissão para criar bloqueio em nome de outro usuário.")
+
+        # Autorizado: agora podemos buscar target sem vazar enumeração.
+        try:
+            target = Usuario.objects.get(pk=target_id)
+        except Usuario.DoesNotExist:
+            raise ValidationError({"usuario_id": "Usuário alvo não encontrado."})
+
+        if not target.is_active:
+            raise ValidationError({"usuario_id": "Usuário alvo está inativo."})
+
+        if not target.groups.filter(name="Formador").exists():  # noqa: RBAC-composite-allowed
+            raise ValidationError({"usuario_id": "Usuário alvo não tem a Função Formador."})
+
+        block = serializer.save(usuario=target, created_by=request_user, status="aprovado")
+
+        # AuditLog (não inclui PII desnecessária — `motivo` ficou de fora).
+        AuditLog.objects.create(
+            usuario=request_user,
+            action="DELEGATE_BLOCK_CREATE",
+            model_name="AvailabilityBlock",
+            details={
+                "delegate_user_id": request_user.id,
+                "target_formador_id": target.id,
+                "block_id": block.id,
+                "inicio": block.inicio.isoformat(),
+                "fim": block.fim.isoformat(),
+                "origem": "delegated",
+            },
+        )
 
 
 class AvailabilityCheckView(APIView):


### PR DESCRIPTION
## Programa Hardening RBAC — PR 13/16 (PR 13A — backend-only)

Permite que **Assistente Administrativo do Controle**, **DAT** e **superuser** criem bloqueios em nome de um Formador, com auditoria. Formador continua podendo criar bloqueio próprio. Frontend não mexe (campo `usuario_id` opcional preserva backwards-compatibility).

PR backend-only. Frontend pode adicionar UI em onda futura.

## Regra de negócio

| Persona | Pode delegar? |
|---------|---------------|
| Superuser | ✅ |
| Assistente Administrativo do Controle (composite) | ✅ |
| DAT (via `manage_admin_registries`) | ✅ |
| Controle puro (sem Função Assistente) | ❌ 403 |
| Coordenador / Apoio | ❌ 403 |
| Gerente da Superintendência | ❌ 403 |
| Gerente pedagógico | ❌ 403 |
| Diretoria | ❌ 403 |
| Formador (delegando para outro Formador) | ❌ 403 |
| Assistente Administrativo fora do Controle | ❌ 403 |

Target precisa ser **Formador ativo** (após autorizar requester).

**Anti-enumeração:** requester não autorizado recebe 403 ANTES de qualquer lookup do target. ID inexistente vs existente vs inativo é indistinguível para requester sem permissão.

## Arquivos

| Arquivo | Mudança |
|---------|---------|
| `migrations/0082_availability_block_created_by.py` | NEW — adiciona `created_by` (FK Usuario, nullable, SET_NULL) |
| `models/agenda.py` | adiciona campo `created_by` no `AvailabilityBlock` |
| `serializers/agenda.py` | `usuario_id` write-only opcional (IntegerField, não PrimaryKeyRelatedField — anti-enumeração) |
| `views_availability.py` | `AvailabilityBlockViewSet.perform_create` ramificado (self vs delegação) |
| `rbac/helpers.py` | extrai `user_is_assistente_administrativo_controle` (SSOT compartilhado) |
| `rbac/permissions.py` | `IsAssistenteAdministrativoControle` consome o helper extraído |
| `rbac/policies.py` | adiciona `user_can_delegate_availability_block`; refatora `_user_has_solicitation_approvals` para reutilizar o helper |
| `tests/test_pr13_delegated_availability_blocks.py` | NEW — 20 cenários |

## Implementação

### Modelo
- `created_by`: FK Usuario, nullable, `on_delete=SET_NULL` (auditoria sobrevive ao usuário).
- Registros antigos: `NULL` (não há identidade histórica retroativa).
- Próprio: `usuario = created_by = request.user`.
- Delegado: `usuario = target_formador, created_by = request.user`.

### Serializer
- `usuario_id = IntegerField(required=False, write_only=True)`.
- **Não usa `PrimaryKeyRelatedField`** — esse faria lookup do Usuario antes da validação de permissão, vazando enumeração via 400 vs 403.

### ViewSet — `perform_create`
1. Se `usuario_id` ausente OU == `request.user.id` → fluxo original (`status=aprovado`, `created_by=request.user`).
2. Se `usuario_id` diferente:
   1. Valida `user_can_delegate_availability_block(request.user)` → 403 ANTES de lookup.
   2. Busca target → 400 se não existir.
   3. Valida `target.is_active` → 400 se não.
   4. Valida `target.groups.filter(name="Formador").exists()` → 400 se não.
   5. Salva `usuario=target, created_by=request.user`.
   6. Cria AuditLog `DELEGATE_BLOCK_CREATE`.

### Helper SSOT
- `helpers.user_is_assistente_administrativo_controle` extraído em `rbac/helpers.py` — reutilizado por `IsAssistenteAdministrativoControle` (DRF), `_user_has_solicitation_approvals` (Policy), e `user_can_delegate_availability_block` (novo). Nenhum lugar duplica `user.groups.filter(name=...)`.
- **Não cria capability nova** — composição de helpers SSOT (diretriz do stakeholder).

### AuditLog
- `action="DELEGATE_BLOCK_CREATE"`, `model_name="AvailabilityBlock"`.
- `details = {delegate_user_id, target_formador_id, block_id, inicio, fim, origem: "delegated"}`.
- **Não inclui `motivo`** (anti-PII).

## Tests

`test_pr13_delegated_availability_blocks.py` — 20 cenários, **20/20 passing**:

- **TestSelfCreate (2)**: self sem `usuario_id`, self com próprio id.
- **TestDelegationAllowed (3)**: Asst Admin Controle, DAT, Superuser.
- **TestDelegationDenied (9 com parametrize)**: Controle puro, Coord, Apoio, Gerente Sup, Gerente pedagógico (Vidas), Diretoria, Formador-outro, Asst Admin fora do Controle, anti-enumeração (ID inexistente para não autorizado retorna 403).
- **TestTargetValidation (3)**: inexistente, não-Formador, inativo (todos 400 para autorizado).
- **TestAuditLog (2)**: delegação cria com IDs corretos; self NÃO cria.
- **TestQuerysetIsolation (1)**: bloqueio delegado não vaza para outro Formador.

## Validação

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR (ver bloco abaixo)
- [x] pytest test_pr13_*.py: 20/20 passing
- [x] pytest core/tests/: 2309/2309 passing (sem regressão)
- [x] black + isort + flake8: limpos

\`\`\`text
==============================================
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS
ALL 8 CHECKS PASSED
==============================================
\`\`\`

## Fora de escopo

- Não mexe em Deslocamentos.
- Não mexe em frontend.
- Não cria UI de seleção de target.
- Não mexe em importação de bloqueios.
- Não mexe em ASQ-005.
- Não libera delegação para Coordenador/Apoio/Gerente Sup.
- Não cria capability nova.

## Programa Hardening RBAC

13/16 PRs concluídos. Próximo: PR 14 (docs auto-sync) ou PR 15 (cleanup legacy mentions).