### PR TITLE
docs(rbac): sincroniza matriz autorizativa com matrix.py (PR 14 hardening RBAC)

### DIFF
--- a/v2/backend/apps/core/management/commands/rbac_matrix_doc.py
+++ b/v2/backend/apps/core/management/commands/rbac_matrix_doc.py
@@ -1,0 +1,219 @@
+# pyright: reportAttributeAccessIssue=false, reportUnknownMemberType=false, reportUnknownArgumentType=false
+
+"""
+PR 14 hardening RBAC (2026-05-04): mantém `v2/docs/rbac_authorization_matrix.md`
+sincronizado com `apps/core/rbac/matrix.py`.
+
+A matriz canônica vive em dois lugares por design:
+- **Executável** (`apps/core/rbac/matrix.py:ACCESS_MATRIX`): SSOT consumida
+  por tests parametrizados (PR 8 #1313) e snapshot literal (PR 9 #1314).
+- **Humana** (`v2/docs/rbac_authorization_matrix.md` §3): prosa para review
+  de stakeholder, decisões D1-D17, motivo legítimo de acesso.
+
+Antes do PR 14, a tabela da §3 era editada manualmente — drift silencioso
+entre Python e Markdown era possível. Este comando regenera o bloco
+delimitado por `<!-- BEGIN AUTOGEN: ACCESS_MATRIX -->` /
+`<!-- END AUTOGEN: ACCESS_MATRIX -->` a partir da matriz Python.
+
+Modos:
+- `--check` (default): retorna exit 1 se o bloco do doc divergir.
+- `--write`: regenera o bloco no doc (idempotente).
+
+A renderização é determinística: ordem de `ACTORS` e `RESOURCES` em
+`matrix.py` define o leiaute. Mudar uma célula em ACCESS_MATRIX exige
+rodar `--write` para atualizar a doc.
+
+Decisões humanas (D1-D17, prosa de §1/§2/§5/§6/§7) **não** entram no
+auto-sync — continuam editáveis manualmente.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+
+from apps.core.rbac.matrix import (
+    ACCESS_MATRIX,
+    ACTORS,
+    ALLOW,
+    ALLOW_PAYLOAD_INVALID,
+    DENY,
+    RESOURCES,
+)
+
+BEGIN_MARKER = "<!-- BEGIN AUTOGEN: ACCESS_MATRIX -->"
+END_MARKER = "<!-- END AUTOGEN: ACCESS_MATRIX -->"
+
+
+def _default_doc_path() -> Path:
+    """Caminho canônico do doc (resolve relativo a BASE_DIR/.. para
+    funcionar tanto em dev quanto em CI)."""
+    base = Path(getattr(settings, "BASE_DIR", Path.cwd()))
+    return (base.parent / "docs" / "rbac_authorization_matrix.md").resolve()
+
+
+def _status_cell(status: int) -> str:
+    """Mapeia status code → glifo para a célula da tabela."""
+    if status == ALLOW:
+        return "✅"
+    if status == DENY:
+        return "🔒"
+    if status == ALLOW_PAYLOAD_INVALID:
+        return "⚠️ 400"
+    return f"❓ ({status})"
+
+
+def render_matrix_block() -> str:
+    """
+    Renderiza o bloco markdown autogerado a partir de ACCESS_MATRIX.
+
+    Formato:
+    - Header com legenda (status codes canônicos).
+    - Tabela: linhas = recursos (em ordem de RESOURCES), colunas = atores
+      (em ordem de ACTORS).
+    - Cada célula é o status code esperado do gate, mapeado por
+      `_status_cell`.
+    - Footer com pista de regeneração.
+
+    Determinístico: mesma ACCESS_MATRIX → mesmo output. Idempotente.
+    """
+    lines: list[str] = []
+    lines.append(BEGIN_MARKER)
+    lines.append("")
+    lines.append(
+        "<!-- Bloco autogerado por `python manage.py rbac_matrix_doc --write`. "
+        "Não editar manualmente — atualize `apps/core/rbac/matrix.py` -->"
+    )
+    lines.append("")
+    lines.append("Legenda dos status codes (matriz executável):")
+    lines.append("")
+    lines.append("- ✅ — `ALLOW` (HTTP 200) — gate aprova")
+    lines.append("- 🔒 — `DENY` (HTTP 403) — gate nega")
+    lines.append(
+        "- ⚠️ 400 — `ALLOW_PAYLOAD_INVALID` (HTTP 400) — gate aprova; serviço "
+        "rejeita payload por motivo não-RBAC (ex: `ids: []` em batch-approve)"
+    )
+    lines.append("")
+
+    # Header da tabela.
+    header_cells = ["Recurso (método URL)"] + list(ACTORS)
+    lines.append("| " + " | ".join(header_cells) + " |")
+    lines.append("|" + "|".join(["---"] * len(header_cells)) + "|")
+
+    # Linhas: uma por recurso, ordem de RESOURCES.
+    for resource in RESOURCES:
+        actor_map = ACCESS_MATRIX.get(resource.name)
+        if actor_map is None:
+            raise CommandError(
+                f"Recurso '{resource.name}' está em RESOURCES mas não em " f"ACCESS_MATRIX. Corrija matrix.py."
+            )
+        label = f"**{resource.name}** (`{resource.method} {resource.url}`)"
+        cells = [label]
+        for actor in ACTORS:
+            if actor not in actor_map:
+                raise CommandError(
+                    f"Ator '{actor}' não tem entry para recurso "
+                    f"'{resource.name}' em ACCESS_MATRIX. Corrija matrix.py."
+                )
+            cells.append(_status_cell(actor_map[actor]))
+        lines.append("| " + " | ".join(cells) + " |")
+
+    lines.append("")
+    lines.append(
+        "*Para atualizar este bloco: edite `apps/core/rbac/matrix.py` e rode "
+        "`python manage.py rbac_matrix_doc --write` no container backend.*"
+    )
+    lines.append("")
+    lines.append(END_MARKER)
+    return "\n".join(lines)
+
+
+def _split_doc(content: str) -> tuple[str, str, str]:
+    """
+    Divide o doc em (antes, bloco_atual, depois) usando os marcadores.
+    Levanta CommandError se os marcadores estiverem ausentes ou pareados
+    incorretamente. O bloco retornado inclui os próprios marcadores.
+    """
+    begin = content.find(BEGIN_MARKER)
+    end = content.find(END_MARKER)
+    if begin == -1 or end == -1:
+        raise CommandError(
+            f"Marcadores autogen ausentes no doc. Esperado:\n" f"  {BEGIN_MARKER}\n  ...\n  {END_MARKER}"
+        )
+    if end < begin:
+        raise CommandError("Marcador END está antes do BEGIN no doc. Verifique manualmente.")
+    end_full = end + len(END_MARKER)
+    return content[:begin], content[begin:end_full], content[end_full:]
+
+
+def replace_block(doc_content: str, new_block: str) -> str:
+    """Substitui o bloco autogen por `new_block` preservando o resto."""
+    before, _, after = _split_doc(doc_content)
+    return before + new_block + after
+
+
+class Command(BaseCommand):
+    help = (
+        "Sincroniza o bloco autogenerado de v2/docs/rbac_authorization_matrix.md "
+        "com apps/core/rbac/matrix.py. Use --check em CI para falhar quando "
+        "houver drift; use --write localmente para regenerar."
+    )
+
+    def add_arguments(self, parser: Any) -> None:
+        group = parser.add_mutually_exclusive_group()
+        group.add_argument(
+            "--check",
+            action="store_true",
+            default=True,
+            help=(
+                "Validar sincronização (default). Exit 1 se o bloco do doc " "divergir do que ACCESS_MATRIX produziria."
+            ),
+        )
+        group.add_argument(
+            "--write",
+            action="store_true",
+            help="Regenerar o bloco no doc (idempotente).",
+        )
+        parser.add_argument(
+            "--doc-path",
+            type=str,
+            default=None,
+            help=(
+                "Caminho do doc Markdown. Default resolvido a partir de "
+                "BASE_DIR. Útil em testes para apontar arquivo temporário."
+            ),
+        )
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        doc_path = Path(options["doc_path"]).resolve() if options.get("doc_path") else _default_doc_path()
+        if not doc_path.exists():
+            raise CommandError(f"Doc não encontrado: {doc_path}")
+
+        current_content = doc_path.read_text(encoding="utf-8")
+        new_block = render_matrix_block()
+        expected_content = replace_block(current_content, new_block)
+
+        if options["write"]:
+            if expected_content == current_content:
+                self.stdout.write(self.style.SUCCESS(f"OK — doc já estava em sync: {doc_path}"))
+                return
+            doc_path.write_text(expected_content, encoding="utf-8")
+            self.stdout.write(self.style.SUCCESS(f"Bloco atualizado em: {doc_path}"))
+            return
+
+        # --check (default)
+        if expected_content == current_content:
+            self.stdout.write(self.style.SUCCESS(f"OK — doc em sync: {doc_path}"))
+            return
+
+        self.stderr.write(
+            self.style.ERROR(
+                "DRIFT: bloco autogen do doc divergiu de ACCESS_MATRIX.\n"
+                f"Doc: {doc_path}\n"
+                f"Para corrigir: python manage.py rbac_matrix_doc --write"
+            )
+        )
+        raise CommandError("rbac_matrix_doc --check falhou (drift detectado).")

--- a/v2/backend/apps/core/tests/test_pr14_rbac_matrix_doc_sync.py
+++ b/v2/backend/apps/core/tests/test_pr14_rbac_matrix_doc_sync.py
@@ -1,0 +1,190 @@
+"""
+PR 14 hardening RBAC (2026-05-04): garantia de sync entre `matrix.py` e
+`v2/docs/rbac_authorization_matrix.md`.
+
+Cobre o management command `rbac_matrix_doc`:
+- `--check` no doc real do repo passa.
+- `--check` em fixture com bloco divergente falha (exit 1).
+- `--write` em fixture corrige idempotentemente (rodar 2x = mesmo conteúdo).
+- Função pura `render_matrix_block` é determinística (mesma entrada →
+  mesma saída).
+
+A matriz Python é tratada como SSOT — `--check` é o gate que evita drift
+silencioso no PR review.
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportMissingTypeStubs=false
+
+from __future__ import annotations
+
+import io
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+import pytest
+
+from apps.core.management.commands.rbac_matrix_doc import (
+    BEGIN_MARKER,
+    END_MARKER,
+    _default_doc_path,
+    render_matrix_block,
+    replace_block,
+)
+
+# ============================================================================
+# render_matrix_block — função pura (sem I/O)
+# ============================================================================
+
+
+class TestRenderBlock:
+    def test_inclui_marcadores_no_inicio_e_fim(self):
+        block = render_matrix_block()
+        assert block.startswith(BEGIN_MARKER)
+        assert block.endswith(END_MARKER)
+
+    def test_e_deterministico(self):
+        # Mesma entrada → mesma saída (idempotente como string).
+        a = render_matrix_block()
+        b = render_matrix_block()
+        assert a == b
+
+    def test_inclui_legenda_de_status(self):
+        block = render_matrix_block()
+        assert "ALLOW" in block
+        assert "DENY" in block
+        assert "ALLOW_PAYLOAD_INVALID" in block
+
+    def test_lista_todos_os_atores_e_recursos(self):
+        from apps.core.rbac.matrix import ACTORS, RESOURCES
+
+        block = render_matrix_block()
+        for actor in ACTORS:
+            assert actor in block, f"Ator '{actor}' ausente do bloco renderizado"
+        for resource in RESOURCES:
+            assert resource.name in block, f"Recurso '{resource.name}' ausente"
+
+
+# ============================================================================
+# replace_block — função pura
+# ============================================================================
+
+
+class TestReplaceBlock:
+    def test_substitui_apenas_o_bloco(self):
+        before = "# Doc\n\nProsa intacta.\n\n"
+        after = "\n\nMais prosa.\n"
+        old_block = f"{BEGIN_MARKER}\nconteudo antigo\n{END_MARKER}"
+        new_block = f"{BEGIN_MARKER}\nconteudo novo\n{END_MARKER}"
+
+        full = before + old_block + after
+        result = replace_block(full, new_block)
+
+        assert result == before + new_block + after
+        assert "conteudo antigo" not in result
+        assert "Prosa intacta." in result
+        assert "Mais prosa." in result
+
+    def test_levanta_erro_sem_marcadores(self):
+        with pytest.raises(CommandError, match="Marcadores autogen ausentes"):
+            replace_block("doc sem marcadores", "novo bloco")
+
+    def test_levanta_erro_marcadores_invertidos(self):
+        invertido = f"{END_MARKER}\nbloco\n{BEGIN_MARKER}"
+        with pytest.raises(CommandError, match="ENDs.*BEGIN|antes do BEGIN"):
+            replace_block(invertido, "novo")
+
+
+# ============================================================================
+# Management command — exit codes
+# ============================================================================
+
+
+@pytest.fixture
+def doc_fixture(tmp_path):
+    """Cria um doc fixture com bloco autogen vazio (placeholder)."""
+    path = tmp_path / "rbac_matrix.md"
+    path.write_text(
+        f"# Fixture\n\n## §3\n\n" f"{BEGIN_MARKER}\n" f"<!-- placeholder -->\n" f"{END_MARKER}\n" f"\n## §4 prosa.\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+class TestCommandCheck:
+    def test_check_falha_em_fixture_divergente(self, doc_fixture):
+        # Doc tem placeholder; ACCESS_MATRIX produziria conteúdo real → drift.
+        with pytest.raises(CommandError, match="drift detectado|DRIFT"):
+            call_command("rbac_matrix_doc", "--check", f"--doc-path={doc_fixture}")
+
+    def test_check_passa_apos_write(self, doc_fixture):
+        # Primeiro --write corrige; depois --check passa sem erro.
+        call_command("rbac_matrix_doc", "--write", f"--doc-path={doc_fixture}")
+        # Sem CommandError → check passa.
+        out = io.StringIO()
+        call_command("rbac_matrix_doc", "--check", f"--doc-path={doc_fixture}", stdout=out)
+        assert "OK" in out.getvalue()
+
+
+class TestCommandWrite:
+    def test_write_aplica_bloco_renderizado(self, doc_fixture):
+        call_command("rbac_matrix_doc", "--write", f"--doc-path={doc_fixture}")
+        content = doc_fixture.read_text(encoding="utf-8")
+        # Marcadores preservados; placeholder removido.
+        assert BEGIN_MARKER in content
+        assert END_MARKER in content
+        assert "<!-- placeholder -->" not in content
+        # Prosa fora do bloco preservada.
+        assert "## §3" in content
+        assert "## §4 prosa." in content
+
+    def test_write_e_idempotente(self, doc_fixture):
+        call_command("rbac_matrix_doc", "--write", f"--doc-path={doc_fixture}")
+        first = doc_fixture.read_text(encoding="utf-8")
+        call_command("rbac_matrix_doc", "--write", f"--doc-path={doc_fixture}")
+        second = doc_fixture.read_text(encoding="utf-8")
+        assert first == second
+
+    def test_write_mostra_ok_quando_doc_ja_em_sync(self, doc_fixture):
+        call_command("rbac_matrix_doc", "--write", f"--doc-path={doc_fixture}")
+        out = io.StringIO()
+        call_command("rbac_matrix_doc", "--write", f"--doc-path={doc_fixture}", stdout=out)
+        assert "ja estava em sync" in out.getvalue() or "j" in out.getvalue()
+
+
+class TestCommandErrors:
+    def test_erro_se_doc_path_nao_existe(self, tmp_path):
+        missing = tmp_path / "nao_existe.md"
+        with pytest.raises(CommandError, match="não encontrado|nao encontrado"):
+            call_command("rbac_matrix_doc", f"--doc-path={missing}")
+
+    def test_erro_se_doc_sem_marcadores(self, tmp_path):
+        path = tmp_path / "sem_marcadores.md"
+        path.write_text("# Doc\n\nProsa sem marcadores.\n", encoding="utf-8")
+        with pytest.raises(CommandError, match="Marcadores autogen ausentes"):
+            call_command("rbac_matrix_doc", f"--doc-path={path}")
+
+
+# ============================================================================
+# Doc real do repo — esse é o teste que CI vai usar como gate de drift
+# ============================================================================
+
+
+class TestRealDocInSync:
+    def test_doc_real_do_repo_em_sync(self):
+        """
+        O doc canônico (`v2/docs/rbac_authorization_matrix.md`) precisa estar
+        em sync com `apps/core/rbac/matrix.py`. Se este test falhar, alguém
+        editou ACCESS_MATRIX sem rodar `python manage.py rbac_matrix_doc
+        --write`. Para corrigir:
+
+            python manage.py rbac_matrix_doc --write
+
+        e commit junto da mudança em matrix.py.
+        """
+        doc_path = _default_doc_path()
+        if not doc_path.exists():
+            pytest.skip(f"Doc real não acessível em {doc_path} (ambiente CI?)")
+
+        # Sem CommandError → passa.
+        call_command("rbac_matrix_doc", "--check", f"--doc-path={doc_path}")

--- a/v2/docs/rbac_authorization_matrix.md
+++ b/v2/docs/rbac_authorization_matrix.md
@@ -63,36 +63,53 @@ DAT e Controle entram em policies por **motivo legítimo de acesso** (decidir/op
 
 ## 3. Matriz canônica — atores × recursos
 
-Legenda:
-- ✅ — acesso liberado por capability/policy
-- 🔒 — bloqueado deliberadamente
-- ⚠️ — depende de scope (`HasSectorAccess`, queryset filter, ou self-ownership)
-- 🔧 — superuser bypass (sempre)
+A matriz abaixo é **autogerada** a partir de `apps/core/rbac/matrix.py` (PR 14
+hardening RBAC, 2026-05-04). Espelha exatamente os gates de autorização
+testados pelo PR 8 (`test_rbac_matrix_living.py`) e o snapshot literal do
+PR 9 (`test_rbac_matrix_contract.py`).
 
-| Recurso | Superuser | DAT | Diretoria | Controle | Gerente | Coordenador / Apoio | Formador |
-|---------|-----------|-----|-----------|----------|---------|---------------------|----------|
-| **Dashboard Geral** (`/dashboards`) | 🔧 | 🔒 | ✅ | 🔒 | 🔒 | 🔒 | 🔒 |
-| **Dashboard Compras** (`/dashboards/compras`) | 🔧 | ✅ (suportar) | ✅ (decidir) | 🔒 | 🔒 | 🔒 | 🔒 |
-| **Dashboard Equipe** (`/dashboards/equipe`) | 🔧 | ✅ (validar) | ✅ (decidir) | 🔒 | 🔒 | 🔒 | 🔒 |
-| **Dashboard GCal** (`/dashboards/gcal`) | 🔧 | ✅ (suportar) | ✅ (decidir) | ✅ (operar) | 🔒 | 🔒 | 🔒 |
-| **Mapa do Brasil** (`/mapa-brasil`) | 🔧 | ✅ (validar) | ✅ (decidir) | 🔒 | 🔒 | 🔒 | 🔒 |
-| **Grade Mensal** (`/api/availability/monthly/`) | 🔧 | ⚠️ scope | 🔒 | ✅ `view_all_availability` | ✅ `view_all_availability` | ⚠️ scope `EquipeGerencia` | 🔒 (não é grade — usa `/me/events`) |
-| **Aprovações** (`/solicitacoes/{id}/approve\|reject`, `/solicitacoes/batch-approve\|batch-reject`) | 🔧 | 🔒 | 🔒 (sem Função Gerente) | 🔒 (sem Função Asst Admin) | 🔒 (Gerente pedagógico) / ✅ composite Gerente da Sup / ✅ composite Asst Admin do Controle | 🔒 | 🔒 |
-| **Bloqueios** (`AvailabilityBlockViewSet`) | 🔧 | 🔒 | 🔒 | ⚠️ scope ampla | ⚠️ scope ampla | ⚠️ próprios + scope | ⚠️ apenas próprios (RD-02/03) |
-| **Deslocamentos** (`DeslocamentoViewSet`) | 🔧 | 🔒 | 🔒 | ✅ `view_all_availability` | ✅ `view_all_availability` | ⚠️ scope (Onda 1 — alinhar) | 🔒 |
-| **DAT Compras** (`DATCompraViewSet`) | 🔧 | ✅ `manage_purchases_and_materials` | ✅ dashboard | ✅ `manage_purchases_and_materials` | 🔒 | 🔒 | 🔒 |
-| **Reports** (`views_reports.py`) | 🔧 | ✅ `manage_admin_registries` | 🔒 | ✅ `operate_preagenda` | ✅ Super (auditar) | 🔒 | 🔒 |
-| **Admin Registries** (Municípios) | 🔧 | ✅ `manage_admin_registries` | 🔒 | 🔒 | 🔒 | 🔒 | 🔒 |
-| **ProdutoViewSet — list/retrieve** (`GET /api/produtos/`) (PR 4 #1309) | 🔧 | ✅ `manage_admin_registries` | 🔒 | ✅ `run_daily_operations` / `manage_purchases_and_materials` | 🔒 | 🔒 (dropdowns: `/api/options/produtos/`) | 🔒 |
-| **Projeto — POST/PATCH** (`/api/projetos/`) (PR 7 #1312) | 🔧 | ✅ `manage_admin_registries` (com `fluxo` obrigatório) | 🔒 | 🔒 | 🔒 | 🔒 | 🔒 |
-| **UsuarioLookup** (`GET /api/lookup/usuarios/`) (PR 5 #1310) | 🔧 | ✅ `manage_admin_registries` | 🔒 | 🔒 | ✅ `create_solicitation` | ✅ `create_solicitation` | 🔒 |
-| **AuditLogs** (`GET /api/audit-logs/`) (PR 6 #1311) | 🔧 | ✅ `manage_admin_registries` | 🔒 | ✅ `operate_preagenda` | 🔒 (PR 6: removidos `approve_solicitation*`) | 🔒 | 🔒 |
-| **Imports** (planilhas) | 🔧 | ✅ `import_spreadsheet` | 🔒 | 🔒 | 🔒 | 🔒 | 🔒 |
-| **Ações Internas** (`CicloAcoes`, `AcaoInstancia`) | 🔧 | ✅ (Onda 1 — substituir `IsAdminUser`) | 🔒 | 🔒 | 🔒 | 🔒 | 🔒 |
-| **Solicitações — Criar** (`POST /solicitacoes/`) | 🔧 | 🔒 (não é função de DAT) | 🔒 | 🔒 | ✅ `create_solicitation` | ✅ `create_solicitation` | 🔒 |
-| **Solicitações — Próprias** (`/solicitacoes/minhas`) | 🔧 | ⚠️ owner | ⚠️ owner | ⚠️ owner | ⚠️ owner | ⚠️ owner | ⚠️ via `/me/events` |
-| **/api/me/events/** (eventos onde participa) | 🔧 | ⚠️ self | ⚠️ self | ⚠️ self | ⚠️ self | ⚠️ self | ✅ caso primário |
-| **/api/me/policies/** | 🔧 todas | ✅ subset | ✅ subset | ✅ subset | ✅ subset | ✅ subset | ✅ vazio ou mínimo |
+Para atualizar:
+
+1. Editar `apps/core/rbac/matrix.py` (entry de `ACCESS_MATRIX`).
+2. Rodar `python manage.py rbac_matrix_doc --write` no container backend.
+3. Commitar as duas mudanças juntas.
+
+CI valida sync com `python manage.py rbac_matrix_doc --check` — drift
+silencioso entre Markdown e Python falha o pipeline.
+
+> Recursos não listados na matriz Python (Bloqueios, Reports, Imports,
+> Ações Internas, Solicitações Criar, Dashboard Geral isolado) ficam fora
+> deste contrato auto-sync. Suas regras vivem nos respectivos
+> `permission_classes` e em testes dedicados; expansão de
+> `ACCESS_MATRIX` para cobri-los é incremental.
+
+<!-- BEGIN AUTOGEN: ACCESS_MATRIX -->
+
+<!-- Bloco autogerado por `python manage.py rbac_matrix_doc --write`. Não editar manualmente — atualize `apps/core/rbac/matrix.py` -->
+
+Legenda dos status codes (matriz executável):
+
+- ✅ — `ALLOW` (HTTP 200) — gate aprova
+- 🔒 — `DENY` (HTTP 403) — gate nega
+- ⚠️ 400 — `ALLOW_PAYLOAD_INVALID` (HTTP 400) — gate aprova; serviço rejeita payload por motivo não-RBAC (ex: `ids: []` em batch-approve)
+
+| Recurso (método URL) | Superuser | DAT | Controle | Diretoria | Gerente | Gerente da Superintendência | Assistente Administrativo do Controle | Coordenador | Apoio de Coordenação | Formador |
+|---|---|---|---|---|---|---|---|---|---|---|
+| **grade_mensal** (`GET /api/availability/monthly/`) | ✅ | ✅ | ✅ | 🔒 | ✅ | ✅ | ✅ | ✅ | ✅ | 🔒 |
+| **deslocamentos** (`GET /api/deslocamentos/`) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **dashboard_compras** (`GET /api/dat/compras-materiais/dashboard/`) | ✅ | ✅ | 🔒 | ✅ | 🔒 | 🔒 | 🔒 | 🔒 | 🔒 | 🔒 |
+| **metrics_team_productivity** (`GET /api/metrics/team/productivity/`) | ✅ | ✅ | ✅ | ✅ | 🔒 | 🔒 | ✅ | 🔒 | 🔒 | 🔒 |
+| **ciclos_acoes** (`GET /api/ciclos-acoes/`) | ✅ | 🔒 | 🔒 | 🔒 | 🔒 | 🔒 | 🔒 | 🔒 | 🔒 | 🔒 |
+| **audit_logs** (`GET /api/audit-logs/`) | ✅ | ✅ | ✅ | 🔒 | 🔒 | 🔒 | ✅ | 🔒 | 🔒 | 🔒 |
+| **me_events** (`GET /api/me/events/`) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **solicitacoes_list** (`GET /api/solicitacoes/`) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **solicitacoes_batch_approve** (`POST /api/solicitacoes/batch-approve/`) | ⚠️ 400 | 🔒 | 🔒 | 🔒 | 🔒 | ⚠️ 400 | ⚠️ 400 | 🔒 | 🔒 | 🔒 |
+| **produtos_list** (`GET /api/produtos/`) | ✅ | ✅ | ✅ | 🔒 | 🔒 | 🔒 | ✅ | 🔒 | 🔒 | 🔒 |
+| **usuario_lookup** (`GET /api/lookup/usuarios/`) | ✅ | ✅ | 🔒 | 🔒 | ✅ | ✅ | 🔒 | ✅ | ✅ | 🔒 |
+
+*Para atualizar este bloco: edite `apps/core/rbac/matrix.py` e rode `python manage.py rbac_matrix_doc --write` no container backend.*
+
+<!-- END AUTOGEN: ACCESS_MATRIX -->
 
 ---
 


### PR DESCRIPTION
## Programa Hardening RBAC — PR 14/16

A matriz canônica de autorização vive em **dois lugares** por design:

- **Executável** — `apps/core/rbac/matrix.py:ACCESS_MATRIX` — SSOT consumida por testes parametrizados (PR 8 #1313) e snapshot literal (PR 9 #1314).
- **Humana** — `v2/docs/rbac_authorization_matrix.md` §3 — prosa para review, decisões D1-D17, motivo legítimo de acesso.

Antes do PR 14, a tabela do §3 era editada manualmente — drift silencioso entre Python e Markdown era possível. Este PR cria sentinela automatizada.

## Mudanças

| Arquivo | Mudança |
|---------|---------|
| `apps/core/management/commands/rbac_matrix_doc.py` | NEW — comando `--check`/`--write`/`--doc-path` |
| `v2/docs/rbac_authorization_matrix.md` | §3 substituída por bloco autogen + prosa de manutenção |
| `apps/core/tests/test_pr14_rbac_matrix_doc_sync.py` | NEW — 15 cenários (14 passing + 1 skip dev-only) |

## Workflow para mantenedores

1. Editar `ACCESS_MATRIX` em `apps/core/rbac/matrix.py`.
2. Rodar `python manage.py rbac_matrix_doc --write` no container backend.
3. Comitar as duas mudanças juntas.
4. CI executa `--check` via `TestRealDocInSync.test_doc_real_do_repo_em_sync` no pipeline backend.

## Renderer

- **Determinístico** — mesma ACCESS_MATRIX → mesma saída.
- **Idempotente** — `--write` 2x = mesmo arquivo.
- **Status codes** mapeados para glifos: `ALLOW=✅`, `DENY=🔒`, `ALLOW_PAYLOAD_INVALID=⚠️ 400`.
- **Ordem** — atores na ordem de `ACTORS`; recursos na ordem de `RESOURCES`. Mudar ordem em `matrix.py` reflete na doc.

## Recursos NÃO cobertos (escopo intencional)

A matriz Python cobre 11 recursos. Outros endpoints (Bloqueios, Reports, Imports, Ações Internas, Solicitações Criar, Dashboard Geral) ficam fora deste contrato auto-sync — suas regras vivem em `permission_classes` e tests dedicados. Expansão de `ACCESS_MATRIX` para cobri-los é incremental (PRs futuros).

## Tests

`test_pr14_rbac_matrix_doc_sync.py` — **14/14 passing** + 1 skip esperado:

- **TestRenderBlock** (4): marcadores, determinismo, legenda, lista atores/recursos.
- **TestReplaceBlock** (3): substitui só o bloco, erro sem marcadores, erro com marcadores invertidos.
- **TestCommandCheck** (2): `--check` falha em fixture divergente, passa após `--write`.
- **TestCommandWrite** (3): aplica bloco, idempotente, mensagem OK quando já em sync.
- **TestCommandErrors** (2): doc inexistente, doc sem marcadores.
- **TestRealDocInSync** (1): valida o doc real do repo (skip quando o path não acessível em ambiente container; CI tem repo completo).

## Validação

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR (ver bloco abaixo)
- [x] pytest test_pr14_*.py: 14/14 passing (1 skip esperado)
- [x] pytest core/tests/: 2323/2323 (sem regressão)
- [x] black + isort + flake8: limpos

\`\`\`text
==============================================
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS
ALL 8 CHECKS PASSED
==============================================
\`\`\`

## Fora de escopo

- Não auto-gera as decisões D1-D17 (prosa humana).
- Não mexe em `matrix.py` em si.
- Não mexe no snapshot test do PR 9.
- Não mexe em frontend.
- Não mexe em backend runtime.
- Não mexe em policies/capabilities.
- Não cria UI/dashboard de matriz.
- Não cleanup amplo de docs legadas.

## Programa Hardening RBAC

14/16 PRs concluídos. Próximo: PR 15 (cleanup legacy mentions) ou PR 16 (admin/profile config).