### PR TITLE
docs(imports): add contracts, templates and dry-run audit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -279,6 +279,8 @@ google_service_account.json
 *.xlsx
 *.xls
 *.csv
+# Exception: import contract templates (fictitious, no real data)
+!v2/docs/imports/templates/*.csv
 extracted_*.json
 dumps/
 backups/*.sql

--- a/v2/docs/imports/README.md
+++ b/v2/docs/imports/README.md
@@ -1,0 +1,256 @@
+# Contratos de Importação — `sheets.banco` → Aprender Sistema v2
+
+Status: **PR 1 — documentação e contratos (revisada 2026-05-05 contra código real)**
+Versão: 2026-05-05 v0.2
+Origem: `sheets.banco` (planilha consolidada externa)
+Destino: PostgreSQL (`apps.core`) via endpoints HTTP DRF (síncronos `POST /api/<recurso>/import/`) ou async (`POST /api/imports/<tipo>/` — ASQ-005 Fase 1, apenas `bloqueios` por enquanto)
+
+> ⚠️ **Atualização v0.2 (2026-05-05)**: a versão inicial v0.1 tratou como "futuro" várias coisas que **já existem no código**. Esta versão corrige o drift, lista paths reais, e reorienta o roadmap. Ver §3.1 "Estado real do código" e §8 "Roadmap revisto".
+
+---
+
+## 1. Propósito
+
+Este diretório define **contratos de importação** entre a planilha externa `sheets.banco` e o sistema Aprender Sistema v2. Cobre:
+
+- Formato esperado das colunas em cada CSV.
+- Normalizações exigidas antes do upload.
+- Validações que o sistema aplica.
+- Idempotência (regras de duplicidade e `external_hash`).
+- Models, services e endpoints do backend envolvidos.
+- O que **não** deve acontecer automaticamente (gates de revisão humana).
+- Como auditar o resultado.
+
+Esta PR (PR 1) entrega **apenas a documentação e templates fictícios**. Não cria endpoints novos, não altera models, não importa dados reais.
+
+---
+
+## 2. Princípios gerais (válidos para os 4 tipos)
+
+### 2.1 Dry-run obrigatório antes de apply
+
+Toda importação tem 2 etapas:
+
+1. **Dry-run** — valida + retorna preview, **não persiste**.
+2. **Apply** — só após dry-run sem erros bloqueantes.
+
+Comandos atuais (referência — não implementados nesta PR):
+- `make etl-acomp-dry` / `etl-acomp-apply` — acompanhamento legacy.
+- `make etl-desloc-dry` / `etl-desloc-apply` — deslocamentos.
+- `make etl-acoes-dry` / `etl-acoes-apply` — ações controle.
+- `make etl-dat-dry` / `etl-dat-apply` — DAT cadastros.
+- `make import-compras-dry` / `import-cadastros-dry` / `import-acoes-dry`.
+
+### 2.2 Idempotência via `external_hash`
+
+Imports históricos usam SHA1 (ou SHA256 nos services novos) sobre uma chave natural composta. Re-rodar o mesmo arquivo **não duplica linhas**.
+
+Implementação atual: vista em `apps/core/services/dat_cadastros_import.py:301`, `controle_acoes_import.py:265`, `controle_imports.py:36`, `deslocamentos_import.py:257` (auditoria 2026-05 sugere consolidar em `services/hash_utils.py::compute_external_hash`).
+
+### 2.3 RBAC — quem pode importar
+
+- Imports históricos (legacy): exigem `import_spreadsheet` (DAT).
+- Imports operacionais: cobertas por policies públicas:
+  - `import_availability_blocks` — DAT + Controle/Gerente/Coord.
+  - `import_compras` — DAT + Compras + Controle.
+  - `import_generic_spreadsheet` — DAT + Controle.
+
+Atribuição via Django Admin (D17 — admin-driven, ratificado 2026-05-04). Não automático em deploy.
+
+### 2.4 Audit trail
+
+Toda importação real grava `AuditLog` com:
+- `usuario` (quem rodou).
+- `action` (ex: `IMPORT_USUARIOS`, `IMPORT_COMPRAS`).
+- `model_name`.
+- `details` (JSON): `arquivo_hash`, `linhas_processadas`, `linhas_criadas`, `linhas_atualizadas`, `linhas_ignoradas`, `linhas_erro`.
+
+Nota: a estrutura `ImportBatch` proposta na PR 4 (futura) substitui parte do `details` por modelo dedicado com rastreabilidade rica.
+
+### 2.5 Timezone
+
+Datas de calendário (Solicitação, AvailabilityBlock) **são armazenadas em UTC** e comparadas em **`America/Fortaleza`** (RD-06). Toda data/hora vinda do CSV deve ser tratada como horário local Fortaleza antes de virar UTC.
+
+### 2.6 Nenhum efeito colateral perigoso
+
+Importação **NUNCA**:
+- Publica eventos no Google Calendar (mesmo se `external_event_id` vier preenchido).
+- Aprova solicitações (PA-01: fluxo SUPER exige aprovação manual).
+- Atribui grupos `Gerente`/`Superintendência` automaticamente.
+- Cria usuário com `is_superuser=True`.
+- Sobrescreve dados sem `external_hash` confirmando match.
+
+---
+
+## 3. Tipos de importação cobertos
+
+| Tipo | Documento | Template CSV | Backend implementado | Endpoint |
+|---|---|---|---|---|
+| Usuários | [usuarios.md](./usuarios.md) | [templates/usuarios.template.csv](./templates/usuarios.template.csv) | ✅ Sim | `POST /api/usuarios/import/` |
+| Produtos / Controle / Compras | [produtos_controle.md](./produtos_controle.md) | [templates/produtos_controle.template.csv](./templates/produtos_controle.template.csv) | ✅ Sim | `POST /api/produtos/import/` + `POST /api/controle/import-compras/` |
+| Agenda / Solicitações / Eventos | [agenda_solicitacoes.md](./agenda_solicitacoes.md) | [templates/agenda_solicitacoes.template.csv](./templates/agenda_solicitacoes.template.csv) | ✅ Sim, com PA-01 | `POST /api/solicitacoes/import/` |
+| Disponibilidade / Bloqueios | [disponibilidade.md](./disponibilidade.md) | [templates/disponibilidade.template.csv](./templates/disponibilidade.template.csv) | ✅ Tipos T/P (D pendente) | `POST /api/disponibilidade/import-bloqueios/` (sync) + `POST /api/imports/bloqueios/` (async, ImportJob) |
+
+Ordem de execução: [ordem_de_importacao.md](./ordem_de_importacao.md).
+
+**Auditoria de shape de retorno** (PR 2, 2026-05-05): [dry_run_response_contract.md](./dry_run_response_contract.md) — análise dos 11 services + contrato padrão proposto + plano de migração em 5 fases.
+
+---
+
+## 3.1 Estado real do código (auditoria 2026-05-05)
+
+Para os 4 tipos acima, o backend **já tem implementação funcional** em produção. Os contratos deste diretório descrevem o formato esperado da planilha `sheets.banco` e servem para **alinhar a geração de CSV externa com o que o backend já aceita** — não para projetar funcionalidades inexistentes.
+
+### Services (11 já implementados em `apps/core/services/`)
+
+| Service | Função pública | Idempotência | Dry-run |
+|---|---|---|---|
+| `usuarios_import.py` | `import_usuarios_from_file(path, dry_run=True)` | CPF (unique) | ✅ |
+| `eventos_import.py` | `import_eventos_from_file(path, dry_run=True)` | `external_hash` + Participation M2M | ✅ |
+| `bloqueios_import.py` | `import_bloqueios_from_file(path, dry_run=True)` | tupla (usuario, inicio, fim, tipo) | ✅ |
+| `produtos_import.py` | `import_produtos_from_file(...)` | `Produto.codigo` | ✅ |
+| `colecoes_import.py` | `import_colecoes_from_file(...)` | — | ✅ |
+| `municipios_import.py` | `import_municipios_from_file(...)` | — | ✅ |
+| `equipe_gerencia_import.py` | `import_equipe_gerencia_from_file(...)` | — | ✅ |
+| `controle_imports.py` | `import_compras_from_file(...)` (alimenta **`Compra`**) | SHA1 `external_hash` | ✅ |
+| `controle_acoes_import.py` | `import_acoes_controle(...)` | SHA1 | ✅ |
+| `dat_cadastros_import.py` | `import_dat_cadastros(...)` | SHA1 | ✅ |
+| `deslocamentos_import.py` | `import_deslocamentos(...)` | SHA1 | ✅ |
+
+Helpers de reconciliação compartilhados em `apps/core/services/resolvers.py`:
+
+- `resolve_user_by_email(email)`, `resolve_user_by_name(name)` (com fallback heurístico por partes do nome).
+- `resolve_municipio(nome)` — aceita formatos `"Cidade"`, `"Cidade - UF"`, `"Cidade (UF)"`, `"Cidade/UF"`; normaliza com NFKD.
+- `resolve_projeto(nome)` — aceita código ou nome; aplica `normalize_projeto_name` com aliases (IDEB→GESTÃO ESCOLAR, "Nível 1"→N1, "Vida &"→"VIDA E", etc.).
+- `resolve_tipo_evento(nome)`.
+- `_nfkd(value)` para normalização case-insensitive sem acento.
+- Texto base em `apps/core/services/normalize.py::norm_text()`.
+
+### Endpoints HTTP
+
+**Síncronos** (10 endpoints, retornam `{stats, pendencias, dry_run, file}`):
+
+| Endpoint | View | Gate RBAC |
+|---|---|---|
+| `POST /api/usuarios/import/` | `ImportUsuariosView` | `HasPerm("manage_admin_registries")` |
+| `POST /api/solicitacoes/import/` | `ImportEventosView` | `HasPerm("import_spreadsheet")` |
+| `POST /api/disponibilidade/import-bloqueios/` | `ImportBloqueiosView` | `HasPerm("import_spreadsheet")` |
+| `POST /api/produtos/import/` | `ImportProdutosView` | `HasPerm("import_spreadsheet")` |
+| `POST /api/municipios/import/` | `ImportMunicipiosView` | `HasPerm("manage_admin_registries")` |
+| `POST /api/colecoes/import/` | `ImportColecoesView` | `HasPerm("manage_admin_registries")` |
+| `POST /api/equipe-gerencia/import/` | `ImportEquipeGerenciaView` | `HasPerm("manage_admin_registries")` |
+| `POST /api/controle/import-compras/` | `ImportComprasView` | `HasPerm("import_spreadsheet")` |
+| `POST /api/controle/import-acoes/` | `ControleImportAcoesView` | `HasPerm("import_spreadsheet")` |
+| `POST /api/dat/import-cadastros/` | `DATImportCadastrosView` | `HasPerm("manage_admin_registries")` |
+
+Todos aceitam `?dry_run=true|false` (default `true`).
+
+**Assíncronos (ASQ-005 Fase 1)** — apenas `bloqueios` por enquanto:
+
+- `POST /api/imports/bloqueios/` — cria `ImportJob` + dispatcha Celery task; retorna `202 Accepted` com `job_id`.
+- `GET /api/imports/<id>/` — status + stats + pendencias do job.
+- `GET /api/imports/` — lista jobs do usuário (filtros `type=`, `status=`).
+
+### Model `ImportJob` ([apps/core/models/import_job.py](../../backend/apps/core/models/import_job.py))
+
+Modelo de rastreabilidade de execuções async. Campos:
+
+- `user` (FK Usuario, PROTECT), `import_type` (TextChoices — hoje só `BLOQUEIOS`), `status` (QUEUED|RUNNING|SUCCESS|FAILED).
+- `file` (FileField em `imports/%Y/%m/%d/`), `original_filename`.
+- `dry_run` (Boolean), `stats` (JSON), `pendencias` (JSON).
+- `error_message` (≤500c), `error_traceback` (não exposto via API).
+- `celery_task_id`, `duration_ms`, timestamps + métodos `mark_running/success/failed`.
+
+Comentário do código: **"Fase 2 migrará USUARIOS, COMPRAS, ACOES, DESLOCAMENTOS, EVENTOS, PRODUTOS, MUNICIPIOS, COLECOES, EQUIPE_GERENCIA"** — esse é o backlog real.
+
+### Frontend (3 páginas confirmadas; mais provavelmente)
+
+- `v2/frontend/src/pages/DAT/ImportacoesPage.tsx` — hub `/dat/importacoes`.
+- `v2/frontend/src/pages/AdminDAT/ColecoesImportPage.tsx`.
+- `v2/frontend/src/pages/AdminDAT/EquipeGerenciaImportPage.tsx`.
+- Páginas adjacentes de cadastro AdminDAT (Usuarios, Municipios, Produtos, Projetos, Grupos, Setores, Funcoes, Gerencias) — gerenciam CRUD, **não confirmado** se cada uma tem botão de upload de planilha.
+
+### Makefile (chama endpoints HTTP via curl)
+
+Targets atuais em `v2/Makefile` (ex: `make import-compras-dry FILE=...`) **chamam `curl` para `/api/<recurso>/import/?dry_run=true`** — **não** existem `management commands` `etl_*.py` nem `import_*.py` em `apps/core/management/commands/`. Documentação `make etl-acomp-dry` em outros docs do projeto é referência histórica.
+
+---
+
+## 4. Convenções dos templates CSV
+
+- **Encoding**: UTF-8 (sem BOM).
+- **Separador**: `,` (vírgula).
+- **Quote**: aspas duplas em campos com vírgula/espaço/linha.
+- **Decimal**: ponto (`12.50`, não `12,50`).
+- **Data**: `dd/mm/yyyy` (BR) — normalizada para ISO no service.
+- **Hora**: `HH:MM` (24h).
+- **Boolean** (quando aplicável): `sim`/`não`, `true`/`false`, `1`/`0`.
+- **CPF**: 11 dígitos sem máscara (vai ser normalizado).
+- **Telefone**: dígitos puros ou com máscara — será normalizado.
+- **Cabeçalho**: snake_case ou nomes da planilha original (documento explicita por tipo).
+
+Todos os templates contêm **uma linha fictícia** com CPF `00000000000` e email `*.exemplo@example.com` — **não usar como dado real**.
+
+---
+
+## 5. Como propor mudanças de contrato
+
+1. Editar o markdown do tipo afetado nesta pasta.
+2. Atualizar o template CSV correspondente.
+3. Documentar a mudança em "Histórico de versões" do próprio arquivo.
+4. PR com label `documentation` + revisão obrigatória do dono da etapa.
+5. Após merge, atualizar service correspondente (PR separada).
+
+Mudanças que quebram contrato (renomear coluna obrigatória, mudar tipo de dado, mudar regra de hash) exigem deprecation period: aceitar formato antigo por 1 release com warning, derrubar no seguinte.
+
+---
+
+## 6. Pendências cross-cutting (para Matheus)
+
+- **Reconciliação de Usuario por nome** vs por email vs por CPF: em Agenda (Formador 1..5), qual chave usar? CPF não aparece na planilha de agenda. Atualmente, services legacy fazem fuzzy-match por nome — **risco de match errado**.
+- **Mapeamento Cargo → Função RBAC**: `usuarios.md` propõe tabela; falta confirmar todos os termos da planilha original.
+- **Disponibilidade** ainda não tem contrato estável — formato em aberto.
+- **Decisão D17 e Imports**: imports não devem atribuir capabilities (admin-driven). Confirmar que `seed_rbac` automático não é parte do pipeline de import.
+
+---
+
+## 7. Referências internas
+
+- `v2/docs/RBAC_NAMING.md` — convenção RBAC.
+- `v2/docs/IMPLEMENTACAO_PA.md` — política de aprovação (PA-01..07).
+- `v2/docs/GUIDE_AVAILABILITY.md` — RD-01..08.
+- `v2/docs/GUIDE_GCAL.md` — integração GCal.
+- `v2/docs/MAPEAMENTO_COMPLETO_SETORES_GERENCIAS.md` — gerência ↔ setor.
+- `apps/core/services/dat_cadastros_import.py` — service exemplar (idempotência via SHA1).
+- `apps/core/management/commands/etl_*.py` — comandos atuais.
+
+---
+
+## 8. Roadmap das próximas PRs (revisto 2026-05-05)
+
+> ⚠️ O roadmap anterior (v0.1) propunha "criar do zero" coisas que já existem. Esta versão alinha o backlog ao código real.
+
+| PR | Escopo | Justificativa | Risco |
+|---|---|---|---|
+| PR 1 | Documentação e contratos + templates (este PR, revisado) | Alinhar `sheets.banco` com formato aceito hoje | Nenhum (docs-only) |
+| PR 2 | **Auditar e padronizar shape de retorno de dry-run** nos 11 services existentes | Cada service hoje retorna estrutura ligeiramente diferente (`stats/pendencias`, `relatório`, `created_ids`, etc.); contrato único facilita frontend e testes | Baixo (não muda comportamento) |
+| PR 3 | **Consolidar helpers de normalização** em `apps/core/imports/normalization.py` extraindo o que já existe em `services/resolvers.py` + `services/normalize.py` | Hoje há helpers úteis (`resolve_municipio`, `resolve_projeto`, `_nfkd`, `norm_text`) mas falta `normalize_cpf`, `normalize_phone`, `parse_br_date`, `parse_bool_ptbr`, `build_import_hash` como API pública | Baixo (refactor) |
+| PR 4 | **Migrar 9 imports síncronos restantes para `ImportJob` async** (ASQ-005 Fase 2) — usuários, compras, ações, deslocamentos, eventos, produtos, municípios, coleções, equipe_gerencia. Um tipo por sub-PR | Padroniza upload + rastreabilidade; já há infra pronta para `bloqueios` | Médio (Celery + auditoria) |
+| PR 5 | **Adicionar botões "Baixar template"** nas páginas de import existentes (`ImportacoesPage.tsx`, `ColecoesImportPage.tsx`, `EquipeGerenciaImportPage.tsx`, e demais que aceitem upload) — apontando para `v2/docs/imports/templates/*.csv` | UX: hoje **não confirmado** se algum botão existe | Baixo (frontend simples) |
+| PR 6 (talvez desnecessária) | Reforçar **validadores específicos** apenas se PR 2 identificar lacuna | Cada service já tem suas validações; provavelmente bastam ajustes pontuais | A definir após PR 2 |
+
+### Ordem sugerida
+
+1. **PR 2** (auditar shape de retorno) — barata, esclarece estado real.
+2. **PR 3** (consolidar normalizadores) — refactor seguro com testes.
+3. **PR 5** (botões de template) — paralelizável com 2 e 3.
+4. **PR 4** (migração async, 1 tipo por sub-PR) — depende de PR 2 estabilizar contrato.
+5. **PR 6** só se PR 2 expuser regras divergentes.
+
+### Coisas que **NÃO** precisam virar PR
+
+- Criar `ImportBatch` (já existe `ImportJob`).
+- Criar dry-run (todos os services já implementam).
+- Criar services `*_import.py` (11 já existem).
+- Criar endpoints (10 síncronos + 3 async já existem).
+- Criar `normalize_text_key`, `resolve_municipio`, `resolve_projeto` (já existem em `resolvers.py`/`normalize.py`).

--- a/v2/docs/imports/agenda_solicitacoes.md
+++ b/v2/docs/imports/agenda_solicitacoes.md
@@ -1,0 +1,279 @@
+# Importação: Agenda / Solicitações / Eventos
+
+Status: PR 1 — contrato fechado, **backend já implementado** com regras PA-01 ativas (revisto 2026-05-05)
+Versão: 2026-05-05 v0.2
+Template: [templates/agenda_solicitacoes.template.csv](./templates/agenda_solicitacoes.template.csv)
+
+> ⚠️ **Atualização v0.2**: a v0.1 tratava o service como "futuro". Na verdade `apps/core/services/eventos_import.py` já existe e funciona com PA-01 aplicado (SUPER + data futura → `pendente`), criação de `Participation` M2M (coordenador + formadores 1..5) e idempotência via `external_hash`. Endpoint funcional: `POST /api/solicitacoes/import/`.
+
+---
+
+## 1. Objetivo
+
+Importar registros de agendamento de eventos pedagógicos (formações, acompanhamentos, provas) a partir da aba de "Agenda" da planilha `sheets.banco`. Alimenta `apps.core.models.solicitacao.Solicitacao`.
+
+Cobre:
+- Criação de `Solicitacao` em status correto (PA-01).
+- Lookup de Municipio, Projeto, Coordenador, Formadores.
+- Validação de horários (RD-06 timezone Fortaleza, fim > início).
+- Idempotência via `external_hash`.
+
+NÃO cobre (crítico):
+- **Publicação no Google Calendar** (RF05/RF06) — só após aprovação manual (PA-03).
+- **Aprovação automática** — se `projeto.fluxo=="SUPER"`, status inicial é `pendente`.
+- **Atualização/cancelamento** de Solicitacao existente automaticamente — exige revisão humana.
+
+---
+
+## 2. Dados de origem esperados
+
+Aba `Agenda` (ou `Acompanhamento`) da planilha `sheets.banco`.
+
+| Coluna planilha | Descrição |
+|---|---|
+| `e` | (?) — semântica a confirmar; possivelmente flag/marker da linha |
+| `Aprovação` | Status de aprovação na planilha (texto livre — "Sim"/"Não"/"Pendente") |
+| `Atualizar` | Flag indicando que a linha foi modificada (não usar como gatilho automático) |
+| `Cancelar` | Flag indicando que o evento foi cancelado |
+| `Municípios` | Nome do município onde ocorre o evento |
+| `encontro` | Tipo/número de encontro (ex: "Formação 3", "Acompanhamento 1") |
+| `tipo` | Tipo de evento (ex: "Formação", "Prova", "Acompanhamento") |
+| `data` | Data do evento (BR `dd/mm/yyyy`) |
+| `hora início` | Hora de início (BR `HH:MM` 24h) |
+| `hora fim` | Hora de fim |
+| `projeto` | Nome ou código do projeto |
+| `segmento` | Segmento (ex: "Fundamental I", "Fundamental II") |
+| `Coord Acompanha` | Coordenador que acompanha (nome) |
+| `Coordenador` | Coordenador principal |
+| `Formador 1` | Primeiro formador |
+| `Formador 2` | Segundo formador (opcional) |
+| `Formador 3..5` | Formadores adicionais (opcional) |
+| `Convidados` | Emails de convidados extras (separados por `;` ou `,`) |
+
+---
+
+## 3. Colunas obrigatórias
+
+| Coluna CSV | Validação |
+|---|---|
+| `municipio` (vem de `Municípios`) | Lookup `Municipio.nome` + sanity UF se vier |
+| `tipo` | Tipo de evento conhecido (proposta: enum mapping) |
+| `data` | Data BR válida; >= hoje - 365 dias e <= hoje + 365 dias (proteção contra typo) |
+| `hora_inicio` | `HH:MM` válido |
+| `hora_fim` | `HH:MM` válido + maior que `hora_inicio` |
+| `projeto` | Lookup `Projeto.nome` ou `Projeto.codigo` |
+| `formador_1` | Lookup `Usuario` com Função `Formador` (reconciliação) |
+
+---
+
+## 4. Colunas opcionais
+
+| Coluna CSV | Comportamento se vazio |
+|---|---|
+| `e` | Ignorado (semântica desconhecida) |
+| `aprovacao_planilha` | **NÃO** usar para aprovar; apenas registrar em `details` do AuditLog |
+| `atualizar`, `cancelar` | Apenas gerar warning + listar para revisão humana; **não disparar update/cancel** |
+| `encontro` | Salvar em campo texto livre ou em `observacoes` |
+| `segmento` | Salvar como tag/texto, sem mapeamento estrito |
+| `coord_acompanha` | Lookup `Usuario`; pode ficar `null` |
+| `coordenador` | Lookup `Usuario` (Função Coordenador); se vazio, herdar do coord. logado |
+| `formador_2..5` | Adicionar à M2M `formadores` se preenchido |
+| `convidados` | Split por `;`/`,`, validar emails, adicionar em `extra_participants` |
+
+---
+
+## 5. Normalizações esperadas (PR 2 — `normalization.py`)
+
+| Campo | Função (futura) | Resultado |
+|---|---|---|
+| `municipio` + (uf?) | `normalize_municipio_uf` | `(nome, uf)` |
+| `data` | `parse_br_date` | `datetime.date` |
+| `hora_inicio`, `hora_fim` | `parse_br_time` | `datetime.time` |
+| `data` + `hora_inicio` → `inicio` | combine + `make_aware(tz=America/Fortaleza)` | `datetime` UTC armazenado |
+| `data` + `hora_fim` → `fim` | idem | `datetime` UTC armazenado |
+| `projeto` | `normalize_text_key` | Lookup nome/código |
+| `coordenador`, `formador_*`, `coord_acompanha` | `normalize_text_key` + lookup | `Usuario.id` ou `None` |
+| `convidados` | split `[;,]` + `normalize_email` | `list[str]` |
+| `atualizar`, `cancelar` | `parse_bool_ptbr` | bool — usado para flag warning, não ação |
+| `aprovacao_planilha` | `parse_bool_ptbr` | bool — só registra |
+
+---
+
+## 6. Validações antes do upload (PR 6)
+
+### Bloqueantes
+- `municipio` não encontrado em `Municipio`.
+- `projeto` não encontrado em `Projeto`.
+- `formador_1` não encontrado em `Usuario` ou usuário não tem Função `Formador`.
+- `hora_fim <= hora_inicio` (RD-01).
+- `data` fora de faixa razoável.
+- Email inválido em `convidados`.
+- `external_hash` duplicado no próprio arquivo.
+
+### Avisos
+- `formador_2..5` não encontrado → criar Solicitacao só com formadores válidos.
+- `coordenador` não encontrado → deixar `null`, exigir admin completar.
+- Linha com `cancelar=true` → **NÃO cancelar**; criar a Solicitacao normal e listar para revisão.
+- Linha com `atualizar=true` → **NÃO atualizar** existente; criar uma nova Solicitacao (idempotência via hash decide se duplica).
+- `aprovacao_planilha=true` → **NÃO aprovar**; status inicial conforme `Projeto.fluxo`.
+- Conflito RD-01..08 detectado (overlap, deslocamento, capacidade) → warning explícito por código (E, T, P, D, M).
+
+### Verificação pós-import (não bloqueante)
+- Reservar slot via `availability_service.check_conflicts()` para cada Solicitacao criada e anotar conflitos em `details`.
+
+---
+
+## 7. Regras de duplicidade / hash
+
+### Chave natural
+Composta: `(data, hora_inicio, projeto, municipio, formador_primary)`.
+
+### `external_hash`
+
+SHA256 sobre:
+```text
+data.isoformat() + "|" + hora_inicio.strftime("%H:%M") + "|" + hora_fim.strftime("%H:%M") + "|"
+  + str(projeto.id) + "|" + str(municipio.id) + "|" + str(formador_primary.id)
+```
+
+`formador_primary` é o primeiro formador não-vazio (`formador_1` ou primeiro preenchido).
+
+### Comportamento por match
+| Hash existe no banco | Linha vem com `cancelar=true` | Linha vem com `atualizar=true` | Ação |
+|---|---|---|---|
+| Não | Não | Não | Criar Solicitacao |
+| Não | Sim | — | **Warning crítico** — pediu para cancelar algo que não existe |
+| Não | — | Sim | Criar (com warning informando que `atualizar` veio em hash novo) |
+| Sim | Não | Não | Ignorar (idempotente); registrar em AuditLog |
+| Sim | Sim | — | **Não cancelar**; gerar relatório de revisão manual |
+| Sim | — | Sim | **Não atualizar**; gerar relatório de revisão manual |
+
+---
+
+## 8. Models / services / endpoints relacionados (estado real do código — 2026-05-05)
+
+| Componente | Caminho | Função | Status |
+|---|---|---|---|
+| Model `Solicitacao` | `apps/core/models/solicitacao.py` | SSOT do agendamento | ✅ existe |
+| Model `Participation` | `apps/core/models/` | M2M Solicitacao ↔ Usuario com role (COORDENADOR/FORMADOR) | ✅ existe |
+| Model `Usuario` | `apps/core/models/usuario.py` | Coordenador/Formador FK + M2M | ✅ existe |
+| Model `Municipio`, `Projeto`, `TipoEvento` | `apps/core/models/organizacao.py` | FKs | ✅ existe |
+| **Service de import** | `apps/core/services/eventos_import.py` | `import_eventos_from_file(path: str, dry_run: bool = True) -> dict`. Aplica PA-01 (`Projeto.fluxo=='SUPER'` + data futura → `status='pendente'`; senão `'aprovado'`). Cria 1 `Participation(role='COORDENADOR')` + até 5 `Participation(role='FORMADOR')`. Idempotência por `external_hash`. Timezone fixado em `America/Fortaleza` (linha 51). | ✅ **já implementado** |
+| Resolvers usados | `apps/core/services/resolvers.py` | `resolve_municipio`, `resolve_projeto`, `resolve_tipo_evento`, `resolve_user_by_email`, `resolve_user_by_name` | ✅ existe |
+| Service availability | `apps/core/services/availability_service.py:check_conflicts()` | RD-01..08 — **não é chamado pelo import** (linhas importadas entram diretamente sem check) | ✅ existe |
+| **Endpoint síncrono** | `POST /api/solicitacoes/import/` (`ImportEventosView` em `apps/core/views_import_eventos.py`) | dry_run via query param; multipart `file=` no body | ✅ **já funciona** |
+| Endpoint async | (não implementado para eventos) | ASQ-005 Fase 2 migrará | ⏳ Fase 2 do `ImportJob` |
+| Gate RBAC efetivo | `IsAuthenticated + HasPerm("import_spreadsheet")` (DAT) | NÃO `manage_admin_registries` — eventos é operacional, não cadastro | ✅ aplicado em prod |
+| Endpoint manual (1 a 1) | `POST /api/solicitacoes/` (`SolicitacaoViewSet.create`) | Para criação não-bulk; usa `HasPerm("create_solicitation")` | ✅ existe |
+| AuditLog action | (registrado pelo service durante apply — não confirmado nome exato) | rastreio | ⚠️ verificar |
+
+### Comportamento real do service (lido em código + docstring)
+
+- **Idempotência**: `external_hash` SHA-? sobre tupla natural (municipio + projeto + tipo + data + hora_inicio + coordenador). Re-import com mesma chave **não duplica**.
+- **PA-01 aplicada automaticamente** (linhas 19-22 do docstring):
+  - `Projeto.fluxo == 'SUPER'` **e** `data >= hoje` → `status='pendente'` (aguarda aprovação manual em `/aprovacoes`).
+  - `Projeto.fluxo == 'NAO_SUPER'` **OU** `data < hoje` → `status='aprovado'`.
+- **Participation criada por linha** (linhas 22-23): 1 `role='COORDENADOR'` + até 5 `role='FORMADOR'`. Reconciliação por email (preferido) ou nome (fallback heurístico via `resolve_user_by_name`).
+- **Timezone**: `ZoneInfo("America/Fortaleza")` (linha 51 do service).
+- **Google Calendar**: **NÃO é tocado pelo import** — `external_event_id` fica `None`, `gcal_status` permanece `NONE`. Publicação só via fluxo manual (preview + publish, gate `CanAccessSolicitationApprovals`).
+
+---
+
+## 9. O que pode ser criado/atualizado
+
+### Pode criar
+- `Solicitacao` com:
+  - `status='pendente'` se `Projeto.fluxo=='SUPER'`.
+  - `status='aprovado'` se `Projeto.fluxo=='NAO_SUPER'` (auto-approve PR18) — **com flag `imported_from_sheets=True`** sugerido para PR futura.
+  - `is_online=False` por default (planilha não indica online/presencial — pendência).
+  - `gcal_status='NONE'` (não publicar).
+  - `external_event_id=None` (não vincular a evento GCal existente).
+  - `meet_link=None`.
+
+### Pode atualizar
+- **Nada** automaticamente. Linhas com hash existente são ignoradas (idempotência).
+- Atualizações reais exigem fluxo manual no frontend (`/solicitacoes/{id}/editar`).
+
+---
+
+## 10. O que NÃO deve acontecer automaticamente
+
+| Item | Por quê |
+|---|---|
+| Publicar no Google Calendar | PA-03: integrações pós-aprovação manual |
+| Aprovar Solicitacao mesmo com `aprovacao_planilha=true` | PA-01: SUPER nunca auto-aprova (PR18 só aplica a NAO_SUPER) |
+| Cancelar Solicitacao mesmo com `cancelar=true` | Cancel envolve `cancel_gcal` policy + AuditLog; precisa fluxo manual |
+| Atualizar Solicitacao mesmo com `atualizar=true` | Update precisa passar por validação RD-01..08 atualizada |
+| Criar Usuario novo (Coordenador/Formador inexistente) | Usuários vêm do import #1; agenda só **reconcilia** |
+| Criar Municipio/Projeto novo | Cadastros mestres vêm dos passos 3-4 da ordem |
+| Atribuir grupo `Gerente` a usuário | Sensibilidade RBAC — admin manual |
+| Enviar emails para `convidados` | Nenhum side-effect de notificação |
+
+---
+
+## 11. Como auditar depois
+
+### AuditLog
+```python
+AuditLog.objects.filter(
+    action__in=["IMPORT_AGENDA", "IMPORT_AGENDA_DRY_RUN"],
+    created_at__gte=<timestamp>
+).values(
+    "usuario", "details__arquivo_hash",
+    "details__linhas_criadas",
+    "details__linhas_ignoradas",
+    "details__linhas_rejeitadas",
+    "details__cancelar_ignorados",   # linhas com flag cancelar=true não-executadas
+    "details__atualizar_ignorados",  # linhas com flag atualizar=true não-executadas
+    "details__conflitos_rd",         # contagem de conflitos RD anotados
+)
+```
+
+### Drift check
+- Comparar `Solicitacao.objects.filter(created_at__date=<dia>).count()` com `linhas_criadas`.
+- Listar Solicitações com `status='pendente'` criadas pelo import — fila de revisão manual.
+- Cruzar `external_hash` da Solicitacao com `external_hash` da linha CSV (se persistido em campo dedicado).
+- Listar conflitos RD-01..08 detectados durante import e ainda não resolvidos.
+
+### Relatório de revisão manual
+Gerar lista de:
+- Linhas com `cancelar=true` cujo hash bate com Solicitação existente → para cancelar manualmente.
+- Linhas com `atualizar=true` cujo hash bate → para atualizar manualmente.
+- Linhas com Coordenador/Formador não encontrado → para reconciliação de usuário.
+
+---
+
+## 12. Riscos identificados
+
+| Risco | Severidade | Mitigação |
+|---|---|---|
+| **Publicação automática em GCal** | **Crítica** | Hard gate: `gcal_status='NONE'`, `external_event_id=None`; nenhum task Celery disparado |
+| **Aprovação automática SUPER** | **Crítica** | PA-01: status `pendente` quando `Projeto.fluxo=="SUPER"`, ignora `aprovacao_planilha` |
+| Cancel automático destruindo dados | Alta | NÃO cancelar; só relatar |
+| Update automático sobrescrevendo decisões | Alta | NÃO atualizar; só relatar |
+| Match errado de Formador por nome (homônimos) | Alta | Pendência: usar CPF/email se vier; senão warning explícito |
+| `data + hora_inicio` em timezone errado (cliente assumindo UTC) | Alta | Sempre assumir Fortaleza local na planilha; converter ao salvar |
+| `hora_fim` no dia seguinte (evento atravessa meia-noite) | Média | Detectar se hora_fim < hora_inicio → assumir +1 dia (com warning) |
+| Convidado com email inválido | Baixa | Bloqueante por linha (rejeitar Convidado); criar Solicitacao sem ele |
+| Encontro/segmento com semântica de domínio (mapeamento) | Média | Texto livre por enquanto; futura tabela auxiliar |
+| Conflitos RD-01..08 silenciados | Média | Anotar em `details`; expor relatório pós-import |
+
+---
+
+## 13. Pendências para Matheus
+
+1. **Semântica de coluna `e`**: o que significa? Provavelmente flag de "encontrado/exportado" — confirmar antes de ignorar.
+2. **`tipo` aceitos**: enum fechado? Quais valores válidos? Hoje o sistema tem campos como `tipo_evento` (não confirmei o nome exato no model).
+3. **Online vs presencial**: a planilha tem coluna para indicar evento online? Hoje `Solicitacao.is_online` afeta geração de Meet link.
+4. **Reconciliação de Formador por nome**: planilha tem CPF/email do formador ou só nome? Se só nome, política para homônimos.
+5. **`aprovacao_planilha=true` em projetos NAO_SUPER**: aceitar como sinal de que a linha está validada (e refletir em `status='aprovado'`) ou ignorar?
+6. **`cancelar=true` e `atualizar=true`**: a planilha quer dar uma "instrução" ao sistema. Política definitiva — gerar issue de revisão automaticamente? Mandar email ao admin?
+7. **Convidados**: emails listados em `Convidados` viram `extra_participants` na Solicitacao ou vão direto pro `attendees` do GCal (quando publicado)?
+8. **`segmento`**: existe tabela `Segmento` no schema? Se sim, lookup; senão, texto livre.
+9. **Conflitos RD-08 (descrição clara dos códigos)**: para cada conflito detectado, gerar email/notificação ao coordenador responsável?
+
+---
+
+## 14. Histórico de versões
+
+- 2026-05-05 — v0.1 — PR 1 (contrato inicial). Gates contra GCal automático, aprovação automática, cancel automático.

--- a/v2/docs/imports/disponibilidade.md
+++ b/v2/docs/imports/disponibilidade.md
@@ -1,0 +1,256 @@
+# Importação: Disponibilidade / Bloqueios
+
+Status: PR 1 — **backend implementado para tipos T/P; tipo D e recorrência ainda em aberto** (revisto 2026-05-05)
+Versão: 2026-05-05 v0.2
+Template: [templates/disponibilidade.template.csv](./templates/disponibilidade.template.csv)
+
+> ⚠️ **Atualização v0.2**: a v0.1 tratava o formato como totalmente pendente. Verificação contra o código mostra que `apps/core/services/bloqueios_import.py` já existe e funciona para tipos **T** (total) e **P** (parcial), com endpoint síncrono `POST /api/disponibilidade/import-bloqueios/` **e** endpoint assíncrono `POST /api/imports/bloqueios/` (ASQ-005 Fase 1 — `bloqueios` é o piloto). Tipo **D** (deslocamento) e bloqueios **recorrentes** continuam em aberto.
+
+---
+
+## 1. Objetivo
+
+Importar bloqueios de disponibilidade de formadores e coordenadores a partir de aba apropriada da planilha `sheets.banco` (nome exato a confirmar). Alimenta `apps.core.models.agenda.AvailabilityBlock`.
+
+Cobre (proposta):
+- Criação de bloqueio Total (T), Parcial (P) ou Deslocamento (D).
+- Reconciliação de Usuário (formador/coordenador).
+- Idempotência via `external_hash`.
+
+---
+
+## 2. Status do contrato (revisto 2026-05-05)
+
+O backend de import de bloqueios **já existe e funciona** para tipos **T** (Total) e **P** (Parcial). O service `bloqueios_import.py` aceita o cabeçalho:
+
+```text
+usuario,inicio,fim,tipo,motivo
+```
+
+(docstring linhas 6-12). Reconciliação de `usuario` é por **nome** via `resolve_user_by_name` — vulnerável a homônimos; preferência por email/CPF ainda é pendência.
+
+Tipo **D** (Deslocamento) **não está no service de bloqueios**: hoje o service `apps/core/services/availability_service.py:check_conflicts()` **calcula** D dinamicamente (RD-04 buffer entre municípios diferentes). Importar D explícito da planilha exigiria mudança de runtime.
+
+Códigos do sistema:
+- **T** (Total), **P** (Parcial) — armazenados em `AvailabilityBlock.tipo`.
+- **D** (Deslocamento) — derivado, não armazenado como bloqueio.
+- **M** (Capacidade), **X** (Evento+Bloqueio) — códigos de **conflito retornado por check_conflicts**, não tipos de bloqueio.
+
+Pendências reais nesta dimensão: importar **D** explícito (decisão), suporte a **recorrência** (não há campo no model), identificador robusto (CPF/email em vez de nome).
+
+---
+
+## 3. Dados de origem esperados (proposta)
+
+| Coluna planilha | Descrição | Confirmado? |
+|---|---|---|
+| `Usuario` (nome ou email ou CPF) | Identificador do formador/coordenador | ❌ Pendência |
+| `Tipo` (T/P/D) | Total / Parcial / Deslocamento | ❌ Pendência |
+| `Data inicio` | Data inicial (BR `dd/mm/yyyy`) | Proposta |
+| `Data fim` | Data final | Proposta |
+| `Hora inicio` (se parcial) | Hora de início | Proposta |
+| `Hora fim` (se parcial) | Hora de fim | Proposta |
+| `Cidade origem` (se deslocamento) | Município de origem | Proposta |
+| `Cidade destino` (se deslocamento) | Município de destino | Proposta |
+| `Motivo` | Texto livre | Proposta |
+
+---
+
+## 4. Colunas obrigatórias (proposta)
+
+| Coluna CSV | Validação |
+|---|---|
+| `usuario` | Lookup `Usuario`; deve existir; deve ter Função `Formador` ou `Coordenador` |
+| `tipo` | Enum `{T, P, D}` |
+| `data_inicio` | Data BR válida |
+| `data_fim` | Data BR válida; >= `data_inicio` |
+
+---
+
+## 5. Colunas opcionais (proposta)
+
+| Coluna CSV | Comportamento se vazio |
+|---|---|
+| `hora_inicio` | Obrigatório se `tipo==P`; senão default 00:00 |
+| `hora_fim` | Obrigatório se `tipo==P`; senão default 23:59 |
+| `cidade_origem`, `cidade_destino` | Obrigatórios se `tipo==D`; senão ignorar |
+| `motivo` | string vazia se vazio |
+
+---
+
+## 6. Normalizações esperadas (PR 2)
+
+| Campo | Função (futura) | Resultado |
+|---|---|---|
+| `usuario` | `normalize_text_key` + lookup | `Usuario.id` |
+| `tipo` | upper + validate enum | `T`/`P`/`D` |
+| `data_inicio`, `data_fim` | `parse_br_date` | `date` |
+| `hora_inicio`, `hora_fim` | `parse_br_time` | `time` |
+| `data + hora` → `inicio`/`fim` | `make_aware(tz=America/Fortaleza)` | `datetime` UTC armazenado |
+| `cidade_*` | `normalize_municipio_uf` ou lookup `Municipio` | FK Municipio (futuro) ou texto |
+| `motivo` | strip | string |
+
+---
+
+## 7. Validações antes do upload (PR 6, proposta)
+
+### Bloqueantes
+- `usuario` não encontrado.
+- `tipo` fora de `{T, P, D}`.
+- `data_fim < data_inicio`.
+- `tipo==P` mas `hora_inicio` e/ou `hora_fim` vazios.
+- `tipo==D` mas `cidade_origem` e/ou `cidade_destino` vazios.
+- `tipo==D` e `cidade_origem == cidade_destino` (não há deslocamento real).
+- `external_hash` duplicado no próprio arquivo.
+
+### Avisos
+- `data_inicio` no passado → criar (histórico) com warning.
+- `data_inicio` muito no futuro (> 1 ano) → warning.
+- Sobreposição com outro bloqueio do mesmo usuário → criar (RD-02/03 permite múltiplos blocos) com warning.
+
+---
+
+## 8. Regras de duplicidade / hash (proposta)
+
+### Chave natural
+`(usuario.id, tipo, inicio, fim)`.
+
+### `external_hash`
+SHA256 sobre:
+```text
+str(usuario.id) + "|" + tipo + "|" + inicio.isoformat() + "|" + fim.isoformat()
+```
+
+### Comportamento por match
+| Hash existe | Ação |
+|---|---|
+| Não | Criar `AvailabilityBlock` |
+| Sim | Ignorar (idempotente) com log |
+
+---
+
+## 9. Models / services / endpoints relacionados (estado real do código — 2026-05-05)
+
+| Componente | Caminho | Função | Status |
+|---|---|---|---|
+| Model `AvailabilityBlock` | `apps/core/models/agenda.py` | `tipo` (T/P — não D), `inicio`, `fim`, `usuario`, `motivo`, `status`, **`created_by`** (PR 13) | ✅ existe |
+| ViewSet (CRUD) | `views_availability.AvailabilityBlockViewSet` | CRUD; `POST` permite delegação via helper `user_can_delegate_availability_block` (PR 13) | ✅ existe |
+| **Service de import** | `apps/core/services/bloqueios_import.py` | `import_bloqueios_from_file(path: str, dry_run: bool = True) -> dict`. Cabeçalho: `usuario,inicio,fim,tipo,motivo`. Reconciliação de `usuario` via `resolve_user_by_name` (linha 28 do service). Timezone `America/Fortaleza` (linha 30). | ✅ **já implementado** |
+| Service `check_conflicts` | `apps/core/services/availability_service.py` | RD-01..08 (consome bloqueios — não é o service de import). **Calcula D dinamicamente** entre Solicitações em municípios diferentes; D não é armazenado como bloqueio. | ✅ existe |
+| **Endpoint síncrono** | `POST /api/disponibilidade/import-bloqueios/` (`ImportBloqueiosView` em `apps/core/views_import_bloqueios.py`) | dry_run + multipart `file=` | ✅ **já funciona** |
+| **Endpoint assíncrono (ASQ-005 Fase 1 — piloto)** | `POST /api/imports/bloqueios/` → cria `ImportJob`, retorna `202 Accepted` | Despacha Celery task `task_run_import_job`. Job persiste com `import_type='bloqueios'`. Status acompanhado via `GET /api/imports/<id>/`. | ✅ **já funciona** (único tipo async hoje) |
+| Endpoint async (status) | `GET /api/imports/<id>/` | Retorna `ImportJob` serializado (status, stats, pendencias) | ✅ existe |
+| Endpoint async (lista) | `GET /api/imports/` | Lista jobs do usuário (filtro `type=` `status=`) | ✅ existe |
+| Gate RBAC (endpoint sync) | `IsAuthenticated + HasPerm("import_spreadsheet")` (DAT) | NÃO `import_availability_blocks` direto — policy `import_availability_blocks` é apenas para exposição via `/api/me/policies/` | ✅ aplicado |
+| Gate RBAC (endpoint async upload) | `IsAuthenticated + CanImportGenericSpreadsheet` (Policy class) | Verificar em `apps/core/views/imports.py` | ✅ aplicado |
+| AuditLog delegação | `DELEGATE_BLOCK_CREATE` (PR 13) | Quando outro user cria bloqueio em nome de Formador (não vem de import — vem de POST manual) | ✅ existe |
+
+### Comportamento real do service (lido em código + docstring)
+
+- **Cabeçalho aceito** (docstring linhas 6-12 de `bloqueios_import.py`):
+  - `usuario` (obrigatório, nome do formador)
+  - `inicio` (obrigatório, datetime)
+  - `fim` (obrigatório, datetime > inicio)
+  - `tipo` (obrigatório, **T=Total** ou **P=Parcial**; **D não suportado**)
+  - `motivo` (opcional)
+- **Reconciliação**: `resolve_user_by_name(name)` em `resolvers.py`, com fallback heurístico (primeiro nome + último nome, ou parte exata). **Vulnerável a homônimos** — pendência conhecida.
+- **Timezone**: `ZoneInfo("America/Fortaleza")` fixo (linha 30 do service).
+- **Idempotência**: tupla natural `(usuario, inicio, fim, tipo)` — não confirmado se há `external_hash` SHA256 explícito (verificar `_process_row`).
+- **`created_by`**: ao chamar `save()` o service grava `created_by=...` (não confirmado se é o usuário que disparou o import ou `None`).
+
+---
+
+## 10. O que pode ser criado/atualizado
+
+### Pode criar
+- `AvailabilityBlock` com:
+  - `usuario` = formador/coordenador alvo.
+  - `created_by` = usuário que rodou o import (audit trail).
+  - `status='aprovado'` (auto-aprovado como bloqueio declarado pelo próprio).
+  - `tipo`, `inicio`, `fim` conforme planilha.
+  - `motivo` (texto).
+
+### Pode atualizar
+- Nada. Idempotência via hash; mudanças exigem fluxo manual ou re-import com hash diferente.
+
+---
+
+## 11. O que NÃO deve acontecer automaticamente
+
+- Deletar bloqueios existentes que não estão na planilha (a planilha é additive).
+- Criar bloqueio para usuário sem Função `Formador` ou `Coordenador`.
+- Ajustar timezone para UTC sem passar por America/Fortaleza.
+- Disparar notificação ao usuário ou ao Controle.
+- Mover/cancelar Solicitação existente que conflita com o novo bloqueio (deixar fluxo manual decidir).
+
+---
+
+## 12. Como auditar depois
+
+### AuditLog
+```python
+AuditLog.objects.filter(
+    action="IMPORT_AVAILABILITY_BLOCKS",
+    created_at__gte=<timestamp>
+).values(
+    "usuario", "details__arquivo_hash",
+    "details__linhas_criadas",
+    "details__linhas_ignoradas",
+    "details__usuarios_unicos",
+)
+```
+
+### Drift check
+- Comparar `AvailabilityBlock.objects.filter(created_at__date=<dia>).count()` com `linhas_criadas`.
+- Listar formadores com bloqueio `>= 90 dias` no horizonte (possível erro de planilha).
+- Cruzar bloqueios com Solicitações existentes para detectar conflitos pré-existentes.
+
+### Relatório de conflitos pós-import
+Listar Solicitações `status='aprovado'` que após o import passam a colidir com bloqueio T/P/D → fila de revisão.
+
+---
+
+## 13. Riscos identificados
+
+| Risco | Severidade | Mitigação |
+|---|---|---|
+| Bloqueio em horário UTC errado | Alta | Sempre normalizar via Fortaleza local |
+| Bloqueio T sobrescrevendo Solicitacao já aprovada | Alta | NÃO mover/cancelar Solicitacao automaticamente; só relatar |
+| Usuario inexistente | Alta | Bloqueante (rejeita linha) |
+| Deslocamento sem origem/destino | Média | Bloqueante |
+| Bloqueio com `hora_fim==hora_inicio` (P) | Média | RD-01: end==start não é conflito, mas é bloqueio degenerado — warning |
+| Match errado de Usuario por nome | Alta | Preferir email/CPF como identificador; senão warning explícito |
+| Lapso de timezone em sync internacional | Baixa | Documentar TZ no template |
+
+---
+
+## 14. Pendências para Matheus (revistas)
+
+### Resolvidas pelo código atual
+
+- ~~Formato definitivo da planilha?~~ → **Resolvido em parte**: `bloqueios_import.py` aceita `usuario,inicio,fim,tipo,motivo`. Falta só confirmar se esse cabeçalho bate com o que `sheets.banco` vai produzir.
+- ~~Existe service?~~ → Sim, há ~6 meses no código.
+- ~~Existe dry-run?~~ → Sim, todos os services aceitam `dry_run=True`.
+- ~~`ImportBatch` para auditoria?~~ → Já existe `ImportJob` (`apps/core/models/import_job.py`) com piloto em `bloqueios`.
+
+### Pendências reais ainda
+
+1. **Identificador do Usuário**: hoje o service usa `resolve_user_by_name` com fallback heurístico. Para evitar match errado, ideal trocar para CPF ou email — exige PR de runtime no service.
+2. **Tipo D (Deslocamento)**: hoje **não suportado** como bloqueio. Deslocamentos são calculados dinamicamente por `availability_service` entre Solicitações de municípios diferentes. Se `sheets.banco` traz D explícito, precisa decidir:
+   - (a) ignorar coluna D na importação (manter cálculo dinâmico);
+   - (b) estender model `AvailabilityBlock` para aceitar D (mudança de schema);
+   - (c) criar model separado `AvailabilityTravel` para deslocamentos declarados.
+3. **Bloqueios recorrentes** (toda quarta, todo mês 25): **não há campo de recorrência no model atual**. Importar exige:
+   - (a) pré-expandir em N linhas (responsabilidade do `sheets.banco`);
+   - (b) ampliar model com `RRULE`/RFC 5545 (mudança grande de runtime).
+4. **Política de re-import**: o service hoje (a verificar lendo `_process_row`) presumivelmente ignora linhas com mesma chave natural. Se a regra desejada for **substituir** todos os bloqueios do usuário no período, exige PR de runtime.
+5. **Status inicial**: o service hoje (a verificar) provavelmente cria com `status='aprovado'`. Confirmar se importação por DAT deve ser auto-aprovada (vem de fonte oficial) ou `pendente` para revisão pelo formador.
+6. **Cancelar bloqueios**: planilha tem coluna `cancelar`? Hoje import é additive (não remove). Se for necessário cancelar via planilha, exige PR de runtime + soft-delete no model.
+7. **`make etl-desloc-dry` e `deslocamentos_import.py`**: confirmar se esse serviço (que existe) cobre o caso de import de deslocamentos como dado independente de bloqueio.
+
+---
+
+## 15. Histórico de versões
+
+- 2026-05-05 — v0.1 — PR 1 (proposta inicial). Tratava formato como totalmente pendente.
+- 2026-05-05 — v0.2 — Auditoria contra código real. **`bloqueios_import.py` confirmado funcional** para T/P + endpoint sync **e** async (ASQ-005 piloto). Pendências reorientadas: identificador robusto, tipo D, recorrência continuam abertas.

--- a/v2/docs/imports/dry_run_response_contract.md
+++ b/v2/docs/imports/dry_run_response_contract.md
@@ -1,0 +1,348 @@
+# Contrato de resposta de dry-run / import — auditoria + proposta
+
+Status: **PR 2 — docs-only (sem alteração de runtime)**
+Versão: 2026-05-05 v0.1
+Escopo: auditoria dos 11 services `*_import.py` existentes + proposta de contrato unificado de resposta.
+
+> Esta PR não altera código. Apenas inspeciona o estado atual, identifica inconsistências e propõe um contrato futuro. Implementação fica para PRs subsequentes.
+
+---
+
+## 1. Resumo executivo
+
+| Métrica | Valor |
+|---|---|
+| Services auditados | **11** |
+| Todos têm parâmetro `dry_run`? | ✅ Sim — todos aceitam `dry_run: bool` (default `True` em 8; `False` em 3 legacy) |
+| Padrões de retorno distintos identificados | **2** ("dataclass legacy" + "dict aninhado moderno") |
+| Services com idempotência via `external_hash` (SHA1) | 4 (compras, ações controle, DAT cadastros, eventos) |
+| Services com idempotência via campo unique | 3 (usuarios=cpf, produtos=codigo, municipios=nome+uf) |
+| Services com idempotência via tupla natural sem hash | 4 (bloqueios, colecoes, equipe_gerencia, deslocamentos) — confirmar lendo `_process_row` |
+| Services que retornam `created_ids` | **1** (compras) |
+| Services que gravam relatório JSON em disco (`out_etl/`) | **3** (compras, ações controle, DAT cadastros) |
+| Padrão `savepoint-per-row` (ASQ-016) | **7** (todos os "modernos") |
+
+**Conclusão principal**: backend tem 2 famílias de imports com shape diferente; padronização exige escolher uma das duas como referência e migrar o restante. **Recomendação: usar família "dict aninhado moderno" como base** (mais recente, mais usada, mais alinhada com `ImportJob.stats`/`pendencias` que já são JSON).
+
+---
+
+## 2. Service-by-service: tabela mestra
+
+> Notação: ✅ confirmado lendo código · ⚠️ inferido sem leitura de `_process_row` · ❓ não verificado
+
+### 2.1 Serviços modernos ("família dict aninhado")
+
+| # | Service | Endpoint | View | Função | dry_run default | Cabeçalho CSV aceito | Models afetados | Cria | Atualiza | Savepoint-per-row | Idempotência | Hash | Padrão de retorno |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| 1 | `usuarios_import.py` | `POST /api/usuarios/import/` | `ImportUsuariosView` (`views_import_usuarios.py`) | `import_usuarios_from_file(*, path, dry_run=True)` | `True` | `cpf,nome,email,telefone,cargo,is_active,grupos` | `Usuario` (+ `Group` M2M) | ✅ | ✅ (campos não-chave) | ✅ ASQ-016 | CPF unique | — | dict aninhado |
+| 2 | `eventos_import.py` | `POST /api/solicitacoes/import/` | `ImportEventosView` | `import_eventos_from_file(*, path, dry_run=True)` | `True` | `municipio,projeto,tipo_evento,data,hora_inicio,hora_fim,coordenador,formador1..5,encontro,segmento,local` | `Solicitacao` (+ `Participation` M2M, role COORDENADOR/FORMADOR) | ✅ | ⚠️ (idempotência absorve) | ⚠️ (provável) | `external_hash` ⚠️ | SHA-? | dict aninhado |
+| 3 | `bloqueios_import.py` | `POST /api/disponibilidade/import-bloqueios/` **+** `POST /api/imports/bloqueios/` (async via `ImportJob`) | `ImportBloqueiosView` + `ImportJobBloqueiosUploadView` | `import_bloqueios_from_file(*, path, dry_run=True)` | `True` | `usuario,inicio,fim,tipo,motivo` (tipo ∈ {T, P}) | `AvailabilityBlock` | ✅ | ⚠️ | ⚠️ | tupla (usuario,inicio,fim,tipo) ⚠️ | — | dict aninhado |
+| 4 | `produtos_import.py` | `POST /api/produtos/import/` | `ImportProdutosView` | `import_produtos_from_file(*, path, dry_run=True)` | `True` | `codigo,nome,projeto,descricao,ativo` | `Produto` | ✅ | ✅ | ✅ ASQ-016 | codigo unique | — | dict aninhado |
+| 5 | `colecoes_import.py` | `POST /api/colecoes/import/` | `ImportColecoesView` | `import_colecoes_from_file(*, path, dry_run=True)` | `True` | `nome,projeto,descricao,ativo` | `Colecao` (+ FK `Projeto`) | ✅ | ✅ | ✅ ASQ-016 | (nome, projeto) ⚠️ | — | dict aninhado |
+| 6 | `municipios_import.py` | `POST /api/municipios/import/` | `ImportMunicipiosView` | `import_municipios_from_file(*, path, dry_run=True)` | `True` | `nome,uf,ibge_code,ativo` | `Municipio` | ✅ | ✅ | ✅ ASQ-016 | (nome, uf) ⚠️ | — | dict aninhado |
+| 7 | `equipe_gerencia_import.py` | `POST /api/equipe-gerencia/import/` | `ImportEquipeGerenciaView` | `import_equipe_gerencia_from_file(*, path, dry_run=True)` | `True` | `setor/gerencia,papel/funcao,usuario_cpf,usuario_email,usuario_nome,coordenador_supervisor,ativo` (flexível) | `EquipeGerencia` + `Gerencia` (+ FK `Usuario`) | ✅ | ✅ | ✅ ASQ-016 | (gerencia, usuario, papel) ⚠️ | — | dict aninhado **+ extras** (`gerencias_created`, `gerencias_existing`) |
+| 8 | `deslocamentos_import.py` | (não confirmado endpoint sync) | (não confirmado view) | `import_deslocamentos_from_file(*, path, dry_run=True)` | `True` | `usuario,origem,destino,data_inicio,data_fim,observacao` | `Deslocamento` | ✅ | ⚠️ | ✅ ASQ-016 | `external_hash` ⚠️ | SHA-? ⚠️ | dict aninhado |
+
+### 2.2 Serviços legacy ("família dataclass + JSON em disco")
+
+| # | Service | Endpoint | View | Função | dry_run default | Cabeçalho CSV aceito | Models afetados | Cria | Atualiza | Savepoint-per-row | Idempotência | Hash | Padrão de retorno |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| 9 | `controle_imports.py` (**Compras**) | `POST /api/controle/import-compras/` | `ImportComprasView` (`views_controle_imports.py`) | `import_compras_from_file(*, path, dry_run=True, auto_create_municipios=False)` | `True` | **`CÓD`/`COD`/`Cód`/`id`/`ID`** (variantes), **`Produto`**, **`Quant.`/`Quant`/`Quantidade`**, **`Município`/`Municipio`**, **`UF`**, **`Data`**, **`Uso das coleções`/`Uso`** | `Compra` (FK `Municipio`, `Projeto`) | ✅ | ✅ (via `update_or_create`) | ❌ — `transaction.atomic()` única | `external_hash` SHA1 | `SHA1(municipio_id\|projeto_id\|codigo\|produto_norm\|quantidade\|data\|uso_norm)` | dataclass + `created_ids` + relatório JSON em `out_etl/import_compras_report.json` |
+| 10 | `controle_acoes_import.py` | `POST /api/controle/import-acoes/` | `ControleImportAcoesView` (`views_imports.py`) | `import_acoes_controle(file_path, dry_run=False)` | **`False`** ⚠️ | (não documentado em docstring; padrão Município, Projeto, Coordenador, datas) | `AcaoControle` | ✅ | ✅ (via `update_or_create`) | ✅ ASQ-016 | `external_hash` SHA1 | `SHA1(municipio_id\|projeto_id\|coordenador_id)` | dict aninhado **+ relatório JSON** em `out_etl/import_acoes_controle_report.json` |
+| 11 | `dat_cadastros_import.py` | `POST /api/dat/import-cadastros/` | `DATImportCadastrosView` (`views_imports.py`) | `import_dat_cadastros(file_path, dry_run=False)` | **`False`** ⚠️ | (não documentado em docstring; padrão Município, Projeto, Tipo de ação, Responsável) | `AcaoDAT` (+ FK `TipoAcaoDAT`) | ✅ | ✅ (via `update_or_create`) | ✅ ASQ-016 | `external_hash` SHA1 | `SHA1(municipio_id\|projeto_id\|tipo_acao\|responsavel_id)` | dict aninhado **+ relatório JSON** em `out_etl/import_dat_cadastros_report.json` |
+
+### 2.3 Observações por inconsistência
+
+| Inconsistência | Services afetados | Risco |
+|---|---|---|
+| **`dry_run` default `False`** em vez de `True` | `controle_acoes_import`, `dat_cadastros_import` | **Alto** — chamada interna sem keyword vai persistir. Endpoints externos protegem via query-param, mas chamada Python direta é perigosa |
+| **Stats com 4 campos vs 4+aninhado** | `controle_imports` (dataclass `{created,updated,skipped,errors}`) vs demais (dict `{created,updated,unchanged,skipped:{...}}`) | Médio — frontend precisa branch lógica |
+| **`pendencias` com chaves diferentes** | Cada service define categorias próprias (`municipios`, `projetos`, `cpf_invalid`, `dates`, `usuarios`, `outros`, etc.) | Médio — frontend não pode tratar genericamente |
+| **`created_ids` só em compras** | `controle_imports` retorna lista; demais não | Baixo — não é semântica universal |
+| **Relatório JSON em `out_etl/`** só em 3 (compras, ações controle, DAT cadastros) | Resto não persiste em disco | Baixo — feature legacy; `ImportJob.stats/pendencias` substitui |
+| **Sem `row_number` na resposta** | Todos | **Alto** — frontend não consegue mapear erro/warning à linha do CSV de forma estruturada (alguns colocam `linha`/`row` dentro do dict de pendência, outros não) |
+| **Sem `error_code` / `warning_code` estruturados** | Todos — categorização vive em chaves do dict de pendências (`cpf_invalid`, `municipios`, etc.) | **Alto** — i18n e filtragem por código ficam difíceis |
+| **Sem preview das primeiras N linhas** | Todos | Médio — frontend não pode exibir prévia visual sem rodar dry-run + parsear |
+| **`auto_create_municipios=False`** parâmetro só em `controle_imports` | Demais não têm flag análoga | Baixo — específico do domínio |
+| **Tipo D (Deslocamento) ausente** em `bloqueios_import` | Apenas T e P aceitos | Médio — RD-04 calcula D dinamicamente; planilha não traz D explícito |
+| **`controle_imports` sem savepoint-per-row** | Apenas ele usa `transaction.atomic()` única | Baixo — rollback total em erro de uma linha; ASQ-016 já protege os demais |
+
+---
+
+## 3. Padrão de retorno — duas famílias
+
+### 3.1 Família A — "dict aninhado moderno" (8 services)
+
+```json
+{
+  "stats": {
+    "created": 10,
+    "updated": 5,
+    "unchanged": 2,
+    "skipped": {"<categoria_1>": 0, "<categoria_2>": 0, "other": 0}
+  },
+  "pendencias": {
+    "<categoria_1>": [{"linha": N, "row": "<repr>", "erro": "msg"}],
+    "<categoria_2>": [],
+    "outros": []
+  },
+  "dry_run": true,
+  "file": "/tmp/xyz.csv"
+}
+```
+
+### 3.2 Família B — "dataclass + relatório JSON" (3 services legacy)
+
+```json
+{
+  "path": "/tmp/xyz.csv",
+  "dry_run": true,
+  "stats": {"created": 10, "updated": 5, "skipped": 2, "errors": 0},
+  "pendencias": {
+    "municipios": [{"row": 2, "municipio": "X", "uf": "CE"}],
+    "projetos": [],
+    "linhas_invalidas": []
+  },
+  "created_ids": [42, 43, 44],
+  "ts": "2026-05-05T12:00:00-03:00"
+}
+```
+
+Além disso, gravam relatório completo em `<settings.BASE_DIR>/out_etl/import_<tipo>_report.json` no apply.
+
+---
+
+## 4. Contrato padrão proposto (PR 6 — futuro)
+
+### 4.1 Objetivo
+
+Unificar resposta entre os 11 services + `ImportJob.stats` + `ImportJob.pendencias` para que **frontend possa renderizar genericamente** qualquer tipo de import.
+
+### 4.2 Princípios
+
+1. **Compatibilidade gradual**: adicionar campos novos sem remover os antigos por 1 release. Migrar service-by-service.
+2. **Códigos estáveis** em vez de chaves descritivas: `INVALID_CPF` em vez de `cpf_invalid`. Permite i18n no frontend.
+3. **`row_number` obrigatório** em cada erro/warning: ancora ao CSV original.
+4. **Preview das primeiras 50 linhas** opcional (`preview=true` query param).
+5. **Idempotência exposta**: campo `import_hash` por linha, mesmo em dry-run, para auditoria de drift.
+6. **Não quebrar `ImportJob`**: `stats` e `pendencias` ali já são JSONField — contrato novo é subset compatível.
+
+### 4.3 Schema proposto
+
+```json
+{
+  "ok": true,
+  "dry_run": true,
+  "import_type": "usuarios",
+  "file": {
+    "path": "/tmp/xyz.csv",
+    "original_filename": "usuarios_2026_05.csv",
+    "size_bytes": 4321,
+    "checksum_sha256": "<file_hash>"
+  },
+  "summary": {
+    "total_rows": 100,
+    "valid_rows": 92,
+    "created_rows": 80,
+    "updated_rows": 8,
+    "unchanged_rows": 4,
+    "skipped_rows": 5,
+    "warning_rows": 3,
+    "invalid_rows": 3
+  },
+  "errors_by_code": {
+    "INVALID_CPF": 2,
+    "MUNICIPIO_NOT_FOUND": 1
+  },
+  "warnings_by_code": {
+    "EMAIL_DOMAIN_UNUSUAL": 3
+  },
+  "rows": [
+    {
+      "row_number": 2,
+      "status": "valid",
+      "action": "create",
+      "errors": [],
+      "warnings": [],
+      "normalized": {"cpf": "12345678901", "nome": "Maria Exemplo"},
+      "import_hash": "sha256:abcdef..."
+    },
+    {
+      "row_number": 3,
+      "status": "invalid",
+      "action": null,
+      "errors": [
+        {"code": "INVALID_CPF", "field": "cpf", "message": "CPF 11 dígitos inválido", "value": "123"}
+      ],
+      "warnings": [],
+      "normalized": null,
+      "import_hash": null
+    }
+  ],
+  "metadata": {
+    "service": "apps.core.services.usuarios_import",
+    "started_at": "2026-05-05T12:00:00-03:00",
+    "finished_at": "2026-05-05T12:00:01-03:00",
+    "duration_ms": 950
+  }
+}
+```
+
+### 4.4 Mapeamento campos atuais → contrato novo
+
+| Campo atual (família A/B) | Campo contrato | Mudança |
+|---|---|---|
+| `stats.created` | `summary.created_rows` | rename |
+| `stats.updated` | `summary.updated_rows` | rename |
+| `stats.unchanged` (apenas A) | `summary.unchanged_rows` | preservar |
+| `stats.skipped` (B) ou `stats.skipped.<cat>` (A) | `summary.invalid_rows` + `summary.skipped_rows` | dividir entre inválido (bloqueante) e skipped (ok mas não persiste) |
+| `stats.errors` (B) | `summary.invalid_rows` | rename |
+| `pendencias.<categoria>` | `rows[*]` com `errors:[{code,...}]` | reestruturar — categoria vira `error.code` |
+| `created_ids` (compras) | `rows[*].metadata.created_id` quando `action==create` | opcional, restrito a apply |
+| `dry_run` | `dry_run` | manter |
+| `file` (string) | `file.path` | aninhar |
+| `ts` (B) | `metadata.finished_at` | rename |
+| `path` (B) | `file.path` | rename |
+
+### 4.5 Códigos de erro propostos (1ª versão — completar conforme migração)
+
+| Código | Significado | Service mais comum |
+|---|---|---|
+| `INVALID_CPF` | CPF não tem 11 dígitos ou DV inválido | usuarios |
+| `MISSING_REQUIRED_FIELD` | Campo obrigatório vazio | todos |
+| `MUNICIPIO_NOT_FOUND` | Lookup `resolve_municipio` retornou None | eventos, compras, ações, DAT |
+| `PROJETO_NOT_FOUND` | Lookup `resolve_projeto` retornou None | eventos, compras, ações, DAT |
+| `USUARIO_NOT_FOUND` | `resolve_user_by_email/name` retornou None | eventos, bloqueios, deslocamentos, equipe_gerencia |
+| `INVALID_DATE` | Falha em `parse_date_flexible` ou similar | todos com data |
+| `INVALID_TIME` | Falha em parse de hora | eventos |
+| `END_BEFORE_START` | `fim <= inicio` | eventos, bloqueios, deslocamentos |
+| `INVALID_QUANTITY` | Quantidade não inteira/<=0 | compras |
+| `INVALID_TIPO_ACAO` | Tipo de ação fora do `TipoAcaoDAT`/`TipoAcaoControle` | ações controle, DAT cadastros |
+| `INVALID_TIPO_BLOQUEIO` | `tipo ∉ {T, P}` | bloqueios |
+| `DUPLICATE_IN_FILE` | Mesma chave natural aparece 2x no CSV | todos |
+| `EMAIL_DOMAIN_UNUSUAL` | Email fora de allowlist (warning) | usuarios |
+| `OTHER` | Erro genérico (fallback) | todos |
+
+---
+
+## 5. Classificação de risco para padronização
+
+Critérios: complexidade, models afetados, dry_run real, idempotência, uso em produção, relação com GCal/RBAC.
+
+### 5.1 Baixo risco (começar por aqui)
+
+| Service | Justificativa |
+|---|---|
+| `municipios_import.py` | Cadastro mestre. Sem FK para nada crítico. Sem GCal. Cache de options para invalidar é simples. |
+| `colecoes_import.py` | Cadastro mestre. FK apenas `Projeto`. Sem GCal. |
+| `usuarios_import.py` | Cadastro de identidade. Atribuição de grupos via coluna `grupos` (não automática para Função sensível). Sem GCal. Padrão moderno já bem alinhado ao contrato. |
+| `produtos_import.py` | Cadastro mestre. FK apenas `Projeto`. |
+| `equipe_gerencia_import.py` | Cadastro de vínculo. Tem extras `gerencias_created/existing` no stats — bom caso de teste para extensibilidade do contrato. |
+
+### 5.2 Médio risco
+
+| Service | Justificativa |
+|---|---|
+| `bloqueios_import.py` | Reconciliação por nome é frágil. Já tem **endpoint sync E async** (`ImportJob`). Bom candidato para validar contrato funcionar nas duas modalidades. |
+| `deslocamentos_import.py` | Reconciliação por nome/email. Endpoint sync não confirmado. |
+| `controle_acoes_import.py` | Legacy. Default `dry_run=False`. Grava JSON em disco. Migrar exige corrigir default. |
+| `dat_cadastros_import.py` | Legacy. Mesmas características de controle_acoes. Mapa `TipoAcaoDAT` complexo. |
+
+### 5.3 Alto risco
+
+| Service | Justificativa |
+|---|---|
+| `eventos_import.py` | **Toca Solicitação + Participation M2M + PA-01** automática. Erro de contrato pode mascarar status/data errados. Relação indireta com GCal (campo `external_event_id` permanece None mas é hot path). Migrar último. |
+| `controle_imports.py` (Compras) | Família dataclass diferente; cabeçalho com variantes case/acento; chave de idempotência depende de `_infer_projeto_from_produto` (cache + heurística). Grava JSON em disco. Endpoint usado em produção pelo Makefile via curl. |
+
+---
+
+## 6. Plano de migração seguro (para PR 6 futura)
+
+### Fase 0 — Acordo de contrato (esta PR 2)
+
+✅ Auditoria + contrato proposto + códigos de erro nomeados.
+
+### Fase 1 — Wrapper que traduz o retorno legado
+
+- Criar helper `apps/core/imports/response_adapter.py::to_standard_response(legacy_response, import_type)`.
+- Frontend consome **apenas** o contrato novo via wrapper, sem mudar services.
+- Risco: baixo (wrapper puro, não toca DB).
+
+### Fase 2 — Migrar services baixo risco (1 PR por service)
+
+Ordem sugerida:
+1. `municipios_import.py`
+2. `colecoes_import.py`
+3. `produtos_import.py`
+4. `equipe_gerencia_import.py`
+5. `usuarios_import.py`
+
+Cada PR:
+- Retorna contrato novo nativo.
+- Wrapper continua aceitando ambos para outros services.
+- Tests cobrem que campos do contrato existem.
+
+### Fase 3 — Migrar services médio risco
+
+6. `deslocamentos_import.py`
+7. `bloqueios_import.py` (cuidado: usado por endpoint sync **e** async via `ImportJob`)
+8. `controle_acoes_import.py` (corrigir `dry_run=False` default antes)
+9. `dat_cadastros_import.py` (corrigir `dry_run=False` default antes)
+
+### Fase 4 — Migrar alto risco
+
+10. `controle_imports.py` (Compras) — preservar `created_ids` e `out_etl/*.json` em modo legacy paralelo.
+11. `eventos_import.py` — testar PA-01 + Participation antes de release.
+
+### Fase 5 — Retirar wrapper de tradução
+
+Quando todos os 11 retornarem contrato novo nativamente, remover `response_adapter.py` e mover frontend a consumir direto.
+
+---
+
+## 7. Critério de aceite desta PR
+
+Quem ler este documento consegue responder:
+
+| Pergunta | Resposta |
+|---|---|
+| Todos os imports retornam o mesmo formato? | **Não** — 2 famílias (dict aninhado moderno: 8; dataclass+JSON em disco: 3). Ver §2.1 / §2.2. |
+| Quais retornam stats? | Todos os 11. Mas com shape diferente (4-campos vs 4+aninhado). Ver §3. |
+| Quais retornam pendências? | Todos os 11. Mas com chaves de categoria diferentes por service. Ver §2.3. |
+| Quais retornam erro por linha? | **Nenhum nativamente** — alguns colocam `linha`/`row` dentro do dict de pendência; nenhum tem array `rows[*]` com `row_number` estruturado. **Lacuna real para padronizar.** |
+| Quais têm dry_run real? | Todos os 11. Mas 2 têm default `False` (`controle_acoes_import`, `dat_cadastros_import`) — risco se chamado via Python direto. |
+| Quais têm idempotência? | **Todos** — 4 via SHA1 explícito (compras, ações controle, DAT cadastros, eventos), 3 via campo unique (usuarios=cpf, produtos=codigo, municipios=nome+uf), 4 via tupla natural sem hash visível (bloqueios, colecoes, equipe_gerencia, deslocamentos). |
+| Quais podem ser migrados para `ImportJob` async? | **Todos os 11**, conforme comentário em `apps/core/models/import_job.py:41-44`. Hoje só `bloqueios` está async (piloto ASQ-005 Fase 1). |
+| Qual deve ser o contrato padrão futuro? | Schema em §4.3. Resume: `summary` agregado, `rows[*]` com `row_number`+`errors[{code,field,message}]`+`warnings[]`+`normalized`+`import_hash`, `errors_by_code`/`warnings_by_code` agregados, `metadata`. |
+| Qual service deve ser padronizado primeiro? | **`municipios_import.py`** (baixo risco, cadastro mestre, sem FK críticas). Sequência completa em §6. |
+
+---
+
+## 8. Pendências de leitura (para validar nesta PR ou em PRs subsequentes)
+
+| Item | O que falta verificar |
+|---|---|
+| Shape final de `usuarios_import._process_row` | Confirmar que tem `import_hash` em alguma forma. Hoje a docstring lista apenas `created/updated/unchanged/skipped` em stats. |
+| Shape final de `eventos_import.py` apply (linha que cria Solicitacao + Participation) | Confirmar valor de `external_hash` exato e como Participation é registrada (1 linha por participante? embebida em row?). |
+| Shape final de `bloqueios_import.py` apply | Confirmar `external_hash` ou chave natural. |
+| `_process_row` de `colecoes_import.py`, `municipios_import.py`, `produtos_import.py`, `equipe_gerencia_import.py`, `deslocamentos_import.py` | Confirmar exatamente quais campos vão para `pendencias.outros` vs categorias específicas. |
+| Endpoint sync de **`deslocamentos`** | Existe view DRF correspondente? `views_import_deslocamentos.py` existe na pasta — falta confirmar rota e gate. |
+| Default `dry_run=False` em `controle_acoes_import` e `dat_cadastros_import` | Decidir se é bug a corrigir ou intencional (Makefile chama com `?dry_run=true|false` explícito). |
+
+---
+
+## 9. Pendências de produto
+
+1. **Códigos de erro nomeados**: validar a lista §4.5 com Matheus. Acrescentar/remover conforme casos reais.
+2. **Preview das primeiras 50 linhas**: implementar como opt-in (`?preview=true`) ou sempre?
+3. **`import_hash` por linha em dry-run**: aceita esforço extra para auditoria pré-apply ou só após apply?
+4. **`out_etl/*_report.json` (legacy)**: continuar gravando mesmo após migração para contrato novo, ou descontinuar?
+5. **`controle_acoes_import` e `dat_cadastros_import` com default `dry_run=False`**: corrigir agora (PR de runtime separada) ou esperar migração ao contrato novo?
+6. **Cabeçalhos com acento (`CÓD`, `Município`, `Uso das coleções`)**: manter aceitação de variantes ou forçar snake_case nos templates (mais limpo)?
+
+---
+
+## 10. Histórico de versões
+
+- 2026-05-05 — v0.1 — PR 2. Auditoria inicial dos 11 services. Proposta de contrato padrão + plano de migração em 5 fases. Cabeçalho de Compras (`CÓD,Produto,Quant.,Município,UF,Data,Uso das coleções`) confirmado lendo `controle_imports.py:156-163`.

--- a/v2/docs/imports/ordem_de_importacao.md
+++ b/v2/docs/imports/ordem_de_importacao.md
@@ -1,0 +1,124 @@
+# Ordem de Importação
+
+Status: PR 1 — documentação (revista 2026-05-05)
+Versão: 2026-05-05 v0.2
+
+> ⚠️ **Atualização v0.2**: substituiu pendências que o código já responde por pendências reais. Os 11 services `*_import.py` já existem; a "ordem" é operacional (sequência de execução em produção) e não mais um roadmap de implementação.
+
+A ordem abaixo respeita as dependências de chave estrangeira e regras de domínio. **Não pular passos**: cada etapa cria os referenciais usados pela próxima.
+
+---
+
+## Ordem recomendada
+
+### 1. Usuários
+
+- **Por quê primeiro**: vários objetos referenciam `Usuario` via FK (Solicitacao.coordenador, Solicitacao.formadores M2M, AvailabilityBlock.usuario, AuditLog.usuario, DATCompra.created_by, etc.).
+- **Documento**: [usuarios.md](./usuarios.md)
+- **Pré-requisito**: nenhum (depois disso, cadastros base já podem ser feitos por usuário admin).
+
+### 2. Cadastros base — Grupos / Setores / Funções
+
+- **Por quê**: definir 13 Setores + 5 Funções (SSOT em `apps/core/constants.py`).
+- **Como**: management command `seed_rbac` (manual, com `--verbose`). **NÃO automatizar** em deploy (D17).
+- **Atribuição Group × Capability**: via Django Admin (`/admin/core/permissaofuncional/`), nunca em migration.
+- **Sem documento de import** porque cadastros base já existem no schema (não vêm de planilha).
+
+### 3. Municípios
+
+- **Por quê**: Solicitacao e DATCompra usam FK para `Municipio`.
+- **Service real**: `apps/core/services/municipios_import.py` (`import_municipios_from_file`).
+- **Endpoint**: `POST /api/municipios/import/` — gate `HasPerm("manage_admin_registries")`.
+- **Pendência para Matheus**: confirmar cabeçalho real esperado e se `sheets.banco` é a fonte ou se há fixture/seed inicial separada.
+
+### 4. Projetos
+
+- **Por quê**: Solicitacao e Produto usam FK para `Projeto`.
+- **Fonte atual**: cadastro inicial; `fluxo` (SUPER/NAO_SUPER) define gate de aprovação (PA-01).
+- **Sem service `projetos_import.py` dedicado** no código atual. `sheets.banco` provavelmente não inclui catálogo de projetos — apenas referencia via nome em Produtos e Agenda. Resolvidos no runtime via `resolve_projeto` (com aliases IDEB→GESTÃO ESCOLAR, Nível N→NN).
+
+### 5. Produtos (catálogo)
+
+- **Por quê**: Compra/DATCompra usam FK para `Produto`.
+- **Service real**: `apps/core/services/produtos_import.py` (`import_produtos_from_file`).
+- **Endpoint**: `POST /api/produtos/import/` — gate `HasPerm("import_spreadsheet")`.
+- **Fonte histórica**: 139 produtos cadastrados (`produtos.xlsx`), cada um com `codigo` único e FK para `Projeto`.
+- Catálogo é **atualizável via importação** — não está congelado.
+
+### 6. Controle/Produtos por município (Compras / DATCompra)
+
+- **Por quê**: registra uso operacional (`DATCompra`) ou histórico (`Compra`) de cada produto em cada município.
+- **Documento**: [produtos_controle.md](./produtos_controle.md)
+- **Pré-requisitos**: Produtos cadastrados (passo 5), Municípios (passo 3), Projetos (passo 4).
+
+### 7. Disponibilidade
+
+- **Por quê**: declara bloqueios (T/P) de formadores.
+- **Documento**: [disponibilidade.md](./disponibilidade.md)
+- **Service real**: `apps/core/services/bloqueios_import.py` (`import_bloqueios_from_file`).
+- **Endpoints**: `POST /api/disponibilidade/import-bloqueios/` (síncrono) **e** `POST /api/imports/bloqueios/` (assíncrono, ASQ-005 Fase 1 — único piloto async hoje).
+- **Pré-requisitos**: Usuários (passo 1).
+- **Limites conhecidos**: tipos `T` e `P` suportados. **`D` (deslocamento) não armazenado como bloqueio** — calculado dinamicamente pelo `availability_service` entre Solicitações de municípios diferentes. **Recorrência** ainda não modelada.
+
+### 8. Agenda / Solicitações / Eventos
+
+- **Por quê**: agendamento concreto de eventos.
+- **Documento**: [agenda_solicitacoes.md](./agenda_solicitacoes.md)
+- **Service real**: `apps/core/services/eventos_import.py` (`import_eventos_from_file`). Cria 1 `Solicitacao` + N `Participation` (coord + formadores 1..5). PA-01 aplicada automaticamente.
+- **Endpoint**: `POST /api/solicitacoes/import/` — gate `HasPerm("import_spreadsheet")`.
+- **Pré-requisitos**: Usuários (passo 1), Municípios (passo 3), Projetos (passo 4).
+- **Crítico**: PA-01 aplicada — SUPER + data futura → `pendente`. GCal **nunca é tocado** pelo import.
+
+### 9. Google Calendar — somente após validação manual
+
+- **Por quê**: publicar é efeito externo (cria evento no calendar de produção).
+- **NÃO faz parte do import** automatizado.
+- **Fluxo correto**:
+  1. Importar Agenda (passo 8) → solicitações ficam `pendente` ou `aprovado` por reconciliação.
+  2. Revisão manual no frontend (`/aprovacoes`).
+  3. Preview GCal (`POST /api/solicitacoes/{id}/preview-gcal/`).
+  4. Publish (`POST /api/solicitacoes/{id}/publish/`) — só após aprovação manual.
+- **PA-03** (CP-02): integrações externas (RF05/RF06) só rodam **após** aprovação manual completa.
+
+---
+
+## Razões da ordem
+
+```text
+Usuários ────► Cadastros base (Grupos/Setores/Funções)
+   │              │
+   ▼              ▼
+   │           Municípios ────► Projetos ────► Produtos
+   │              │                │              │
+   │              ▼                ▼              ▼
+   └────► Disponibilidade        Agenda ────► Controle/Compras
+                                  │
+                                  ▼
+                          (revisão manual)
+                                  │
+                                  ▼
+                          Google Calendar
+```
+
+Cada seta indica dependência de FK ou de validação de domínio.
+
+---
+
+## Reentrância (re-execução de imports)
+
+Todos os imports são **idempotentes** via `external_hash`. Re-rodar o mesmo arquivo:
+
+- **Sem mudança**: nenhuma operação (linhas com hash existente são ignoradas).
+- **Atualização tolerada**: campos não-chave podem ser atualizados se `external_hash` bater e linha vier com dados diferentes (depende do tipo — ver doc específico).
+- **Re-criação**: para forçar re-criação, deletar a linha do banco antes (com cuidado em FKs).
+
+Auditar reentrância via `AuditLog` filtrado por `action LIKE 'IMPORT_%'` e `usuario`.
+
+---
+
+## Pendências para Matheus
+
+- Existe pipeline automatizado entre `sheets.banco` e o sistema (ex: cron + API) ou todo import é manual via UI/CLI?
+- Municípios e Projetos têm uma fonte de cadastro contínua na planilha ou ficam congelados após o seed inicial?
+- Em quais cenários **Cadastros base** (passo 2) precisam ser refeitos pós-deploy? Sentinela D17 deveria bloquear?
+- Disponibilidade deve preceder Agenda no fluxo real ou as duas chegam juntas?

--- a/v2/docs/imports/produtos_controle.md
+++ b/v2/docs/imports/produtos_controle.md
@@ -1,0 +1,318 @@
+# Importação: Produtos / Controle (Compras)
+
+Status: PR 1 — contrato fechado, **backend já implementado** para vários fluxos (revisto 2026-05-05)
+Versão: 2026-05-05 v0.2
+Template: [templates/produtos_controle.template.csv](./templates/produtos_controle.template.csv)
+
+> ⚠️ **Atualização v0.2**: a v0.1 tratava o service como "futuro" e deixava aberta a decisão `Compra` vs `DATCompra`. Verificação no código (`controle_imports.py:26`) confirma que **`import_compras_from_file` alimenta `Compra`** (não `DATCompra`). Existem ainda services separados para `Produto` (catálogo), `Municipio`, `Colecoes`, etc. Esta versão lista todos.
+
+---
+
+## 1. Objetivo
+
+Importar registros de uso/aquisição de produtos por município, a partir da aba de "Controle" da planilha `sheets.banco`. Alimenta a tabela `DATCompra` (gestão operacional DAT) — ou alternativamente `Compra` (histórico ETL), conforme decisão de produto.
+
+Cobre:
+- Lookup de `Produto` por código (`F`).
+- Lookup de `Municipio` por nome + UF.
+- Lookup de `Projeto` (via `Produto.projeto`).
+- Criação/atualização de `DATCompra` com idempotência via `external_hash`.
+
+Não cobre:
+- Criação de Produto novo (catálogo é cadastrado separadamente, ver `ordem_de_importacao.md` passo 5).
+- Criação de Município novo (cadastro mestre).
+
+---
+
+## 2. Dados de origem esperados
+
+Aba `Controle` (ou similar) da planilha `sheets.banco`.
+
+| Coluna planilha | Descrição |
+|---|---|
+| `F` | Código do produto (ex: `NL-C1`, `BRC-C2`) |
+| `Produto` | Nome do produto (sanity check vs `F`) |
+| `Quant.` | Quantidade adquirida/utilizada |
+| `Município` | Nome do município |
+| `UF` | Sigla da unidade federativa |
+| `Data` | Data da compra/uso (BR `dd/mm/yyyy`) |
+| `Uso das coleções` | Texto livre descrevendo finalidade |
+
+---
+
+## 3. Colunas obrigatórias
+
+| Coluna CSV | Validação |
+|---|---|
+| `codigo` (vem de `F`) | deve existir em `Produto.codigo` |
+| `quantidade` (vem de `Quant.`) | inteiro positivo (>0) |
+| `municipio` | deve casar com `Municipio.nome` (case-insensitive, sem acento) |
+| `uf` | sigla UF válida (lookup em `Municipio` junto com `municipio`) |
+| `data` | data BR válida e razoável (>= 2020-01-01, <= hoje + 7d) |
+
+---
+
+## 4. Colunas opcionais
+
+| Coluna CSV | Comportamento se vazio |
+|---|---|
+| `produto_nome` (vem de `Produto`) | Usar apenas como sanity check; lookup oficial é por `codigo` |
+| `uso` (vem de `Uso das coleções`) | Salvar string vazia em `DATCompra.uso` |
+
+---
+
+## 5. Normalizações esperadas (PR 2 — `normalization.py`)
+
+| Campo | Função (futura) | Resultado |
+|---|---|---|
+| `codigo` | `normalize_text_key` | Uppercase, strip, remove espaços internos |
+| `produto_nome` | `normalize_text_key` | Lowercase, strip, remove acentos para comparação |
+| `quantidade` | `int()` + validate >=1 | Inteiro |
+| `municipio` + `uf` | `normalize_municipio_uf` | `(nome_normalized, uf_uppercase)` |
+| `data` | `parse_br_date` | `datetime.date` em America/Fortaleza |
+| `uso` | trim + strip | string |
+
+---
+
+## 6. Validações antes do upload (PR 6)
+
+### Bloqueantes
+- `codigo` não existe em `Produto` → rejeitar (catálogo deve ser cadastrado antes).
+- `quantidade` <= 0 ou não numérico.
+- `municipio` + `uf` não existe em `Municipio`.
+- `data` fora da faixa razoável (futuro distante > 7d ou passado anterior a 2020).
+- `external_hash` duplicado **no próprio arquivo**.
+
+### Avisos
+- `produto_nome` da planilha diverge do `Produto.nome` do banco (sanity check) → aceitar mas avisar (pode ser typo na planilha).
+- Linha com `external_hash` já existente no banco → ignorar (idempotência) com warning.
+- `data` no futuro próximo (1-7 dias) → aceitar (pode ser agendamento).
+
+---
+
+## 7. Regras de duplicidade / hash
+
+### Chave natural
+Tupla: `(produto.codigo, municipio.id, projeto.id, data)`.
+
+`projeto` é derivado de `Produto.projeto` (FK do catálogo). Cada produto pertence a um único projeto, então `projeto` não vem da planilha.
+
+### `external_hash` (idempotência)
+
+SHA1 (consistente com services legacy) ou SHA256 (novo padrão) sobre:
+```text
+normalize_text_key(codigo) + "|" + str(municipio.id) + "|" + str(projeto.id) + "|" + data.isoformat()
+```
+
+### Comportamento por match
+| Hash existe | Linha igual | Ação |
+|---|---|---|
+| Não | — | Criar `DATCompra` |
+| Sim | Sim (campos não-chave iguais) | Ignorar (idempotente) |
+| Sim | Não (`quantidade`/`uso` diferentes) | **Atualizar** com warning explícito (drift entre planilha e banco) |
+
+---
+
+## 8. Models / services / endpoints relacionados (estado real do código — 2026-05-05)
+
+### Decisão `Compra` vs `DATCompra` — **RESOLVIDA pelo código atual**
+
+Lendo `apps/core/services/controle_imports.py:26`:
+
+```python
+from apps.core.models import Compra, Municipio, Produto, Projeto
+```
+
+→ **O fluxo de import de "Compras" alimenta `Compra` (histórico ETL com `external_hash` SHA1)**, **não** `DATCompra`. Este é o estado em produção. `DATCompra` é alimentado por outro fluxo operacional (Admin/UI), não por planilha.
+
+### Tabela completa de imports relacionados
+
+| Componente | Caminho | Função | Status |
+|---|---|---|---|
+| **Service Compras** | `apps/core/services/controle_imports.py` | `import_compras_from_file(...)`. Aba "🟥 COMPRAS" da Planilha de Controle. Alimenta `Compra`. Idempotência via `external_hash` SHA1 determinístico. Gera relatório em `out_etl/import_compras_report.json`. | ✅ **já implementado** |
+| **Service Catálogo Produtos** | `apps/core/services/produtos_import.py` | `import_produtos_from_file(...)`. Alimenta `Produto` (catálogo). Idempotência por `Produto.codigo`. | ✅ **já implementado** |
+| **Service Municipios** | `apps/core/services/municipios_import.py` | `import_municipios_from_file(...)`. Cadastro mestre. | ✅ **já implementado** |
+| **Service Coleções** | `apps/core/services/colecoes_import.py` | `import_colecoes_from_file(...)`. | ✅ **já implementado** |
+| **Service Ações Controle** | `apps/core/services/controle_acoes_import.py` | `import_acoes_controle(...)`. Idempotência SHA1. | ✅ **já implementado** |
+| **Service DAT Cadastros** | `apps/core/services/dat_cadastros_import.py` | `import_dat_cadastros(...)`. Cadastros consolidados DAT. Idempotência SHA1 (linha 301). | ✅ **já implementado** |
+| **Service Deslocamentos** | `apps/core/services/deslocamentos_import.py` | `import_deslocamentos(...)`. Idempotência SHA1. | ✅ **já implementado** |
+| Model `Compra` | `apps/core/models/compra.py` | Histórico ETL: `codigo`+`municipio`+`projeto`+`data` + `external_hash` | ✅ existe |
+| Model `DATCompra` | `apps/core/models/dat_compra.py` | Gestão operacional (`quantidade_utilizada`, `status_uso`, `valor_unitario`, `ano_uso`) — **não alimentado por import** | ✅ existe |
+| Model `Produto` | `apps/core/models/organizacao.py` | Catálogo (codigo único, FK Projeto) | ✅ existe |
+| Model `Municipio` | `apps/core/models/organizacao.py` | nome, uf, ibge_code | ✅ existe |
+| Resolvers compartilhados | `apps/core/services/resolvers.py` | `resolve_municipio` (com `_split_city_uf` para "Cidade - UF"), `resolve_projeto` (aliases IDEB→GESTÃO ESCOLAR, Nível N→NN) | ✅ existe |
+
+### Endpoints HTTP (estado real — 2026-05-05)
+
+| Endpoint | View | Gate RBAC |
+|---|---|---|
+| `POST /api/controle/import-compras/` | `ImportComprasView` em `apps/core/views_controle_imports.py` | `IsAuthenticated + HasPerm("import_spreadsheet")` (PR-A1 DAT-Imports 2026-04-29 centralizou em DAT-only) |
+| `POST /api/produtos/import/` | `ImportProdutosView` em `apps/core/views_import_produtos.py` | `IsAuthenticated + HasPerm("import_spreadsheet")` |
+| `POST /api/municipios/import/` | `ImportMunicipiosView` em `apps/core/views_import_municipios.py` | `IsAuthenticated + HasPerm("manage_admin_registries")` |
+| `POST /api/colecoes/import/` | `ImportColecoesView` em `apps/core/views_import_colecoes.py` | `IsAuthenticated + HasPerm("manage_admin_registries")` |
+| `POST /api/controle/import-acoes/` | `ControleImportAcoesView` em `apps/core/views_imports.py` | `IsAuthenticated + HasPerm("import_spreadsheet")` |
+| `POST /api/dat/import-cadastros/` | `DATImportCadastrosView` em `apps/core/views_imports.py` | `IsAuthenticated + HasPerm("manage_admin_registries")` |
+
+Todos aceitam `?dry_run=true|false` (default `true`).
+
+**Endpoints async** (ASQ-005 Fase 1): apenas `/api/imports/bloqueios/` por enquanto. Compras + produtos + cadastros migram em Fase 2 (ver `apps/core/models/import_job.py` linhas 41-44 — comentário do código define ordem).
+
+### Shape de retorno (exemplo confirmado em `ImportComprasView` linha 60-72)
+
+```json
+{
+    "path": "/tmp/xyz.csv",
+    "dry_run": true,
+    "stats": {"created": 10, "updated": 5, "skipped": 2, "errors": 0},
+    "pendencias": {
+        "municipios": [...],
+        "projetos": [...],
+        "linhas_invalidas": [...]
+    },
+    "created_ids": [...],
+    "ts": "2025-10-21T..."
+}
+```
+
+> ⚠️ Cada service retorna shape ligeiramente diferente (uns têm `created_ids`, outros não; `stats.unchanged` em uns, `stats.skipped` em outros). Padronização é objetivo de **PR 2** do roadmap revisto.
+
+### Makefile
+
+`make import-compras-dry FILE=...` no Makefile chama via curl `POST /api/controle/import-compras/?dry_run=true` — **não** é management command Django.
+
+---
+
+## 9. O que pode ser criado/atualizado
+
+### Pode criar
+- Novo `DATCompra` com `status_uso='disponivel'` (default do save() do model).
+- `quantidade_utilizada=0` inicialmente (atualizado por outro fluxo).
+
+### Pode atualizar
+- `quantidade` (se planilha re-importa com valor diferente — warning).
+- `uso` (texto livre, atualizar tolerado).
+- `valor_unitario` (se vier — futuro).
+
+---
+
+## 10. O que NÃO deve acontecer automaticamente
+
+- Criar `Produto` novo (catálogo deve estar completo antes).
+- Criar `Municipio` novo (cadastro mestre separado).
+- Marcar `status_uso=ESGOTADO` automaticamente — model já calcula em `save()` baseado em `quantidade_utilizada`, mas sem efeito colateral externo.
+- Reduzir `quantidade` se planilha vier menor — gerar warning, deixar admin decidir.
+- Deletar linhas que sumiram da planilha — soft-delete só via admin.
+
+---
+
+## 11. Como auditar depois
+
+### AuditLog
+```python
+AuditLog.objects.filter(
+    action="IMPORT_PRODUTOS_CONTROLE",
+    created_at__gte=<timestamp>
+).values(
+    "usuario",
+    "details__arquivo_hash",
+    "details__linhas_criadas",
+    "details__linhas_atualizadas",
+    "details__linhas_ignoradas",
+    "details__warnings_count",
+)
+```
+
+### Drift check
+- Comparar contagem por município: `DATCompra.objects.values("municipio").annotate(c=Count("id"))`.
+- Listar drift quantidade: `DATCompra` com `quantidade != Compra` (legacy) para a mesma chave natural.
+- Reconciliação: gerar relatório `produto × municipio × ano` e comparar com planilha original.
+
+### Reports operacionais
+- `view_compras_dashboard` (Diretoria + DAT) exibe dashboard.
+- `view_compras_pendencias`, `view_compras_stats` para painéis específicos.
+
+---
+
+## 12. Riscos identificados
+
+| Risco | Severidade | Mitigação |
+|---|---|---|
+| Produto com nome variante (acento, caixa) → lookup falha | Média | Lookup oficial por `codigo` (`F`); `Produto` é sanity check; rejeitar só se `F` não existe |
+| `F` mal preenchido ou trocado entre linhas | Alta | Validar match `F` ↔ `Produto.nome` (warning se diverge) |
+| Município duplicado (homônimos sem UF) | Alta | Sempre exigir `UF`; lookup conjunto |
+| Quantidade negativa ou zero | Média | Bloqueante; importação rejeita |
+| Data futura > 7 dias | Baixa | Warning; aceitar (pode ser agendamento) |
+| Reimport com `quantidade` diferente | Média | Atualizar com warning explícito + AuditLog `details.before` |
+| Encoding latin-1 do Excel | Média | Especificar UTF-8 no template; rejeitar decode |
+| Decimal com vírgula (`12,50`) | Baixa | Normalizador converte; warning se ambíguo |
+
+---
+
+## 13. Pendências para Matheus (revistas — só as que o código ainda não responde)
+
+### Resolvidas pelo código atual
+
+- ~~`Compra` vs `DATCompra`?~~ → **Resolvido**: import atual alimenta `Compra`. `DATCompra` é fluxo operacional separado (Admin/UI), não importação.
+- ~~Catálogo de Produtos é congelado?~~ → **Resolvido**: existe `produtos_import.py` + `POST /api/produtos/import/`. Catálogo é atualizável via planilha.
+
+### Pendências reais ainda
+
+1. **`valor_unitario` no `sheets.banco`**: o template original (7 colunas) não inclui. Se vier na planilha real, `Compra` aceita? (verificar schema do model — não confirmado).
+2. **Granularidade**: 1 linha = 1 compra única, ou 1 linha = somatório por município/ano? Definir como o `external_hash` deve ser composto se for agregado.
+3. **`Uso das coleções`** (campo texto livre): há vocabulário fechado (Alfabetização, Acompanhamento, Reposição) ou string livre?
+4. **Atualização vs criação** em re-import com mesmo hash + `quantidade` diferente:
+   - O código atual (a confirmar lendo `_process_row` de `controle_imports.py`) provavelmente **ignora** (idempotência total).
+   - Se a regra desejada for **atualizar** (sobrescrever) ou **acumular**, exige PR de runtime separada.
+5. **Cabeçalho real do CSV** que `controle_imports.py` aceita: a docstring (linhas 1-8) menciona "aba 🟥 COMPRAS". Confirmar com Matheus se planilha real tem essas mesmas colunas (`F`, `Produto`, `Quant.`, `Município`, `UF`, `Data`, `Uso das coleções`) **OU** colunas em snake_case (`codigo`, `produto_nome`, `quantidade`, etc.).
+6. **Alinhar template CSV deste doc** com o cabeçalho real que `controle_imports.py` aceita (não confirmado se v0.1 do template está certo).
+
+---
+
+## 14. Histórico de versões
+
+- 2026-05-05 — v0.1 — PR 1 (contrato inicial). Decisão `Compra` vs `DATCompra` pendente.
+- 2026-05-05 — v0.2 — PR 1 v0.2. Auditoria contra código real. **`Compra` confirmado como destino** do import. Lista 7 services adjacentes já implementados. Reorienta roadmap.
+- 2026-05-05 — v0.3 — PR 2. **Cabeçalho real confirmado** (`CÓD,Produto,Quant.,Município,UF,Data,Uso das coleções` com variantes case/acento). Template atualizado. Shape de retorno documentado em [dry_run_response_contract.md](./dry_run_response_contract.md) (§3.2 família dataclass + JSON em disco).
+
+---
+
+## 15. Cabeçalho real do CSV de Compras (confirmado em PR 2 — 2026-05-05)
+
+Lendo `apps/core/services/controle_imports.py` linhas 156-163, o service aceita **múltiplas variantes** do mesmo cabeçalho:
+
+| Campo destino | Variantes aceitas no CSV/XLSX |
+|---|---|
+| `codigo` | `CÓD` · `COD` · `Cód` · `id` · `ID` |
+| `produto` | `Produto` |
+| `quantidade` | `Quant.` · `Quant` · `Quantidade` |
+| `municipio` | `Município` · `Municipio` |
+| `uf` | `UF` |
+| `data` | `Data` |
+| `uso` | `Uso das coleções` · `Uso` |
+
+O template [templates/produtos_controle.template.csv](./templates/produtos_controle.template.csv) foi atualizado em PR 2 para usar o cabeçalho da planilha original (`CÓD,Produto,Quant.,Município,UF,Data,Uso das coleções`), pois é o que o service mais provavelmente recebe ao ler diretamente XLSX exportado do `sheets.banco`.
+
+### Idempotência
+
+Confirmado em `controle_imports.py:187-199`:
+
+```text
+external_hash = SHA1( municipio_id | projeto_id | codigo | produto_norm | quantidade | data | uso_norm )
+```
+
+`projeto_id` é **inferido** a partir do nome do produto via `_infer_projeto_from_produto(produto_norm)` (cache pré-construído de `Produto → Projeto`), **não vem do CSV**.
+
+### Validações bloqueantes (linhas 204-205)
+
+Linha é rejeitada (com entrada em `pendencias.linhas_invalidas`) se:
+- `municipio` vazio, **OU**
+- `quantidade` é `None` (parse de int falhou), **OU**
+- `codigo` vazio.
+
+Linha é rejeitada (em `pendencias.municipios` ou `pendencias.projetos`) se:
+- `resolve_municipio(nome)` retornar `None`, **OU**
+- `_infer_projeto_from_produto(produto_norm)` retornar `None`.
+
+### Shape de retorno (confirmado em `controle_imports.py:279-290`)
+
+Padrão "dataclass + relatório JSON em disco" — ver [dry_run_response_contract.md §3.2](./dry_run_response_contract.md). É **diferente** do shape dos demais 8 services modernos (família "dict aninhado"). PR 6 futura unifica.

--- a/v2/docs/imports/templates/agenda_solicitacoes.template.csv
+++ b/v2/docs/imports/templates/agenda_solicitacoes.template.csv
@@ -1,0 +1,2 @@
+municipio,projeto,tipo_evento,data,hora_inicio,hora_fim,coordenador,formador1,formador2,formador3,formador4,formador5,encontro,segmento,local
+Cidade Exemplo,Projeto Exemplo,Formação,01/02/2026,08:00,12:00,coordenadora.exemplo@example.com,formadora.exemplo.1@example.com,,,,,Encontro 1,Fundamental I,Escola Exemplo

--- a/v2/docs/imports/templates/disponibilidade.template.csv
+++ b/v2/docs/imports/templates/disponibilidade.template.csv
@@ -1,0 +1,2 @@
+usuario,inicio,fim,tipo,motivo
+Maria de Souza Exemplo,01/03/2026 14:00,01/03/2026 18:00,P,Reunião administrativa (template fictício)

--- a/v2/docs/imports/templates/produtos_controle.template.csv
+++ b/v2/docs/imports/templates/produtos_controle.template.csv
@@ -1,0 +1,2 @@
+CÓD,Produto,Quant.,Município,UF,Data,Uso das coleções
+EX-C0,Produto Exemplo Coleção 0,10,Cidade Exemplo,CE,01/01/2026,Uso fictício para template

--- a/v2/docs/imports/templates/usuarios.template.csv
+++ b/v2/docs/imports/templates/usuarios.template.csv
@@ -1,0 +1,2 @@
+cpf,nome,email,telefone,cargo,is_active,grupos
+00000000000,Maria de Souza Exemplo,maria.exemplo@example.com,85999999999,Formadora,true,"Superintendência,Formador"

--- a/v2/docs/imports/usuarios.md
+++ b/v2/docs/imports/usuarios.md
@@ -1,0 +1,295 @@
+# Importação: Usuários
+
+Status: PR 1 — contrato fechado, **backend já implementado** (revisto 2026-05-05)
+Versão: 2026-05-05 v0.2
+Template: [templates/usuarios.template.csv](./templates/usuarios.template.csv)
+
+> ⚠️ **Atualização v0.2**: a v0.1 tratava o service como "futuro PR 6". Na verdade `apps/core/services/usuarios_import.py` já existe e funciona com dry-run + idempotência por CPF + savepoint-per-row. Esta versão alinha o doc ao código real.
+
+---
+
+## 1. Objetivo
+
+Importar/atualizar usuários do sistema (`apps.core.models.usuario.Usuario`) a partir da aba "Usuários" da planilha `sheets.banco`. Cobre:
+
+- Criação de usuário novo (se CPF/email não existir).
+- Atualização de dados não-chave (telefone, cargo) em usuário existente.
+- Atribuição **automática de Setor** (grupo Django) conforme coluna `Gerência`.
+- Atribuição **automática de Função** (grupo Django) conforme coluna `Cargo`, **com whitelist**.
+
+Não cobre (gate manual obrigatório):
+- Atribuição de função `Gerente` ou `Superintendência`.
+- `is_superuser=True`.
+- Atribuição de capabilities individuais (D17 — admin-driven).
+
+---
+
+## 2. Dados de origem esperados
+
+Aba `Usuários` da planilha `sheets.banco`.
+
+| Coluna planilha | Descrição |
+|---|---|
+| `Nome` | Nome curto (ex: "Maria Silva") |
+| `Nome Completo` | Nome completo (ex: "Maria Silva de Souza") |
+| `CPF` | 11 dígitos (com ou sem máscara) |
+| `Telefone` | Telefone (com ou sem máscara, com ou sem DDD) |
+| `Email` | Email institucional ou pessoal |
+| `Cargo` | Função operacional (ex: "Formadora", "Coordenadora", "Assistente") |
+| `Gerência` | Setor de trabalho (ex: "Superintendência", "Vidas", "DAT") |
+
+---
+
+## 3. Colunas obrigatórias
+
+| Coluna CSV | Validação |
+|---|---|
+| `cpf` | 11 dígitos após normalização; dígito verificador válido |
+| `email` | RFC 5322 simples; unique no banco |
+| `nome_completo` | mínimo 2 palavras |
+| `gerencia` | deve mapear para um `Setor` em `SETOR_GROUPS` |
+
+---
+
+## 4. Colunas opcionais
+
+| Coluna CSV | Comportamento se vazio |
+|---|---|
+| `nome` | Derivar do `nome_completo` (primeiro nome) |
+| `telefone` | Salvar string vazia; usuário consegue editar depois |
+| `cargo` | Salvar string vazia; **NÃO atribui Função RBAC** automaticamente |
+
+---
+
+## 5. Normalizações esperadas (PR 2 — `normalization.py`)
+
+| Campo | Função (futura) | Resultado |
+|---|---|---|
+| `cpf` | `normalize_cpf` | Strip máscara, validar 11 dígitos + DV |
+| `telefone` | `normalize_phone` | E.164 ou padrão BR `(85) 99999-9999` |
+| `email` | `normalize_email` | Lowercase, strip, validar shape |
+| `nome` / `nome_completo` | `normalize_text_key` | Strip, title case (configurável) |
+| `cargo` | `normalize_text_key` | Strip, lookup em mapa Cargo→Função |
+| `gerencia` | `normalize_text_key` | Strip, lookup em `SETOR_GROUPS` |
+
+Mapeamento `Cargo → Função RBAC` (proposta — confirmar com Matheus):
+
+| `Cargo` planilha | Função RBAC | Aceito em import? |
+|---|---|---|
+| Formador / Formadora | Formador | ✅ sim |
+| Coordenador / Coordenadora | Coordenador | ✅ sim |
+| Apoio de Coordenação | Apoio de Coordenação | ✅ sim |
+| Assistente Administrativo | Assistente Administrativo | ✅ sim |
+| Gerente | Gerente | ⚠️ **revisão manual** — pode habilitar aprovação |
+| Diretor / Superintendente | (sem mapeamento direto) | ❌ não atribuir; criar usuário sem Função |
+
+---
+
+## 6. Validações antes do upload (PR 6)
+
+### Bloqueantes (linha rejeitada)
+- CPF inválido (formato ou DV).
+- Email mal-formado.
+- `gerencia` não encontrada em `SETOR_GROUPS`.
+- CPF duplicado **no próprio arquivo**.
+- Email duplicado **no próprio arquivo**.
+
+### Avisos (linha aceita com warning)
+- CPF já existe no banco com nome diferente → atualizar telefone/cargo mas avisar.
+- Email já existe no banco mas com CPF diferente → **rejeitar** (conflito de identidade).
+- Telefone fora do padrão BR.
+- `cargo` sem mapeamento → criar usuário sem Função.
+
+---
+
+## 7. Regras de duplicidade / hash
+
+### Chave natural
+`CPF` é a chave primária de identidade. `email` é secundária (unique constraint).
+
+### `external_hash` (idempotência)
+SHA1 ou SHA256 sobre:
+```text
+normalize_cpf(cpf) + "|" + normalize_email(email)
+```
+
+### Comportamento por match
+| CPF existe | Email existe | Ação |
+|---|---|---|
+| Não | Não | Criar usuário novo + atribuir Setor (+ Função se mapeada) |
+| Sim | Sim (mesmo user) | Atualizar telefone, cargo (se mapeado); manter grupos atuais |
+| Sim | Não, ou email diferente | Atualizar email (com warning) |
+| Sim | Sim (user diferente) | **Erro bloqueante** — conflito de identidade |
+| Não | Sim | **Erro bloqueante** — não pode haver email sem CPF |
+
+---
+
+## 8. Models / services / endpoints relacionados (estado real do código — 2026-05-05)
+
+| Componente | Caminho | Função | Status |
+|---|---|---|---|
+| Model `Usuario` | `apps/core/models/usuario.py` | `AbstractUser` custom + cpf único, telefone, cargo | ✅ existe |
+| Model `Group` | Django auth | Setor (13) + Função (5) | ✅ existe |
+| Constantes | `apps/core/constants.py:16-45` | `SETOR_GROUPS`, `FUNCAO_GROUPS`, `ALLOWED_USER_GROUPS` | ✅ existe |
+| **Service** | `apps/core/services/usuarios_import.py` | `import_usuarios_from_file(path: str, dry_run: bool = True) -> dict` | ✅ **já implementado** |
+| **Endpoint síncrono** | `POST /api/usuarios/import/` (`ImportUsuariosView` em `apps/core/views_import_usuarios.py`) | dry_run via query param `?dry_run=true\|false`; multipart `file=` no body | ✅ **já funciona** |
+| Endpoint async | (não implementado para usuarios) | ASQ-005 Fase 1 só cobre `bloqueios`; Fase 2 migrará usuarios | ⏳ Fase 2 do ImportJob |
+| Gate RBAC efetivo | `IsAuthenticated + HasPerm("manage_admin_registries")` | DAT + Diretoria (via cap `manage_admin_registries`) — **NÃO** `import_spreadsheet` | ✅ aplicado em prod |
+| Validação de upload | `apps.core.upload_validators.validate_upload` | Magic bytes + tamanho + content-type | ✅ existe |
+| Reconciliação | (não usa `resolvers.py` — Usuario é destino, não FK alvo) | — | — |
+
+### Comportamento real do service (lido em código)
+
+- **Idempotência**: por CPF (campo unique).
+- **Transação**: `transaction.atomic()` externa para dry-run rollback + `transaction.atomic()` interno por linha (savepoint-per-row, padrão ASQ-016).
+- **Retorno**:
+  ```python
+  {
+      "stats": {"created": N, "updated": N, "unchanged": N, "skipped": {"cpf_invalid": N, "nome_missing": N, "other": N}},
+      "pendencias": {"cpf_invalid": [...], "nome_missing": [...], "outros": [...]},
+      "dry_run": bool,
+      "file": str,
+  }
+  ```
+- **Colunas esperadas pelo service** (docstring linha 6-13):
+  - `cpf` (obrigatório, 11 dígitos)
+  - `nome` (obrigatório, completo — vira first_name + last_name)
+  - `email` (opcional)
+  - `telefone` (opcional)
+  - `cargo` (opcional)
+  - `is_active` (opcional, default `True`)
+  - `grupos` (opcional, separados por vírgula)
+
+> ⚠️ **Atenção template CSV**: o cabeçalho atual do template (`nome,nome_completo,cpf,telefone,email,cargo,gerencia`) **não bate** com o cabeçalho aceito pelo service (`cpf,nome,email,telefone,cargo,is_active,grupos`). Ver §15 abaixo.
+
+---
+
+## 9. O que pode ser criado/atualizado
+
+### Pode criar
+- Novo `Usuario` (sem `is_superuser`, sem `is_staff`).
+- Atribuir **Setor** (1 grupo) conforme `Gerência`.
+- Atribuir **Função** (1 grupo) conforme `Cargo`, se estiver no whitelist do mapa.
+
+### Pode atualizar
+- `telefone`, `cargo` (string livre), `email` (com warning).
+- Setor: **adicionar** um grupo de setor; **não remover** automaticamente.
+- Função: **adicionar** Função do whitelist; **não remover** automaticamente.
+
+---
+
+## 10. O que NÃO deve acontecer automaticamente
+
+- `is_superuser = True` — **nunca** vinda de import.
+- `is_staff = True` — só via Admin (manual).
+- Atribuir Função **`Gerente`** — exige aprovação humana (pode habilitar aprovação de solicitação).
+- Atribuir Setor **`Superintendência` + Função `Gerente`** (composite) — pode aprovar fluxo SUPER (PA-02).
+- Atribuir Função **`Assistente Administrativo`** combinada com Setor **`Controle`** — composite delega aprovação.
+- Remover Setor/Função existente.
+- Capabilities individuais (`PermissaoFuncional.groups`) — admin-driven (D17).
+- Reset de senha — usuário recebe email de bem-vindo separado (fora deste import).
+
+Mecânica sugerida (PR 6): linhas que cairiam em qualquer um desses casos viram **warning + log**, e o sistema cria o usuário **sem** a atribuição sensível, deixando para o admin completar.
+
+---
+
+## 11. Como auditar depois
+
+### AuditLog
+Filtrar:
+```python
+AuditLog.objects.filter(
+    action="IMPORT_USUARIOS",
+    created_at__gte=<timestamp>
+).values(
+    "usuario", "details__arquivo_hash",
+    "details__linhas_criadas",
+    "details__linhas_atualizadas",
+    "details__linhas_warnings",
+)
+```
+
+### Snapshot por arquivo
+`ImportBatch` (PR 4 futura) registra:
+- `arquivo_hash` (SHA256 do arquivo CSV inteiro).
+- Linhas processadas e seu estado individual.
+
+### Drift check
+- Comparar `Usuario.objects.filter(date_joined__date=<dia_import>).count()` com `linhas_criadas`.
+- Listar usuários com `groups.count() == 0` (criados sem Setor — sinal de mapa inválido).
+- Listar usuários sem Função (`FUNCAO_GROUPS` não intersecciona com `user.groups`).
+
+---
+
+## 12. Riscos identificados
+
+| Risco | Severidade | Mitigação |
+|---|---|---|
+| **CPF duplicado** entre planilha e banco | Alta | Bloqueante; whitelist explícita para forçar match |
+| **Email duplicado** com CPF diferente | Alta | Bloqueante; conflito de identidade |
+| Telefone em formatos heterogêneos | Média | `normalize_phone` aceita variantes; warning se inválido |
+| Cargo/Gerência mapeando errado para grupo | Alta | Whitelist explícita; "Diretor" não vira Função; "Gerente" gera warning |
+| Atribuição automática de `Gerente` Superintendência → aprovador SUPER inesperado | **Crítica** | NÃO atribuir automaticamente; gate manual sempre |
+| Nome com acento variável (ex: "Sá" vs "Sa") | Baixa | `nome` é livre; chave é CPF |
+| Encoding (latin-1 vs utf-8) | Média | Especificar UTF-8 no template; rejeitar se decode falhar |
+
+---
+
+## 13. Pendências para Matheus (revistas — só as que o código ainda não responde)
+
+1. **Drift de cabeçalho do template** (ver §15): alinhar `sheets.banco` ao cabeçalho que o service aceita hoje (`cpf,nome,email,telefone,cargo,is_active,grupos`) **OU** ajustar service para aceitar o cabeçalho v0.1 (`nome,nome_completo,...,gerencia`). Decisão de produto.
+2. **Mapa completo `Cargo` → Função RBAC**: confirmar termos reais da coluna `Cargo`. O service hoje só armazena texto livre em `Usuario.cargo`; **não atribui Função RBAC automaticamente**. Se atribuição automática for desejada, exige feature nova (não está no roadmap atual).
+3. **Coluna `grupos` no service real** aceita lista separada por vírgula (`"DAT,Vidas,Formador"`). Confirmar se `sheets.banco` exporta nesse formato ou se prefere `gerencia` + `cargo` separados (transformação no client).
+4. **Política de email**: aceita emails pessoais (`@gmail.com`) ou só institucional?
+5. **Senha inicial**: o service hoje usa `set_unusable_password()` + token de reset (não confirmado se já dispara email; verificar `_process_row`). Se não dispara, criar fluxo de envio é PR separada.
+6. **Cargo `"Gerente"`** + Setor `"Superintendência"`: política definitiva. Hoje o service simplesmente grava no campo `cargo` (texto) — não atribui grupo `Gerente` automaticamente. Atribuição via grupos só acontece pela coluna `grupos` explícita.
+7. **`Assistente Administrativo` + `Controle`** (composite de aprovação): mesma situação. Atribuição automática violaria D17; só admin manual.
+8. **Telefone obrigatório?** Hoje no model é opcional; service aceita vazio.
+
+### Pendências que a v0.1 listava e o código já resolve
+
+- ~~Como reconciliar usuário por CPF/email~~ → resolvido: CPF é chave (unique constraint).
+- ~~`normalize_cpf` precisa ser criado~~ → existe lógica de validação básica em `_process_row`; consolidar em `apps/core/imports/normalization.py` é PR 3 do roadmap.
+- ~~`normalize_phone`~~ → idem.
+- ~~Como tratar `is_active`~~ → coluna opcional aceita pelo service, default `True`.
+
+---
+
+## 14. Histórico de versões
+
+- 2026-05-05 — v0.1 — PR 1 (contrato inicial). Tratou service como "futuro".
+- 2026-05-05 — v0.2 — Auditoria contra código. Confirmado: `usuarios_import.py` + `ImportUsuariosView` já existem e funcionam. Documenta cabeçalho real esperado. Reorienta pendências.
+
+---
+
+## 15. Drift conhecido: template CSV vs cabeçalho aceito pelo service
+
+**Cabeçalho do template atual** (`templates/usuarios.template.csv`):
+```text
+nome,nome_completo,cpf,telefone,email,cargo,gerencia
+```
+
+**Cabeçalho aceito pelo service** (docstring `usuarios_import.py` linhas 6-13):
+```text
+cpf,nome,email,telefone,cargo,is_active,grupos
+```
+
+### Diferenças
+
+| Coluna template v0.1 | Coluna service | Ação |
+|---|---|---|
+| `nome` + `nome_completo` | só `nome` (vira `first_name` + `last_name` via split) | Service usa **só `nome`** completo — eliminar `nome_completo` ou consolidar |
+| `gerencia` | `grupos` (lista) | Renomear no template ou implementar `gerencia` no service |
+| (ausente) | `is_active` (opcional) | Adicionar ao template como coluna opcional |
+
+### Resolução proposta (decisão pendente Matheus)
+
+**Opção A** — Atualizar template para casar com o service (caminho mais rápido):
+```csv
+cpf,nome,email,telefone,cargo,is_active,grupos
+00000000000,Maria de Souza Exemplo,maria.exemplo@example.com,85999999999,Formadora,true,"Superintendência,Formador"
+```
+
+**Opção B** — Estender o service para aceitar o cabeçalho v0.1 (mantendo compatibilidade): mapear `nome_completo`→`nome`, `gerencia`→`grupos[0]`. Exige PR de runtime no service (fora do escopo desta PR).
+
+A v0.2 da doc deixa o template original e marca esta decisão como pendência.


### PR DESCRIPTION
Docs-only PR.

## Summary
- Adds import contracts for users, products/control, agenda/solicitations and availability.
- Adds fictitious CSV templates.
- Documents current code state for import services/endpoints.
- Adds dry-run response contract audit for 11 import services.
- Confirms products/control template header from existing code.

## Safety
- No runtime changes.
- No models or migrations.
- No endpoints.
- No RBAC changes.
- No frontend changes.
- No real data.