### PR TITLE
fix(security): avoid stack trace exposure in solicitation validate

### DIFF
--- a/v2/backend/apps/core/tests/test_pr_security_validate_no_stack_trace.py
+++ b/v2/backend/apps/core/tests/test_pr_security_validate_no_stack_trace.py
@@ -6,7 +6,7 @@ Detalhe do exception vai apenas para o log server-side; usuário recebe
 mensagem genérica.
 """
 
-# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportCallIssue=false
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportCallIssue=false, reportMissingTypeArgument=false
 
 from __future__ import annotations
 

--- a/v2/backend/apps/core/tests/test_pr_security_validate_no_stack_trace.py
+++ b/v2/backend/apps/core/tests/test_pr_security_validate_no_stack_trace.py
@@ -1,0 +1,81 @@
+"""
+Hardening: ``SolicitationValidateView`` não vaza ``str(e)`` de ValueError
+na response (CodeQL py/stack-trace-exposure, alert #5).
+
+Detalhe do exception vai apenas para o log server-side; usuário recebe
+mensagem genérica.
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportCallIssue=false
+
+from __future__ import annotations
+
+from django.contrib.auth.models import Group
+from rest_framework.test import APIClient
+
+import pytest
+
+from apps.core.models import Usuario
+
+
+@pytest.fixture
+def authenticated_client(db) -> APIClient:
+    user = Usuario.objects.create_user(  # type: ignore[attr-defined]
+        username="validate_user",
+        email="validate.user@example.com",
+        password="testpass123",
+        cpf="12345678901",
+    )
+    coord_group, _ = Group.objects.get_or_create(name="Coordenador")
+    user.groups.add(coord_group)
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+@pytest.mark.django_db
+class TestValidateStackTraceNotExposed:
+    URL = "/api/solicitacoes/validate/"
+
+    def _payload(self, *, date: str = "2026-08-15", start: str = "09:00", end: str = "12:00") -> dict:
+        return {
+            "municipio": "Fortaleza",
+            "projeto": "ACerta",
+            "tipo_evento": "Formação",
+            "date": date,
+            "start": start,
+            "end": end,
+            "participants": {},
+        }
+
+    def test_invalid_date_does_not_leak_str_of_exception(self, authenticated_client):
+        # Data com formato inválido: dispara ValueError em datetime.strptime
+        payload = self._payload(date="not-a-date")
+        resp = authenticated_client.post(self.URL, payload, format="json")
+        assert resp.status_code == 200
+        errors_text = " ".join(resp.data.get("errors") or [])
+        # Mensagem genérica preserve UX
+        assert "formato inválido" in errors_text or "Data ou horário" in errors_text
+        # Não pode vazar conteúdo típico de ValueError do strptime:
+        # "time data 'not-a-date' does not match format '%Y-%m-%d'"
+        assert "does not match format" not in errors_text
+        assert "time data" not in errors_text
+        assert "not-a-date" not in errors_text  # nem o input maliciental
+
+    def test_invalid_time_does_not_leak_str_of_exception(self, authenticated_client):
+        payload = self._payload(start="25:99")  # hora inválida
+        resp = authenticated_client.post(self.URL, payload, format="json")
+        assert resp.status_code == 200
+        errors_text = " ".join(resp.data.get("errors") or [])
+        assert "does not match format" not in errors_text
+        assert "unconverted data" not in errors_text
+        assert "25:99" not in errors_text
+
+    def test_logs_traceback_server_side_only(self, authenticated_client, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="apps.core.views_validate"):
+            payload = self._payload(date="bad-date")
+            authenticated_client.post(self.URL, payload, format="json")
+        # Não asserta conteúdo do traceback aqui (logger pode estar com propagate=False);
+        # apenas garante que o teste de runtime não quebra com a chamada.

--- a/v2/backend/apps/core/views_validate.py
+++ b/v2/backend/apps/core/views_validate.py
@@ -42,6 +42,7 @@ Retorna:
 
 from __future__ import annotations
 
+import logging
 from datetime import datetime, time
 from typing import Any
 from zoneinfo import ZoneInfo
@@ -52,6 +53,8 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
+
+logger = logging.getLogger(__name__)
 
 from apps.core.services.resolvers import resolve_municipio, resolve_projeto, resolve_tipo_evento, resolve_user_by_email
 
@@ -151,8 +154,12 @@ class SolicitationValidateView(APIView):
                     canonical["inicio"] = inicio_aware.isoformat()
                     canonical["fim"] = fim_aware.isoformat()
 
-            except ValueError as e:
-                errors.append(f"Erro ao processar data/hora: {str(e)}")
+            except ValueError:
+                # Security: não expor ``str(e)`` na response — pode propagar
+                # detalhes do parsing/stack trace (CodeQL py/stack-trace-exposure).
+                # Detalhes completos ficam no log server-side.
+                logger.warning("Validate solicitacao: failed to parse data/hora", exc_info=True)
+                errors.append("Data ou horário em formato inválido (use YYYY-MM-DD para data e HH:MM para horários)")
 
         # 5. Validar e resolver participantes
         participants = data.get("participants", {})

--- a/v2/backend/apps/core/views_validate.py
+++ b/v2/backend/apps/core/views_validate.py
@@ -54,11 +54,11 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-logger = logging.getLogger(__name__)
-
 from apps.core.services.resolvers import resolve_municipio, resolve_projeto, resolve_tipo_evento, resolve_user_by_email
 
 from .models import Compra, Municipio, Projeto, TipoEvento
+
+logger = logging.getLogger(__name__)
 
 
 class SolicitationValidateView(APIView):


### PR DESCRIPTION
## Summary

Closes CodeQL alert #5 (`py/stack-trace-exposure`, medium) on `apps/core/views_validate.py:201`.

`SolicitationValidateView.post` formerly appended `str(e)` of a caught `ValueError` to the response payload. The exception comes from `datetime.strptime` parsing user-supplied `date`/`start`/`end`, so its text contained the offending input verbatim (e.g. `"time data 'not-a-date' does not match format '%Y-%m-%d'"`), leaking internal format strings.

After this PR:

- The response carries a single generic message (`"Data ou horário em formato inválido (use YYYY-MM-DD para data e HH:MM para horários)"`).
- Full traceback continues to be available server-side via `logger.warning(..., exc_info=True)`.

## Changes

- **`v2/backend/apps/core/views_validate.py`**:
  - Add `import logging` and module-level `logger`.
  - Replace `errors.append(f"Erro ao processar data/hora: {str(e)}")` with a generic message + `logger.warning(..., exc_info=True)`.
- **`v2/backend/apps/core/tests/test_pr_security_validate_no_stack_trace.py`** (new):
  - Invalid date input ⇒ response doesn't include `"time data"`, `"does not match format"`, or the raw input.
  - Invalid time input ⇒ same guarantee.

## Safety

- No models or migrations.
- No endpoints added/removed.
- No RBAC change.
- No frontend change.
- UX: error message is more user-friendly (fixed string) instead of internal Python repr.

## Staging Gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

ALL 8 CHECKS PASSED

Note: response shape unchanged (`{ok, errors, canonical}`); only the contents of one string in `errors` becomes generic.

## Closes (CodeQL alerts)

- #5 — py/stack-trace-exposure (views_validate.py)