### PR TITLE
fix(security): add Secure flag to cookies in vitest fixture

### DIFF
--- a/v2/frontend/src/api/__tests__/config.test.ts
+++ b/v2/frontend/src/api/__tests__/config.test.ts
@@ -41,20 +41,22 @@ describe('API Config', () => {
     })
 
     test('deve extrair csrftoken do cookie', () => {
-      document.cookie = 'csrftoken=abc123xyz'
+      // `; Secure` evita CodeQL js/clear-text-cookie; jsdom roda em HTTPS
+      // (ver vitest.config.ts) então o jar aceita.
+      document.cookie = 'csrftoken=abc123xyz; Secure'
       expect(getCsrfToken()).toBe('abc123xyz')
     })
 
     test('deve encontrar csrftoken entre múltiplos cookies', () => {
       // Em jsdom, cookies devem ser setados individualmente
-      document.cookie = 'sessionid=xyz123'
-      document.cookie = 'csrftoken=token456'
-      document.cookie = 'other=value'
+      document.cookie = 'sessionid=xyz123; Secure'
+      document.cookie = 'csrftoken=token456; Secure'
+      document.cookie = 'other=value; Secure'
       expect(getCsrfToken()).toBe('token456')
     })
 
     test('deve decodificar valor do cookie', () => {
-      document.cookie = 'csrftoken=hello%20world'
+      document.cookie = 'csrftoken=hello%20world; Secure'
       expect(getCsrfToken()).toBe('hello world')
     })
   })

--- a/v2/frontend/vitest.config.ts
+++ b/v2/frontend/vitest.config.ts
@@ -11,6 +11,13 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
+    // Run jsdom under HTTPS so tests that set `Secure` cookies (frontend hardening
+    // against CodeQL js/clear-text-cookie) are accepted by the cookie jar.
+    environmentOptions: {
+      jsdom: {
+        url: 'https://localhost/',
+      },
+    },
     setupFiles: './src/test/setup.js',
     include: ['src/**/*.{test,spec}.{js,jsx,ts,tsx}'],
     exclude: ['**/node_modules/**', '**/dist/**', '**/e2e/**'],


### PR DESCRIPTION
## Summary

Closes CodeQL alert #22 (`js/clear-text-cookie`, medium) on `v2/frontend/src/api/__tests__/config.test.ts:50`.

The test sets `document.cookie = 'sessionid=xyz123'` etc. without `Secure`, which CodeQL flags even for jsdom test fixtures.

Two changes:

1. Add `; Secure` to every test cookie write.
2. Configure jsdom to run under `https://localhost/` in `vitest.config.ts` so the cookie jar accepts `Secure` cookies (without HTTPS context, jsdom silently rejects them).

## Changes

- `v2/frontend/vitest.config.ts`: `test.environmentOptions.jsdom.url = 'https://localhost/'`.
- `v2/frontend/src/api/__tests__/config.test.ts`: append `; Secure` to 4 `document.cookie =` assignments.

## Safety

- Test-only change; no application code touched.
- No backend, RBAC, models, migrations.
- Tests assert cookie *parsing*, not transport security — appending `Secure` doesn't affect what `getCsrfToken()` returns once the cookie is in the jar.

## Validation

- Existing 4 tests in `TESTES DE getCsrfToken` continue to assert the same parsed values.
- jsdom on HTTPS accepts `Secure` cookies (treats `localhost` as a secure context).

## Staging Gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

ALL 8 CHECKS PASSED

Note: change touches only `vitest.config.ts` (test runner config) and one test file under `src/api/__tests__/`. No `src/` runtime code modified, no backend, no migrations. Staging behaviour identical to current main.