### PR TITLE
fix(security): avoid polynomial regex in city/uf resolver

### DIFF
--- a/v2/backend/apps/core/services/resolvers.py
+++ b/v2/backend/apps/core/services/resolvers.py
@@ -112,36 +112,70 @@ def _nfkd(value: str | None) -> str:
     return v.casefold()
 
 
+# Comprimento máximo aceito para texto Município/UF antes de short-circuit.
+# Guard defensivo (CodeQL py/polynomial-redos): mesmo o algoritmo sem regex
+# evita processar entradas absurdas vindas de planilhas / API.
+_MAX_CITY_UF_LEN = 200
+
+
 def _split_city_uf(raw: str | None) -> tuple[str, str | None]:
     """
-    Separa município e UF de formatos variados:
-    - "Cidade - UF"
-    - "Cidade (UF)"
-    - "Cidade/UF"
+    Separa município e UF de formatos variados.
+
+    Implementação sem regex backtracking (CodeQL py/polynomial-redos):
+    usa ``rpartition`` / ``rfind`` por separadores conhecidos, em ordem
+    de precedência. Cada operação é O(n).
+
+    Formatos aceitos:
+    - ``"Cidade - UF"``
+    - ``"Cidade (UF)"``
+    - ``"Cidade/UF"``
+    - ``"Cidade, UF"``
+    - ``"Cidade"`` (sem UF)
 
     Returns:
-        (nome_cidade, uf) ou (texto_original, None) se não separou
+        ``(nome_cidade, uf)`` ou ``(texto_original, None)`` se não separou.
     """
     if raw is None:
         return ("", None)
 
     txt = str(raw).strip()
-    # Normaliza separadores (diferentes tipos de hífen)
-    txt = txt.replace("–", "-").replace("—", "-").replace("/", "-")
-    txt = re.sub(r"\s+", " ", txt)  # Collapse espaços
+    # Defensive cap: entrada muito longa volta como-está sem tentar parse
+    # (CodeQL py/polynomial-redos — limitar tamanho como segunda camada).
+    if not txt or len(txt) > _MAX_CITY_UF_LEN:
+        return (txt[:_MAX_CITY_UF_LEN], None)
 
-    # Padrão 1: "Cidade - UF"
-    m = re.match(r"^(?P<nome>.+?)\s*-\s*(?P<uf>[A-Za-z]{2})$", txt)
-    if not m:
-        # Padrão 2: "Cidade (UF)"
-        m = re.match(r"^(?P<nome>.+?)\s*\((?P<uf>[A-Za-z]{2})\)\s*$", txt)
+    # Normaliza variantes de hífen para "-"; mantém os demais separadores
+    # explícitos para o algoritmo abaixo.
+    txt = txt.replace("–", "-").replace("—", "-")
+    # Collapse espaços sem regex (split() trata qualquer whitespace).
+    txt = " ".join(txt.split())
 
-    if m:
-        nome = m.group("nome").strip()
-        uf = m.group("uf").upper()
-        return (nome, uf)
+    # Padrão "Cidade (UF)" — UF em parênteses no final.
+    if txt.endswith(")") and "(" in txt:
+        before, sep, after = txt.rpartition("(")
+        if sep == "(":
+            candidate = after[:-1].strip()  # remove ")" final
+            if _is_uf(candidate):
+                return (before.strip(), candidate.upper())
+
+    # Padrões "Cidade <sep> UF" — separadores em ordem de precedência
+    # (mais específico primeiro para evitar match espúrio em nomes com
+    # vírgula/hífen internos).
+    for sep in (" - ", " – ", " — ", "/", ",", "-"):
+        idx = txt.rfind(sep)
+        if idx == -1:
+            continue
+        candidate = txt[idx + len(sep) :].strip()
+        if _is_uf(candidate):
+            return (txt[:idx].strip(), candidate.upper())
 
     return (txt, None)
+
+
+def _is_uf(value: str) -> bool:
+    """``True`` se ``value`` parece sigla de UF brasileira (2 letras ASCII)."""
+    return len(value) == 2 and value.isascii() and value.isalpha()
 
 
 def resolve_municipio(nome: str) -> Municipio | None:

--- a/v2/backend/apps/core/tests/test_pr_security_redos_resolvers.py
+++ b/v2/backend/apps/core/tests/test_pr_security_redos_resolvers.py
@@ -1,0 +1,92 @@
+"""
+Hardening: ``_split_city_uf`` substituído por parser por-separador (sem regex
+ambígua) para fechar CodeQL py/polynomial-redos #1 e #2 em
+``services/resolvers.py:134,137``.
+
+Cobertura:
+- Formatos aceitos pelo parser ("Cidade - UF", "/", "(UF)", ",", sem UF).
+- Variantes Unicode de hífen (–, —).
+- Cap de tamanho previne DoS quando entrada é absurdamente longa.
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportCallIssue=false
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from apps.core.services.resolvers import _MAX_CITY_UF_LEN, _is_uf, _split_city_uf
+
+
+class TestSplitCityUf:
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("São Paulo - SP", ("São Paulo", "SP")),
+            ("São Paulo/SP", ("São Paulo", "SP")),
+            ("São Paulo (SP)", ("São Paulo", "SP")),
+            ("São Paulo, SP", ("São Paulo", "SP")),
+            ("São Paulo", ("São Paulo", None)),
+            # Variantes Unicode de hífen
+            ("São Paulo – SP", ("São Paulo", "SP")),  # en-dash
+            ("São Paulo — SP", ("São Paulo", "SP")),  # em-dash
+            # Espaços extras devem ser colapsados
+            ("  São   Paulo  -  SP  ", ("São Paulo", "SP")),
+            # Caso UF lowercase: normaliza para upper
+            ("Fortaleza - ce", ("Fortaleza", "CE")),
+            # Cidade com hífen no nome + UF no final: rfind pega o último " - "
+            ("Mato Grosso do Sul - MS", ("Mato Grosso do Sul", "MS")),
+        ],
+    )
+    def test_formatos_aceitos(self, raw, expected):
+        assert _split_city_uf(raw) == expected
+
+    def test_none_returns_empty(self):
+        assert _split_city_uf(None) == ("", None)
+
+    def test_empty_string(self):
+        assert _split_city_uf("") == ("", None)
+        assert _split_city_uf("   ") == ("", None)
+
+    def test_invalid_uf_returns_no_uf(self):
+        # UF com 3 letras não é UF brasileira válida
+        assert _split_city_uf("Brasília - DFG") == ("Brasília - DFG", None)
+        # UF com dígito
+        assert _split_city_uf("Cidade - S1") == ("Cidade - S1", None)
+
+    def test_long_input_capped_no_dos(self):
+        """Entrada com 100k espaços deve retornar em <100ms (sem ReDoS)."""
+        malicious = "a" + " " * 100_000
+        start = time.perf_counter()
+        result = _split_city_uf(malicious)
+        elapsed_ms = (time.perf_counter() - start) * 1000
+        # Defensive cap aplicado: texto cortado e sem UF parseada
+        assert result[1] is None
+        assert len(result[0]) <= _MAX_CITY_UF_LEN
+        # Deve ser muito rápido — sem catastrophic backtracking
+        assert elapsed_ms < 100, f"too slow: {elapsed_ms:.1f}ms"
+
+    def test_long_input_exact_boundary(self):
+        # Entrada exatamente no limite + 1 é trimmed
+        boundary = "a" * (_MAX_CITY_UF_LEN + 50)
+        result = _split_city_uf(boundary)
+        assert result[1] is None
+        assert len(result[0]) == _MAX_CITY_UF_LEN
+
+    def test_paren_uf_does_not_swallow_internal_paren(self):
+        # Não deve perder dados se cidade tem parênteses no nome
+        # mas última UF é parseada corretamente
+        result = _split_city_uf("Cidade (XPTO) (CE)")
+        assert result == ("Cidade (XPTO)", "CE")
+
+
+class TestIsUf:
+    @pytest.mark.parametrize("v", ["SP", "ce", "MG", "Rj", "ba"])
+    def test_valid_uf(self, v):
+        assert _is_uf(v) is True
+
+    @pytest.mark.parametrize("v", ["", "A", "ABC", "S1", "1B", "ção"])
+    def test_invalid_uf(self, v):
+        assert _is_uf(v) is False


### PR DESCRIPTION
## Summary

Closes CodeQL alerts #1 and #2 (`py/polynomial-redos`, high — CWE-1333, CWE-400, CWE-730) on `apps/core/services/resolvers.py:134,137`.

The previous implementation of `_split_city_uf` used two backtracking regexes (`^(?P<nome>.+?)\s*-\s*(?P<uf>[A-Za-z]{2})$` and the parens variant) over arbitrary user input from spreadsheet uploads. With crafted input (`"a" + " " * 100_000`) the lazy quantifier `.+?` combined with adjacent `\s*` produced polynomial backtracking — usable for DoS.

This PR replaces the regex with **separator-based parsing** (no backtracking) and adds a **length cap** as second defense.

## Changes

- **`v2/backend/apps/core/services/resolvers.py`**:
  - Add `_MAX_CITY_UF_LEN = 200` module constant.
  - Rewrite `_split_city_uf` using `rpartition` / `rfind` per separator, O(n).
  - Add `_is_uf(value)` helper.
  - Support new separator `,` (was not accepted before — required by spreadsheet variants).
  - Preserve all formats accepted before: `Cidade - UF`, `Cidade/UF`, `Cidade (UF)`, `Cidade`.
  - Handle Unicode hyphens (`–`, `—`).
- **`v2/backend/apps/core/tests/test_pr_security_redos_resolvers.py`** (new):
  - Parametrized format tests (10 cases).
  - DoS-prevention test: 100k spaces input completes in <100ms.
  - Boundary test for `_MAX_CITY_UF_LEN`.
  - `_is_uf` valid/invalid cases.

## Safety

- No models or migrations.
- No endpoints.
- No RBAC change.
- No frontend change.
- Behaviour for valid inputs is preserved.

## Acceptance criteria

| Input | Expected | Result |
|---|---|---|
| `"São Paulo - SP"` | `("São Paulo", "SP")` | ✅ |
| `"São Paulo/SP"` | `("São Paulo", "SP")` | ✅ |
| `"São Paulo (SP)"` | `("São Paulo", "SP")` | ✅ |
| `"São Paulo, SP"` | `("São Paulo", "SP")` | ✅ (new) |
| `"São Paulo"` | `("São Paulo", None)` | ✅ |
| `"a" + " " * 100000` | trimmed, <100ms | ✅ |

## Staging Gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

ALL 8 CHECKS PASSED

Note: change is internal to a parsing helper. Same semantic output for every previously-accepted input; only adds support for `","` and adds a defensive cap. Staging behavior is identical for any non-pathological input.

## Closes (CodeQL alerts)

- #1 — py/polynomial-redos (resolvers.py:134)
- #2 — py/polynomial-redos (resolvers.py:137)