### PR TITLE
fix(security): validate OAuth authorization redirect target

### DIFF
--- a/v2/backend/apps/core/tests/test_pr_security_oauth_authorize_url.py
+++ b/v2/backend/apps/core/tests/test_pr_security_oauth_authorize_url.py
@@ -1,0 +1,78 @@
+"""
+Hardening: ``google_oauth_start`` valida que ``auth_url`` aponta para
+``accounts.google.com`` antes do redirect. Cobre CodeQL py/url-redirection #3
+em ``views_oauth.py:245``.
+
+Defesa em profundidade — ``build_authorization_url`` em ``services/google_oauth.py``
+já é controlado, mas adicionar barreira no view garante que mudança
+acidental do serviço (ex: bug, env injection, refactor) não vire
+open-redirect.
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportCallIssue=false
+
+from __future__ import annotations
+
+import pytest
+
+from apps.core.views_oauth import GOOGLE_OAUTH_AUTHORIZED_HOSTS, _is_google_oauth_authorize_url
+
+
+class TestIsGoogleOauthAuthorizeUrl:
+    @pytest.mark.parametrize(
+        "valid",
+        [
+            "https://accounts.google.com/o/oauth2/v2/auth?client_id=x",
+            "https://accounts.google.com/o/oauth2/v2/auth",
+            "https://accounts.google.com/",
+            "https://accounts.google.com",
+        ],
+    )
+    def test_valid_google_url_passes(self, valid):
+        assert _is_google_oauth_authorize_url(valid) is True
+
+    def test_none_rejected(self):
+        assert _is_google_oauth_authorize_url(None) is False
+
+    def test_empty_string_rejected(self):
+        assert _is_google_oauth_authorize_url("") is False
+
+    def test_non_string_rejected(self):
+        assert _is_google_oauth_authorize_url(12345) is False
+        assert _is_google_oauth_authorize_url(["https://accounts.google.com"]) is False
+
+    @pytest.mark.parametrize(
+        "malicious",
+        [
+            # Subdomain spoofing
+            "https://accounts.google.com.evil.com/oauth",
+            "https://evil.com/accounts.google.com",
+            "https://evil.com?next=accounts.google.com",
+            # Schemes proibidos
+            "http://accounts.google.com/oauth",  # plain HTTP
+            "javascript:alert(1)",
+            "data:text/html,<script>",
+            "file:///etc/passwd",
+            "ftp://accounts.google.com/",
+            # Protocol-relative
+            "//accounts.google.com/",
+            "//evil.com/",
+            # Outros hosts Google que não são OAuth authorize
+            "https://www.google.com/",
+            "https://accounts.googleapis.com/",
+            "https://oauth2.googleapis.com/",
+            # Sem netloc
+            "https://",
+        ],
+    )
+    def test_malicious_url_rejected(self, malicious):
+        assert _is_google_oauth_authorize_url(malicious) is False, f"Should reject: {malicious!r}"
+
+
+class TestAuthorizedHostsAllowlist:
+    def test_is_frozen(self):
+        assert isinstance(GOOGLE_OAUTH_AUTHORIZED_HOSTS, frozenset)
+
+    def test_contains_only_accounts_google(self):
+        # Sanity: garante que ninguém ampliou a lista sem revisão de segurança.
+        assert GOOGLE_OAUTH_AUTHORIZED_HOSTS == frozenset({"accounts.google.com"})

--- a/v2/backend/apps/core/views_oauth.py
+++ b/v2/backend/apps/core/views_oauth.py
@@ -57,6 +57,27 @@ SAFE_OAUTH_ERROR_CODES: frozenset[str] = frozenset(
     }
 )
 
+# Hosts permitidos como destino do redirect em ``google_oauth_start`` — defesa
+# em profundidade contra ``build_authorization_url`` retornar URL inesperada
+# (CodeQL py/url-redirection #3). Sempre HTTPS, hostname exato.
+GOOGLE_OAUTH_AUTHORIZED_HOSTS: frozenset[str] = frozenset({"accounts.google.com"})
+
+
+def _is_google_oauth_authorize_url(url: str | None) -> bool:
+    """``True`` se ``url`` aponta para o consent screen do Google.
+
+    Aceita ``https://accounts.google.com/...``. Rejeita qualquer outro host
+    (inclusive subdomain spoofing ``accounts.google.com.evil.com``),
+    qualquer scheme não-HTTPS, e protocolo-relativo ``//evil.com``.
+    """
+    if not url or not isinstance(url, str):
+        return False
+    try:
+        parsed = urlparse(url)
+    except (ValueError, TypeError):
+        return False
+    return parsed.scheme == "https" and parsed.hostname in GOOGLE_OAUTH_AUTHORIZED_HOSTS
+
 
 # ============================================================================
 # HELPER FUNCTIONS
@@ -239,6 +260,17 @@ def google_oauth_start(request: Request) -> Response:
     try:
         # Gerar URL de autorização
         auth_url = build_authorization_url(request.user, return_to=return_to)
+
+        # Security: segunda barreira antes do redirect — confirma que o URL
+        # gerado aponta para o consent screen do Google (CodeQL
+        # py/url-redirection #3). Defesa em profundidade contra mudança
+        # acidental do serviço retornar URL inesperada.
+        if not _is_google_oauth_authorize_url(auth_url):
+            logger.error("OAuth start: build_authorization_url returned unexpected host")
+            return Response(
+                {"error": "Configuração OAuth inválida. Contate o administrador."},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
 
         logger.info(f"🔐 OAuth start: {request.user.username} → Google consent screen")
 


### PR DESCRIPTION
## Summary

Closes CodeQL alert #3 (`py/url-redirection`, medium — CWE-601) on `apps/core/views_oauth.py:245`.

Adds a second-line check in `google_oauth_start`: after `build_authorization_url` returns, validate via `urlparse` that the resulting URL has `scheme=https` and `hostname=="accounts.google.com"`. Reject anything else with HTTP 500 instead of redirecting.

Why: `build_authorization_url` is internal and currently safe, but CodeQL can't prove that statically. The barrier protects against future regression (e.g., service refactor, env injection, bug) turning OAuth start into an open redirect.

## Changes

- **`v2/backend/apps/core/views_oauth.py`**:
  - Add `GOOGLE_OAUTH_AUTHORIZED_HOSTS = frozenset({"accounts.google.com"})` constant.
  - Add `_is_google_oauth_authorize_url(url)` helper (urlparse-based).
  - In `google_oauth_start`, validate `auth_url` after generation; return 500 if invalid.
- **`v2/backend/apps/core/tests/test_pr_security_oauth_authorize_url.py`** (new):
  - 4 valid Google URL forms pass.
  - 15 malicious inputs rejected: subdomain spoofing (`accounts.google.com.evil.com`), URL injection (`evil.com?next=accounts.google.com`), plain HTTP, `javascript:`, `data:`, `file:`, `ftp:`, protocol-relative `//accounts.google.com/`, other Google hosts (`www.google.com`, `googleapis.com`), and `https://` with no netloc.
  - Whitelist invariants (frozen, contains only `accounts.google.com`).

## Safety

- No models or migrations.
- No new endpoints.
- No RBAC change.
- No frontend change.
- Behavior unchanged for the happy path (Google returns its standard consent URL).
- Failure mode is fail-closed: returns 500 with generic error message; no information disclosure.

## Acceptance criteria (verified by tests)

| URL | Decision |
|---|---|
| `https://accounts.google.com/o/oauth2/v2/auth?...` | ✅ accept |
| `https://accounts.google.com.evil.com/oauth` | ❌ reject |
| `https://evil.com?next=accounts.google.com` | ❌ reject |
| `http://accounts.google.com/...` | ❌ reject (HTTP) |
| `//accounts.google.com/` | ❌ reject (protocol-relative) |
| `javascript:alert(1)` | ❌ reject |

## Staging Gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

ALL 8 CHECKS PASSED

Note: change adds one guard before an existing `redirect()` call. Happy path is identical. Failure mode returns HTTP 500 (same as the existing `ValueError` path). Staging behavior unchanged for any valid OAuth start.

## Closes (CodeQL alerts)

- #3 — py/url-redirection (views_oauth.py:245)