### PR TITLE
chore(security): mark non-security SHA1 usage explicitly

### DIFF
--- a/v2/backend/apps/core/services/controle_imports.py
+++ b/v2/backend/apps/core/services/controle_imports.py
@@ -33,7 +33,16 @@ OUT_DIR.mkdir(parents=True, exist_ok=True)
 
 
 def sha1_str(s: str) -> str:
-    """Gera SHA1 hex digest de uma string."""
+    """Gera SHA1 hex digest de uma string.
+
+    Used for deterministic idempotency key generation (``Compra.external_hash``),
+    not for cryptographic security. The ``usedforsecurity=False`` flag is set
+    per PEP 644 to silence general weak-crypto linters; CodeQL
+    ``py/weak-sensitive-data-hashing`` is also dismissed as false-positive
+    in this context (the input is a composite natural key, not a credential).
+    Trocar para SHA-256 quebraria ``external_hash`` histórico em
+    ``core_compra`` — manter SHA-1 preserva idempotência.
+    """
     return hashlib.sha1(s.encode("utf-8"), usedforsecurity=False).hexdigest()
 
 

--- a/v2/backend/apps/core/services/gcal/utils.py
+++ b/v2/backend/apps/core/services/gcal/utils.py
@@ -145,6 +145,15 @@ def _payload_hash(payload: JsonDict) -> PayloadHash:
     """
     Calcula SHA1 hash determinístico do payload (PR14).
 
+    Used for deterministic idempotency key generation
+    (``Solicitacao.gcal_payload_hash`` — drift detection for GCal events),
+    not for cryptographic security. The ``usedforsecurity=False`` flag is set
+    per PEP 644 to silence general weak-crypto linters; CodeQL
+    ``py/weak-sensitive-data-hashing`` is also dismissed as false-positive in
+    this context (the input is a normalized event payload, not a credential).
+    Trocar para SHA-256 invalidaria todos os ``gcal_payload_hash`` históricos
+    e forçaria re-sync do GCal — manter SHA-1 preserva o contrato de drift.
+
     Exclui ``conferenceData`` do cálculo porque contém metadata
     da API Google (requestId) que não representa dados do evento.
     Fix #573: evita falsos positivos de drift em eventos online.


### PR DESCRIPTION
## Summary

Documents intent for the two SHA-1 usages CodeQL still flags (alerts #20 and #21, `py/weak-sensitive-data-hashing`, high — CWE-327, CWE-328, CWE-916).

Both call sites already pass `usedforsecurity=False` (PEP 644). CodeQL flags them anyway because its dataflow tracker classifies the input as "sensitive data" (`certificate` / `id`) — a false positive in this context.

| # | Path | Purpose | Why SHA-1 stays |
|---|---|---|---|
| 20 | `services/controle_imports.py:37` (`sha1_str`) | `Compra.external_hash` (idempotency key) | Historical `external_hash` in `core_compra` — switching to SHA-256 would break re-import deduplication |
| 21 | `services/gcal/utils.py:161` (`_payload_hash`) | `Solicitacao.gcal_payload_hash` (GCal drift detection) | All historical hashes invalidated → forced re-sync of GCal events |

## Changes

- **`v2/backend/apps/core/services/controle_imports.py`**: extended docstring of `sha1_str` explaining the deterministic-idempotency purpose, the `usedforsecurity=False` flag, and why SHA-256 migration is not chosen here.
- **`v2/backend/apps/core/services/gcal/utils.py`**: extended docstring of `_payload_hash` with the same justification.

No code behavior changes — only comments/docstrings.

## Decision

Per the security-context discussion, **option (a)** was chosen: keep SHA-1 with explicit `usedforsecurity=False`, document the intent, and dismiss CodeQL alerts #20/#21 as false-positive (these inputs are not credentials or certificates; CodeQL's "sensitive data" classifier is wrong for this dataflow).

The two alerts will be dismissed via the GitHub Security UI / API after this PR merges, with reason `won't fix` + comment pointing here.

## Safety

- No models or migrations.
- No endpoints.
- No RBAC change.
- No frontend change.
- No `external_hash` values change.
- No existing data invalidated.
- Idempotency semantics preserved.

## Why not SHA-256 (option b)

`Compra.external_hash` is unique-indexed and used for `update_or_create` in re-imports. Switching the algorithm would:
- regenerate every hash on next run → every existing row gets `external_hash` mismatch;
- force a 2-step migration (dual-read SHA-1+SHA-256 for one release, then sunset) or accept duplicate rows.

Cost is high; benefit is zero because the hash is not protecting credentials.

## Staging Gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

ALL 8 CHECKS PASSED

Note: docs-only change to two function docstrings. No runtime, no migrations, no data. Staging behavior identical.

## Closes (CodeQL alerts — after dismissal)

- #20 — py/weak-sensitive-data-hashing (controle_imports.py:37) — to be dismissed as `false-positive`
- #21 — py/weak-sensitive-data-hashing (gcal/utils.py:161) — to be dismissed as `false-positive`