### PR TITLE
docs(backup): designate BACKUP_OPERATIONS.md as SSOT for backup/DR/SLO

### DIFF
--- a/docs/operations/backup.md
+++ b/docs/operations/backup.md
@@ -2,11 +2,17 @@
 
 Estratégias de backup para o Aprender Sistema v2.
 
+> **SSOT**: parâmetros canônicos (RPO/RTO/retenção/frequência) e procedimentos
+> operacionais ficam em `v2/docs/BACKUP_OPERATIONS.md` (fora do escopo do
+> MkDocs deste site). Este doc é um overview público; para detalhes de operação,
+> sempre consulte o SSOT no repositório. Para procedimentos de recovery, ver
+> `v2/docs/DISASTER_RECOVERY.md` (Docker) ou `v2/docs/GUIDE_DR.md` (VM).
+
 ## Componentes para Backup
 
 | Componente | Frequência | Retenção |
 |------------|------------|----------|
-| PostgreSQL | Diário | 30 dias |
+| PostgreSQL | Diário (ver SSOT) | 7 dias (configurável) |
 | Redis | Não necessário | - |
 | Uploads | Diário | 90 dias |
 | Configurações | Por deploy | Indefinido |
@@ -35,21 +41,10 @@ gunzip -c backup_20250115.sql.gz | docker compose exec -T db psql -U aprender ap
 
 ### Backup Automatizado
 
-```yaml
-# docker-compose.yml
-services:
-  backup:
-    image: prodrigestivill/postgres-backup-local
-    environment:
-      POSTGRES_HOST: db
-      POSTGRES_DB: aprender_db
-      POSTGRES_USER: aprender
-      POSTGRES_PASSWORD: ${DB_PASSWORD}
-      SCHEDULE: "@daily"
-      BACKUP_KEEP_DAYS: 30
-    volumes:
-      - ./backups:/backups
-```
+O AS v2 usa o script `v2/infra/scripts/backup_db.sh` orquestrado por Celery Beat
+(Docker, 2:00 AM) ou cron (VM, 3:00 AM). Para configuração completa de env vars,
+volume `backup_data`, S3 opcional e criptografia age opcional (SEC-017),
+consultar a seção `Configuration` no SSOT `v2/docs/BACKUP_OPERATIONS.md`.
 
 ## Uploads
 

--- a/v2/docs/BACKUP_OPERATIONS.md
+++ b/v2/docs/BACKUP_OPERATIONS.md
@@ -1,19 +1,45 @@
 # Backup Operations Guide — AS v2
 
-**Implemented in**: Issue #169, PR #186
 **Status**: ✅ Production-ready
-**Last Updated**: 2025-11-18
+**Refs**: Issue #169, PR #186, SEC-017 (criptografia opcional)
+**Last Updated**: 2026-05-17
+
+> **SSOT de operações de backup do AS v2.** Outros docs (`DISASTER_RECOVERY.md`,
+> `GUIDE_DR.md`, `SLO_DEFINITIONS.md`, `docs/operations/backup.md`) devem apontar
+> para este arquivo em vez de duplicar parâmetros.
+
+## Parâmetros canônicos (RPO / RTO / Retenção / Frequência)
+
+| Métrica | Valor | Nota |
+|---|---|---|
+| **RPO** (Recovery Point Objective) | **5 minutos** | WAL archiving contínuo (`archive_timeout=300`) |
+| **RTO** (Recovery Time Objective) | **1 hora** | Inclui restore + migrations + smoke; restore puro é tipicamente 10-30 min em base atual |
+| **Retenção padrão** | **7 dias** | Configurável via `BACKUP_RETENTION_DAYS`; S3 pode ter lifecycle policy mais longa |
+| **Frequência** | **1×/dia** | 2:00 AM em Docker (Celery beat) / 3:00 AM em VM (cron) — janela noturna |
+| **Verificação** | Semanal (domingos) | `verify_backup_health` (Docker) ou `verify_backup.sh` (VM) |
 
 ## Overview
 
 The AS v2 backup system provides automated, reliable PostgreSQL backups with:
 
-- **Daily full backups** at 2:00 AM (America/Fortaleza)
-- **Retention policies** (7 days default)
+- **Daily full backups** (parâmetros acima)
 - **S3/MinIO upload** support (optional)
+- **Optional age encryption at rest** (SEC-017, set `BACKUP_AGE_RECIPIENT`)
 - **Automated health checks** (weekly)
 - **Failure alerting** via Sentry
 - **Disaster recovery** with tested restore procedures
+
+## Contextos suportados (mesmo script `backup_db.sh`)
+
+| Contexto | Schedule | Storage | Doc complementar |
+|---|---|---|---|
+| **Docker Compose** (dev/staging/prod-like) | Celery Beat 2:00 AM (`tasks_backup.py`) | volume `backup_data` → `/backups` (+ S3 opcional) | `DISASTER_RECOVERY.md` (cenários de recovery) |
+| **VM de produção** (systemd + PostgreSQL nativo) | Cron 3:00 AM (`/etc/cron.d/aprender-backup`) | `/var/backups/aprender` (+ S3 opcional) | `GUIDE_DR.md` (PITR via WAL) |
+
+Em ambos os contextos, o script `v2/infra/scripts/backup_db.sh` é o **mesmo**;
+muda apenas a chamada (Celery vs cron) e os defaults das env vars
+(`DB_HOST=db` em Docker, `DB_HOST=localhost` em VM; `BACKUP_DIR=/backups` vs
+`/var/backups/aprender`).
 
 ## Architecture
 

--- a/v2/docs/DISASTER_RECOVERY.md
+++ b/v2/docs/DISASTER_RECOVERY.md
@@ -1,29 +1,36 @@
 # Disaster Recovery Runbook
 
-**Data**: 2026-04-06
+**Data**: 2026-05-17 (alinhamento SSOT)
 **Status**: Ativo
 **Referência**: PLAN_maturity_gaps.md (Gap 9)
 **Ambiente**: Docker Compose (dev/staging). Para procedimentos em VM de produção, ver [GUIDE_DR.md](./GUIDE_DR.md).
+
+> **Parâmetros de backup (RPO/RTO/retenção/frequência)** são definidos no SSOT
+> [`BACKUP_OPERATIONS.md`](./BACKUP_OPERATIONS.md#parâmetros-canônicos-rpo--rto--retenção--frequência).
+> Este documento foca em **cenários de recovery** (procedimentos operacionais).
 
 ---
 
 ## 1. Visão Geral
 
-Este documento define os procedimentos de recuperação de desastres para o AS v2.
+Este documento define os procedimentos de recuperação de desastres para o AS v2
+em ambientes Docker Compose. Para a configuração do pipeline de backup (script,
+agendamento, criptografia opcional, S3), consulte o SSOT
+[`BACKUP_OPERATIONS.md`](./BACKUP_OPERATIONS.md).
 
-### 1.1 RTO/RPO
+### 1.1 RTO/RPO (resumo — fonte: SSOT)
 
-| Métrica | Valor | Descrição |
-|---------|-------|-----------|
-| **RPO** (Recovery Point Objective) | 5 minutos | Perda máxima de dados aceitável |
-| **RTO** (Recovery Time Objective) | 1 hora | Tempo máximo para restaurar serviço |
+| Métrica | Valor |
+|---------|-------|
+| **RPO** | 5 minutos (WAL archiving) |
+| **RTO** | 1 hora (restore + migrations + smoke) |
 
-### 1.2 Backups
+### 1.2 Backups (resumo — fonte: SSOT)
 
 | Tipo | Frequência | Retenção | Storage |
 |------|------------|----------|---------|
-| Full dump | Diário (3h) | 30 dias | S3/Local |
-| WAL archiving | Contínuo | 7 dias | S3/Local |
+| Full dump | Diário (2:00 AM Docker / 3:00 AM VM) | 7 dias (configurável `BACKUP_RETENTION_DAYS`) | volume `backup_data` + S3 opcional |
+| WAL archiving | Contínuo (`archive_timeout=300`) | 7 dias | `/var/lib/postgresql/wal_archive/` + S3 opcional |
 | Redis snapshot | Não persistido | - | Memory only |
 
 ---
@@ -154,78 +161,19 @@ docker compose logs -f web | grep gcal
 
 ## 3. Scripts de Backup/Restore
 
-### 3.1 Backup Script
+Scripts canônicos em `v2/infra/scripts/`:
 
-```bash
-#!/bin/bash
-# scripts/backup_db.sh
+- **`backup_db.sh`** — script unificado Docker+VM. Configurável via env vars
+  (`DB_HOST/DB_PORT/DB_USER/DB_NAME/PGPASSWORD`, `BACKUP_DIR`,
+  `BACKUP_RETENTION_DAYS`, `S3_BUCKET`, `BACKUP_AGE_RECIPIENT`). Nomenclatura
+  `backup_full_YYYYMMDD_HHMMSS.sql.gz[.age]`. Retenção via
+  `find -mtime +$BACKUP_RETENTION_DAYS -delete`. **Não duplicar lógica neste doc.**
+- **`restore_db.sh`** — interativo (exige confirmação). Em modo não-interativo,
+  invocar via `docker compose exec -T web /app/infra/scripts/restore_db.sh <file>`.
 
-set -e
-
-TIMESTAMP=$(date +%Y%m%d_%H%M%S)
-BACKUP_DIR="${BACKUP_DIR:-/backups}"
-BACKUP_FILE="${BACKUP_DIR}/backup_full_${TIMESTAMP}.sql.gz"
-
-# Criar diretório se não existir
-mkdir -p "$BACKUP_DIR"
-
-# Dump com pg_dump
-docker compose exec -T db pg_dump -U aprender_user aprender_db | gzip > "$BACKUP_FILE"
-
-# Verificar tamanho mínimo (proteção contra backup vazio)
-SIZE=$(stat -f%z "$BACKUP_FILE" 2>/dev/null || stat -c%s "$BACKUP_FILE")
-if [ "$SIZE" -lt 1000 ]; then
-    echo "ERROR: Backup suspeitamente pequeno ($SIZE bytes)"
-    rm "$BACKUP_FILE"
-    exit 1
-fi
-
-echo "Backup criado: $BACKUP_FILE ($SIZE bytes)"
-
-# Limpar backups antigos (manter últimos 30)
-ls -t "$BACKUP_DIR"/backup_full_*.sql.gz | tail -n +31 | xargs -r rm
-
-# Upload para S3 (opcional)
-if [ -n "$S3_BUCKET" ]; then
-    aws s3 cp "$BACKUP_FILE" "s3://${S3_BUCKET}/backups/"
-fi
-```
-
-### 3.2 Restore Script
-
-```bash
-#!/bin/bash
-# scripts/restore_db.sh
-
-set -e
-
-BACKUP_FILE="${1:?Uso: restore_db.sh <arquivo.sql.gz>}"
-
-if [ ! -f "$BACKUP_FILE" ]; then
-    echo "ERROR: Arquivo não encontrado: $BACKUP_FILE"
-    exit 1
-fi
-
-echo "⚠️  ATENÇÃO: Isso irá SUBSTITUIR todo o banco de dados!"
-echo "Backup: $BACKUP_FILE"
-read -p "Continuar? (yes/no): " CONFIRM
-
-if [ "$CONFIRM" != "yes" ]; then
-    echo "Abortado."
-    exit 0
-fi
-
-# Parar aplicação
-echo "Parando aplicação..."
-docker compose stop web celery
-
-# Restaurar banco
-echo "Restaurando banco..."
-gunzip -c "$BACKUP_FILE" | docker compose exec -T db psql -U aprender_user -d aprender_db
-
-echo "Restauração completa!"
-echo "Reinicie a aplicação com: docker compose up -d"
-```
+Para detalhes completos (variáveis, S3 setup, criptografia age opcional —
+SEC-017), consultar [`BACKUP_OPERATIONS.md`](./BACKUP_OPERATIONS.md). Os exemplos
+operacionais nas seções 2.1-2.4 acima referenciam esses scripts.
 
 ---
 

--- a/v2/docs/GUIDE_DR.md
+++ b/v2/docs/GUIDE_DR.md
@@ -2,14 +2,19 @@
 
 **Ambiente**: VM de produção (systemd + PostgreSQL nativo). Para Docker Compose, ver [DISASTER_RECOVERY.md](./DISASTER_RECOVERY.md).
 
+> **Parâmetros canônicos** (RPO/RTO/retenção/frequência) vêm do SSOT
+> [`BACKUP_OPERATIONS.md`](./BACKUP_OPERATIONS.md#parâmetros-canônicos-rpo--rto--retenção--frequência).
+> Este documento foca em **PITR via WAL archiving** e procedimentos específicos
+> de VM (systemd, cron, restore PostgreSQL nativo).
+
 ## Visão Geral
 
 | Métrica | Valor |
 |---------|-------|
-| **RPO** (Recovery Point Objective) | 5 minutos |
+| **RPO** (Recovery Point Objective) | 5 minutos (WAL archiving) |
 | **RTO** (Recovery Time Objective) | 1 hora |
-| **Retenção** | 7 dias |
-| **Frequência** | Diário às 3h |
+| **Retenção** | 7 dias (configurável via `BACKUP_RETENTION_DAYS`) |
+| **Frequência** | Diário às 3h (cron VM); 2h em Docker — ver SSOT |
 
 ## Arquitetura de Backup
 

--- a/v2/docs/SLO_DEFINITIONS.md
+++ b/v2/docs/SLO_DEFINITIONS.md
@@ -111,9 +111,12 @@ Error Budget (horas/mês) = (100 - SLO%) × 720 / 100
 
 | Dado | RPO | RTO | Backup |
 |------|-----|-----|--------|
-| Banco de Dados | 5 min | 1 hora | WAL + Daily dump |
+| Banco de Dados | 5 min | 1 hora | WAL + Daily dump — ver SSOT [`BACKUP_OPERATIONS.md`](./BACKUP_OPERATIONS.md) |
 | Redis (cache) | N/A | 5 min | Não persistido |
 | Google Calendar | 0 | 24 horas | Resync automático |
+
+> Para detalhes de backup (frequência, retenção, criptografia opcional, S3,
+> health checks) consultar o SSOT [`BACKUP_OPERATIONS.md`](./BACKUP_OPERATIONS.md).
 
 ### 6.2 Consistência
 


### PR DESCRIPTION
## Resumo

Audit `phase-01-07-fix-plan-verification.md` (P3 item 4.1) já marcava que os docs de backup/DR/SLO estavam divergentes e a tarefa de unificar estava **não iniciada** desde 2026-02-05. Verificação manual confirmou divergências reais e potencialmente perigosas em incidente:

| Doc | RTO | Retenção | Frequência | Notas |
|---|---|---|---|---|
| BACKUP_OPERATIONS | **10-30 min** | 7 dias | 2h | Mais alinhado ao código atual |
| GUIDE_DR | 1 hora | 7 dias | 3h | VM-específico |
| DISASTER_RECOVERY | 1 hora | **30 dias** (script inline) | 3h | Script INLINE diverge do real (\`stat -f%z\`, \`ls\|tail -n +31\|xargs rm\`) |
| SLO_DEFINITIONS | 1 hora | — | — | Só SLO |
| docs/operations/backup.md | — | **30 dias** | @daily | Cita \`prodrigestivill/postgres-backup-local\` que **não existe no projeto** |

Adicionalmente, nenhum doc mencionava a **criptografia age opcional (SEC-017)** que já existe no \`backup_db.sh\` via \`BACKUP_AGE_RECIPIENT\`.

## Solução

**BACKUP_OPERATIONS.md vira SSOT canônico** com parâmetros unificados:

| Métrica | Valor |
|---|---|
| RPO | 5 min (WAL archiving) |
| RTO | 1 hora (restore + migrations + smoke) |
| Retenção | 7 dias (configurável via \`BACKUP_RETENTION_DAYS\`) |
| Frequência | Diário — 2h Docker (Celery beat) / 3h VM (cron) |
| Contextos | Mesmo script \`backup_db.sh\` para Docker + VM |

Demais docs (DISASTER_RECOVERY, GUIDE_DR, SLO_DEFINITIONS, docs/operations/backup.md) agora **apontam para o SSOT** em vez de duplicar parâmetros divergentes.

Mudanças adicionais:

- **DISASTER_RECOVERY**: removido o script bash INLINE divergente (retia 30 dias, usava \`stat -f%z\`, não tinha criptografia age) — substituído por referência ao \`backup_db.sh\` real
- **docs/operations/backup.md**: removida config docker-compose com \`prodrigestivill/postgres-backup-local\` (image 3rd-party que não existe no projeto)

## Checklist Tecnico (Code Review Expert - Slim)

- [x] Arquitetura e SOLID: estabelece SSOT explícito; doc duplicado vira "view" do SSOT
- [x] Seguranca: documenta criptografia age (SEC-017) que estava implementada mas não documentada
- [x] Performance: N/A (só doc)
- [x] Tratamento de erros: instruções operacionais não conflitam mais entre docs (segurança operacional em incidente)
- [x] Condicoes de fronteira: ambos contextos (Docker + VM) explicitamente cobertos no SSOT

## Workflow (Superpowers - Parcial)

- [x] Escopo definido em ate 5 passos objetivos antes da implementacao
- [x] Testes criados/ajustados — N/A (só doc)
- [x] Evidencias anexadas: comparativo lado-a-lado das 5 divergências (acima)

## Staging Gate

Este PR **não** altera runtime (somente \`.md\`). Staging gate não se aplica.

## Validacoes

- [x] Sem alteracoes fora do escopo combinado
- [ ] Markdown lint pré-existente nos arquivos (warnings MD031/MD032/MD040 já existiam antes — não introduzi novos)

## Refs

- Phase 01-07 fix plan, item 4.1 (não iniciado desde 2026-02-05)
- SEC-017 (criptografia age — agora documentada no SSOT)