### PR TITLE
refactor(rd): use TextChoices enum for Solicitacao/AvailabilityBlock status

### DIFF
--- a/v2/backend/apps/core/models/agenda.py
+++ b/v2/backend/apps/core/models/agenda.py
@@ -32,11 +32,18 @@ class AvailabilityBlock(models.Model):
         ("P", "Parcial"),
     ]
 
-    STATUS_CHOICES = [
-        ("pendente", "Pendente"),
-        ("aprovado", "Aprovado"),
-        ("reprovado", "Reprovado"),
-    ]
+    class Status(models.TextChoices):
+        """Status do bloqueio (segue PA-01..PA-07).
+
+        Use AvailabilityBlock.Status.APROVADO em vez de literal "aprovado"
+        em codigo novo. Refs: audit 2026-05 finding B3.
+        """
+
+        PENDENTE = "pendente", "Pendente"
+        APROVADO = "aprovado", "Aprovado"
+        REPROVADO = "reprovado", "Reprovado"
+
+    STATUS_CHOICES = Status.choices
 
     usuario = models.ForeignKey(  # type: ignore[misc]
         "core.Usuario", on_delete=models.PROTECT, related_name="availability_blocks"

--- a/v2/backend/apps/core/models/solicitacao.py
+++ b/v2/backend/apps/core/models/solicitacao.py
@@ -29,11 +29,19 @@ class Solicitacao(models.Model):
     RD-06: Armazena UTC, compara em America/Fortaleza.
     """
 
-    STATUS_CHOICES = [
-        ("pendente", "Pendente"),
-        ("aprovado", "Aprovado"),
-        ("reprovado", "Reprovado"),
-    ]
+    class Status(models.TextChoices):
+        """Status do fluxo de aprovacao (PA-01..PA-07).
+
+        Use Solicitacao.Status.APROVADO em vez de literal "aprovado" em
+        codigo novo. Valores preservados (zero migration de dados).
+        Refs: audit 2026-05 finding B3.
+        """
+
+        PENDENTE = "pendente", "Pendente"
+        APROVADO = "aprovado", "Aprovado"
+        REPROVADO = "reprovado", "Reprovado"
+
+    STATUS_CHOICES = Status.choices
 
     class GCalStatus(models.TextChoices):
         """Status de sincronizacao com Google Calendar."""

--- a/v2/backend/apps/core/services/availability_service.py
+++ b/v2/backend/apps/core/services/availability_service.py
@@ -151,14 +151,14 @@ def check_conflicts(
     )
 
     conflicts: list[Conflict] = []
-    events_qs = Solicitacao.objects.filter(status="aprovado").filter(
+    events_qs = Solicitacao.objects.filter(status=Solicitacao.Status.APROVADO).filter(
         Q(usuario=usuario) | Q(participations__usuario=usuario)
     )
 
     # ================================================================
     # RD-02, RD-03: BLOQUEIOS aprovados
     # ================================================================
-    blocks = AvailabilityBlock.objects.filter(usuario=usuario, status="aprovado").filter(
+    blocks = AvailabilityBlock.objects.filter(usuario=usuario, status=AvailabilityBlock.Status.APROVADO).filter(
         Q(inicio__lt=fim) & Q(fim__gt=inicio)  # Interseção
     )
 


### PR DESCRIPTION
## Resumo

Audit `PLATFORM_HARDCODED_RULES_AUDIT_2026-05.md` apontou achado **B3 (P1)**: `filter(status="aprovado")` hardcoded em hot path RD-01..08 (`availability_service.py:154,161`). Renomear o valor "aprovado" no model quebraria silenciosamente as queries.

## Mudanças

### 1. `apps/core/models/solicitacao.py` — `STATUS_CHOICES` → `class Status(TextChoices)`

```python
class Status(models.TextChoices):
    PENDENTE = "pendente", "Pendente"
    APROVADO = "aprovado", "Aprovado"
    REPROVADO = "reprovado", "Reprovado"

STATUS_CHOICES = Status.choices  # alias para retrocompat (forms etc.)
```

Audit cita "Solicitacao.Status.APROVADO (TextChoices) onde já existe" — mas existia só como tuple legacy. PR promove para o mesmo padrão de `GCalStatus` (já TextChoices no mesmo model).

### 2. `apps/core/models/agenda.py` (`AvailabilityBlock`) — mesma promoção

Audit cita ambas as linhas (`Solicitacao` na 154, `AvailabilityBlock` na 161). Faz sentido alinhar os 2 models com TextChoices simultaneamente.

### 3. `apps/core/services/availability_service.py` — 2 literais trocados

```python
# Antes
events_qs = Solicitacao.objects.filter(status="aprovado").filter(...)
blocks = AvailabilityBlock.objects.filter(usuario=usuario, status="aprovado").filter(...)

# Depois
events_qs = Solicitacao.objects.filter(status=Solicitacao.Status.APROVADO).filter(...)
blocks = AvailabilityBlock.objects.filter(usuario=usuario, status=AvailabilityBlock.Status.APROVADO).filter(...)
```

## Compatibilidade

- **Zero migration de dados**: valor armazenado no banco continua `"aprovado"` (TextChoices preserva).
- **Zero breakage em consumers**: outros lugares que comparam contra string literal (`status == "aprovado"`, `filter(status="aprovado")`) continuam funcionando porque `Status.APROVADO.value == "aprovado"`.
- **`STATUS_CHOICES` retrocompat**: agora é alias para `Status.choices`; forms e admin continuam usando.

## Checklist Tecnico (Code Review Expert - Slim)

- [x] Arquitetura e SOLID: alinha com padrão já existente (`GCalStatus` TextChoices em Solicitacao); SSOT no model
- [x] Seguranca: refactor preventivo; sem mudança comportamental
- [x] Performance: sem impacto (enum constante)
- [x] Tratamento de erros: queries idênticas em runtime
- [x] Condicoes de fronteira: STATUS_CHOICES alias preserva forms/admin

## Workflow (Superpowers - Parcial)

- [x] Escopo definido em ate 5 passos objetivos antes da implementacao
- [x] Testes criados/ajustados — N/A neste PR (tests existentes comparam contra `"aprovado"` literal que continua válido)
- [x] Evidencias anexadas: 3 arquivos alterados, +27/-12

## Staging Gate

Validação local executada na branch `refactor/rd-status-enum` sobre baseline main `e9d3682` (pós #1351).

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

```
==============================================
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS
ALL 8 CHECKS PASSED
==============================================
```
## Validacoes

- [x] `make staging-full` (8/8 PASS) — pendente, draft
- [x] Sem alteracoes fora do escopo combinado

## Refs

- Audit: `v2/docs/audits/PLATFORM_HARDCODED_RULES_AUDIT_2026-05.md` — finding B3 (P1)
