### PR TITLE
refactor(gcal): extract GCAL_EVENT_ID_PREFIX and GCAL_REQUEST_ID_PREFIX constants

### DIFF
--- a/v2/backend/apps/core/services/gcal/payload.py
+++ b/v2/backend/apps/core/services/gcal/payload.py
@@ -17,7 +17,7 @@ from apps.core.models import Solicitacao
 from apps.core.types import JsonDict, PayloadHash
 
 from .utils import _payload_hash
-from .validation import _event_id_for
+from .validation import GCAL_EVENT_ID_PREFIX, _event_id_for, _request_id_for
 
 logger = logging.getLogger(__name__)
 
@@ -229,7 +229,7 @@ def _build_payload(s: Solicitacao, *, enable_meet: bool = False) -> JsonDict:
     if enable_meet:
         # requestId determinístico para idempotência (fix #573: era uuid4 aleatório)
         # Google usa requestId para deduplicar createRequest — mesmo ID = mesmo Meet link
-        request_id = f"meet-asv2-{s.id}"
+        request_id = _request_id_for(s)
         conference_data = {
             "createRequest": {
                 "requestId": request_id,
@@ -308,7 +308,7 @@ def build_preview_for_solicitacao(s: Solicitacao) -> JsonDict:
     # Gerar meet_link fake para preview (não persiste) apenas quando online
     meet_link_preview = None
     if enable_meet:
-        # Extrai número do event_id (formato: asv2-{id})
+        # Extrai número do event_id (formato: {GCAL_EVENT_ID_PREFIX}-{id})
         event_num = event_id.split("-")[-1] if "-" in event_id else event_id
         meet_link_preview = f"https://meet.google.com/fake-{event_num}"
 

--- a/v2/backend/apps/core/services/gcal/validation.py
+++ b/v2/backend/apps/core/services/gcal/validation.py
@@ -13,6 +13,14 @@ import re
 from apps.core.models import Solicitacao
 from apps.core.types import EventId
 
+# Prefixos canonicos dos identificadores GCal.
+# Sao contrato com Google (eventId determinstico — ADR-008) e devem ser estaveis
+# entre client real e fake (audit 2026-05 finding B2). Mudanca aqui propaga para
+# todos os call sites e quebra idempotencia retroativa: nao alterar sem migration
+# explicita dos eventos ja publicados.
+GCAL_EVENT_ID_PREFIX: str = "asv2"
+GCAL_REQUEST_ID_PREFIX: str = "meet-asv2"
+
 
 def _validate_event_id(event_id: EventId) -> bool:
     """
@@ -52,7 +60,7 @@ def _event_id_for(s: Solicitacao) -> EventId:
     """
     Gera eventId determinístico para uma Solicitacao.
 
-    Format: asv2-{id}
+    Format: ``{GCAL_EVENT_ID_PREFIX}-{id}`` (ex: ``asv2-123``)
 
     Args:
         s: Solicitacao
@@ -63,9 +71,28 @@ def _event_id_for(s: Solicitacao) -> EventId:
     Raises:
         ValueError: Se ID gerado for inválido
     """
-    event_id = f"asv2-{s.id}"
+    event_id = f"{GCAL_EVENT_ID_PREFIX}-{s.id}"
 
     # Validar antes de retornar
     _validate_event_id(event_id)
 
     return event_id
+
+
+def _request_id_for(s: Solicitacao) -> str:
+    """
+    Gera requestId determinístico para criacao de Google Meet (ADR-008).
+
+    Google usa requestId para deduplicar createRequest — mesmo ID = mesmo Meet
+    link. Distinto de ``_event_id_for`` (event_id vs request_id sao IDs
+    separados, com prefixos diferentes para deixar a relacao explicita).
+
+    Format: ``{GCAL_REQUEST_ID_PREFIX}-{id}`` (ex: ``meet-asv2-123``)
+
+    Args:
+        s: Solicitacao
+
+    Returns:
+        str: Request ID determinístico (ex: meet-asv2-123)
+    """
+    return f"{GCAL_REQUEST_ID_PREFIX}-{s.id}"

--- a/v2/backend/apps/core/views_gcal/detail.py
+++ b/v2/backend/apps/core/views_gcal/detail.py
@@ -31,6 +31,7 @@ from apps.core.serializers.gcal_dashboard_contract import (
     PaginatedSolicitacaoResponseSerializer,
 )
 from apps.core.services.gcal import compute_payload_hash
+from apps.core.services.gcal.validation import _event_id_for
 from apps.core.views_gcal.helpers import DashboardEventsPagination, _filter_events_queryset
 
 
@@ -302,7 +303,7 @@ class GCalDriftView(APIView):
                         "projeto": s.projeto.nome if s.projeto else "",
                         "stored_hash": s.gcal_payload_hash,
                         "current_hash": current_hash,
-                        "external_event_id": s.external_event_id or f"asv2-{s.id}",
+                        "external_event_id": s.external_event_id or _event_id_for(s),
                     }
                 )
 


### PR DESCRIPTION
## Resumo

Audit `PLATFORM_HARDCODED_RULES_AUDIT_2026-05.md` apontou achado **B2 (P1)**: prefixos `asv2-` (event_id) e `meet-asv2-` (request_id, [ADR-008](docs/architecture/project-decisions/ADR-008-gcal-deterministic-requestid.md)) hardcoded em 4 lugares de produção. Risco: divergência entre client real (Google) e fake (dev) quebra idempotência retroativa do Google Calendar.

## Mudanças

### 1. `apps/core/services/gcal/validation.py` — novas constantes + helper

```python
GCAL_EVENT_ID_PREFIX: str = "asv2"
GCAL_REQUEST_ID_PREFIX: str = "meet-asv2"

def _event_id_for(s: Solicitacao) -> EventId:
    event_id = f"{GCAL_EVENT_ID_PREFIX}-{s.id}"
    _validate_event_id(event_id)
    return event_id

def _request_id_for(s: Solicitacao) -> str:
    return f"{GCAL_REQUEST_ID_PREFIX}-{s.id}"
```

### 2. `apps/core/services/gcal/payload.py` — usa helper em vez de literal

```python
from .validation import GCAL_EVENT_ID_PREFIX, _event_id_for, _request_id_for
request_id = _request_id_for(s)
```

### 3. `apps/core/views_gcal/detail.py` — usa `_event_id_for` no fallback

```python
"external_event_id": s.external_event_id or _event_id_for(s),
```

## Cobertura

Grep confirma zero literais `f"asv2-` ou `f"meet-asv2-` restantes em código de produção.

- Valor final preservado: continua exatamente `asv2-{id}` / `meet-asv2-{id}`.
- Tests preservados: fixtures com literais `"asv2-..."` continuam válidos.

## Staging Gate

PR mexe em runtime (services/views GCal). Validação local executada na branch `refactor/gcal-id-prefix-constants` (commit `4ff28fb`) sobre baseline main `379cabc`.

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

```
==============================================
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS
ALL 8 CHECKS PASSED
==============================================
```

## Checklist Técnico

- [x] Arquitetura e SOLID: constantes + helpers no módulo validation.py
- [x] Segurança: idempotência GCal garantida por construção
- [x] Performance: sem impacto (constantes em tempo de compilação)
- [x] Tratamento de erros: docstring explícita sobre estabilidade da constante
- [x] Condições de fronteira: docstring de aviso no topo do módulo
- [x] Sem alterações fora do escopo combinado

## Refs

- Audit: `v2/docs/audits/PLATFORM_HARDCODED_RULES_AUDIT_2026-05.md` — finding B2 (P1)
- ADR-008: RequestId determinístico GCal
