### PR TITLE
fix(frontend): adapt import endpoint response shape in postMultipart

### DIFF
--- a/v2/frontend/src/api/__tests__/ops.normalizeImportResponse.test.ts
+++ b/v2/frontend/src/api/__tests__/ops.normalizeImportResponse.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Tests for `normalizeImportResponse` in api/ops.ts.
+ *
+ * Backend importers return different shapes (stats/pendencias variants).
+ * The adapter must reshape them into the canonical `ImportResult` so the
+ * page-level helpers (`toValidationResult`, `toApplyResult`) keep working
+ * without page-by-page changes.
+ *
+ * Reproduces the production crash:
+ *   "Cannot read properties of undefined (reading 'map')"
+ * which was triggered when the page did `result.errors.map(...)` on a raw
+ * `{stats, pendencias, dry_run, file}` payload from the backend.
+ */
+
+import { describe, expect, test } from 'vitest';
+import { __testing } from '../ops';
+
+const { normalizeImportResponse } = __testing;
+
+describe('normalizeImportResponse — bug fix #DAT-imports response shape', () => {
+  test('handles bloqueios shape: stats.skipped object + pendencias categories', () => {
+    const raw = {
+      stats: {
+        created: 66,
+        updated: 0,
+        unchanged: 2,
+        skipped: { usuario: 0, dates: 0, other: 0 },
+      },
+      pendencias: { usuarios: [], dates: [], outros: [] },
+      dry_run: true,
+      file: '/tmp/x.xlsx',
+    };
+    const r = normalizeImportResponse(raw);
+    expect(r.created).toBe(66);
+    expect(r.updated).toBe(0);
+    expect(r.skipped).toBe(2); // unchanged + sum(skipped categories)
+    expect(r.errors).toEqual([]);
+    expect(r.warnings).toEqual([]);
+  });
+
+  test('handles compras shape: stats.skipped number + pendencias categories', () => {
+    const raw = {
+      stats: { created: 1884, updated: 0, skipped: 105, errors: 0 },
+      pendencias: { municipios: [], projetos: [], linhas_invalidas: [] },
+      dry_run: true,
+      file: '/tmp/c.csv',
+    };
+    const r = normalizeImportResponse(raw);
+    expect(r.created).toBe(1884);
+    expect(r.skipped).toBe(105);
+    expect(r.errors).toEqual([]);
+  });
+
+  test('handles eventos shape: nested stats.solicitacoes', () => {
+    const raw = {
+      stats: {
+        solicitacoes: { created: 2081, updated: 0, unchanged: 113 },
+        participations: { created: 4996, updated: 29 },
+        skipped: {
+          municipio: 0,
+          projeto: 0,
+          tipo_evento: 0,
+          coordenador: 212,
+          dates: 17,
+          other: 0,
+        },
+      },
+      pendencias: {
+        municipios: [],
+        projetos: [],
+        tipos_evento: [],
+        usuarios: [],
+        dates: [],
+        outros: [],
+      },
+      dry_run: true,
+      file: '/tmp/e.xlsx',
+    };
+    const r = normalizeImportResponse(raw);
+    expect(r.created).toBe(2081); // from solicitacoes (not participations)
+    expect(r.updated).toBe(0);
+    expect(r.skipped).toBe(113 + 212 + 17); // unchanged + skipped categories
+  });
+
+  test('flattens pendencias dict-of-arrays into errors[]', () => {
+    const raw = {
+      stats: { created: 0, updated: 0, skipped: { usuario: 2 } },
+      pendencias: {
+        usuarios: [
+          { linha: 5, nome: 'X', erro: 'usuario não encontrado' },
+          { linha: 7, erro: 'cpf inválido' },
+        ],
+      },
+    };
+    const r = normalizeImportResponse(raw);
+    expect(r.errors).toHaveLength(2);
+    expect(r.errors[0]).toEqual({ row: 5, message: '[usuarios] usuario não encontrado — X' });
+    expect(r.errors[1]).toEqual({ row: 7, message: '[usuarios] cpf inválido' });
+  });
+
+  test('accepts legacy/flat shape (pass-through)', () => {
+    const raw = {
+      created: 10,
+      updated: 5,
+      skipped: 2,
+      errors: [{ row: 3, message: 'oops' }],
+      warnings: ['be careful'],
+    };
+    const r = normalizeImportResponse(raw);
+    expect(r.created).toBe(10);
+    expect(r.skipped).toBe(2);
+    expect(r.errors).toEqual([{ row: 3, message: 'oops' }]);
+    expect(r.warnings).toEqual(['be careful']);
+  });
+
+  test('returns safe zeros for null/undefined/non-object input', () => {
+    expect(normalizeImportResponse(null)).toEqual({
+      created: 0,
+      updated: 0,
+      skipped: 0,
+      errors: [],
+      warnings: [],
+    });
+    expect(normalizeImportResponse(undefined)).toEqual({
+      created: 0,
+      updated: 0,
+      skipped: 0,
+      errors: [],
+      warnings: [],
+    });
+    expect(normalizeImportResponse('not an object')).toMatchObject({
+      created: 0,
+      errors: [],
+    });
+  });
+
+  test('regression: result.errors is always an array (defeats .map of undefined)', () => {
+    // The original crash: `result.errors.map(...)` when backend returns
+    // {stats, pendencias} without `errors`. The adapter must always set errors[].
+    const minimal = { stats: { created: 1 } };
+    const r = normalizeImportResponse(minimal);
+    expect(Array.isArray(r.errors)).toBe(true);
+    // .map must work
+    expect(r.errors.map((e) => e.message)).toEqual([]);
+  });
+
+  test('handles row number from alternative key (linha_num for municipios)', () => {
+    const raw = {
+      stats: { created: 0, updated: 0, skipped: { municipios: 1 } },
+      pendencias: {
+        municipios: [{ linha_num: 12, erro: 'Nome ausente' }],
+      },
+    };
+    const r = normalizeImportResponse(raw);
+    expect(r.errors[0].row).toBe(12);
+    expect(r.errors[0].message).toContain('Nome ausente');
+  });
+});

--- a/v2/frontend/src/api/ops.ts
+++ b/v2/frontend/src/api/ops.ts
@@ -121,8 +121,107 @@ async function postMultipart(url: string, file: File, dryRun: boolean = true): P
     throw new Error(error.detail || `HTTP ${response.status}: ${response.statusText}`);
   }
 
-  return response.json();
+  const raw: unknown = await response.json();
+  return normalizeImportResponse(raw);
 }
+
+/**
+ * Adapt backend `{stats, pendencias, dry_run, file}` shape to `ImportResult`.
+ *
+ * Backend service responses are not uniform across importers, so the raw JSON
+ * must be reshaped before the page-level adapters (`toValidationResult` /
+ * `toApplyResult`) can read it as `{created, updated, skipped, errors}`.
+ *
+ * Variants seen in production:
+ *   - bloqueios / usuarios / municipios / colecoes / produtos / equipe_gerencia /
+ *     acoes / deslocamentos / cadastros:
+ *       stats = { created, updated, unchanged, skipped: {cat1: N, cat2: N, ...} }
+ *       pendencias = { cat1: [{linha, erro, ...}], ... }
+ *   - compras (controle_imports):
+ *       stats = { created, updated, skipped: N, errors: N }
+ *       pendencias = { municipios: [...], projetos: [...], linhas_invalidas: [...] }
+ *   - eventos (eventos_import):
+ *       stats = { solicitacoes: {created, updated, unchanged}, participations: {...}, skipped: {...} }
+ *       pendencias = { ... }
+ *
+ * The adapter also accepts already-flat payloads (`{created, updated, errors}`)
+ * so future endpoints conforming to ImportResult directly keep working.
+ */
+function normalizeImportResponse(raw: unknown): ImportResult {
+  if (!raw || typeof raw !== 'object') {
+    return { created: 0, updated: 0, skipped: 0, errors: [], warnings: [] };
+  }
+  const r = raw as Record<string, unknown>;
+
+  const toNum = (v: unknown): number => {
+    const n = Number(v);
+    return Number.isFinite(n) ? n : 0;
+  };
+
+  // Pass-through if response already matches the ImportResult contract
+  if (Array.isArray(r.errors) && typeof r.created !== 'undefined') {
+    return {
+      created: toNum(r.created),
+      updated: toNum(r.updated),
+      skipped: toNum(r.skipped),
+      errors: r.errors as Array<{ row: number; message: string }>,
+      warnings: Array.isArray(r.warnings) ? (r.warnings as string[]) : [],
+    };
+  }
+
+  const stats = (r.stats ?? {}) as Record<string, unknown>;
+
+  // eventos returns stats.solicitacoes = {created, updated, unchanged}
+  const nested = stats.solicitacoes;
+  const baseStats =
+    nested && typeof nested === 'object'
+      ? (nested as Record<string, unknown>)
+      : stats;
+
+  // stats.skipped may be a number (compras) or an object keyed by skip reason
+  let skippedTotal = 0;
+  const sk = stats.skipped;
+  if (typeof sk === 'number') {
+    skippedTotal = sk;
+  } else if (sk && typeof sk === 'object') {
+    for (const v of Object.values(sk as Record<string, unknown>)) {
+      skippedTotal += toNum(v);
+    }
+  }
+  // `unchanged` rows are also "non-mutating" — surface them in the same bucket
+  // so the page label "registros não alterados" reflects everything that
+  // didn't create or update.
+  skippedTotal += toNum(baseStats.unchanged);
+
+  // Flatten pendencias dict-of-arrays into errors[]
+  const pendencias = (r.pendencias ?? {}) as Record<string, unknown>;
+  const errors: Array<{ row: number; message: string }> = [];
+  for (const [cat, items] of Object.entries(pendencias)) {
+    if (!Array.isArray(items)) continue;
+    for (const e of items) {
+      if (typeof e !== 'object' || e === null) continue;
+      const item = e as Record<string, unknown>;
+      const rowNum = toNum(item.linha ?? item.linha_num ?? item.row);
+      const detail = [item.erro, item.nome, item.message]
+        .filter((x): x is string => typeof x === 'string' && x.length > 0)
+        .join(' — ');
+      errors.push({
+        row: rowNum,
+        message: detail ? `[${cat}] ${detail}` : `[${cat}]`,
+      });
+    }
+  }
+
+  return {
+    created: toNum(baseStats.created),
+    updated: toNum(baseStats.updated),
+    skipped: skippedTotal,
+    errors,
+    warnings: [],
+  };
+}
+
+export const __testing = { normalizeImportResponse };
 
 /**
  * Importa COMPRAS de CSV/XLSX.


### PR DESCRIPTION
## Summary

Fixes the `Cannot read properties of undefined (reading 'map')` crash that hit any user trying to import via `/dat/importacoes` or `/admin-dat/usuarios` — affects **dev and production**.

Adds `normalizeImportResponse(raw)` inside `postMultipart` (`v2/frontend/src/api/ops.ts`) to reshape the backend's `{stats, pendencias, dry_run, file}` payload into the canonical `ImportResult` contract the pages already consume.

## Root cause

- Backend importers return: `{ stats: {...}, pendencias: {...}, dry_run, file }`.
- Frontend `ImportResult` interface declares: `{ created, updated, skipped, errors[], warnings[] }`.
- `postMultipart` did a raw `response.json()` with no adapter.
- Page-level helpers `toValidationResult` / `toApplyResult` then ran `result.errors.map(...)` on `undefined` → crash.

Verified live: HTTP 200 from backend, JS crash on frontend. Same pattern in `ImportacoesPage.tsx:57` and `UsuariosPage.tsx:59`.

## What the adapter handles

| Importer | Backend shape | Adapter output |
|---|---|---|
| bloqueios / usuarios / municipios / colecoes / produtos / equipe_gerencia / acoes / deslocamentos / cadastros | `stats.skipped` is an object keyed by reason; `pendencias` is dict-of-arrays | flattened |
| compras (controle_imports) | `stats.skipped` is already a number | preserved |
| eventos | nested `stats.solicitacoes = {created, updated, unchanged}` | unwrapped |
| any future endpoint already conforming to `ImportResult` | (defensive) | pass-through |

Per-row `errors[]` is built from `pendencias` by flattening each category into entries like `{ row, message: "[categoria] erro — nome" }`. Row number reads from `linha`, `linha_num`, or `row` (all variants seen in services).

## Files

- `v2/frontend/src/api/ops.ts` — adapter + minor type imports.
- `v2/frontend/src/api/__tests__/ops.normalizeImportResponse.test.ts` — 8 unit tests covering each shape, regression (errors[] always defined), and edge cases.

## Tests local

- 8/8 new adapter tests pass.
- 78/78 tests pass in `src/api/__tests__/`, `src/pages/DAT/`, `src/pages/AdminDAT/`.
- `tsc --noEmit` clean.

## Staging Gate

Validação local executada na branch `fix/dat-imports-response-adapter` sobre baseline main `3ec72ad`.

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

```
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS
ALL 8 CHECKS PASSED
```

## Test plan

- [x] CI verde
- [x] Subir `bloqueios.xlsx` em `/dat/importacoes` no dev → ver tabela de resultado sem crash
- [x] Subir `usuarios.csv` em `/admin-dat/usuarios` no dev → ver tabela de resultado sem crash