### PR TITLE
fix(backend): clear ordering on DATAcao stats to fix GROUP BY fragmentation

### DIFF
--- a/v2/backend/apps/core/tests/test_dat_module.py
+++ b/v2/backend/apps/core/tests/test_dat_module.py
@@ -632,7 +632,8 @@ class DATAcaoAPITests(DATModuleAPITestCase):
         # Critério de aceite obrigatório
         sum_carta = sum(por_etapa["carta"].values())
         self.assertEqual(
-            sum_carta, total,
+            sum_carta,
+            total,
             f"por_etapa.carta groups should sum to total ({total}); got {sum_carta} "
             f"— likely regression of ORDER BY → GROUP BY fragmentation. "
             f"Raw por_etapa.carta={por_etapa['carta']!r}",
@@ -644,7 +645,8 @@ class DATAcaoAPITests(DATModuleAPITestCase):
         for etapa in ("contato", "reuniao", "entrega"):
             sum_etapa = sum(por_etapa[etapa].values())
             self.assertEqual(
-                sum_etapa, total,
+                sum_etapa,
+                total,
                 f"por_etapa.{etapa} groups should sum to total ({total}); got {sum_etapa}",
             )
 

--- a/v2/backend/apps/core/tests/test_dat_module.py
+++ b/v2/backend/apps/core/tests/test_dat_module.py
@@ -585,6 +585,74 @@ class DATAcaoAPITests(DATModuleAPITestCase):
         self.assertIn("total", response.data)
         self.assertIn("por_etapa", response.data)
 
+    def test_stats_por_etapa_aggregates_correctly_across_priorities_and_municipios(self):
+        """Regression: por_etapa.<status>.values() must sum to total.
+
+        The ViewSet's base queryset is ordered by `-prioridade, municipio__nome`.
+        When `.values_list("status_carta").annotate(c=Count("id"))` is called
+        on that ordered queryset, Django pulls the ORDER BY columns into the
+        GROUP BY clause, producing a fragmented count
+        (one bucket per (status, prioridade, municipio_nome) tuple) so the
+        stats endpoint reported sum << total.
+
+        With the fix, `stats_qs = qs.order_by()` strips the inherited ordering
+        before aggregation, restoring the correct GROUP BY status_carta only.
+        """
+        self.client.force_authenticate(user=self.dat_user)
+
+        # 6 acoes, same status_carta="concluido", varied prioridade + municipio
+        # → without the fix, GROUP BY (status_carta, prioridade, municipio__nome)
+        # would yield 6 distinct buckets of count=1 instead of {"concluido": 6}.
+        # DATAcao has unique_together(municipio, projeto), so we create one
+        # fresh municipio per row (different prioridade for each).
+        import uuid
+
+        uid = uuid.uuid4().hex[:6]
+        for prio in range(1, 7):
+            mun = Municipio.objects.create(nome=f"StatsCity_{uid}_{prio}", uf="CE")
+            DATAcao.objects.create(
+                municipio=mun,
+                projeto=self.projeto,
+                status_carta="concluido",
+                status_contato="pendente",
+                status_reuniao="pendente",
+                status_entrega="pendente",
+                prioridade=prio,
+                created_by=self.dat_user,
+            )
+
+        url = reverse("core:dat-acao-ciclo-stats")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        total = response.data["total"]
+        self.assertEqual(total, 6, "Sanity: 6 DATAcao created in this test")
+
+        por_etapa = response.data["por_etapa"]
+        # Critério de aceite obrigatório
+        sum_carta = sum(por_etapa["carta"].values())
+        self.assertEqual(
+            sum_carta, total,
+            f"por_etapa.carta groups should sum to total ({total}); got {sum_carta} "
+            f"— likely regression of ORDER BY → GROUP BY fragmentation. "
+            f"Raw por_etapa.carta={por_etapa['carta']!r}",
+        )
+        # E os 6 devem estar em UMA bucket (concluido), não fragmentados
+        self.assertEqual(por_etapa["carta"].get("concluido"), 6)
+
+        # Mesma propriedade para as outras 3 etapas
+        for etapa in ("contato", "reuniao", "entrega"):
+            sum_etapa = sum(por_etapa[etapa].values())
+            self.assertEqual(
+                sum_etapa, total,
+                f"por_etapa.{etapa} groups should sum to total ({total}); got {sum_etapa}",
+            )
+
+        # por_projeto / por_coordenador também devem usar mesmo queryset stats
+        # → soma de counts deve bater com total quando há 1 projeto único
+        sum_projeto = sum(p["count"] for p in response.data["por_projeto"])
+        self.assertEqual(sum_projeto, total)
+
 
 class DATCompraAPITests(DATModuleAPITestCase):
     """Tests for DATCompra API endpoints."""

--- a/v2/backend/apps/core/views/dat_module.py
+++ b/v2/backend/apps/core/views/dat_module.py
@@ -279,20 +279,30 @@ class DATAcaoViewSet(viewsets.ModelViewSet):
 
         total = qs.count()
 
+        # `.order_by()` clears the listing ordering before aggregation.
+        # The base queryset is ordered by ("-prioridade", "municipio__nome").
+        # Django would add those columns to GROUP BY when combined with
+        # values/values_list + annotate, producing fragmented counts
+        # (e.g. status_carta grouped by (status, prioridade, municipio) so
+        # `sum(por_etapa.carta.values()) << total`).
+        stats_qs = qs.order_by()
+
         # Por status de cada etapa
         por_etapa = {
-            "carta": dict(qs.values_list("status_carta").annotate(c=Count("id"))),
-            "contato": dict(qs.values_list("status_contato").annotate(c=Count("id"))),
-            "reuniao": dict(qs.values_list("status_reuniao").annotate(c=Count("id"))),
-            "entrega": dict(qs.values_list("status_entrega").annotate(c=Count("id"))),
+            "carta": dict(stats_qs.values_list("status_carta").annotate(c=Count("id"))),
+            "contato": dict(stats_qs.values_list("status_contato").annotate(c=Count("id"))),
+            "reuniao": dict(stats_qs.values_list("status_reuniao").annotate(c=Count("id"))),
+            "entrega": dict(stats_qs.values_list("status_entrega").annotate(c=Count("id"))),
         }
 
         # Por projeto (top 10)
-        por_projeto = list(qs.values("projeto__nome").annotate(count=Count("id")).order_by("-count")[:10])
+        por_projeto = list(
+            stats_qs.values("projeto__nome").annotate(count=Count("id")).order_by("-count")[:10]
+        )
 
         # Por coordenador (top 10)
         por_coordenador = list(
-            qs.filter(coordenador__isnull=False)
+            stats_qs.filter(coordenador__isnull=False)
             .values("coordenador__nome")
             .annotate(count=Count("id"))
             .order_by("-count")[:10]

--- a/v2/backend/apps/core/views/dat_module.py
+++ b/v2/backend/apps/core/views/dat_module.py
@@ -296,9 +296,7 @@ class DATAcaoViewSet(viewsets.ModelViewSet):
         }
 
         # Por projeto (top 10)
-        por_projeto = list(
-            stats_qs.values("projeto__nome").annotate(count=Count("id")).order_by("-count")[:10]
-        )
+        por_projeto = list(stats_qs.values("projeto__nome").annotate(count=Count("id")).order_by("-count")[:10])
 
         # Por coordenador (top 10)
         por_coordenador = list(


### PR DESCRIPTION
## Summary

Fixes `GET /api/dat/acoes/stats/` returning fragmented counts in `por_etapa` (and `por_projeto`, `por_coordenador`). Frontend page `/controle/acoes` displayed **"0 / 247"** for Cartas/Reuniões/Entregas concluídas even when the underlying records had real concluded dates.

## Root cause

`DATAcaoViewSet`'s base queryset is ordered for the listing:

```python
queryset = DATAcao.objects.select_related(...).order_by("-prioridade", "municipio__nome")
```

The stats action reused that queryset directly. When Django combines an ordered queryset with `.values_list().annotate(Count())`, it **pulls the ORDER BY columns into the GROUP BY clause**:

```sql
-- OLD (buggy):
SELECT status_carta, COUNT(id) FROM core_dat_acao GROUP BY 1, 2, 3  -- status, prioridade, municipio_nome
-- → one bucket per (status, prioridade, municipio) tuple → sum = 5

-- NEW (fixed):
SELECT status_carta, COUNT(id) FROM core_dat_acao GROUP BY 1
-- → sum = 247 (matches total)
```

Verified live against dev DB with 247 DATAcao:

| | sum |
|---|---:|
| OLD (ordering herdada) | **5** ❌ |
| NEW (ordering limpa) | **247** ✅ |

## Fix

Introduce `stats_qs = qs.order_by()` once at the top of the stats action and use it for all aggregations. The listing queryset (and ListView) **keeps** the `("-prioridade", "municipio__nome")` ordering — only the stats queryset is cleared.

```python
qs = self.filter_queryset(self.get_queryset())
total = qs.count()
stats_qs = qs.order_by()  # ← clears listing ordering before aggregation
por_etapa = {"carta": dict(stats_qs.values_list("status_carta").annotate(c=Count("id"))), ...}
```

## Scope

**Only DATAcao.stats**. The same antipattern lives in 3 sibling stats endpoints in the same file and will be fixed in follow-up PRs:

| ViewSet | Location | Base queryset ordering |
|---|---|---|
| `DATCompraViewSet.stats` | `views/dat_module.py:419` | `("-ano_uso", "municipio__nome")` |
| `DATCadastroViewSet.stats` | `views/dat_module.py:757` | `("plataforma", "municipio__nome")` |
| `DATFormacaoViewSet.stats` | `views/dat_module.py:903+` | `("-data_formacao", "horario_inicio")` |

## Tests

- **`test_stats_por_etapa_aggregates_correctly_across_priorities_and_municipios`** (new regression):
  - Creates 6 `DATAcao` with same `status_carta="concluido"` but varied `prioridade` (1..6) and **one fresh `Municipio` per row** (`DATAcao` has `unique_together(municipio, projeto)`).
  - Asserts `sum(por_etapa.carta.values()) == total` (the critério de aceite obrigatório).
  - Asserts all 6 land in a single `concluido` bucket (no fragmentation).
  - Same property checked for `contato`, `reuniao`, `entrega`, and `por_projeto`.
- **All 53 tests in `test_dat_module.py` pass** (5/5 in DATAcaoAPITests, including pre-existing `test_stats_action`).

```
$ pytest apps/core/tests/test_dat_module.py -q
53 passed in 9.93s
```

## Staging Gate

Validação local executada na branch `fix/datacao-stats-aggregation` sobre baseline main `673f7c9`.

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

```
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS
ALL 8 CHECKS PASSED
```

## Test plan

- [ ] CI verde
- [ ] Após merge + deploy, conferir em prod: `GET /api/dat/acoes/stats/` deve retornar `sum(por_etapa.*.values()) == total` para qualquer dataset
- [ ] Frontend `/controle/acoes` deve mostrar os contadores corretos (Cartas Enviadas / Reuniões Realizadas / Entregas Concluídas)

## Outros itens NÃO incluídos nesta PR

(conforme escopo isolado solicitado)

- Re-import de Produtos
- Bridge DATCompra (descricao_produto, UF)
- Dedup de projetos canônicos
- Reclassificação agenda/Outros
- Dedup Solicitacao Super ↔ Disponibilidade/Eventos
- Formações / PlanoFormacoes (aguardando sheets.banco)
- UI cosmetic (banner "centralizadas", coluna Utilizado, cards Áreas/Média)
- Fix do mesmo bug em DATCompra/DATCadastro/DATFormacao stats (follow-up)