### PR TITLE
chore(ci): ignore 2 CVEs sem fix upstream no pip-audit (TTL trimestral)

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -79,7 +79,20 @@ jobs:
       - name: Run pip-audit (PyPI Advisory Database)
         run: |
           cd v2/backend
-          pip-audit -r requirements.txt --format json > pip-audit-report.json
+          # Ignored CVEs (TTL — revisar trimestralmente, próxima 2026-08-20):
+          #   PYSEC-2024-271 (CVE-2024-1681): flask-cors log injection via CRLF em debug log.
+          #     Transitiva de `locust` (dev-only, não-runtime). Sem fix em nenhuma versão
+          #     publicada (afetadas 0.* até 6.0.2 — última no PyPI).
+          #   PYSEC-2025-183 (CVE-2025-45768): PyJWT "weak encryption" alegado.
+          #     DISPUTADO oficialmente pelo maintainer (key length é responsabilidade da
+          #     aplicação, não da lib). Sem fix em nenhuma versão (afetadas até 2.12.1).
+          # Validado em osv.dev + NVD + PyPI: nenhum fix disponível upstream.
+          # Plano de saída: remover --ignore-vuln quando upstream publicar patch
+          # ou ao renovar TTL trimestralmente (re-checar advisories nessa data).
+          pip-audit -r requirements.txt --format json \
+            --ignore-vuln PYSEC-2024-271 \
+            --ignore-vuln PYSEC-2025-183 \
+            > pip-audit-report.json
 
       - name: Run Bandit (SAST)
         run: |


### PR DESCRIPTION
## Resumo

`[required] Python Dependencies` está bloqueando todos os PRs (#1363 inclusive) desde **2026-05-20 ~09:30 UTC**. Causa: 2 CVEs novos publicados na PyPI Advisory Database entre 19/05 e 20/05, **ambos sem fix upstream**.

## CVEs detectados

| CVE oficial | Pacote | Versão atual | Última no PyPI | Fix? |
|---|---|---|---|---|
| **CVE-2024-1681** (PYSEC-2024-271) | flask-cors | 6.0.2 | 6.0.2 | ❌ |
| **CVE-2025-45768** (PYSEC-2025-183) | PyJWT | 2.12.1 | 2.12.1 | ❌ |

Validado em **3 fontes oficiais** (osv.dev API + NVD + PyPI metadata):

- flask-cors: afetadas `0.* até 6.0.2` (todas) — last release 12/dez/2025, ainda afetada
- PyJWT: afetadas `0.1.1 até 2.12.1` (todas) — last release 13/mar/2026, ainda afetada
- **PyJWT CVE oficialmente DISPUTADO pelo maintainer** (registrado em osv.dev): _"encryption key length is determined by the application using the library rather than the library itself"_

## Por que não fazer bump

Não há versão posterior com fix em nenhum dos dois pacotes. `pip install --upgrade pyjwt flask-cors` literalmente não faz nada (já estamos na latest).

## Risco prático no projeto

### flask-cors (PYSEC-2024-271) — risco mínimo
- Dep transitiva de `locust` (load testing, dev-only, não-runtime)
- Log injection exige log level=debug (não usado em prod)
- Severidade NVD: 5.3 MEDIUM
- Em prod usamos `django-cors-headers`, não flask-cors

### PyJWT (PYSEC-2025-183) — risco baixo (com nuance)
- Dep transitiva de `djangorestframework-simplejwt` (runtime auth)
- CVE oficialmente **disputado pelo maintainer**
- DRF SimpleJWT abstrai escolha de algoritmo/chave — pratica padrão segura
- Severidade NVD: 7.0 HIGH **(em disputa)**

## Solução implementada

Adicionado `--ignore-vuln PYSEC-2024-271 --ignore-vuln PYSEC-2025-183` no step `Run pip-audit` do workflow Security Scan, com comentário inline documentando:

1. CVE IDs + GHSA aliases
2. Razão técnica de cada ignore
3. **TTL trimestral** (próxima revisão: **2026-08-20**)
4. Plano de saída (remover ignore quando patch sair)

## Diff

```yaml
# .github/workflows/security-scan.yml (step "Run pip-audit")
pip-audit -r requirements.txt --format json \
  --ignore-vuln PYSEC-2024-271 \
  --ignore-vuln PYSEC-2025-183 \
  > pip-audit-report.json
```

+14 / -1 linhas em 1 arquivo. Resto do workflow intocado.

## Alternativas descartadas (documentadas no commit)

- **Bump deps**: impossível, sem fix upstream
- **Trocar `djangorestframework-simplejwt`**: alto custo refactor auth para CVE em disputa
- **Remover `locust`**: perde load testing por CVE sem impacto prod
- **Aguardar maintainer**: indefinido (PyJWT pode nunca corrigir CVE em disputa)

## Validação

- [x] YAML validado (`python -c "yaml.safe_load(...)"`)
- [x] Diff cirúrgico (1 step, +14 -1)
- [x] Outros steps intocados
- [x] CVEs validados em 3 fontes oficiais
- [ ] Próximo run de Security Scan passa verde após merge

## Pós-merge

PR #1363 (baseline frontend-ci) precisa de re-trigger ou rebase para pegar essa mudança. Mesmo padrão para qualquer outro PR aberto hoje.

## Sem impacto runtime

Esse PR só toca `.github/workflows/security-scan.yml` — não é runtime-impacting. Staging gate deve skipar.