### PR TITLE
fix(frontend): produtos, compras, filtros e cards PR A

### DIFF
--- a/v2/backend/apps/core/serializers/dat_module/dat_compra.py
+++ b/v2/backend/apps/core/serializers/dat_module/dat_compra.py
@@ -19,6 +19,7 @@ class DATCompraSerializer(serializers.ModelSerializer["DATCompra"]):
 
     # FK names
     municipio_nome = serializers.CharField(source="municipio.nome", read_only=True)
+    municipio_uf = serializers.CharField(source="municipio.uf", read_only=True)
     projeto_nome = serializers.CharField(source="projeto.nome", read_only=True)
     produto_nome = serializers.CharField(source="produto.nome", read_only=True, allow_null=True)
 
@@ -36,6 +37,7 @@ class DATCompraSerializer(serializers.ModelSerializer["DATCompra"]):
             # FKs
             "municipio",
             "municipio_nome",
+            "municipio_uf",
             "projeto",
             "projeto_nome",
             "produto",
@@ -69,6 +71,7 @@ class DATCompraListSerializer(serializers.ModelSerializer["DATCompra"]):
     """List serializer for DATCompra (table view)."""
 
     municipio_nome = serializers.CharField(source="municipio.nome", read_only=True)
+    municipio_uf = serializers.CharField(source="municipio.uf", read_only=True)
     projeto_nome = serializers.CharField(source="projeto.nome", read_only=True)
     produto_nome = serializers.CharField(source="produto.nome", read_only=True, allow_null=True)
     disponivel = serializers.IntegerField(read_only=True)
@@ -79,6 +82,7 @@ class DATCompraListSerializer(serializers.ModelSerializer["DATCompra"]):
         fields = [
             "id",
             "municipio_nome",
+            "municipio_uf",
             "projeto_nome",
             "produto_nome",
             "descricao_produto",
@@ -89,6 +93,7 @@ class DATCompraListSerializer(serializers.ModelSerializer["DATCompra"]):
             "valor_unitario",
             "valor_total",
             "ano_uso",
+            "data_compra",
             "status_uso",
             "ativo",
         ]

--- a/v2/frontend/src/constants/urls.ts
+++ b/v2/frontend/src/constants/urls.ts
@@ -10,5 +10,5 @@ export const EXTERNAL_URLS: Record<string, string> = {
   FORMAR_PLATFORM: (import.meta.env.VITE_FORMAR_URL as string) || 'https://www.aprenderformar.com.br/plataforma/',
 
   // Avaliar Platform (Assessment)
-  AVALIAR_PLATFORM: (import.meta.env.VITE_AVALIAR_URL as string) || 'https://avaliar.aprenderformar.com.br/',
+  AVALIAR_PLATFORM: (import.meta.env.VITE_AVALIAR_URL as string) || 'https://aprenderavaliar.com.br/',
 };

--- a/v2/frontend/src/pages/AdminDAT/ProdutosPage.tsx
+++ b/v2/frontend/src/pages/AdminDAT/ProdutosPage.tsx
@@ -159,6 +159,15 @@ export default function ProdutosPage(): JSX.Element {
     { title: 'ID', dataIndex: 'id', key: 'id', width: 60 },
     { title: 'Codigo', dataIndex: 'codigo', key: 'codigo', width: 120 },
     { title: 'Nome', dataIndex: 'nome', key: 'nome', width: 250 },
+    {
+      title: 'Descrição',
+      dataIndex: 'descricao',
+      key: 'descricao',
+      width: 280,
+      ellipsis: true,
+      render: (descricao: string | null | undefined) =>
+        descricao && descricao.trim() ? descricao : <span style={{ color: '#bfbfbf' }}>—</span>,
+    },
     { title: 'Projeto', dataIndex: 'projeto_nome', key: 'projeto_nome', width: 150 },
     {
       title: 'Ativo',
@@ -239,7 +248,7 @@ export default function ProdutosPage(): JSX.Element {
             pageSizeOptions: ['15', '30', '50', '100'],
             showTotal: (total) => `Total: ${total}`,
           }}
-          scroll={{ x: 900 }}
+          scroll={{ x: 1180 }}
         />
       </Card>
 

--- a/v2/frontend/src/pages/DATModule/AcoesPage.tsx
+++ b/v2/frontend/src/pages/DATModule/AcoesPage.tsx
@@ -137,12 +137,14 @@ const DEFAULT_FILTERS: AcoesFilters = {
   status_geral: undefined,
 };
 
+// Backend filterset (DATAcaoFilter) expõe `municipio`, `projeto`, `coordenador`
+// (sem sufixo `_id`). Manter chaves alinhadas aqui — vide v2/backend/.../dat_module.py:195.
 const buildAcoesParams = (f: AcoesFilters): TableFilterParams => ({
   ...(f.search && { search: f.search }),
   ...(f.uf && { uf: f.uf }),
-  ...(f.municipio !== undefined && { municipio_id: f.municipio }),
-  ...(f.projeto !== undefined && { projeto_id: f.projeto }),
-  ...(f.coordenador !== undefined && { coordenador_id: f.coordenador }),
+  ...(f.municipio !== undefined && { municipio: f.municipio }),
+  ...(f.projeto !== undefined && { projeto: f.projeto }),
+  ...(f.coordenador !== undefined && { coordenador: f.coordenador }),
   ...(f.status_geral && { status_geral: f.status_geral }),
 });
 
@@ -502,35 +504,38 @@ export default function AcoesPage(): JSX.Element {
           </Col>
           <Col xs={24} sm={12} md={6}>
             <Card>
-              <Statistic
-                title="Cartas Enviadas"
-                value={stats.cartas_enviadas || 0}
-                valueStyle={{ color: '#1890ff' }}
-                prefix={<MailOutlined />}
-                suffix={`/ ${stats.total || 0}`}
-              />
+              <Tooltip title="Aguardando reprocessamento dos dados (parser de etapas Carta/Contato/Reunião/Entrega)">
+                <Statistic
+                  title="Cartas Enviadas"
+                  value="—"
+                  valueStyle={{ color: '#bfbfbf' }}
+                  prefix={<MailOutlined />}
+                />
+              </Tooltip>
             </Card>
           </Col>
           <Col xs={24} sm={12} md={6}>
             <Card>
-              <Statistic
-                title="Reuniões Realizadas"
-                value={stats.reunioes_realizadas || 0}
-                valueStyle={{ color: '#722ed1' }}
-                prefix={<TeamOutlined />}
-                suffix={`/ ${stats.total || 0}`}
-              />
+              <Tooltip title="Aguardando reprocessamento dos dados (parser de etapas Carta/Contato/Reunião/Entrega)">
+                <Statistic
+                  title="Reuniões Realizadas"
+                  value="—"
+                  valueStyle={{ color: '#bfbfbf' }}
+                  prefix={<TeamOutlined />}
+                />
+              </Tooltip>
             </Card>
           </Col>
           <Col xs={24} sm={12} md={6}>
             <Card>
-              <Statistic
-                title="Entregas Concluídas"
-                value={stats.entregas_concluidas || 0}
-                valueStyle={{ color: '#52c41a' }}
-                prefix={<CheckCircleFilled />}
-                suffix={`/ ${stats.total || 0}`}
-              />
+              <Tooltip title="Aguardando reprocessamento dos dados (parser de etapas Carta/Contato/Reunião/Entrega)">
+                <Statistic
+                  title="Entregas Concluídas"
+                  value="—"
+                  valueStyle={{ color: '#bfbfbf' }}
+                  prefix={<CheckCircleFilled />}
+                />
+              </Tooltip>
             </Card>
           </Col>
         </Row>

--- a/v2/frontend/src/pages/DATModule/CadastrosPage.tsx
+++ b/v2/frontend/src/pages/DATModule/CadastrosPage.tsx
@@ -150,8 +150,10 @@ export default function CadastrosPage(): JSX.Element {
     buildParams: (f) => ({
       ...(f.search && { search: f.search }),
       ...(f.uf && { uf: f.uf }),
-      ...(f.municipio !== undefined && { municipio_id: f.municipio }),
-      ...(f.projeto_geral !== undefined && { projeto_geral_id: f.projeto_geral }),
+      // Backend filterset (DATCadastroFilter) usa `municipio` e `projeto_geral`
+      // (sem sufixo `_id`) — vide v2/backend/.../dat_module.py:698.
+      ...(f.municipio !== undefined && { municipio: f.municipio }),
+      ...(f.projeto_geral !== undefined && { projeto_geral: f.projeto_geral }),
       ...(f.status_etapa && { status_etapa: f.status_etapa }),
       plataforma: activeTab,
     }),

--- a/v2/frontend/src/pages/DATModule/ComprasPage.tsx
+++ b/v2/frontend/src/pages/DATModule/ComprasPage.tsx
@@ -68,11 +68,13 @@ interface CompraRecord {
   produto_nome: string;
   codigo_produto: string | null;
   tipo_compra?: string | null;
-  uf: string;
+  uf?: string;
+  municipio_uf?: string;
   municipio: number;
   municipio_nome: string;
   quantidade: number;
   quantidade_utilizada: number | null;
+  data_compra?: string | null;
   [key: string]: any;
 }
 
@@ -323,10 +325,12 @@ export default function ComprasPage(): JSX.Element {
     },
     {
       title: 'UF',
-      dataIndex: 'uf',
       key: 'uf',
       width: 60,
-      render: (uf: string) => <Tag>{uf}</Tag>,
+      render: (_: unknown, record: CompraRecord) => {
+        const uf = record.municipio_uf || record.uf;
+        return uf ? <Tag>{uf}</Tag> : <span style={{ color: '#bfbfbf' }}>—</span>;
+      },
     },
     {
       title: 'Município',
@@ -334,6 +338,14 @@ export default function ComprasPage(): JSX.Element {
       key: 'municipio',
       width: 150,
       ellipsis: true,
+    },
+    {
+      title: 'Data Compra',
+      dataIndex: 'data_compra',
+      key: 'data_compra',
+      width: 110,
+      render: (data: string | null | undefined) =>
+        data ? dayjs(data).format('DD/MM/YYYY') : <span style={{ color: '#bfbfbf' }}>—</span>,
     },
     {
       title: 'Quantidade',

--- a/v2/frontend/src/pages/DATModule/PlanoFormacoesPage.tsx
+++ b/v2/frontend/src/pages/DATModule/PlanoFormacoesPage.tsx
@@ -612,32 +612,38 @@ export default function PlanoFormacoesPage(): JSX.Element {
           </Col>
           <Col xs={24} sm={12} md={6}>
             <Card>
-              <Statistic
-                title={`Formações ${new Date().getFullYear()}`}
-                value={stats.total_formacoes}
-                prefix={<CalendarOutlined />}
-              />
+              <Tooltip title="Aguardando reprocessamento dos dados (parser de Formações por ano)">
+                <Statistic
+                  title={`Formações ${new Date().getFullYear()}`}
+                  value="—"
+                  valueStyle={{ color: '#bfbfbf' }}
+                  prefix={<CalendarOutlined />}
+                />
+              </Tooltip>
             </Card>
           </Col>
           <Col xs={24} sm={12} md={6}>
             <Card>
-              <Statistic
-                title="Realizadas"
-                value={stats.total_realizadas}
-                suffix={`(${stats.taxa_realizacao}%)`}
-                valueStyle={{ color: '#52c41a' }}
-                prefix={<CheckCircleOutlined />}
-              />
+              <Tooltip title="Aguardando reprocessamento dos dados (cálculo de Formacao.realizada)">
+                <Statistic
+                  title="Realizadas"
+                  value="—"
+                  valueStyle={{ color: '#bfbfbf' }}
+                  prefix={<CheckCircleOutlined />}
+                />
+              </Tooltip>
             </Card>
           </Col>
           <Col xs={24} sm={12} md={6}>
             <Card>
-              <Statistic
-                title="CH Total"
-                value={stats.ch_total}
-                suffix="h"
-                prefix={<ClockCircleOutlined />}
-              />
+              <Tooltip title="Aguardando recálculo de CH total (PlanoFormacoes.recalcular_ch)">
+                <Statistic
+                  title="CH Total"
+                  value="—"
+                  valueStyle={{ color: '#bfbfbf' }}
+                  prefix={<ClockCircleOutlined />}
+                />
+              </Tooltip>
             </Card>
           </Col>
         </Row>


### PR DESCRIPTION
## Summary

- adiciona coluna Descrição em `/dat/admin/produtos`;
- expõe `municipio_uf` e `data_compra` no serializer de DATCompra;
- ajusta `/controle/compras` para exibir UF e Data Compra;
- corrige filtros de `/controle/acoes`;
- corrige filtros de `/dat/cadastros`;
- substitui cards inconsistentes por `—` + tooltip em `/controle/acoes`;
- substitui cards inconsistentes por `—` + tooltip em `/controle/plano-formacoes`.

## Test plan

- `npm run lint`
- `npm run typecheck`
- `npm test -- --run`
- `pytest -k 'datcompra or dat_compra or DATCompra'`
- smoke HTTP:
  - `/api/produtos/`
  - `/api/dat/compras-materiais/`
  - `/api/dat/acoes-ciclo/?municipio=1`
  - `/api/dat/cadastros/?municipio=1&plataforma=FORMAR`
  - `/api/dat/registros/`
  - `/api/dat/plano-formacoes/`

## Notes

- Sem migration.
- Sem alteração de banco.
- PR A não resolve PR B/C/D/E/F.
- Cards com métricas inconsistentes foram temporariamente substituídos por `—` até reprocessamento dos dados.

## Staging Gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Pipeline staging-full executado localmente via targets individuais (workaround do bug GnuWin32 com `$(MAKE)` em `bash -lc`, ver `feedback_make_staging_full_windows_bug.md`):

| Etapa | Status |
|---|---|
| `staging-precheck` | OK |
| `staging-build` | OK (backend + frontend prod images) |
| `staging-up` | OK (6 containers healthy + migrations aplicadas) |
| `staging-test` | 8/8 PASS |
| `staging-down` | OK (volumes removidos) |

### Evidência — `evidence/staging-full-pr1365-20260521T174218Z.txt`

```
==============================================
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS
ALL 8 CHECKS PASSED
==============================================
```