### PR TITLE
fix(backend): adicionar filtro regiao em /api/dat/registros/ PR B

### DIFF
--- a/v2/backend/apps/core/tests/test_dat_registros.py
+++ b/v2/backend/apps/core/tests/test_dat_registros.py
@@ -529,9 +529,7 @@ class DATRegistroFilterRegiaoTests(APITestCase):
 
         suffix = str(uuid.uuid4())[:8]
         cls.dat_group, _ = Group.objects.get_or_create(name="DAT")
-        cls.user = User.objects.create_user(
-            username=f"regiao_test_{suffix}", password="t123", cpf=f"444{suffix[:8]}"
-        )
+        cls.user = User.objects.create_user(username=f"regiao_test_{suffix}", password="t123", cpf=f"444{suffix[:8]}")
         cls.user.groups.add(cls.dat_group)
         cls.pg = ProjetoGeral.objects.create(nome=f"PG Regiao Test {suffix}", usa_avaliar=False)
         cls.projeto = Projeto.objects.create(
@@ -594,7 +592,9 @@ class DATRegistroFilterRegiaoTests(APITestCase):
 
     def test_filter_regiao_unknown_returns_empty(self):
         self.assertEqual(self._filter("XYZ").count(), 0)
-        self.assertEqual(self._filter("").count(), DATRegistro.objects.count())  # empty = no filter applied by django-filter
+        self.assertEqual(
+            self._filter("").count(), DATRegistro.objects.count()
+        )  # empty = no filter applied by django-filter
 
     def test_filter_regiao_does_not_match_uf_outside_region(self):
         nordeste_ids = set(self._filter("Nordeste").values_list("id", flat=True))

--- a/v2/backend/apps/core/tests/test_dat_registros.py
+++ b/v2/backend/apps/core/tests/test_dat_registros.py
@@ -518,3 +518,92 @@ class ProjetoGeralAPITests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 1)
         self.assertIn("Linked Project", response.data[0]["nome"])
+
+
+class DATRegistroFilterRegiaoTests(APITestCase):
+    """Tests for the regiao filter on DATRegistroFilter (PR B audit)."""
+
+    @classmethod
+    def setUpTestData(cls):
+        import uuid
+
+        suffix = str(uuid.uuid4())[:8]
+        cls.dat_group, _ = Group.objects.get_or_create(name="DAT")
+        cls.user = User.objects.create_user(
+            username=f"regiao_test_{suffix}", password="t123", cpf=f"444{suffix[:8]}"
+        )
+        cls.user.groups.add(cls.dat_group)
+        cls.pg = ProjetoGeral.objects.create(nome=f"PG Regiao Test {suffix}", usa_avaliar=False)
+        cls.projeto = Projeto.objects.create(
+            nome=f"Projeto Regiao Test {suffix}",
+            codigo=f"REG{suffix}",
+            fluxo="NAO_SUPER",
+            projeto_geral=cls.pg,
+        )
+
+        # One município per Brazilian region (UF picked from REGIAO_UFS).
+        cls.mun_nordeste = Municipio.objects.create(nome=f"MunNE_{suffix}", uf="CE")
+        cls.mun_sudeste = Municipio.objects.create(nome=f"MunSE_{suffix}", uf="SP")
+        cls.mun_sul = Municipio.objects.create(nome=f"MunS_{suffix}", uf="RS")
+        cls.mun_centro = Municipio.objects.create(nome=f"MunCO_{suffix}", uf="DF")
+        cls.mun_norte = Municipio.objects.create(nome=f"MunN_{suffix}", uf="PA")
+
+        for mun in (cls.mun_nordeste, cls.mun_sudeste, cls.mun_sul, cls.mun_centro, cls.mun_norte):
+            DATRegistro.objects.create(
+                municipio=mun,
+                projeto_geral=cls.pg,
+                projeto=cls.projeto,
+                aluno_qtde=10,
+                created_by=cls.user,
+            )
+
+    def _filter(self, regiao):
+        from apps.core.views.dat import DATRegistroFilter
+
+        fs = DATRegistroFilter({"regiao": regiao}, queryset=DATRegistro.objects.all())
+        return fs.qs
+
+    def test_filter_regiao_nordeste_keeps_only_nordeste_municipios(self):
+        qs = self._filter("Nordeste")
+        ufs = list(qs.values_list("municipio__uf", flat=True))
+        self.assertEqual(ufs, ["CE"])
+
+    def test_filter_regiao_sudeste_keeps_only_sudeste(self):
+        qs = self._filter("Sudeste")
+        self.assertEqual(list(qs.values_list("municipio__uf", flat=True)), ["SP"])
+
+    def test_filter_regiao_sul_keeps_only_sul(self):
+        qs = self._filter("Sul")
+        self.assertEqual(list(qs.values_list("municipio__uf", flat=True)), ["RS"])
+
+    def test_filter_regiao_centro_oeste_keeps_only_centro_oeste(self):
+        qs = self._filter("Centro-Oeste")
+        self.assertEqual(list(qs.values_list("municipio__uf", flat=True)), ["DF"])
+
+    def test_filter_regiao_norte_keeps_only_norte(self):
+        qs = self._filter("Norte")
+        self.assertEqual(list(qs.values_list("municipio__uf", flat=True)), ["PA"])
+
+    def test_filter_regiao_is_case_insensitive(self):
+        upper = self._filter("NORDESTE").count()
+        lower = self._filter("nordeste").count()
+        title = self._filter("Nordeste").count()
+        self.assertEqual(upper, lower)
+        self.assertEqual(lower, title)
+        self.assertEqual(title, 1)
+
+    def test_filter_regiao_unknown_returns_empty(self):
+        self.assertEqual(self._filter("XYZ").count(), 0)
+        self.assertEqual(self._filter("").count(), DATRegistro.objects.count())  # empty = no filter applied by django-filter
+
+    def test_filter_regiao_does_not_match_uf_outside_region(self):
+        nordeste_ids = set(self._filter("Nordeste").values_list("id", flat=True))
+        sul_ids = set(self._filter("Sul").values_list("id", flat=True))
+        self.assertEqual(nordeste_ids.intersection(sul_ids), set())
+
+    def test_filter_regiao_via_http_list_endpoint(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get("/api/dat/registros/?regiao=Nordeste")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ufs = {r["municipio_uf"] for r in response.data["results"] if r.get("municipio_uf")}
+        self.assertTrue(ufs.issubset({"AL", "BA", "CE", "MA", "PB", "PE", "PI", "RN", "SE"}))

--- a/v2/backend/apps/core/views/dat.py
+++ b/v2/backend/apps/core/views/dat.py
@@ -37,11 +37,25 @@ if TYPE_CHECKING:
     from rest_framework.request import Request
 
 
+# Canonical Brazilian region → UF tuple mapping. Must match frontend
+# constant at v2/frontend/src/pages/DATModule/DATRegistros/constants.tsx
+# (REGIAO_UFS) — divergence breaks the regiao filter on /dat/registros.
+REGIAO_UFS: dict[str, tuple[str, ...]] = {
+    "Norte": ("AC", "AP", "AM", "PA", "RO", "RR", "TO"),
+    "Nordeste": ("AL", "BA", "CE", "MA", "PB", "PE", "PI", "RN", "SE"),
+    "Centro-Oeste": ("DF", "GO", "MT", "MS"),
+    "Sudeste": ("ES", "MG", "RJ", "SP"),
+    "Sul": ("PR", "RS", "SC"),
+}
+_REGIAO_UFS_CI: dict[str, tuple[str, ...]] = {k.lower(): v for k, v in REGIAO_UFS.items()}
+
+
 class DATRegistroFilter(filters.FilterSet):
     """
     FilterSet for DATRegistro.
 
     Supports filtering by:
+    - regiao: Brazilian region (Norte, Nordeste, Centro-Oeste, Sudeste, Sul)
     - uf: Município UF (e.g., CE, BA)
     - municipio: Município ID
     - projeto_geral: ProjetoGeral ID
@@ -51,7 +65,15 @@ class DATRegistroFilter(filters.FilterSet):
     """
 
     uf = filters.CharFilter(field_name="municipio__uf", lookup_expr="iexact")
+    regiao = filters.CharFilter(method="filter_regiao")
     status_formar = filters.CharFilter(method="filter_status_formar")
+
+    def filter_regiao(self, queryset: QuerySet, name: str, value: str) -> QuerySet:
+        """Filter by Brazilian region → set of UFs (case-insensitive)."""
+        ufs = _REGIAO_UFS_CI.get(value.lower())
+        if not ufs:
+            return queryset.none()
+        return queryset.filter(municipio__uf__in=ufs)
 
     def filter_status_formar(self, queryset: QuerySet, name: str, value: str) -> QuerySet:
         """Filter by FORMAR completion status."""

--- a/v2/frontend/src/pages/DATModule/DATRegistrosPage.tsx
+++ b/v2/frontend/src/pages/DATModule/DATRegistrosPage.tsx
@@ -110,6 +110,7 @@ interface UFOption {
 
 
 const buildRegistrosParams = (f: DATRegistrosFilters): TableFilterParams => ({
+  ...(f.regiao && { regiao: f.regiao }),
   ...(f.uf && { uf: f.uf }),
   ...(f.municipio !== undefined && { municipio: f.municipio }),
   ...(f.projeto_geral !== undefined && { projeto_geral: f.projeto_geral }),


### PR DESCRIPTION
## Summary

- adiciona filtro `regiao` em `DATRegistroFilter`;
- adiciona mapeamento backend `REGIAO_UFS` para as 5 regiões brasileiras;
- torna o filtro case-insensitive;
- retorna queryset vazio para região desconhecida;
- envia `regiao` no frontend em `/dat/registros`;
- adiciona testes focados para filtro por região.

## Diagnostics

- `/controle/acoes` filtro município: backend já OK; filtro retorna resultado correto por `municipio`.
- `/dat/cadastros` filtros município/projeto geral: backend já OK.
- `/solicitacoes/aprovacoes`: vazio por design atual da PA-01; dataset tem 146 pendentes `NAO_SUPER` e 0 pendentes `SUPER`. Correção de dados/fluxo fica para PR futura.
- PR B corrige apenas o bug confirmado de `/dat/registros` filtro região.

## Test plan

- `pytest v2/backend/apps/core/tests/test_dat_registros.py -k DATRegistroFilterRegiaoTests`
- `pytest -k "DATAcao or DATRegistro or DATCadastro or aprovacao or approval or solicitacao"`
- `npm run typecheck`
- `npm run lint`
- smoke shell no dev DB:
  - regiões retornam apenas UFs esperadas;
  - filtro é case-insensitive;
  - região desconhecida retorna 0.

## Notes

- Sem migration.
- Sem alteração de banco.
- Sem alteração de importers.
- Sem alteração de catálogo Projeto/Produto.
- Sem aliases contextuais nesta PR.
- `evidence/` local permanece fora do commit.

## Fora do escopo

- CH em PlanoFormacoes.
- Reparser DATRegistro.
- Catálogo Projeto canônico.
- EquipeGerencia.papel.
- 146 solicitações `NAO_SUPER` pendentes.
- Divergência AFRÂNIO-PE.
- DATFormacao vazio.

## Staging Gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Pipeline staging-full executado localmente via targets individuais (workaround do bug GnuWin32 com `$(MAKE)` em `bash -lc`, ver `feedback_make_staging_full_windows_bug.md`):

| Etapa | Status |
|---|---|
| `staging-precheck` | OK |
| `staging-build` | OK (backend + frontend prod images, GIT_SHA=5da1f6b) |
| `staging-up` | OK (6 containers healthy + migrations aplicadas) |
| `staging-test` | 8/8 PASS |
| `staging-down` | OK (volumes removidos) |

### Evidência — `evidence/staging-full-pr1366-20260522T132316Z.txt`

```
=== PR #1366 — staging-full pipeline ===
Commit: 5da1f6be33664ad9b4245c354bde935fd5a6632c

=== staging-precheck === OK
=== staging-build === OK (norjosamatheus/aprender-{backend,frontend}:staging-local)
=== staging-up === 6 containers healthy (frontend/web/beat/worker/redis/db)

=== staging-test ===
==============================================
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS
ALL 8 CHECKS PASSED
==============================================

=== staging-down === OK (ambiente finalizado, volumes removidos)
```