### PR TITLE
fix(backend): corrigir seed de gerentes

### DIFF
--- a/v2/backend/apps/dev_tools/management/commands/seed_gerentes.py
+++ b/v2/backend/apps/dev_tools/management/commands/seed_gerentes.py
@@ -1,9 +1,11 @@
 """
-Seed gerentes ao grupo "Gerência" e vincular a Gerencia.
+Seed gerentes ao grupo função canônico "Gerente" + EquipeGerencia.papel=GERENTE.
 
 Baseado em:
-- Planilha Usuários.xlsx (coluna F = "Gerente", coluna G = "Gerência")
+- Planilha Usuários.xlsx (Cargo="Gerente", Gerência=setor)
 - 7 gerentes identificados, 4 faltam no banco (serão criados)
+
+Fonte de verdade do papel hierárquico = Cargo (não participação na agenda).
 
 Usage:
     python manage.py seed_gerentes --dry-run  # Preview
@@ -17,6 +19,13 @@ Mapping (Planilha Gerência → Database Gerencia.nome_setor):
 - "Brincando" → nome_setor="Brincando" (GERENCIA 5)
 - "Sou da Paz" → nome_setor="Sou da Paz" (GERENCIA 6)
 - "Individual" → nome_setor="Individual" (GERENCIA INDIVIDUAL)
+
+Cada gerente recebe:
+- grupo Django função "Gerente" (FUNCAO_GROUPS canônico, não "Gerência")
+- EquipeGerencia.papel=GERENTE na gerência resolvida (idempotente)
+- Gerencia.gerente FK (1 gerente principal por gerência)
+
+Gerência ambígua/sem mapping seguro é pulada (skip + warning), sem erro.
 """
 
 # pyright: reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false
@@ -32,7 +41,7 @@ from django.db import transaction
 
 import pandas as pd
 
-from apps.core.models import Gerencia, Usuario
+from apps.core.models import EquipeGerencia, Gerencia, Usuario
 
 # Managers from Usuários.xlsx (Ativos sheet, cargo="Gerente")
 GERENTES = [
@@ -122,7 +131,7 @@ def generate_username(first_name: str, last_name: str) -> str:
 
 
 class Command(BaseCommand):
-    help = "Seed gerentes ao grupo Gerência e vincular a Gerencia"
+    help = "Seed gerentes ao grupo função Gerente + EquipeGerencia.papel=GERENTE"
 
     def add_arguments(self, parser: CommandParser) -> None:
         parser.add_argument(
@@ -144,14 +153,17 @@ class Command(BaseCommand):
         users_existing = 0
         group_assignments = 0
         gerencia_links = 0
+        equipe_created = 0
+        equipe_existing = 0
+        skipped_ambiguous = 0
         errors = []
 
-        # Get or create "Gerência" group
-        gerencia_group, group_created = Group.objects.get_or_create(name="Gerência")
+        # Get or create canonical função group "Gerente" (FUNCAO_GROUPS).
+        gerente_group, group_created = Group.objects.get_or_create(name="Gerente")
         if group_created:
-            self.stdout.write(self.style.SUCCESS("  ✓ Created Django Group: Gerência"))
+            self.stdout.write(self.style.SUCCESS("  ✓ Created Django Group: Gerente"))
         else:
-            self.stdout.write("  - Group 'Gerência' already exists")
+            self.stdout.write("  - Group 'Gerente' already exists")
 
         with transaction.atomic():
             for gerente_data in GERENTES:
@@ -159,7 +171,7 @@ class Command(BaseCommand):
                 first_name = gerente_data["first_name"]
                 last_name = gerente_data["last_name"]
                 email = gerente_data["email"]
-                gerencia_setor = gerente_data["gerencia_setor"]
+                gerencia_setor = (gerente_data["gerencia_setor"] or "").strip()
 
                 # 1. Get or create Usuario
                 usuario, created = Usuario.objects.get_or_create(
@@ -183,20 +195,43 @@ class Command(BaseCommand):
                     users_existing += 1
                     self.stdout.write(f"  - Usuario already exists: {usuario.username} ({first_name} {last_name})")
 
-                # 2. Add to "Gerência" group
-                if not usuario.groups.filter(name="Gerência").exists():
-                    usuario.groups.add(gerencia_group)
+                # 2. Add to canonical função group "Gerente"
+                if not usuario.groups.filter(name="Gerente").exists():
+                    usuario.groups.add(gerente_group)
                     group_assignments += 1
-                    self.stdout.write(self.style.SUCCESS(f"    → Added {usuario.username} to group 'Gerência'"))
+                    self.stdout.write(self.style.SUCCESS(f"    → Added {usuario.username} to group 'Gerente'"))
                 else:
-                    self.stdout.write(f"    - {usuario.username} already in group 'Gerência'")
+                    self.stdout.write(f"    - {usuario.username} already in group 'Gerente'")
 
-                # 3. Link to Gerencia via gerente FK
+                # Skip gerência ambígua/sem mapping seguro (sem erro).
+                if not gerencia_setor or gerencia_setor in {"-", "Individual"}:
+                    skipped_ambiguous += 1
+                    self.stdout.write(
+                        self.style.WARNING(
+                            f"    ⚠️  Gerência ambígua para {usuario.username} (setor={gerencia_setor!r}) — "
+                            f"EquipeGerencia/FK pulados (decisão humana)"
+                        )
+                    )
+                    continue
+
+                # 3. Resolve gerência + criar EquipeGerencia.papel=GERENTE + FK
                 try:
                     gerencia = Gerencia.objects.get(nome_setor=gerencia_setor)
 
-                    # Special case: SUPERINTENDENCIA has 4 managers
-                    # Only link if gerente is not already set
+                    # 3a. EquipeGerencia.papel=GERENTE (idempotente via UK gerencia+usuario+papel)
+                    _, eq_created = EquipeGerencia.objects.get_or_create(
+                        gerencia=gerencia,
+                        usuario=usuario,
+                        papel="GERENTE",
+                        defaults={"ativo": True},
+                    )
+                    if eq_created:
+                        equipe_created += 1
+                        self.stdout.write(self.style.SUCCESS(f"    → EquipeGerencia GERENTE em {gerencia.nome_setor}"))
+                    else:
+                        equipe_existing += 1
+
+                    # 3b. Gerencia.gerente FK (1 gerente principal; SUPERINTENDENCIA tem múltiplos)
                     if gerencia.gerente is None:
                         gerencia.gerente = usuario  # type: ignore[misc]
                         gerencia.save()
@@ -209,7 +244,6 @@ class Command(BaseCommand):
                     elif gerencia.gerente == usuario:
                         self.stdout.write(f"    - {usuario.username} already linked to {gerencia.nome}")
                     else:
-                        # SUPERINTENDENCIA has multiple managers - only first one gets linked
                         self.stdout.write(
                             self.style.WARNING(
                                 f"    ⚠️  {gerencia.nome} already has gerente {gerencia.gerente.username}, skipping FK link for {usuario.username}"
@@ -233,7 +267,10 @@ class Command(BaseCommand):
   - Usuarios created: {users_created}
   - Usuarios existing: {users_existing}
   - Group assignments: {group_assignments}
+  - EquipeGerencia created: {equipe_created}
+  - EquipeGerencia existing: {equipe_existing}
   - Gerencia FK links: {gerencia_links}
+  - Skipped (gerência ambígua): {skipped_ambiguous}
   - Errors: {len(errors)}
 """))
 
@@ -248,12 +285,15 @@ class Command(BaseCommand):
             )
         else:
             self.stdout.write("\n" + "=" * 60)
-            self.stdout.write(self.style.SUCCESS(f"\n✅ {len(GERENTES)} gerentes seeded to group 'Gerência'"))
+            self.stdout.write(self.style.SUCCESS(f"\n✅ {len(GERENTES)} gerentes seeded to group 'Gerente'"))
 
             # Verification
             self.stdout.write("\n🔍 Verification:")
-            gerencia_count = Group.objects.get(name="Gerência").user_set.count()  # type: ignore[attr-defined]
-            self.stdout.write(f"  - Users in 'Gerência' group: {gerencia_count}")
+            gerente_count = Group.objects.get(name="Gerente").user_set.count()  # type: ignore[attr-defined]
+            self.stdout.write(f"  - Users in 'Gerente' group: {gerente_count}")
+
+            equipe_gerente_count = EquipeGerencia.objects.filter(papel="GERENTE").count()
+            self.stdout.write(f"  - EquipeGerencia papel=GERENTE: {equipe_gerente_count}")
 
             gerencias_with_gerente = Gerencia.objects.filter(gerente__isnull=False).count()
             self.stdout.write(f"  - Gerencias with gerente assigned: {gerencias_with_gerente}/7")

--- a/v2/backend/apps/dev_tools/tests/test_seed_gerentes.py
+++ b/v2/backend/apps/dev_tools/tests/test_seed_gerentes.py
@@ -89,10 +89,19 @@ class TestSeedGerentesCommand:
         assert "Created Django Group: Gerente" in output
 
     def test_seed_gerentes_does_not_use_legacy_gerencia_group(self, clean_gerencias, clean_gerentes):
-        """Regression C2-B1: command must NOT create non-canonical 'Gerência' group."""
+        """Regression C2-B1: gerentes vão para grupo canônico 'Gerente', não para o legado 'Gerência'.
+
+        Valida comportamento (a quais grupos os gerentes são atribuídos), não a
+        inexistência global do grupo 'Gerência' — que pode existir no DB por
+        migration/seed de RBAC independente deste command.
+        """
         call_command("seed_gerentes")
-        assert not Group.objects.filter(name="Gerência").exists()
-        assert Group.objects.filter(name="Gerente").exists()
+
+        gerentes = Usuario.objects.filter(cargo="Gerente")
+        assert gerentes.exists()
+        for usuario in gerentes:
+            assert usuario.groups.filter(name="Gerente").exists()
+            assert not usuario.groups.filter(name="Gerência").exists()
 
     def test_seed_gerentes_creates_missing_usuarios(self, clean_gerencias, clean_gerentes):
         """Test that command creates 4 missing usuarios."""

--- a/v2/backend/apps/dev_tools/tests/test_seed_gerentes.py
+++ b/v2/backend/apps/dev_tools/tests/test_seed_gerentes.py
@@ -23,7 +23,7 @@ from django.core.management import call_command
 
 import pytest
 
-from apps.core.models import Gerencia, Usuario
+from apps.core.models import EquipeGerencia, Gerencia, Usuario
 
 
 @pytest.fixture
@@ -44,24 +44,26 @@ def clean_gerencias(db):
 @pytest.fixture
 def clean_gerentes(db):
     """Remove gerentes from DB and Group."""
-    # Remove gerentes from Group
+    # Remove gerentes from canonical função group
     try:
-        gerencia_group = Group.objects.get(name="Gerência")
-        gerencia_group.user_set.clear()
+        gerente_group = Group.objects.get(name="Gerente")
+        gerente_group.user_set.clear()
     except Group.DoesNotExist:
         pass
 
-    # Delete gerentes (keep other usuarios)
+    # Delete EquipeGerencia GERENTE + gerentes (keep other usuarios)
+    EquipeGerencia.objects.filter(papel="GERENTE").delete()
     Usuario.objects.filter(cargo="Gerente").delete()
 
     yield
 
     # Cleanup
     try:
-        gerencia_group = Group.objects.get(name="Gerência")
-        gerencia_group.user_set.clear()
+        gerente_group = Group.objects.get(name="Gerente")
+        gerente_group.user_set.clear()
     except Group.DoesNotExist:
         pass
+    EquipeGerencia.objects.filter(papel="GERENTE").delete()
     Usuario.objects.filter(cargo="Gerente").delete()
 
 
@@ -70,11 +72,11 @@ class TestSeedGerentesCommand:
     """Tests for seed_gerentes management command."""
 
     def test_seed_gerentes_creates_group_if_not_exists(self, clean_gerencias, clean_gerentes):
-        """Test that command creates 'Gerência' group if it doesn't exist."""
+        """Test that command creates canonical função group 'Gerente' if it doesn't exist."""
         # Simula ausência do grupo sem deletar registro referenciado por FKs auxiliares.
-        existing = Group.objects.filter(name="Gerência").first()
+        existing = Group.objects.filter(name="Gerente").first()
         if existing is not None:
-            existing.name = "Gerência (temp)"
+            existing.name = "Gerente (temp)"
             existing.save(update_fields=["name"])
 
         # Run command
@@ -82,9 +84,15 @@ class TestSeedGerentesCommand:
         call_command("seed_gerentes", stdout=out)
 
         # Verify group was created
-        assert Group.objects.filter(name="Gerência").exists()
+        assert Group.objects.filter(name="Gerente").exists()
         output = out.getvalue()
-        assert "Created Django Group: Gerência" in output
+        assert "Created Django Group: Gerente" in output
+
+    def test_seed_gerentes_does_not_use_legacy_gerencia_group(self, clean_gerencias, clean_gerentes):
+        """Regression C2-B1: command must NOT create non-canonical 'Gerência' group."""
+        call_command("seed_gerentes")
+        assert not Group.objects.filter(name="Gerência").exists()
+        assert Group.objects.filter(name="Gerente").exists()
 
     def test_seed_gerentes_creates_missing_usuarios(self, clean_gerencias, clean_gerentes):
         """Test that command creates 4 missing usuarios."""
@@ -114,17 +122,37 @@ class TestSeedGerentesCommand:
         assert set(actual_cpfs) == set(expected_cpfs)
 
     def test_seed_gerentes_adds_usuarios_to_group(self, clean_gerencias, clean_gerentes):
-        """Test that all 7 gerentes are added to 'Gerência' group."""
+        """Test that all 7 gerentes are added to canonical 'Gerente' group."""
         # Run command
         call_command("seed_gerentes")
 
         # Verify all gerentes are in group
-        gerencia_group = Group.objects.get(name="Gerência")
-        assert gerencia_group.user_set.count() == 7
+        gerente_group = Group.objects.get(name="Gerente")
+        assert gerente_group.user_set.count() == 7
 
         # Verify all usuarios with cargo="Gerente" are in group
         for usuario in Usuario.objects.filter(cargo="Gerente"):
-            assert gerencia_group in usuario.groups.all()
+            assert gerente_group in usuario.groups.all()
+
+    def test_seed_gerentes_creates_equipe_gerencia_gerente(self, clean_gerencias, clean_gerentes):
+        """C2-B1: command must create EquipeGerencia.papel=GERENTE for each resolved gerente."""
+        call_command("seed_gerentes")
+
+        # 7 gerentes, all with resolvable gerencia_setor → 7 EquipeGerencia GERENTE rows
+        equipe_gerente = EquipeGerencia.objects.filter(papel="GERENTE")
+        assert equipe_gerente.count() == 7
+
+        # Each gerente usuario has exactly one GERENTE row
+        for usuario in Usuario.objects.filter(cargo="Gerente"):
+            assert EquipeGerencia.objects.filter(usuario=usuario, papel="GERENTE").count() == 1
+
+    def test_seed_gerentes_equipe_gerencia_idempotent(self, clean_gerencias, clean_gerentes):
+        """C2-B1: running twice must not duplicate EquipeGerencia GERENTE rows."""
+        call_command("seed_gerentes")
+        first = EquipeGerencia.objects.filter(papel="GERENTE").count()
+        call_command("seed_gerentes")
+        second = EquipeGerencia.objects.filter(papel="GERENTE").count()
+        assert first == second == 7
 
     def test_seed_gerentes_links_gerencia_fk(self, clean_gerencias, clean_gerentes):
         """Test that gerentes are linked to Gerencia.gerente FK."""
@@ -164,7 +192,7 @@ class TestSeedGerentesCommand:
 
         # Verify counts
         first_gerentes_count = Usuario.objects.filter(cargo="Gerente").count()
-        first_group_count = Group.objects.get(name="Gerência").user_set.count()
+        first_group_count = Group.objects.get(name="Gerente").user_set.count()
         first_gerencia_links = Gerencia.objects.filter(gerente__isnull=False).count()
 
         assert first_gerentes_count == 7
@@ -177,7 +205,7 @@ class TestSeedGerentesCommand:
 
         # Verify counts haven't changed
         second_gerentes_count = Usuario.objects.filter(cargo="Gerente").count()
-        second_group_count = Group.objects.get(name="Gerência").user_set.count()
+        second_group_count = Group.objects.get(name="Gerente").user_set.count()
         second_gerencia_links = Gerencia.objects.filter(gerente__isnull=False).count()
 
         assert second_gerentes_count == first_gerentes_count
@@ -239,7 +267,7 @@ class TestSeedGerentesCommand:
         assert super_gerencia.gerente is not None
 
         # Verify all 4 SUPERINTENDENCIA managers are in Group
-        gerencia_group = Group.objects.get(name="Gerência")
+        gerente_group = Group.objects.get(name="Gerente")
         super_managers = Usuario.objects.filter(
             cargo="Gerente",
             email__in=[
@@ -252,7 +280,7 @@ class TestSeedGerentesCommand:
         assert super_managers.count() == 4
 
         for manager in super_managers:
-            assert gerencia_group in manager.groups.all()
+            assert gerente_group in manager.groups.all()
 
         # Verify output warns about multiple managers
         output = out.getvalue()


### PR DESCRIPTION
## Summary

- troca o grupo legado `Gerência` pelo grupo canônico `Gerente` no seed de gerentes;
- garante `EquipeGerencia.papel=GERENTE` de forma idempotente;
- adiciona cobertura para grupo canônico, criação de `EquipeGerencia` e idempotência.

## Test plan

- `pytest v2/backend/apps/dev_tools/tests/test_seed_gerentes.py -v`
- `pytest v2/backend/apps/dev_tools/tests -q`
- `black --check` + `isort --check-only` + `flake8` nos arquivos tocados
- `graphify update .`

## Notes

- Sem migration.
- Sem alteração de banco.
- Sem apply/reimport de dados.
- C2-A já corrigiu os 7 Gerentes no banco dev; esta PR corrige a causa raiz versionada.
- `graphify update .` reconstruiu o grafo, mas `graphify-out/` é gitignored e não entrou no commit.
- Teste de regressão ajustado para validar comportamento (gerentes vão para grupo `Gerente`, não `Gerência`) em vez de inexistência global do grupo legado.

## Staging Gate (antes de Ready)

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidência: `evidence/staging-full-pr1369-20260528T165022Z.txt`

```
=== staging-precheck === OK
=== staging-build === OK
=== staging-up === 6 containers healthy
=== staging-test ===
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS
ALL 8 CHECKS PASSED
=== staging-down === OK (volumes removidos)
```