### PR TITLE
fix(backend): respeitar PA-01 no importador de eventos

### DIFF
--- a/v2/backend/apps/core/services/eventos_import.py
+++ b/v2/backend/apps/core/services/eventos_import.py
@@ -16,9 +16,11 @@ Colunas esperadas:
 - segmento (opcional): segmento educacional
 - local (opcional): local do evento
 
-Regras de negocio (PA):
-- Se projeto.fluxo == 'SUPER' e data >= hoje: status = 'pendente'
-- Se projeto.fluxo == 'NAO_SUPER' ou data < hoje: status = 'aprovado'
+Regras de negocio (PA-01/PA-04):
+- Status inicial decidido por resolve_initial_status (mesma regra da API):
+  - projeto.fluxo == 'SUPER'      -> 'pendente' (PA-01: SUPER NUNCA auto-aprova)
+  - projeto.fluxo == 'NAO_SUPER'  -> 'aprovado'
+  - A data do evento NAO influencia o status (passado/futuro irrelevante).
 - Criar Participation para coordenador (role='COORDENADOR')
 - Criar Participation para cada formador1-5 (role='FORMADOR')
 """
@@ -47,6 +49,7 @@ from apps.core.services.resolvers import (
     resolve_user_by_email,
     resolve_user_by_name,
 )
+from apps.core.services.solicitacao_create import resolve_initial_status
 
 TZ = ZoneInfo("America/Fortaleza")
 
@@ -96,9 +99,6 @@ def import_eventos_from_file(*, path: str, dry_run: bool = True) -> dict[str, An
         "outros": [],
     }
 
-    # Data de referencia para status
-    today = timezone.localdate()
-
     # Carregar arquivo
     rows = _load_file(path)
 
@@ -109,7 +109,7 @@ def import_eventos_from_file(*, path: str, dry_run: bool = True) -> dict[str, An
         for idx, row in enumerate(rows, start=1):
             try:
                 with transaction.atomic():  # savepoint
-                    _process_row(row, idx, stats, pendencias, today)
+                    _process_row(row, idx, stats, pendencias)
             except Exception as e:
                 stats["skipped"]["other"] += 1
                 pendencias["outros"].append(
@@ -373,22 +373,6 @@ def _compute_external_hash(
     return hashlib.sha1(content.encode("utf-8"), usedforsecurity=False).hexdigest()
 
 
-def _determine_status(projeto: Any, data_evento: date, today: date) -> str:
-    """
-    Determina status da solicitacao conforme regras PA:
-    - data < hoje → aprovado
-    - projeto.fluxo == 'SUPER' → pendente
-    - projeto.fluxo == 'NAO_SUPER' → aprovado
-    """
-    if data_evento < today:
-        return "aprovado"
-
-    if projeto and projeto.fluxo == "SUPER":
-        return "pendente"
-
-    return "aprovado"
-
-
 def _resolve_user(identifier: str) -> Any:
     """Resolve usuario por email ou nome."""
     if not identifier:
@@ -409,7 +393,6 @@ def _process_row(
     linha_num: int,
     stats: dict[str, Any],
     pendencias: dict[str, list[dict[str, Any]]],
-    today: date,
 ) -> None:
     """Processa uma linha do arquivo."""
     # Resolver municipio
@@ -517,8 +500,9 @@ def _process_row(
     fim = datetime.combine(data_evento, hora_fim)
     fim = timezone.make_aware(fim, TZ)
 
-    # Determinar status (PA rules)
-    status = _determine_status(projeto, data_evento, today)
+    # Determinar status inicial (PA-01/PA-04) — mesma regra da API.
+    # SUPER -> pendente, NAO_SUPER -> aprovado. A data do evento NAO decide.
+    status = resolve_initial_status(projeto=projeto).status
 
     # Campos opcionais
     encontro = row.get("encontro", "").strip()

--- a/v2/backend/apps/core/tests/test_import_eventos.py
+++ b/v2/backend/apps/core/tests/test_import_eventos.py
@@ -179,6 +179,20 @@ def sample_csv_nao_super(coordenador_user, municipio, projeto_nao_super, tipo_ev
 
 
 @pytest.fixture
+def sample_csv_super_passado(coordenador_user, municipio, projeto_super, tipo_evento):
+    """CSV com projeto SUPER e data PASSADA (PA-01: deve permanecer pendente)."""
+    d_passado = (date.today() - timedelta(days=30)).isoformat()
+    content = f"""municipio,projeto,tipo_evento,data,hora_inicio,hora_fim,coordenador
+{municipio.nome},{projeto_super.nome},{tipo_evento.nome},{d_passado},08:00,12:00,{coordenador_user.email}
+"""
+    temp = tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False, encoding="utf-8")
+    temp.write(content)
+    temp.close()
+    yield temp.name
+    Path(temp.name).unlink(missing_ok=True)
+
+
+@pytest.fixture
 def sample_csv_invalid_municipio():
     """CSV com municipio inexistente."""
     content = """municipio,projeto,tipo_evento,data,hora_inicio,hora_fim,coordenador
@@ -266,6 +280,23 @@ class TestEventosImportService:
         solicitacoes = Solicitacao.objects.all()
         for sol in solicitacoes:
             assert sol.status == "pendente"
+
+    def test_projeto_super_passado_status_pendente(
+        self, sample_csv_super_passado, coordenador_user, municipio, projeto_super, tipo_evento
+    ):
+        """PA-01: projeto SUPER com data PASSADA NUNCA auto-aprova — deve ficar pendente.
+
+        Regressao do bug latente: o importer decidia status por data (passado -> aprovado)
+        ANTES de checar o fluxo, auto-aprovando eventos SUPER historicos. A regra correta
+        (resolve_initial_status) ignora a data: SUPER sempre nasce pendente.
+        """
+        result = import_eventos_from_file(path=sample_csv_super_passado, dry_run=False)
+
+        assert result["stats"]["solicitacoes"]["created"] == 1
+
+        solicitacao = Solicitacao.objects.first()
+        assert solicitacao is not None
+        assert solicitacao.status == "pendente"
 
     def test_projeto_nao_super_status_aprovado(
         self, sample_csv_nao_super, coordenador_user, municipio, projeto_nao_super, tipo_evento


### PR DESCRIPTION
## Summary

- troca a decisão de status do importador de eventos para usar `resolve_initial_status`;
- garante que projetos `SUPER` não sejam auto-aprovados pelo import, mesmo com data passada;
- adiciona teste de regressão para `SUPER` passado nascer como `pendente`.

## Test plan

- `pytest apps/core/tests/test_import_eventos.py apps/core/tests/test_solicitacao_create_service.py apps/core/tests/test_fluxo_por_projeto.py apps/core/tests/test_pr7_projeto_fluxo_required.py -q`
- `black --check apps/core/services/eventos_import.py apps/core/tests/test_import_eventos.py`
- `isort --check-only apps/core/services/eventos_import.py apps/core/tests/test_import_eventos.py`
- `flake8 apps/core/services/eventos_import.py apps/core/tests/test_import_eventos.py`

## Notes

- Sem migration.
- Sem alteração de banco.
- Sem data patch.
- Dev DB não foi alterado.
- `pyright` não rodou no container por gap conhecido de ambiente.

## Staging Gate (antes de Ready)

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

ALL 8 CHECKS PASSED

Evidencia local: `evidence/staging-full-pr1370-20260601-171137.txt` (gitignored).
Pipeline executada via sub-targets `make -C` (precheck/build/up/test/down) — workaround do
bug GnuWin32 `$(MAKE)` com espaco no path; equivalente a `make staging-full`. PIPELINE_RC=0.

Checks: [1] Backend readyz PASS · [2] Backend version PASS · [3] CSRF PASS ·
[4] Auth pipeline PASS (HTTP 400) · [5] Celery worker PASS · [6] Celery beat PASS ·
[7] Frontend HTTP PASS · [8] Frontend health PASS.
