### PR TITLE
fix(backend): resolver projeto do export-contract

### DIFF
--- a/v2/backend/apps/core/services/export_contract_projeto_resolver.py
+++ b/v2/backend/apps/core/services/export_contract_projeto_resolver.py
@@ -1,0 +1,170 @@
+"""
+Resolver de Projeto para o import do export-contract (Gap C).
+
+O DB (catálogo de 123 projetos) é o SSOT. Este resolver mapeia o NOME de projeto que
+vem do export-contract para um `Projeto` existente, fechando os resíduos de forma:
+
+1. Regras determinísticas (aplicadas a ambos os lados via chave canônica):
+   - `&` <-> `E`
+   - remover hífen separador (`SUPERATIVAR - MATEMATICA 4` -> `SUPERATIVAR MATEMATICA 4`)
+   - remover prefixo `PROJETO `
+   - normalizar vírgula (`LER, OUVIR` <-> `LER OUVIR`)
+2. Aliases ESCOPADOS por família (nunca regra global `Português -> Língua Portuguesa`):
+   - `Superativar (Língua )Português N` -> `Superativar Linguagens N` (N in 3,4,5)
+   - `ACerta Brasil Português` -> `ACerta Brasil Língua Portuguesa`
+   - `Brincando e Aprendendo Professor` -> `Brincando e Aprendendo`
+
+Ambiguidade (a chave canônica casa >1 projeto distinto) **falha explicitamente**
+(`status="ambiguous"`), nunca escolhe um alvo no chute.
+
+NÃO importa dados; só resolve nomes. Não tem efeito colateral.
+"""
+
+# pyright: reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportAttributeAccessIssue=false
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from collections import defaultdict
+from dataclasses import dataclass, field
+
+from apps.core.models import Projeto
+
+# ── Aliases escopados (chave = nome NORMALIZADO de origem; valor = nome NORMALIZADO alvo) ──
+# Apenas famílias confirmadas por decisão humana. NÃO é regra global.
+_SCOPED_ALIASES: dict[str, str] = {
+    # Superativar: "Português"/"Língua Portuguesa" N -> "Linguagens" N (rename de catálogo já aplicado)
+    "SUPERATIVAR PORTUGUES 3": "SUPERATIVAR LINGUAGENS 3",
+    "SUPERATIVAR PORTUGUES 4": "SUPERATIVAR LINGUAGENS 4",
+    "SUPERATIVAR PORTUGUES 5": "SUPERATIVAR LINGUAGENS 5",
+    "SUPERATIVAR LINGUA PORTUGUESA 3": "SUPERATIVAR LINGUAGENS 3",
+    "SUPERATIVAR LINGUA PORTUGUESA 4": "SUPERATIVAR LINGUAGENS 4",
+    "SUPERATIVAR LINGUA PORTUGUESA 5": "SUPERATIVAR LINGUAGENS 5",
+    # ACerta Brasil: "Português" -> "Língua Portuguesa" (DB já tem o nome certo)
+    "ACERTA BRASIL PORTUGUES": "ACERTA BRASIL LINGUA PORTUGUESA",
+    # E1 (merge já aplicado no catálogo)
+    "BRINCANDO E APRENDENDO PROFESSOR": "BRINCANDO E APRENDENDO",
+}
+
+
+@dataclass(frozen=True)
+class ProjetoResolution:
+    """Resultado da resolução. `status` in {matched, ambiguous, unmatched}."""
+
+    status: str
+    projeto: Projeto | None = None
+    matched_via: str = ""  # "norm" | "alias" | "canon_rule"
+    canonical_key: str = ""
+    candidates: list[str] = field(default_factory=list)
+    reason: str = ""
+
+
+def _norm(s: str) -> str:
+    """NFKD + remove acentos + colapsa espaços + UPPERCASE."""
+    s = unicodedata.normalize("NFKD", (s or "").strip())
+    s = "".join(c for c in s if not unicodedata.combining(c))
+    return re.sub(r"\s+", " ", s).upper()
+
+
+def _canon_key(s: str) -> str:
+    """Chave canônica determinística: norm + (& -> E) + remover hífen/vírgula + remover prefixo PROJETO."""
+    s = _norm(s).replace("&", "E").replace(",", " ").replace("-", " ")
+    s = re.sub(r"^PROJETO\s+", "", s)
+    return re.sub(r"\s+", " ", s).strip()
+
+
+@dataclass
+class ProjetoIndex:
+    """Índice do catálogo do DB para resolução em lote (construir 1x por import)."""
+
+    by_norm: dict[str, list[Projeto]]
+    by_canon: dict[str, list[Projeto]]
+
+
+def build_projeto_index() -> ProjetoIndex:
+    """Constrói o índice a partir do catálogo atual do DB (SSOT)."""
+    by_norm: dict[str, list[Projeto]] = defaultdict(list)
+    by_canon: dict[str, list[Projeto]] = defaultdict(list)
+    for p in Projeto.objects.all():
+        by_norm[_norm(p.nome)].append(p)
+        by_canon[_canon_key(p.nome)].append(p)
+    return ProjetoIndex(by_norm=dict(by_norm), by_canon=dict(by_canon))
+
+
+def resolve_projeto_export(raw_name: str, *, index: ProjetoIndex | None = None) -> ProjetoResolution:
+    """
+    Resolve o nome de projeto do export-contract para um `Projeto` do catálogo.
+
+    Args:
+        raw_name: nome bruto vindo do export.
+        index: índice pré-construído (opcional; se ausente, constrói do DB).
+
+    Returns:
+        ProjetoResolution com status matched/ambiguous/unmatched.
+    """
+    if not (raw_name or "").strip():
+        return ProjetoResolution(status="unmatched", reason="nome vazio")
+
+    idx = index or build_projeto_index()
+
+    n = _norm(raw_name)
+    ck = _canon_key(raw_name)
+    # alias é keyed pela CHAVE CANÔNICA (tolerante a hífen/vírgula/&/prefixo)
+    alias_target = _SCOPED_ALIASES.get(ck)
+
+    if alias_target is not None:
+        # alias escopado: resolve pelo alvo canônico (já é forma canônica do catálogo)
+        hits = idx.by_canon.get(alias_target, [])
+        if len(hits) == 1:
+            return ProjetoResolution(
+                status="matched",
+                projeto=hits[0],
+                matched_via="alias",
+                canonical_key=alias_target,
+                reason="match por alias escopado",
+            )
+        if len(hits) > 1:
+            return ProjetoResolution(
+                status="ambiguous",
+                canonical_key=alias_target,
+                candidates=sorted(str(p.nome) for p in hits),
+                reason="alias casa múltiplos projetos (não escolher no chute)",
+            )
+        return ProjetoResolution(
+            status="unmatched", canonical_key=alias_target, reason="alvo do alias não existe no catálogo"
+        )
+
+    # 1) match exato por norm (preferido — evita falsa ambiguidade da chave canônica)
+    norm_hits = idx.by_norm.get(n, [])
+    if len(norm_hits) == 1:
+        return ProjetoResolution(
+            status="matched", projeto=norm_hits[0], matched_via="norm", canonical_key=n, reason="match exato por norm"
+        )
+    if len(norm_hits) > 1:
+        return ProjetoResolution(
+            status="ambiguous",
+            canonical_key=n,
+            candidates=sorted(str(p.nome) for p in norm_hits),
+            reason="múltiplos projetos com o mesmo nome normalizado",
+        )
+
+    # 2) match por chave canônica determinística (& <-> E, hífen, vírgula, prefixo PROJETO)
+    canon_hits = idx.by_canon.get(ck, [])
+    if len(canon_hits) == 1:
+        return ProjetoResolution(
+            status="matched",
+            projeto=canon_hits[0],
+            matched_via="canon_rule",
+            canonical_key=ck,
+            reason="match por regra determinística",
+        )
+    if len(canon_hits) > 1:
+        return ProjetoResolution(
+            status="ambiguous",
+            canonical_key=ck,
+            candidates=sorted(str(p.nome) for p in canon_hits),
+            reason="chave canônica casa múltiplos projetos (não escolher no chute)",
+        )
+
+    return ProjetoResolution(status="unmatched", canonical_key=ck, reason="nenhum projeto correspondente")

--- a/v2/backend/apps/core/tests/test_export_contract_projeto_resolver.py
+++ b/v2/backend/apps/core/tests/test_export_contract_projeto_resolver.py
@@ -1,0 +1,123 @@
+"""
+Tests para o resolver de Projeto do import do export-contract (Gap C).
+
+Cobre canonicalização determinística (& <-> E, hífen, prefixo PROJETO, vírgula) +
+aliases escopados por família (Superativar -> Linguagens, ACerta Brasil -> Língua
+Portuguesa, Brincando e Aprendendo Professor) e falha explícita em ambiguidade.
+
+O DB é o SSOT do catálogo (123 projetos). NÃO importa dados — só resolve nomes.
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportAttributeAccessIssue=false, reportOptionalMemberAccess=false
+
+from __future__ import annotations
+
+import pytest
+
+from apps.core.models import Projeto
+from apps.core.services.export_contract_projeto_resolver import resolve_projeto_export
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def catalogo():
+    """Subconjunto do catálogo canônico do DB (formas exatas armazenadas)."""
+    nomes = [
+        "Vida & Matemática 6",
+        "Superativar Matemática 4",
+        "Uni Duni Tê 4",
+        "Ler, Ouvir e Contar 1",
+        "Escrever Comunicar e Ser",
+        "Superativar Linguagens 3",
+        "Superativar Linguagens 4",
+        "Superativar Linguagens 5",
+        "ACerta Brasil Língua Portuguesa",
+        "Brincando e Aprendendo",
+        "ACerta Português",
+        "Avançando Juntos Português",
+    ]
+    return {n: Projeto.objects.create(nome=n, fluxo="NAO_SUPER") for n in nomes}
+
+
+def _assert_matches(raw, expected_nome):
+    res = resolve_projeto_export(raw)
+    assert res.status == "matched", f"{raw!r} -> {res.status} ({res.reason})"
+    assert res.projeto is not None
+    assert res.projeto.nome == expected_nome, f"{raw!r} -> {res.projeto.nome!r} (esperado {expected_nome!r})"
+
+
+# ---------- regras determinísticas ----------
+def test_e_vira_ampersand(catalogo):
+    _assert_matches("VIDA E MATEMATICA 6", "Vida & Matemática 6")
+
+
+def test_remove_hifen_separador(catalogo):
+    _assert_matches("SUPERATIVAR - MATEMATICA 4", "Superativar Matemática 4")
+
+
+def test_remove_prefixo_projeto(catalogo):
+    _assert_matches("PROJETO UNI DUNI TÊ 4", "Uni Duni Tê 4")
+
+
+def test_normaliza_virgula_add(catalogo):
+    _assert_matches("LER OUVIR E CONTAR 1", "Ler, Ouvir e Contar 1")
+
+
+def test_normaliza_virgula_del(catalogo):
+    _assert_matches("ESCREVER, COMUNICAR E SER", "Escrever Comunicar e Ser")
+
+
+# ---------- aliases escopados ----------
+@pytest.mark.parametrize("n", [3, 4, 5])
+def test_superativar_portugues_vira_linguagens(catalogo, n):
+    _assert_matches(f"SUPERATIVAR - PORTUGUES {n}", f"Superativar Linguagens {n}")
+
+
+@pytest.mark.parametrize("n", [3, 4, 5])
+def test_superativar_lingua_portuguesa_vira_linguagens(catalogo, n):
+    _assert_matches(f"SUPERATIVAR LINGUA PORTUGUESA {n}", f"Superativar Linguagens {n}")
+
+
+def test_acerta_brasil_portugues_vira_lingua_portuguesa(catalogo):
+    _assert_matches("ACERTA BRASIL PORTUGUES", "ACerta Brasil Língua Portuguesa")
+
+
+def test_brincando_professor_vira_brincando(catalogo):
+    _assert_matches("BRINCANDO E APRENDENDO PROFESSOR", "Brincando e Aprendendo")
+
+
+# ---------- NÃO mapear (sem regra global Português) ----------
+def test_acerta_portugues_nao_vira_brasil_lingua_portuguesa(catalogo):
+    res = resolve_projeto_export("ACERTA PORTUGUES")
+    assert res.status == "matched"
+    assert res.projeto.nome == "ACerta Português"
+
+
+def test_avancando_juntos_portugues_nao_vira_lingua_portuguesa(catalogo):
+    res = resolve_projeto_export("AVANÇANDO JUNTOS PORTUGUÊS")
+    assert res.status == "matched"
+    assert res.projeto.nome == "Avançando Juntos Português"
+
+
+# ---------- ambiguidade falha explícita ----------
+def test_ambiguidade_falha_explicita(db):
+    # Dois projetos que colapsam para a mesma chave canônica (& <-> E).
+    # Raw com hífen NÃO casa nenhum norm exato → cai na chave canônica, que casa os 2 → ambíguo.
+    Projeto.objects.create(nome="Vida & Matemática 6", fluxo="NAO_SUPER")
+    Projeto.objects.create(nome="Vida E Matemática 6", fluxo="NAO_SUPER")
+    res = resolve_projeto_export("VIDA - E - MATEMATICA 6")
+    assert res.status == "ambiguous", f"esperado ambiguous, veio {res.status}"
+    assert res.projeto is None
+    assert len(res.candidates) >= 2
+
+
+def test_sem_match_retorna_unmatched(catalogo):
+    res = resolve_projeto_export("PROJETO TOTALMENTE INEXISTENTE XYZ")
+    assert res.status == "unmatched"
+    assert res.projeto is None
+
+
+def test_vazio_retorna_unmatched(catalogo):
+    res = resolve_projeto_export("")
+    assert res.status == "unmatched"


### PR DESCRIPTION
## Summary

- adiciona resolver de Projeto para o import futuro do export-contract;
- cobre regras determinísticas de canonicalização (`&`/`E`, hífen, prefixo `PROJETO`, vírgula);
- adiciona aliases escopados por família, incluindo Superativar Linguagens, ACerta Brasil Língua Portuguesa e Brincando e Aprendendo;
- evita resolução por chute em casos ambíguos.

## Test plan

- `pytest apps/core/tests/test_export_contract_projeto_resolver.py -q`
- `black --check apps/core/services/export_contract_projeto_resolver.py apps/core/tests/test_export_contract_projeto_resolver.py`
- `isort --check-only apps/core/services/export_contract_projeto_resolver.py apps/core/tests/test_export_contract_projeto_resolver.py`
- `flake8 apps/core/services/export_contract_projeto_resolver.py apps/core/tests/test_export_contract_projeto_resolver.py`
- comparação read-only do `C:\tmp\export-contract-2026-06-02-fix1\` com o novo resolver

## Notes

- Sem migration.
- Sem alteração de banco.
- Sem import/apply.
- Export fix1 não foi alterado.
- Os 2 resíduos restantes são produtos `SEM_CATALOGO` 507/508, fora do escopo de Projeto.

## Staging Gate (antes de Ready)

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

ALL 8 CHECKS PASSED

Evidencia local: `evidence/staging-full-pr1372-20260602-153930.txt` (gitignored). PIPELINE_RC=0.
Pipeline via sub-targets `make -C` (precheck/build/up/test/down) — workaround do bug GnuWin32 `$(MAKE)`;
equivalente a `make staging-full`. Checks: [1] Backend readyz · [2] Backend version · [3] CSRF ·
[4] Auth pipeline (HTTP 400) · [5] Celery worker · [6] Celery beat · [7] Frontend HTTP · [8] Frontend health — todos PASS.
