### PR TITLE
feat(backend): criar importer dry-run do export-contract

### DIFF
--- a/v2/backend/apps/core/management/commands/import_export_contract.py
+++ b/v2/backend/apps/core/management/commands/import_export_contract.py
@@ -1,0 +1,85 @@
+"""
+Management command — importer do export-contract (dry-run-first).
+
+Uso:
+    # dry-run (padrão, não escreve):
+    python manage.py import_export_contract --path /caminho/export-contract-2026-06-02-fix1
+
+    # apply create-only de entidades EXPLICITAMENTE permitidas (futuro):
+    python manage.py import_export_contract --path ... --apply --allow-entity dat_area
+
+Segurança:
+- sem `--apply` → dry-run (só classifica).
+- `--apply` sem `--allow-entity` → BLOQUEADO (nada escrito).
+- modo `create-only`: só insere would_create; nunca atualiza; nunca sobrescreve campo protegido.
+"""
+
+# pyright: reportUnknownMemberType=false, reportUnknownVariableType=false, reportAttributeAccessIssue=false
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+from django.core.management.base import BaseCommand
+
+from apps.core.services.export_contract_importer import ExportContractImporter
+
+if TYPE_CHECKING:
+    from argparse import ArgumentParser
+
+
+class Command(BaseCommand):
+    help = "Importer do export-contract (dry-run por padrão; --apply exige --allow-entity)."
+
+    def add_arguments(self, parser: ArgumentParser) -> None:
+        parser.add_argument("--path", required=True, help="Diretório do export-contract (com manifest.json).")
+        parser.add_argument(
+            "--mode",
+            default="create-only",
+            choices=["create-only"],
+            help="Modo de import (apenas create-only nesta fase).",
+        )
+        parser.add_argument(
+            "--apply",
+            action="store_true",
+            default=False,
+            help="Executa writes. Exige --allow-entity; sem allowlist é bloqueado.",
+        )
+        parser.add_argument(
+            "--allow-entity",
+            action="append",
+            default=[],
+            dest="allow",
+            help="Entidade permitida para apply (repetível). Sem isto, --apply não escreve.",
+        )
+        parser.add_argument("--json", action="store_true", default=False, help="Saída em JSON.")
+
+    def handle(self, *args: Any, **opts: Any) -> None:
+        importer = ExportContractImporter(
+            path=opts["path"],
+            mode=opts["mode"],
+            apply=opts["apply"],
+            allow=tuple(opts["allow"]),
+        )
+        report = importer.run()
+
+        if opts["json"]:
+            self.stdout.write(json.dumps(report, ensure_ascii=False, indent=2))
+            return
+
+        self.stdout.write(self.style.MIGRATE_HEADING("Import export-contract"))
+        self.stdout.write(f"  path={opts['path']}  mode={report['mode']}  apply={report['apply']}")
+        if report["apply_blocked"]:
+            self.stdout.write(self.style.WARNING("  ⚠️  --apply BLOQUEADO: forneça --allow-entity. Nada escrito."))
+        for ent, v in report["por_entidade"].items():
+            if v.get("status") == "not_implemented":
+                self.stdout.write(f"  [{ent}] NOT_IMPLEMENTED (rows={v['export_rows']})")
+            else:
+                self.stdout.write(
+                    f"  [{ent}] rows={v['export_rows']} create={v['would_create']} "
+                    f"update={v['would_update']} skip={v['would_skip_same']} "
+                    f"protected_diff={v['protected_diff']} reject={v['would_reject']}"
+                )
+        if report["applied"]:
+            self.stdout.write(self.style.SUCCESS(f"  applied(create-only)={report['applied']}"))

--- a/v2/backend/apps/core/management/commands/import_export_contract.py
+++ b/v2/backend/apps/core/management/commands/import_export_contract.py
@@ -76,10 +76,11 @@ class Command(BaseCommand):
             if v.get("status") == "not_implemented":
                 self.stdout.write(f"  [{ent}] NOT_IMPLEMENTED (rows={v['export_rows']})")
             else:
-                self.stdout.write(
-                    f"  [{ent}] rows={v['export_rows']} create={v['would_create']} "
-                    f"update={v['would_update']} skip={v['would_skip_same']} "
-                    f"protected_diff={v['protected_diff']} reject={v['would_reject']}"
+                linha = (
+                    f"  [{ent}] rows={v['export_rows']} create={v['would_create']}"
+                    + f" update={v['would_update']} skip={v['would_skip_same']}"
+                    + f" protected_diff={v['protected_diff']} reject={v['would_reject']}"
                 )
+                self.stdout.write(linha)
         if report["applied"]:
             self.stdout.write(self.style.SUCCESS(f"  applied(create-only)={report['applied']}"))

--- a/v2/backend/apps/core/services/export_contract_importer.py
+++ b/v2/backend/apps/core/services/export_contract_importer.py
@@ -1,0 +1,248 @@
+"""
+Importer dedicado do export-contract (skeleton seguro).
+
+Princípios de segurança:
+- **dry-run por padrão** (`apply=False`): só classifica, nunca escreve.
+- **`apply=True` exige allowlist** (`allow=(...)`); sem allowlist → `apply_blocked`, nada escrito.
+- **modo `create-only`**: na escrita, só insere `would_create`; nunca faz update.
+- **never-overwrite de campos protegidos**: se um registro existe e diverge num campo protegido
+  (`Solicitacao.status`, `Formacao.data_formacao`, `Acompanhamento.data_acompanhamento/realizado`),
+  classifica como `protected_diff` e deixa para decisão humana (nunca sobrescreve).
+
+Primeira fatia implementada (master, baixo risco): `dat_area`, `municipio`, `projeto_geral`.
+Demais entidades → `not_implemented` (contagem reportada, sem processamento).
+
+NÃO importa dados reais por padrão. Sem PII no relatório (só counts/nomes de entidade).
+"""
+
+# pyright: reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportAttributeAccessIssue=false
+
+from __future__ import annotations
+
+import csv
+import json
+import os
+import re
+import unicodedata
+from typing import Any
+
+from django.db import transaction
+
+from apps.core.models import DATArea, Municipio, ProjetoGeral
+from apps.core.services.export_contract_projeto_resolver import build_projeto_index, resolve_projeto_export
+
+# Campos protegidos por entidade — NUNCA sobrescrever em update (decisão humana).
+PROTECTED_FIELDS: dict[str, set[str]] = {
+    "solicitacao": {"status"},
+    "formacao": {"data_formacao"},
+    "acompanhamento": {"data_acompanhamento", "realizado"},
+}
+
+# Ordem canônica (master → operacional). IMPLEMENTED = fatia atual.
+ENTITY_ORDER = [
+    "municipio",
+    "projeto_geral",
+    "projeto",
+    "produto",
+    "colecao",
+    "usuario",
+    "gerencia",
+    "equipe_gerencia",
+    "tipo_evento",
+    "dat_area",
+    "dat_coordenador",
+    "solicitacao",
+    "participation",
+    "availability_block",
+    "deslocamento",
+    "dat_registro",
+    "dat_cadastro",
+    "dat_acao",
+    "dat_compra",
+    "plano_formacao",
+    "formacao",
+    "acompanhamento",
+    "prova",
+]
+IMPLEMENTED = {"dat_area", "municipio", "projeto_geral"}
+
+
+def _norm(s: str) -> str:
+    s = unicodedata.normalize("NFKD", (s or "").strip())
+    s = "".join(c for c in s if not unicodedata.combining(c))
+    return re.sub(r"\s+", " ", s).upper()
+
+
+def _cmp(v: Any) -> str:
+    """Forma comparável canônica (bool/None/str) para detectar diferença de campo."""
+    if isinstance(v, bool):
+        return "true" if v else "false"
+    if v is None:
+        return ""
+    return str(v).strip().casefold()
+
+
+def _to_bool(v: Any) -> bool:
+    return str(v).strip().casefold() in {"true", "1", "yes", "sim", "t"}
+
+
+def diff_and_classify(
+    existing: dict[str, Any] | None, export: dict[str, Any], protected: set[str]
+) -> tuple[str, list[str]]:
+    """
+    Classifica um registro comparando o estado existente (ou None) com o do export.
+
+    Returns (status, campos):
+      - would_create   : não existe.
+      - would_skip_same: existe e idêntico nos campos comparados.
+      - protected_diff : existe e diverge em campo protegido (NUNCA sobrescrever).
+      - would_update   : existe e diverge só em campos não-protegidos.
+    """
+    if existing is None:
+        return "would_create", []
+    diffs = [k for k in export if _cmp(existing.get(k)) != _cmp(export.get(k))]
+    if not diffs:
+        return "would_skip_same", []
+    prot = sorted(k for k in diffs if k in protected)
+    if prot:
+        return "protected_diff", prot
+    return "would_update", sorted(diffs)
+
+
+class ExportContractImporter:
+    """Importer dry-run-first do export-contract. Veja docstring do módulo."""
+
+    def __init__(
+        self, path: str, *, mode: str = "create-only", apply: bool = False, allow: tuple[str, ...] = ()
+    ) -> None:
+        self.path = path
+        self.mode = mode
+        self.apply = apply
+        self.allow = tuple(allow)
+        self._pidx = None
+
+    # ── resolver de Projeto (delegação ao módulo mergeado na #1372) ──
+    def resolve_projeto(self, raw_name: str) -> int | None:
+        if self._pidx is None:
+            self._pidx = build_projeto_index()
+        res = resolve_projeto_export(raw_name, index=self._pidx)
+        return res.projeto.id if res.status == "matched" and res.projeto else None
+
+    def _load(self, name: str) -> list[dict[str, str]]:
+        fp = os.path.join(self.path, f"{name}.csv")
+        if not os.path.exists(fp):
+            return []
+        with open(fp, encoding="utf-8") as f:
+            return list(csv.DictReader(f))
+
+    def _read_manifest(self) -> dict[str, Any]:
+        fp = os.path.join(self.path, "manifest.json")
+        if not os.path.exists(fp):
+            return {}
+        with open(fp, encoding="utf-8") as f:
+            return json.load(f)
+
+    # ── handlers da fatia implementada ──
+    def _classify_master(self, name: str) -> dict[str, int]:
+        rows = self._load(name)
+        tally = {k: 0 for k in ("would_create", "would_update", "would_skip_same", "protected_diff", "would_reject")}
+        protected = PROTECTED_FIELDS.get(name, set())
+
+        if name == "dat_area":
+            # DATArea não tem campo comparável vindo do export (export traz só nome/descricao;
+            # 'descricao' não existe no model). → existência decide create vs skip.
+            idx = {_norm(n) for n in DATArea.objects.values_list("nome", flat=True)}
+            for r in rows:
+                nome = (r.get("nome") or "").strip()
+                if not nome:
+                    tally["would_reject"] += 1
+                    continue
+                existing = {} if _norm(nome) in idx else None
+                st, _ = diff_and_classify(existing, {}, protected)
+                tally[st] += 1
+
+        elif name == "municipio":
+            idx = {
+                (_norm(n), (u or "").upper()): {"ativo": a}
+                for n, u, a in Municipio.objects.values_list("nome", "uf", "ativo")
+            }
+            for r in rows:
+                nome = (r.get("nome") or "").strip()
+                if not nome:
+                    tally["would_reject"] += 1
+                    continue
+                key = (_norm(nome), (r.get("uf") or "").upper())
+                st, _ = diff_and_classify(idx.get(key), {"ativo": _to_bool(r.get("ativo"))}, protected)
+                tally[st] += 1
+
+        elif name == "projeto_geral":
+            idx = {_norm(n): {"usa_avaliar": a} for n, a in ProjetoGeral.objects.values_list("nome", "usa_avaliar")}
+            for r in rows:
+                nome = (r.get("nome") or "").strip()
+                if not nome:
+                    tally["would_reject"] += 1
+                    continue
+                st, _ = diff_and_classify(
+                    idx.get(_norm(nome)), {"usa_avaliar": _to_bool(r.get("usa_avaliar"))}, protected
+                )
+                tally[st] += 1
+
+        tally["export_rows"] = len(rows)
+        return tally
+
+    def run(self) -> dict[str, Any]:
+        manifest = self._read_manifest()
+        apply_blocked = bool(self.apply) and not self.allow
+
+        por_entidade: dict[str, Any] = {}
+        for name in ENTITY_ORDER:
+            fp = os.path.join(self.path, f"{name}.csv")
+            if not os.path.exists(fp):
+                continue
+            if name in IMPLEMENTED:
+                por_entidade[name] = self._classify_master(name)
+            else:
+                por_entidade[name] = {"status": "not_implemented", "export_rows": len(self._load(name))}
+
+        # ── escrita (create-only) — só se apply + allowlist; NÃO exercida no skeleton ──
+        applied: dict[str, int] = {}
+        if self.apply and self.allow and self.mode == "create-only":
+            applied = self._apply_create_only()
+
+        return {
+            "phase": "EXPORT_CONTRACT_IMPORTER",
+            "mode": self.mode,
+            "apply": self.apply,
+            "apply_blocked": apply_blocked,
+            "allow": list(self.allow),
+            "manifest": manifest,
+            "por_entidade": por_entidade,
+            "applied": applied,
+            "protected_fields": {k: sorted(v) for k, v in PROTECTED_FIELDS.items()},
+        }
+
+    def _apply_create_only(self) -> dict[str, int]:
+        """Cria SOMENTE would_create das entidades em allow (create-only). Transacional."""
+        applied: dict[str, int] = {}
+        with transaction.atomic():
+            for name in self.allow:
+                if name not in IMPLEMENTED:
+                    continue
+                created = 0
+                for r in self._load(name):
+                    nome = (r.get("nome") or "").strip()
+                    if not nome:
+                        continue
+                    if name == "dat_area" and not DATArea.objects.filter(nome__iexact=nome).exists():
+                        DATArea.objects.create(nome=nome)
+                        created += 1
+                    elif name == "municipio":
+                        uf = (r.get("uf") or "").upper()
+                        if not Municipio.objects.filter(nome__iexact=nome, uf=uf).exists():
+                            Municipio.objects.create(nome=nome, uf=uf, ativo=_to_bool(r.get("ativo")))
+                            created += 1
+                    elif name == "projeto_geral" and not ProjetoGeral.objects.filter(nome__iexact=nome).exists():
+                        ProjetoGeral.objects.create(nome=nome, usa_avaliar=_to_bool(r.get("usa_avaliar")))
+                        created += 1
+                applied[name] = created
+        return applied

--- a/v2/backend/apps/core/tests/test_export_contract_importer.py
+++ b/v2/backend/apps/core/tests/test_export_contract_importer.py
@@ -1,0 +1,150 @@
+"""
+Tests do importer dedicado do export-contract (skeleton, dry-run/create-only).
+
+Política de segurança:
+- dry-run por padrão (apply=False não escreve);
+- --apply sem allowlist NÃO escreve;
+- modo create-only;
+- never-overwrite de campos protegidos (Solicitacao.status, Formacao.data_formacao,
+  Acompanhamento.data_acompanhamento/realizado) -> classificados como protected_diff.
+
+Primeira fatia implementada: dat_area, municipio, projeto_geral (master, baixo risco).
+NÃO importa dados reais.
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportAttributeAccessIssue=false, reportOptionalMemberAccess=false
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from apps.core.models import DATArea, Municipio, Projeto, ProjetoGeral
+from apps.core.services.export_contract_importer import (
+    ExportContractImporter,
+    diff_and_classify,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+def _write_export(tmp_path, files: dict[str, str]):
+    """Cria um diretório de export mínimo com manifest + CSVs."""
+    d = tmp_path / "export"
+    d.mkdir()
+    manifest = {"generated_at": "2026-06-02", "snapshot_date": "2026-05-19", "entities": {}}
+    for name, content in files.items():
+        (d / f"{name}.csv").write_text(content, encoding="utf-8")
+        rows = max(content.strip().count("\n"), 0)
+        manifest["entities"][name] = {"file_csv": f"{name}.csv", "rows": rows}
+    (d / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+    return str(d)
+
+
+# ───────── política de campos protegidos (unit puro) ─────────
+def test_diff_create_when_no_existing():
+    assert diff_and_classify(None, {"status": "aprovado"}, {"status"})[0] == "would_create"
+
+
+def test_diff_skip_same():
+    st, _ = diff_and_classify({"descricao": "x"}, {"descricao": "x"}, set())
+    assert st == "would_skip_same"
+
+
+def test_diff_protected_field_never_overwrite():
+    st, fields = diff_and_classify({"status": "aprovado"}, {"status": "pendente"}, {"status"})
+    assert st == "protected_diff"
+    assert "status" in fields
+
+
+def test_diff_update_non_protected():
+    st, fields = diff_and_classify({"descricao": "a"}, {"descricao": "b"}, {"status"})
+    assert st == "would_update"
+    assert "descricao" in fields
+
+
+# ───────── dry-run / apply safety ─────────
+def test_dry_run_is_default_and_writes_nothing(tmp_path):
+    path = _write_export(tmp_path, {"dat_area": "nome,descricao\nArea Nova,desc\n"})
+    before = DATArea.objects.count()
+    imp = ExportContractImporter(path=path)  # apply default False
+    report = imp.run()
+    assert imp.apply is False
+    assert DATArea.objects.count() == before  # nada escrito
+    assert report["por_entidade"]["dat_area"]["would_create"] == 1
+
+
+def test_apply_without_allowlist_writes_nothing(tmp_path):
+    path = _write_export(tmp_path, {"dat_area": "nome,descricao\nArea Nova,desc\n"})
+    before = DATArea.objects.count()
+    imp = ExportContractImporter(path=path, apply=True, allow=())
+    report = imp.run()
+    assert DATArea.objects.count() == before  # abort/no-write sem allowlist
+    assert report.get("apply_blocked") is True
+
+
+def test_reads_manifest(tmp_path):
+    path = _write_export(tmp_path, {"dat_area": "nome,descricao\nA,d\n"})
+    report = ExportContractImporter(path=path).run()
+    assert "manifest" in report
+    assert report["manifest"]["snapshot_date"] == "2026-05-19"
+
+
+# ───────── classificação por entidade (master, baixo risco) ─────────
+def test_classify_dat_area(tmp_path):
+    # DATArea não tem campo comparável no export → existência decide create vs skip (sem update).
+    DATArea.objects.create(nome="Area Existente")
+    csv = "nome,descricao\nArea Existente,old\nArea Existente,nova desc\nArea Nova,d\n,sem nome\n"
+    path = _write_export(tmp_path, {"dat_area": csv})
+    r = ExportContractImporter(path=path).run()["por_entidade"]["dat_area"]
+    assert r["would_skip_same"] == 2  # ambas as linhas da area existente
+    assert r["would_create"] == 1  # Area Nova
+    assert r["would_reject"] == 1  # linha sem nome
+    assert r["would_update"] == 0
+
+
+def test_classify_municipio(tmp_path):
+    Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
+    csv = "nome,uf,ativo\nFortaleza,CE,True\nNova Cidade,PE,True\n"
+    path = _write_export(tmp_path, {"municipio": csv})
+    r = ExportContractImporter(path=path).run()["por_entidade"]["municipio"]
+    assert r["would_skip_same"] == 1  # Fortaleza/CE existe, ativo igual
+    assert r["would_create"] == 1  # Nova Cidade/PE novo
+
+
+def test_classify_projeto_geral(tmp_path):
+    ProjetoGeral.objects.create(nome="VIDA E LINGUAGEM", usa_avaliar=True)
+    ProjetoGeral.objects.create(nome="ACERTA MAT", usa_avaliar=True)
+    # VIDA E LINGUAGEM igual -> skip; ACERTA MAT usa_avaliar diverge -> would_update; NOVO PG -> create
+    csv = "nome,usa_avaliar\nVIDA E LINGUAGEM,True\nACERTA MAT,False\nNOVO PG,False\n"
+    path = _write_export(tmp_path, {"projeto_geral": csv})
+    r = ExportContractImporter(path=path).run()["por_entidade"]["projeto_geral"]
+    assert r["would_skip_same"] == 1
+    assert r["would_update"] == 1
+    assert r["would_create"] == 1
+
+
+# ───────── uso do resolver de Projeto ─────────
+def test_uses_projeto_resolver():
+    Projeto.objects.create(nome="Vida & Matemática 6", fluxo="NAO_SUPER")
+    imp = ExportContractImporter(path=".")
+    pid = imp.resolve_projeto("VIDA E MATEMATICA 6")
+    assert pid is not None
+    assert Projeto.objects.get(id=pid).nome == "Vida & Matemática 6"
+
+
+# ───────── entidades não implementadas ─────────
+def test_not_implemented_entities_marked(tmp_path):
+    path = _write_export(tmp_path, {"solicitacao": "municipio,projeto\nX,Y\n"})
+    r = ExportContractImporter(path=path).run()["por_entidade"]
+    assert r["solicitacao"]["status"] == "not_implemented"
+
+
+# ───────── sem PII no relatório ─────────
+def test_report_has_no_pii(tmp_path):
+    path = _write_export(tmp_path, {"dat_area": "nome,descricao\nA,d\n"})
+    report = ExportContractImporter(path=path).run()
+    blob = json.dumps(report).lower()
+    for token in ("cpf", "telefone", "@"):
+        assert token not in blob

--- a/v2/backend/apps/core/tests/test_export_contract_importer.py
+++ b/v2/backend/apps/core/tests/test_export_contract_importer.py
@@ -17,6 +17,7 @@ NÃO importa dados reais.
 from __future__ import annotations
 
 import json
+from typing import Any
 
 import pytest
 
@@ -33,7 +34,7 @@ def _write_export(tmp_path, files: dict[str, str]):
     """Cria um diretório de export mínimo com manifest + CSVs."""
     d = tmp_path / "export"
     d.mkdir()
-    manifest = {"generated_at": "2026-06-02", "snapshot_date": "2026-05-19", "entities": {}}
+    manifest: dict[str, Any] = {"generated_at": "2026-06-02", "snapshot_date": "2026-05-19", "entities": {}}
     for name, content in files.items():
         (d / f"{name}.csv").write_text(content, encoding="utf-8")
         rows = max(content.strip().count("\n"), 0)
@@ -114,10 +115,11 @@ def test_classify_municipio(tmp_path):
 
 
 def test_classify_projeto_geral(tmp_path):
-    ProjetoGeral.objects.create(nome="VIDA E LINGUAGEM", usa_avaliar=True)
-    ProjetoGeral.objects.create(nome="ACERTA MAT", usa_avaliar=True)
-    # VIDA E LINGUAGEM igual -> skip; ACERTA MAT usa_avaliar diverge -> would_update; NOVO PG -> create
-    csv = "nome,usa_avaliar\nVIDA E LINGUAGEM,True\nACERTA MAT,False\nNOVO PG,False\n"
+    # Nomes sintéticos (PG TESTE *) para não colidir com ProjetoGeral seedado por migração.
+    ProjetoGeral.objects.create(nome="PG TESTE SKIP", usa_avaliar=True)
+    ProjetoGeral.objects.create(nome="PG TESTE UPD", usa_avaliar=True)
+    # SKIP igual -> skip; UPD usa_avaliar diverge -> would_update; PG TESTE NOVO -> create
+    csv = "nome,usa_avaliar\nPG TESTE SKIP,True\nPG TESTE UPD,False\nPG TESTE NOVO,False\n"
     path = _write_export(tmp_path, {"projeto_geral": csv})
     r = ExportContractImporter(path=path).run()["por_entidade"]["projeto_geral"]
     assert r["would_skip_same"] == 1


### PR DESCRIPTION
## Summary

- adiciona skeleton do importer dedicado ao export-contract;
- implementa dry-run por padrão e bloqueia `--apply` sem allowlist;
- suporta modo `create-only` e política de campos protegidos;
- lê `manifest.json`, usa o resolver de Projeto e classifica entidades em create/update/skip/reject/protected_diff/not_implemented;
- cobre a primeira fatia segura: `dat_area`, `municipio` e `projeto_geral`.

## Test plan

- `pytest apps/core/tests/test_export_contract_importer.py -q`
- `black --check apps/core/services/export_contract_importer.py apps/core/management/commands/import_export_contract.py apps/core/tests/test_export_contract_importer.py`
- `isort --check-only apps/core/services/export_contract_importer.py apps/core/management/commands/import_export_contract.py apps/core/tests/test_export_contract_importer.py`
- `flake8 apps/core/services/export_contract_importer.py apps/core/management/commands/import_export_contract.py apps/core/tests/test_export_contract_importer.py`
- demo dry-run read-only do export real `C:\tmp\export-contract-2026-06-02-fix1`

## Notes

- Sem migration.
- Sem alteração de banco.
- Sem import/apply real.
- `--apply` permanece bloqueado sem allowlist.
- Entidades fora da primeira fatia ficam como `NOT_IMPLEMENTED`.

## Staging Gate (antes de Ready)

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

ALL 8 CHECKS PASSED

Evidencia local: `evidence/staging-full-pr1373-20260603-110307.txt` (gitignored). PIPELINE_RC=0.
Pipeline via sub-targets `make -C` (precheck/build/up/test/down) — workaround do bug GnuWin32 `$(MAKE)`;
equivalente a `make staging-full`. Checks: [1] Backend readyz · [2] Backend version · [3] CSRF ·
[4] Auth pipeline (HTTP 400) · [5] Celery worker · [6] Celery beat · [7] Frontend HTTP · [8] Frontend health — todos PASS.
