### PR TITLE
feat(backend): importer export-contract entidades-mestre

### DIFF
--- a/v2/backend/apps/core/services/export_contract_importer.py
+++ b/v2/backend/apps/core/services/export_contract_importer.py
@@ -28,7 +28,16 @@ from typing import Any
 
 from django.db import transaction
 
-from apps.core.models import DATArea, Municipio, ProjetoGeral
+from apps.core.models import (
+    DATArea,
+    DATCoordenador,
+    Gerencia,
+    Municipio,
+    Produto,
+    ProjetoGeral,
+    TipoEvento,
+    Usuario,
+)
 from apps.core.services.export_contract_projeto_resolver import build_projeto_index, resolve_projeto_export
 
 # Campos protegidos por entidade — NUNCA sobrescrever em update (decisão humana).
@@ -64,7 +73,16 @@ ENTITY_ORDER = [
     "acompanhamento",
     "prova",
 ]
-IMPLEMENTED = {"dat_area", "municipio", "projeto_geral"}
+IMPLEMENTED = {
+    "dat_area",
+    "municipio",
+    "projeto_geral",
+    "produto",
+    "usuario",
+    "tipo_evento",
+    "gerencia",
+    "dat_coordenador",
+}
 
 
 def _norm(s: str) -> str:
@@ -185,6 +203,74 @@ class ExportContractImporter:
                 st, _ = diff_and_classify(
                     idx.get(_norm(nome)), {"usa_avaliar": _to_bool(r.get("usa_avaliar"))}, protected
                 )
+                tally[st] += 1
+
+        elif name == "produto":
+            # NK = codigo (unique). Compara nome (não-protegido).
+            idx = {
+                (c or "").strip().upper(): {"nome": n or ""} for c, n in Produto.objects.values_list("codigo", "nome")
+            }
+            for r in rows:
+                codigo = (r.get("codigo") or "").strip()
+                if not codigo:
+                    tally["would_reject"] += 1
+                    continue
+                st, _ = diff_and_classify(idx.get(codigo.upper()), {"nome": r.get("nome") or ""}, protected)
+                tally[st] += 1
+
+        elif name == "usuario":
+            # NK = CPF (unique), fallback email. PII: só conta/resolve, nunca imprime valores.
+            cpfs = {
+                re.sub(r"\D", "", c)
+                for c in Usuario.objects.values_list("cpf", flat=True)
+                if re.sub(r"\D", "", c or "")
+            }
+            emails = {(e or "").lower() for e in Usuario.objects.values_list("email", flat=True) if e}
+            for r in rows:
+                cpf = re.sub(r"\D", "", r.get("cpf") or "")
+                email = (r.get("email") or "").lower().strip()
+                if not cpf and not email:
+                    tally["would_reject"] += 1
+                    continue
+                existe = (cpf in cpfs) or (email in emails)
+                # sem comparação de campo (evita PII); existência decide skip vs create.
+                st, _ = diff_and_classify({} if existe else None, {}, protected)
+                tally[st] += 1
+
+        elif name == "tipo_evento":
+            idx = {_norm(n): {"cor": (c or "")} for n, c in TipoEvento.objects.values_list("nome", "cor")}
+            for r in rows:
+                nome = (r.get("nome") or "").strip()
+                if not nome:
+                    tally["would_reject"] += 1
+                    continue
+                st, _ = diff_and_classify(idx.get(_norm(nome)), {"cor": r.get("cor") or ""}, protected)
+                tally[st] += 1
+
+        elif name == "gerencia":
+            # Export `nome` é o SETOR ("Vidas"); casa DB.nome_setor (não DB.nome="GERENCIA N").
+            # Create é complexo (falta o `nome` canônico) → classifica, mas apply de create não suportado.
+            idx = {_norm(s) for s in Gerencia.objects.values_list("nome_setor", flat=True)}
+            for r in rows:
+                nome = (r.get("nome") or "").strip()
+                if not nome or nome == "-":
+                    tally["would_reject"] += 1
+                    continue
+                st, _ = diff_and_classify({} if _norm(nome) in idx else None, {}, protected)
+                tally[st] += 1
+
+        elif name == "dat_coordenador":
+            # DATCoordenador não tem unique no model; matching por email (lower) ∪ norm(nome).
+            # PII: coordenador é pessoa → só conta/resolve, nunca imprime valores.
+            emails = {(e or "").lower() for e in DATCoordenador.objects.values_list("email", flat=True) if e}
+            nomes = {_norm(n) for n in DATCoordenador.objects.values_list("nome", flat=True) if n}
+            for r in rows:
+                val = (r.get("usuario") or "").strip()
+                if not val:
+                    tally["would_reject"] += 1
+                    continue
+                existe = ("@" in val and val.lower() in emails) or (_norm(val) in nomes)
+                st, _ = diff_and_classify({} if existe else None, {}, protected)
                 tally[st] += 1
 
         tally["export_rows"] = len(rows)

--- a/v2/backend/apps/core/tests/test_export_contract_importer.py
+++ b/v2/backend/apps/core/tests/test_export_contract_importer.py
@@ -21,7 +21,17 @@ from typing import Any
 
 import pytest
 
-from apps.core.models import DATArea, Municipio, Projeto, ProjetoGeral
+from apps.core.models import (
+    DATArea,
+    DATCoordenador,
+    Gerencia,
+    Municipio,
+    Produto,
+    Projeto,
+    ProjetoGeral,
+    TipoEvento,
+    Usuario,
+)
 from apps.core.services.export_contract_importer import (
     ExportContractImporter,
     diff_and_classify,
@@ -150,3 +160,94 @@ def test_report_has_no_pii(tmp_path):
     blob = json.dumps(report).lower()
     for token in ("cpf", "telefone", "@"):
         assert token not in blob
+
+
+# ───────── entidades-mestre adicionais (PR feat/export-contract-master-importers) ─────────
+def test_classify_produto(tmp_path):
+    proj = Projeto.objects.create(nome="Proj Prod Teste", fluxo="NAO_SUPER")
+    Produto.objects.create(codigo="PT-1", nome="Produto Existente", projeto=proj)
+    Produto.objects.create(codigo="PT-2", nome="Produto Upd", projeto=proj)
+    # PT-1 nome igual -> skip; PT-2 nome diverge -> update; PT-NOVO -> create; vazio -> reject
+    csv = "codigo,nome\nPT-1,Produto Existente\nPT-2,Nome Mudou\nPT-NOVO,Novo\n,Sem Codigo\n"
+    r = ExportContractImporter(path=_write_export(tmp_path, {"produto": csv})).run()["por_entidade"]["produto"]
+    assert r["would_skip_same"] == 1
+    assert r["would_update"] == 1
+    assert r["would_create"] == 1
+    assert r["would_reject"] == 1
+
+
+def test_classify_usuario(tmp_path):
+    Usuario.objects.create_user(username="u_imp_exist", password="x", cpf="11122233344", email="u.exist@ex.com")
+    # existente por cpf -> skip; novo -> create; sem cpf/email -> reject
+    csv = "nome_completo,cpf,email\nFulano,11122233344,u.exist@ex.com\nBeltrano,55566677788,novo@ex.com\nSem Id,,\n"
+    r = ExportContractImporter(path=_write_export(tmp_path, {"usuario": csv})).run()["por_entidade"]["usuario"]
+    assert r["would_skip_same"] == 1
+    assert r["would_create"] == 1
+    assert r["would_reject"] == 1
+
+
+def test_usuario_no_pii_in_report(tmp_path):
+    csv = "nome_completo,cpf,email\nFulano Secreto,12398712399,fulano.secreto@ex.com\n"
+    report = ExportContractImporter(path=_write_export(tmp_path, {"usuario": csv})).run()
+    blob = json.dumps(report)
+    assert "12398712399" not in blob  # CPF não vaza
+    assert "fulano.secreto@ex.com" not in blob  # email não vaza
+    assert "Fulano Secreto" not in blob  # nome não vaza
+
+
+def test_classify_tipo_evento(tmp_path):
+    TipoEvento.objects.create(nome="Formacao TE", cor="#111111")
+    TipoEvento.objects.create(nome="Visita TE", cor="#222222")
+    # Formacao igual -> skip; Visita cor diverge -> update; Novo -> create
+    csv = "nome,cor\nFormacao TE,#111111\nVisita TE,#999999\nEvento Novo TE,#333333\n"
+    r = ExportContractImporter(path=_write_export(tmp_path, {"tipo_evento": csv})).run()["por_entidade"]["tipo_evento"]
+    assert r["would_skip_same"] == 1
+    assert r["would_update"] == 1
+    assert r["would_create"] == 1
+
+
+def test_classify_gerencia_matches_by_setor(tmp_path):
+    # Export `nome` é o setor → casa DB.nome_setor (não DB.nome canônico).
+    Gerencia.objects.create(nome="GERENCIA TESTE", nome_setor="Setor Existente")
+    csv = "nome,nome_setor\nSetor Existente,Setor Existente\nSetor Novo,Setor Novo\n-,-\n"
+    r = ExportContractImporter(path=_write_export(tmp_path, {"gerencia": csv})).run()["por_entidade"]["gerencia"]
+    assert r["would_skip_same"] == 1  # casou por nome_setor
+    assert r["would_create"] == 1  # setor novo (create exige nome canônico — caveat)
+    assert r["would_reject"] == 1  # linha "-"
+
+
+def test_classify_dat_coordenador(tmp_path):
+    creator = Usuario.objects.create_user(username="u_dc_creator", password="x", cpf="99900011122")
+    area = DATArea.objects.create(nome="Area Coord Teste")
+    DATCoordenador.objects.create(nome="Coord Existente", email="coord.exist@ex.com", area=area, created_by=creator)
+    # existente por email -> skip; novo -> create; vazio -> reject
+    csv = "usuario,area\ncoord.exist@ex.com,Area Coord Teste\nNovo Coord,Area Coord Teste\n,Area Coord Teste\n"
+    r = ExportContractImporter(path=_write_export(tmp_path, {"dat_coordenador": csv})).run()["por_entidade"][
+        "dat_coordenador"
+    ]
+    assert r["would_skip_same"] == 1
+    assert r["would_create"] == 1
+    assert r["would_reject"] == 1
+
+
+def test_dat_coordenador_no_pii(tmp_path):
+    csv = "usuario,area\ncoord.secreto@ex.com,Area X\n"
+    report = ExportContractImporter(path=_write_export(tmp_path, {"dat_coordenador": csv})).run()
+    assert "coord.secreto@ex.com" not in json.dumps(report)
+
+
+def test_demo_oito_entidades_implementadas(tmp_path):
+    files = {
+        "dat_area": "nome,descricao\nA,d\n",
+        "municipio": "nome,uf,ativo\nC,CE,True\n",
+        "projeto_geral": "nome,usa_avaliar\nPG,True\n",
+        "produto": "codigo,nome\nC1,N\n",
+        "usuario": "nome_completo,cpf,email\nF,11111111111,f@ex.com\n",
+        "tipo_evento": "nome,cor\nT,#000000\n",
+        "gerencia": "nome,nome_setor\nSetor,Setor\n",
+        "dat_coordenador": "usuario,area\ncoord@ex.com,Area\n",
+    }
+    r = ExportContractImporter(path=_write_export(tmp_path, files)).run()["por_entidade"]
+    for ent in files:
+        assert "status" not in r[ent], f"{ent} deveria estar implementada"
+        assert "export_rows" in r[ent]


### PR DESCRIPTION
## Summary

- expande o importer dry-run do export-contract com novas entidades-mestre;
- adiciona suporte para `produto`, `usuario`, `tipo_evento`, `gerencia` e `dat_coordenador`;
- mantém o modo `create-only`, sem writes por padrão;
- preserva entidades fora do escopo como `NOT_IMPLEMENTED`;
- reforça testes para classificação, divergências e proteção contra PII.

## Test plan

- `pytest apps/core/tests/test_export_contract_importer.py -q`
- `black --check apps/core/services/export_contract_importer.py apps/core/tests/test_export_contract_importer.py`
- `isort --check-only apps/core/services/export_contract_importer.py apps/core/tests/test_export_contract_importer.py`
- `flake8 apps/core/services/export_contract_importer.py apps/core/tests/test_export_contract_importer.py`
- demo dry-run read-only do export real `C:\tmp\export-contract-2026-06-02-fix1`

## Notes

- Sem migration.
- Sem alteração de banco.
- Sem import/apply real.
- `--apply` continua bloqueado sem allowlist.
- Entidades operacionais seguem fora do escopo.

## Staging Gate (antes de Ready)

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

ALL 8 CHECKS PASSED

Comando exato (sub-alvos individuais p/ contornar bug `$(MAKE)`/GnuWin32):
`make -C v2/infra staging-precheck && staging-build && staging-up && staging-test` (+ `staging-down` no teardown).

Evidencia: `evidence/staging-full-pr1375-20260603-145601.txt`

```
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS
ALL 8 CHECKS PASSED
```
