### PR TITLE
fix(ci): cache-bust upgrade de SO nas imagens prod + dependabot docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -89,11 +89,17 @@ updates:
   # ================================  
   # DOCKER DEPENDENCIES
   # ================================
+  # NOTE: os Dockerfiles ficam em /v2/infra e /v2/frontend, NÃO na raiz.
+  # Com `directory: "/"` (antigo) o Dependabot não encontrava Dockerfile nenhum
+  # e nunca abria PR de bump de imagem-base — as bases driftavam até um deploy
+  # falhar no gate de CVE de SO. `directories` (plural) cobre os dois caminhos.
   - package-ecosystem: "docker"
-    directory: "/"
+    directories:
+      - "/v2/infra"
+      - "/v2/frontend"
     schedule:
-      interval: "monthly"
-      day: "first-tuesday"
+      interval: "weekly"
+      day: "tuesday"
       time: "10:00"
       timezone: "America/Fortaleza"
     

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -184,6 +184,8 @@ jobs:
           tags: aprender-frontend:scan-${{ github.run_id }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            GIT_SHA=${{ github.sha }}
 
       - name: Generate Trivy report (backend)
         uses: aquasecurity/trivy-action@e368e328979b113139d6f9068e03accaed98a518 # 0.34.1
@@ -260,6 +262,8 @@ jobs:
             ${{ env.FRONTEND_IMAGE }}:${{ needs.prepare.outputs.release_version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            GIT_SHA=${{ github.sha }}
 
       - name: Create git tag if missing
         env:

--- a/v2/frontend/Dockerfile.prod
+++ b/v2/frontend/Dockerfile.prod
@@ -26,6 +26,12 @@ RUN npm run build
 # -----------------------------------------------------------------------------
 FROM nginx:alpine AS production
 
+# Cache-bust the apk upgrade layer per release. GIT_SHA changes every commit, so
+# `apk upgrade` re-runs against the CURRENT Alpine mirror instead of reusing a
+# stale cached layer (the gha build cache otherwise pins the upgrade to whatever
+# packages existed when the layer was first built).
+ARG GIT_SHA=unknown
+
 # Labels para Docker Hub
 LABEL org.opencontainers.image.title="Aprender Sistema Frontend"
 LABEL org.opencontainers.image.description="React frontend for Aprender Sistema"
@@ -33,7 +39,7 @@ LABEL org.opencontainers.image.vendor="norjosamatheus"
 LABEL org.opencontainers.image.source="https://github.com/matheusnorjosa/aprender-sistema"
 
 # Atualiza pacotes base para reduzir CVEs conhecidos da imagem runtime.
-RUN apk upgrade --no-cache
+RUN echo "os-security-upgrade for ${GIT_SHA}" && apk upgrade --no-cache
 
 # Remover configuracao default do nginx
 RUN rm /etc/nginx/conf.d/default.conf

--- a/v2/infra/Dockerfile.prod
+++ b/v2/infra/Dockerfile.prod
@@ -37,10 +37,18 @@ ENV DEBIAN_FRONTEND=noninteractive \
     PYTHONUNBUFFERED=1 \
     PATH="/home/appuser/.local/bin:/opt/venv/bin:$PATH"
 
+# Cache-bust the OS security-upgrade layer per release. GIT_SHA changes every
+# commit, so `apt-get upgrade` re-runs against the CURRENT Debian mirror instead
+# of reusing a stale cached layer (the gha build cache otherwise pins the upgrade
+# to whatever packages existed when the layer was first built). Pairs with the
+# Dependabot docker base-image bumps to keep the runtime image free of fixed OS CVEs.
+ARG GIT_SHA=unknown
+
 # Runtime OS packages only (NO compilers, NO headers)
 # - postgresql-client: required for backup scripts (Issue #562 C-05)
 # - libmagic1: required by python-magic at runtime
-RUN apt-get update \
+RUN echo "os-security-upgrade for ${GIT_SHA}" \
+ && apt-get update \
  && apt-get upgrade -y \
  && apt-get install -y --no-install-recommends \
     curl tzdata ca-certificates libpq5 postgresql-client libmagic1 \

--- a/v2/infra/Makefile
+++ b/v2/infra/Makefile
@@ -409,6 +409,7 @@ staging-build: ## Build backend+frontend PROD images para staging gate
 	  -t $(BACKEND_IMAGE) ..
 	@echo "🔨 [STAGING] building frontend ($(FRONTEND_IMAGE))..."
 	docker build -f ../frontend/Dockerfile.prod \
+	  --build-arg GIT_SHA=$(GIT_SHA) \
 	  -t $(FRONTEND_IMAGE) ../frontend
 	@echo "✅ [STAGING] build concluído"
 


### PR DESCRIPTION
## Summary

Destrava o deploy de produção, que ficou bloqueado pelo gate de segurança de imagem (`Enforce security gate (block HIGH/CRITICAL)`) após o merge do #1390.

**Causa-raiz:** as imagens runtime carregavam pacotes de **SO** desatualizados (Debian no backend, Alpine no frontend). Os Dockerfiles **já** fazem `apt-get upgrade`/`apk upgrade`, mas o layer de upgrade ficava **cacheado** (gha `cache-to/from: type=gha,mode=max`), então o upgrade não re-rodava contra o mirror atual — a imagem ficava pinada nos pacotes existentes quando o layer foi criado pela primeira vez. CVEs Debian/Alpine recém-publicadas (2026-06) acumularam até o gate bloquear.

Nenhuma vulnerabilidade era de **aplicação** (Python/npm): o scan acusava 100% camada de SO. Produção seguiu intacta (jobs de push/deploy foram `skipped`).

## Mudanças

- **`v2/infra/Dockerfile.prod`** (backend) e **`v2/frontend/Dockerfile.prod`**: `ARG GIT_SHA` declarado antes do layer de upgrade e referenciado no `RUN` → cache-bust por commit faz o upgrade re-rodar contra o mirror atual a cada release.
- **`.github/workflows/deploy.yaml`** + **`v2/infra/Makefile`**: passar `GIT_SHA` ao build do frontend (o backend já recebia).
- **`.github/dependabot.yml`**: o ecossistema `docker` usava `directory: "/"` (sem Dockerfile lá → **inerte**, nunca abria PR de bump de imagem-base). Corrigido para `directories: [/v2/infra, /v2/frontend]` + cadência `weekly`. Fecha o gap sistêmico que deixou as bases driftarem silenciosamente.

## Verificação local (Trivy 0.69.1, mesma config do gate: `--severity HIGH,CRITICAL --ignore-unfixed --vuln-type os,library`)

| Imagem | Antes | Depois |
|---|---|---|
| backend | 33 HIGH/CRITICAL (3 CRITICAL: gnutls, openssl) | **0** |
| frontend | 3 HIGH (openssl, libxml2) | **0** |

→ O gate `Enforce security gate` (conta HIGH+CRITICAL) passaria com total=0.

## Notes

- Sem mudança de código de aplicação, migration ou banco.
- Pareia com o roadmap CI/CD: o fix de `directory` do Dependabot é o **mesmo bug** do pip (#1391) — aqui resolvido para o ecossistema docker.

## Staging Gate (antes de Ready)

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

> Rodado por etapas (precheck/build/up/test/down) por causa do bug `$(MAKE)` no GnuWin32; equivalente ao pipeline completo.

```
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS
ALL 8 CHECKS PASSED
```
