### PR TITLE
fix(ci): corrigir day invalido no dependabot.yml (github-actions)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -128,8 +128,10 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/.github/workflows"
     schedule:
+      # `day` aceita SOMENTE nome de dia da semana (monday..sunday); "first-wednesday"
+      # quebrava o parser do Dependabot e invalidava o arquivo INTEIRO (todos os blocos).
       interval: "monthly"
-      day: "first-wednesday"  
+      day: "wednesday"
       time: "11:00"
       timezone: "America/Fortaleza"
     


### PR DESCRIPTION
## Summary

Corrige o erro de parse do Dependabot visto na PR #1406:

> `The property '#/updates/2/schedule/day' value "first-wednesday" did not match one of the following values: monday, tuesday, ...`

`schedule.day` no Dependabot aceita **somente** nome de dia da semana (`monday`..`sunday`). O bloco `github-actions` usava `"first-wednesday"`, valor inválido. Como o Dependabot valida o arquivo **inteiro**, isso invalidava TODA a config — inclusive deixando inertes os fixes de `directory` do docker (#1407) e do pip.

## Mudança
- `.github/dependabot.yml`: `github-actions` `day: "first-wednesday"` → `"wednesday"`.

(O bloco docker já tinha sido corrigido de `"first-tuesday"` → `"tuesday"` no #1407; este era o último valor inválido remanescente.)

## Notes
- Só CI config; sem impacto de runtime → o gate `staging gate evidence` não exige evidência (regex de runtime-impact não cobre `.github/`).
- YAML validado; os 3 `day:` agora são dias da semana válidos.
