### PR TITLE
chore(ci): pinar base-image a patch-only e bloquear major auto no dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -113,14 +113,29 @@ updates:
           - "patch"
     
     open-pull-requests-limit: 5
-    
+
     commit-message:
       prefix: "docker"
-    
+
     labels:
       - "docker"
       - "infrastructure"
       - "automated"
+
+    # Base-image = patch/seguranca SOMENTE. Saltar versao de linguagem (python 3.12->3.14,
+    # node 20->26) e decisao DELIBERADA, nao automatica: quebra build/runtime e exige
+    # validacao. A seguranca de SO ja vem do `apt-get/apk upgrade` no build (cache-bust por
+    # GIT_SHA, ver memoria image-os-cve-deploy-gate). Dependabot trata 3.12->3.14 como
+    # semver-minor da tag e node 20->26 como semver-major; ignoramos ambos p/ python e node.
+    ignore:
+      - dependency-name: "python"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+      - dependency-name: "node"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
 
   # ================================
   # GITHUB ACTIONS
@@ -148,14 +163,22 @@ updates:
     
     commit-message:
       prefix: "ci"
-    
+
     labels:
       - "github-actions"
       - "ci-cd"
       - "automated"
 
+    # Actions: minor/patch automaticos; major (ex.: codecov 4->7, setup-chrome 1->2) e
+    # decisao deliberada (pode ter breaking change) e fica fora do auto-update. Updates
+    # de SEGURANCA do Dependabot ignoram este filtro e continuam vindo normalmente.
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+
 # ================================
-# SECURITY AND VULNERABILITY UPDATES  
+# SECURITY AND VULNERABILITY UPDATES
 # ================================
 # Note: Dependabot automatically creates PRs for security vulnerabilities
 # regardless of the schedule configuration above.


### PR DESCRIPTION
## Summary

Após o fix de config (#1407 directories + #1408 day) reativar o Dependabot, ele passou a propor **saltos de versão indesejados** de base-image e actions, porque interpreta as tags como semver:

- `python 3.12-slim → 3.14-slim` (lido como semver-**minor** da tag → passou pelo filtro `minor,patch` do grupo docker) — major da **linguagem**, quebra build/runtime.
- `node 20-alpine → 26-alpine` (semver-major) e `codecov-action 4→7`, `setup-chrome 1→2` (majors de action) — abriram como PR individual, fora do filtro do grupo.

**Decisão:** saltar versão de linguagem/runtime/action é deliberado, não automático. Base-image recebe **só patch/segurança**; a segurança de SO já vem do `apt-get`/`apk upgrade` no build (cache-bust por GIT_SHA, #1407), não de bump de tag.

## Mudança (`.github/dependabot.yml`)
- **docker**: `ignore` semver-major **+** semver-minor de `python` e `node`.
- **github-actions**: `ignore` semver-major (minor/patch continuam automáticos).
- **pip**: já ignorava major (inalterado).

Updates de **segurança** do Dependabot ignoram estes filtros e continuam vindo normalmente.

## Notes
- Fecha o ciclo de PRs de salto (#1413, #1414, #1417, #1419) — serão fechados manualmente.
- Só CI config; sem impacto de runtime (gate `staging gate evidence` não exige evidência p/ `.github/`).
