### PR TITLE
chore(docs): bump MkDocs toolchain (consolida #1409-#1412)

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -2,9 +2,9 @@
 # Issue #269: Automatic documentation generation
 # Install: pip install -r requirements-docs.txt
 
-mkdocs>=1.6.0
-mkdocs-material>=9.5.0
-mkdocstrings[python]>=0.24.0
+mkdocs>=1.6.1
+mkdocs-material>=9.7.6
+mkdocstrings[python]>=0.30.1
 
 # Optional plugins
-pymdown-extensions>=10.7.0
+pymdown-extensions>=10.21.3


### PR DESCRIPTION
Consolida os 4 Dependabot PRs de docs (#1409 pymdown, #1410 mkdocstrings, #1411 mkdocs-material, #1412 mkdocs) num só PR — todos mexem em `requirements-docs.txt`. Só tooling de documentação MkDocs; sem impacto de runtime. As 4 PRs serão fechadas.