### PR TITLE
fix(frontend): melhorias de acessibilidade (react-doctor)

### DIFF
--- a/v2/frontend/src/components/AppHeader.tsx
+++ b/v2/frontend/src/components/AppHeader.tsx
@@ -150,9 +150,9 @@ export function AppHeader({
                           }
                           description={
                             <span style={{ fontSize: 12 }}>
-                              <Tag color="purple" style={{ fontSize: 11 }}>{item.fase_disparo}</Tag>
-                              {item.prioridade === 'CRITICA' ? <Tag color="red" style={{ fontSize: 11 }}>CRÍTICA</Tag>
-                                : item.prioridade === 'ALTA' ? <Tag color="orange" style={{ fontSize: 11 }}>ALTA</Tag>
+                              <Tag color="purple" style={{ fontSize: 12 }}>{item.fase_disparo}</Tag>
+                              {item.prioridade === 'CRITICA' ? <Tag color="red" style={{ fontSize: 12 }}>CRÍTICA</Tag>
+                                : item.prioridade === 'ALTA' ? <Tag color="orange" style={{ fontSize: 12 }}>ALTA</Tag>
                                 : null}
                             </span>
                           }

--- a/v2/frontend/src/components/ImportUploader.tsx
+++ b/v2/frontend/src/components/ImportUploader.tsx
@@ -339,7 +339,7 @@ export default function ImportUploader({ label, onDryRun, onApply, description }
                   description={
                     <Collapse ghost size="small">
                       <Panel header="Ver detalhes" key="1">
-                        <pre style={{ fontSize: 11, margin: 0, overflow: 'auto' }}>
+                        <pre style={{ fontSize: 12, margin: 0, overflow: 'auto' }}>
                           {JSON.stringify(validationResult.pendencias, null, 2)}
                         </pre>
                       </Panel>

--- a/v2/frontend/src/pages/AdminDAT/AdminDATHomePage.tsx
+++ b/v2/frontend/src/pages/AdminDAT/AdminDATHomePage.tsx
@@ -139,7 +139,7 @@ export default function AdminDATHomePage(): JSX.Element {
               <Text
                 type={module.status === 'Disponível' ? 'success' : 'warning'}
                 strong
-                style={{ fontSize: '11px' }}
+                style={{ fontSize: '12px' }}
               >
                 {module.status}
               </Text>

--- a/v2/frontend/src/pages/DATModule/AcoesPage.tsx
+++ b/v2/frontend/src/pages/DATModule/AcoesPage.tsx
@@ -339,7 +339,7 @@ export default function AcoesPage(): JSX.Element {
       render: (_: unknown, record: AcaoRecord) => (
         <Space direction="vertical" size={0} align="center">
           {renderStatusIcon(record.status_carta)}
-          <Text type="secondary" style={{ fontSize: 11 }}>
+          <Text type="secondary" style={{ fontSize: 12 }}>
             {record.data_carta ? dayjs(record.data_carta).format('DD/MM') : '-'}
           </Text>
         </Space>
@@ -360,7 +360,7 @@ export default function AcoesPage(): JSX.Element {
       render: (_: unknown, record: AcaoRecord) => (
         <Space direction="vertical" size={0} align="center">
           {renderStatusIcon(record.status_contato)}
-          <Text type="secondary" style={{ fontSize: 11 }}>
+          <Text type="secondary" style={{ fontSize: 12 }}>
             {record.data_contato ? dayjs(record.data_contato).format('DD/MM') : '-'}
           </Text>
         </Space>
@@ -381,7 +381,7 @@ export default function AcoesPage(): JSX.Element {
       render: (_: unknown, record: AcaoRecord) => (
         <Space direction="vertical" size={0} align="center">
           {renderStatusIcon(record.status_reuniao)}
-          <Text type="secondary" style={{ fontSize: 11 }}>
+          <Text type="secondary" style={{ fontSize: 12 }}>
             {record.data_reuniao ? dayjs(record.data_reuniao).format('DD/MM') : '-'}
           </Text>
         </Space>
@@ -402,7 +402,7 @@ export default function AcoesPage(): JSX.Element {
       render: (_: unknown, record: AcaoRecord) => (
         <Space direction="vertical" size={0} align="center">
           {renderStatusIcon(record.status_entrega)}
-          <Text type="secondary" style={{ fontSize: 11 }}>
+          <Text type="secondary" style={{ fontSize: 12 }}>
             {record.data_entrega ? dayjs(record.data_entrega).format('DD/MM') : '-'}
           </Text>
         </Space>

--- a/v2/frontend/src/pages/DATModule/Cadastros/columns.tsx
+++ b/v2/frontend/src/pages/DATModule/Cadastros/columns.tsx
@@ -81,14 +81,24 @@ export function getColumnsFormar({ onQuickStatusUpdate, onEdit, onDelete }: Colu
       key: 'criacao_curso',
       width: 110,
       align: 'center',
-      render: (_, record) => (
+      render: (_, record) => {
+        const handleToggle = () => {
+          const newStatus =
+            record.status_criacao_curso === 'concluido' ? 'pendente' : 'concluido';
+          onQuickStatusUpdate(record, 'criacao_curso', newStatus);
+        };
+        return (
         <Tooltip title="Clique para alterar status">
           <div
             className="cursor-pointer"
-            onClick={() => {
-              const newStatus =
-                record.status_criacao_curso === 'concluido' ? 'pendente' : 'concluido';
-              onQuickStatusUpdate(record, 'criacao_curso', newStatus);
+            role="button"
+            tabIndex={0}
+            onClick={handleToggle}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                handleToggle();
+              }
             }}
           >
             {renderStatusIcon(record.status_criacao_curso)}
@@ -99,21 +109,32 @@ export function getColumnsFormar({ onQuickStatusUpdate, onEdit, onDelete }: Colu
             </div>
           </div>
         </Tooltip>
-      ),
+        );
+      },
     },
     {
       title: 'Chaves',
       key: 'chaves',
       width: 100,
       align: 'center',
-      render: (_, record) => (
+      render: (_, record) => {
+        const handleToggle = () => {
+          const newStatus =
+            record.status_chaves === 'concluido' ? 'pendente' : 'concluido';
+          onQuickStatusUpdate(record, 'chaves', newStatus);
+        };
+        return (
         <Tooltip title="Clique para alterar status">
           <div
             className="cursor-pointer"
-            onClick={() => {
-              const newStatus =
-                record.status_chaves === 'concluido' ? 'pendente' : 'concluido';
-              onQuickStatusUpdate(record, 'chaves', newStatus);
+            role="button"
+            tabIndex={0}
+            onClick={handleToggle}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                handleToggle();
+              }
             }}
           >
             {renderStatusIcon(record.status_chaves)}
@@ -122,21 +143,32 @@ export function getColumnsFormar({ onQuickStatusUpdate, onEdit, onDelete }: Colu
             </div>
           </div>
         </Tooltip>
-      ),
+        );
+      },
     },
     {
       title: 'Instruções',
       key: 'instrucoes',
       width: 100,
       align: 'center',
-      render: (_, record) => (
+      render: (_, record) => {
+        const handleToggle = () => {
+          const newStatus =
+            record.status_instrucoes === 'concluido' ? 'pendente' : 'concluido';
+          onQuickStatusUpdate(record, 'instrucoes', newStatus);
+        };
+        return (
         <Tooltip title="Clique para alterar status">
           <div
             className="cursor-pointer"
-            onClick={() => {
-              const newStatus =
-                record.status_instrucoes === 'concluido' ? 'pendente' : 'concluido';
-              onQuickStatusUpdate(record, 'instrucoes', newStatus);
+            role="button"
+            tabIndex={0}
+            onClick={handleToggle}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                handleToggle();
+              }
             }}
           >
             {renderStatusIcon(record.status_instrucoes)}
@@ -145,21 +177,32 @@ export function getColumnsFormar({ onQuickStatusUpdate, onEdit, onDelete }: Colu
             </div>
           </div>
         </Tooltip>
-      ),
+        );
+      },
     },
     {
       title: 'Envio',
       key: 'envio',
       width: 100,
       align: 'center',
-      render: (_, record) => (
+      render: (_, record) => {
+        const handleToggle = () => {
+          const newStatus =
+            record.status_envio === 'concluido' ? 'pendente' : 'concluido';
+          onQuickStatusUpdate(record, 'envio', newStatus);
+        };
+        return (
         <Tooltip title="Clique para alterar status">
           <div
             className="cursor-pointer"
-            onClick={() => {
-              const newStatus =
-                record.status_envio === 'concluido' ? 'pendente' : 'concluido';
-              onQuickStatusUpdate(record, 'envio', newStatus);
+            role="button"
+            tabIndex={0}
+            onClick={handleToggle}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                handleToggle();
+              }
             }}
           >
             {renderStatusIcon(record.status_envio)}
@@ -168,7 +211,8 @@ export function getColumnsFormar({ onQuickStatusUpdate, onEdit, onDelete }: Colu
             </div>
           </div>
         </Tooltip>
-      ),
+        );
+      },
     },
     {
       title: 'Link',
@@ -253,15 +297,25 @@ export function getColumnsAvaliar({ onQuickStatusUpdate, onEdit, onDelete }: Col
       title: 'Recebidos',
       key: 'recebidos',
       width: 120,
-      render: (_, record) => (
+      render: (_, record) => {
+        const handleToggle = () => {
+          const newStatus =
+            record.status_recebidos === 'concluido' ? 'pendente' : 'concluido';
+          onQuickStatusUpdate(record, 'recebidos', newStatus);
+        };
+        return (
         <Space direction="vertical" size={0} align="center">
           <Tooltip title="Clique para alterar status">
             <div
               className="cursor-pointer"
-              onClick={() => {
-                const newStatus =
-                  record.status_recebidos === 'concluido' ? 'pendente' : 'concluido';
-                onQuickStatusUpdate(record, 'recebidos', newStatus);
+              role="button"
+              tabIndex={0}
+              onClick={handleToggle}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  handleToggle();
+                }
               }}
             >
               {renderStatusIcon(record.status_recebidos)}
@@ -269,21 +323,32 @@ export function getColumnsAvaliar({ onQuickStatusUpdate, onEdit, onDelete }: Col
           </Tooltip>
           <Text type="secondary">{record.quantidade_recebidos || 0}</Text>
         </Space>
-      ),
+        );
+      },
     },
     {
       title: 'Validados',
       key: 'validados',
       width: 120,
-      render: (_, record) => (
+      render: (_, record) => {
+        const handleToggle = () => {
+          const newStatus =
+            record.status_validados === 'concluido' ? 'pendente' : 'concluido';
+          onQuickStatusUpdate(record, 'validados', newStatus);
+        };
+        return (
         <Space direction="vertical" size={0} align="center">
           <Tooltip title="Clique para alterar status">
             <div
               className="cursor-pointer"
-              onClick={() => {
-                const newStatus =
-                  record.status_validados === 'concluido' ? 'pendente' : 'concluido';
-                onQuickStatusUpdate(record, 'validados', newStatus);
+              role="button"
+              tabIndex={0}
+              onClick={handleToggle}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  handleToggle();
+                }
               }}
             >
               {renderStatusIcon(record.status_validados)}
@@ -291,21 +356,32 @@ export function getColumnsAvaliar({ onQuickStatusUpdate, onEdit, onDelete }: Col
           </Tooltip>
           <Text type="secondary">{record.quantidade_validados || 0}</Text>
         </Space>
-      ),
+        );
+      },
     },
     {
       title: 'Importados',
       key: 'importados',
       width: 120,
-      render: (_, record) => (
+      render: (_, record) => {
+        const handleToggle = () => {
+          const newStatus =
+            record.status_importados === 'concluido' ? 'pendente' : 'concluido';
+          onQuickStatusUpdate(record, 'importados', newStatus);
+        };
+        return (
         <Space direction="vertical" size={0} align="center">
           <Tooltip title="Clique para alterar status">
             <div
               className="cursor-pointer"
-              onClick={() => {
-                const newStatus =
-                  record.status_importados === 'concluido' ? 'pendente' : 'concluido';
-                onQuickStatusUpdate(record, 'importados', newStatus);
+              role="button"
+              tabIndex={0}
+              onClick={handleToggle}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  handleToggle();
+                }
               }}
             >
               {renderStatusIcon(record.status_importados)}
@@ -313,7 +389,8 @@ export function getColumnsAvaliar({ onQuickStatusUpdate, onEdit, onDelete }: Col
           </Tooltip>
           <Text type="secondary">{record.quantidade_importados || 0}</Text>
         </Space>
-      ),
+        );
+      },
     },
     {
       title: 'Progresso',

--- a/v2/frontend/src/pages/DATModule/ComprasPage.tsx
+++ b/v2/frontend/src/pages/DATModule/ComprasPage.tsx
@@ -315,7 +315,7 @@ export default function ComprasPage(): JSX.Element {
           <Text strong>{nome}</Text>
           {record.codigo_produto && (
             <div>
-              <Text type="secondary" style={{ fontSize: 11 }}>
+              <Text type="secondary" style={{ fontSize: 12 }}>
                 Cód: {record.codigo_produto}
               </Text>
             </div>

--- a/v2/frontend/src/pages/DATModule/CoordenadoresPage.tsx
+++ b/v2/frontend/src/pages/DATModule/CoordenadoresPage.tsx
@@ -382,12 +382,12 @@ export default function CoordenadoresPage(): JSX.Element {
               <Divider style={{ margin: '8px 0' }} />
               <Row gutter={8}>
                 <Col span={12}>
-                  <Text type="secondary" style={{ fontSize: 11 }}>
+                  <Text type="secondary" style={{ fontSize: 12 }}>
                     <EnvironmentOutlined /> {coord.total_municipios || 0} municípios
                   </Text>
                 </Col>
                 <Col span={12}>
-                  <Text type="secondary" style={{ fontSize: 11 }}>
+                  <Text type="secondary" style={{ fontSize: 12 }}>
                     <ProjectOutlined /> {coord.total_projetos || 0} projetos
                   </Text>
                 </Col>
@@ -434,7 +434,7 @@ export default function CoordenadoresPage(): JSX.Element {
                     <div>
                       <Text strong>{coord.nome}</Text>
                       <div>
-                        <Text type="secondary" style={{ fontSize: 11 }}>
+                        <Text type="secondary" style={{ fontSize: 12 }}>
                           {coord.total_municipios || 0} mun. | {coord.total_projetos || 0} proj.
                         </Text>
                       </div>

--- a/v2/frontend/src/pages/DATModule/FormacoesPage.tsx
+++ b/v2/frontend/src/pages/DATModule/FormacoesPage.tsx
@@ -296,7 +296,7 @@ export default function FormacoesPage(): JSX.Element {
               <Badge
                 status={statusConfig?.color === 'green' ? 'success' : statusConfig?.color === 'red' ? 'error' : 'processing'}
                 text={
-                  <Text style={{ fontSize: 11 }} ellipsis>
+                  <Text style={{ fontSize: 12 }} ellipsis>
                     {item.projeto_nome}
                   </Text>
                 }
@@ -306,7 +306,7 @@ export default function FormacoesPage(): JSX.Element {
         })}
         {dayFormacoes.length > 3 && (
           <li>
-            <Text type="secondary" style={{ fontSize: 11 }}>
+            <Text type="secondary" style={{ fontSize: 12 }}>
               +{dayFormacoes.length - 3} mais
             </Text>
           </li>
@@ -577,6 +577,7 @@ export default function FormacoesPage(): JSX.Element {
                           style={{ marginBottom: 8 }}
                           actions={[
                             <Button
+                              key="edit"
                               type="link"
                               size="small"
                               onClick={() => {

--- a/v2/frontend/src/pages/DATModule/PlanoFormacoesPage.tsx
+++ b/v2/frontend/src/pages/DATModule/PlanoFormacoesPage.tsx
@@ -366,8 +366,16 @@ export default function PlanoFormacoesPage(): JSX.Element {
 
     return (
       <div
+        role="button"
+        tabIndex={0}
         style={{ textAlign: 'center', cursor: 'pointer', padding: 4 }}
         onClick={() => handleFormacaoClick(plano, formacao)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            handleFormacaoClick(plano, formacao);
+          }
+        }}
       >
         {hasData ? (
           <>
@@ -385,7 +393,7 @@ export default function PlanoFormacoesPage(): JSX.Element {
             )}
           </>
         ) : (
-          <Text type="secondary" style={{ fontSize: 11 }}>-</Text>
+          <Text type="secondary" style={{ fontSize: 12 }}>-</Text>
         )}
       </div>
     );
@@ -441,7 +449,7 @@ export default function PlanoFormacoesPage(): JSX.Element {
       render: (nome: string, record: PlanoFormacaoRecord) => (
         <div>
           <Text strong>{nome}</Text>
-          <div style={{ fontSize: 11, color: '#888' }}>{record.municipio_uf}</div>
+          <div style={{ fontSize: 12, color: '#888' }}>{record.municipio_uf}</div>
         </div>
       ),
     },

--- a/v2/frontend/src/pages/Dashboards/GCalDashboardPage.tsx
+++ b/v2/frontend/src/pages/Dashboards/GCalDashboardPage.tsx
@@ -793,8 +793,8 @@ export default function GCalDashboardPage(): JSX.Element {
               <>
                 <Divider orientation="left">Participações</Divider>
                 <Space direction="vertical" style={{ width: '100%' }}>
-                  {eventDetail.participations.map((p, idx) => (
-                    <Card key={idx} size="small">
+                  {eventDetail.participations.map((p) => (
+                    <Card key={p.email} size="small">
                       <Space>
                         <UserOutlined />
                         <Text strong>{p.email}</Text>

--- a/v2/frontend/src/pages/Disponibilidade/DetailsDrawer.tsx
+++ b/v2/frontend/src/pages/Disponibilidade/DetailsDrawer.tsx
@@ -43,8 +43,17 @@ export default function DetailsDrawer({ open, onClose, person, day, details }: D
     <>
       {/* Overlay */}
       <div
+        role="button"
+        tabIndex={0}
+        aria-label="Fechar detalhes"
         className="fixed inset-0 bg-black/30 z-40"
         onClick={onClose}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            onClose();
+          }
+        }}
       ></div>
 
       {/* Drawer */}

--- a/v2/frontend/src/pages/Disponibilidade/FiltersBar.tsx
+++ b/v2/frontend/src/pages/Disponibilidade/FiltersBar.tsx
@@ -151,10 +151,11 @@ export default function FiltersBar({ year, month, gerenciaId, sector, q, onChang
 
       {/* Filtro de gerência */}
       <div>
-        <label className="block text-xs font-medium text-gray-700 mb-1">
+        <label htmlFor="filtersbar-gerencia" className="block text-xs font-medium text-gray-700 mb-1">
           Gerência
         </label>
         <select
+          id="filtersbar-gerencia"
           value={gerenciaId || ''}
           onChange={(e: ChangeEvent<HTMLSelectElement>) => onChange({ gerenciaId: e.target.value ? Number(e.target.value) : null })}
           disabled={loading}
@@ -172,10 +173,11 @@ export default function FiltersBar({ year, month, gerenciaId, sector, q, onChang
 
       {/* Filtro de setor (texto) */}
       <div>
-        <label className="block text-xs font-medium text-gray-700 mb-1">
+        <label htmlFor="filtersbar-setor" className="block text-xs font-medium text-gray-700 mb-1">
           Setor
         </label>
         <input
+          id="filtersbar-setor"
           type="text"
           value={sector}
           onChange={(e: ChangeEvent<HTMLInputElement>) => onChange({ sector: e.target.value })}
@@ -186,10 +188,11 @@ export default function FiltersBar({ year, month, gerenciaId, sector, q, onChang
 
       {/* Filtro de busca */}
       <div>
-        <label className="block text-xs font-medium text-gray-700 mb-1">
+        <label htmlFor="filtersbar-buscar" className="block text-xs font-medium text-gray-700 mb-1">
           Buscar
         </label>
         <input
+          id="filtersbar-buscar"
           type="text"
           value={q}
           onChange={(e: ChangeEvent<HTMLInputElement>) => onChange({ q: e.target.value })}

--- a/v2/frontend/src/pages/MapaBrasil/MapaBrasilPage.tsx
+++ b/v2/frontend/src/pages/MapaBrasil/MapaBrasilPage.tsx
@@ -475,8 +475,8 @@ export default function MapaBrasilPage(): JSX.Element {
       key: 'projetos',
       render: (projetos: CoordenadorProjetoType[]) => (
         <Space wrap size={[4, 4]}>
-          {projetos.map((p, idx) => (
-            <Tag key={idx} color="purple" style={{ margin: 0 }}>
+          {projetos.map((p) => (
+            <Tag key={p.nome} color="purple" style={{ margin: 0 }}>
               {p.nome}: <strong>{p.eventos}</strong>
             </Tag>
           ))}
@@ -489,8 +489,8 @@ export default function MapaBrasilPage(): JSX.Element {
       key: 'municipios',
       render: (municipios: CoordenadorMunicipioType[]) => (
         <Space wrap size={[4, 4]}>
-          {municipios.map((m, idx) => (
-            <Tag key={idx} color="green" style={{ margin: 0 }}>
+          {municipios.map((m) => (
+            <Tag key={m.nome} color="green" style={{ margin: 0 }}>
               {m.nome}: <strong>{m.eventos}</strong>
             </Tag>
           ))}
@@ -955,8 +955,8 @@ export default function MapaBrasilPage(): JSX.Element {
                     Municípios com eventos ({estadosData[selectedState].municipiosTotal})
                   </Title>
                   <Space wrap>
-                    {estadosData[selectedState].municipios.map((municipio, idx) => (
-                      <Tag key={idx} color="green">{municipio}</Tag>
+                    {estadosData[selectedState].municipios.map((municipio) => (
+                      <Tag key={municipio} color="green">{municipio}</Tag>
                     ))}
                   </Space>
                 </div>

--- a/v2/frontend/src/pages/PreAgenda/PreAgendaPage.tsx
+++ b/v2/frontend/src/pages/PreAgenda/PreAgendaPage.tsx
@@ -995,7 +995,7 @@ export default function PreAgendaPage(): JSX.Element {
                       <Space direction="vertical" style={{ width: '100%' }}>
                         <Descriptions size="small" column={1}>
                           <Descriptions.Item label="Payload Hash">
-                            <Text code copyable style={{ fontSize: '11px' }}>
+                            <Text code copyable style={{ fontSize: '12px' }}>
                               {previewData.preview.payload_hash}
                             </Text>
                           </Descriptions.Item>
@@ -1006,7 +1006,7 @@ export default function PreAgendaPage(): JSX.Element {
                           overflow: 'auto',
                           backgroundColor: '#f5f5f5',
                           padding: 12,
-                          fontSize: '11px',
+                          fontSize: '12px',
                           borderRadius: '4px'
                         }}>
                           {JSON.stringify(previewData, null, 2)}

--- a/v2/frontend/src/pages/Solicitacoes/NewSolicitacaoWizard.tsx
+++ b/v2/frontend/src/pages/Solicitacoes/NewSolicitacaoWizard.tsx
@@ -646,8 +646,8 @@ export default function NewSolicitacaoWizard(): JSX.Element {
         {/* Navegacao do wizard */}
         <nav aria-label="Passos do wizard" className="mt-6 mb-8">
           <Steps current={currentStep}>
-            {steps.map((step, index) => (
-              <Step key={index} title={step.title} icon={step.icon} />
+            {steps.map((step) => (
+              <Step key={step.title} title={step.title} icon={step.icon} />
             ))}
           </Steps>
         </nav>

--- a/v2/frontend/src/pages/Solicitacoes/__tests__/NewSolicitacaoWizard.test.tsx
+++ b/v2/frontend/src/pages/Solicitacoes/__tests__/NewSolicitacaoWizard.test.tsx
@@ -53,39 +53,41 @@ vi.mock('../../../components/CoordenadoresPicker', () => ({
   default: () => <div data-testid="coordenadores-picker">CoordenadoresPicker</div>,
 }));
 
-vi.mock('../../../components/ComboBox', () => ({
-  default: ({
-    placeholder = '',
-    lookupFunction,
-    onChange,
-    disabled = false,
-  }: {
-    placeholder?: string;
-    lookupFunction: (query: string) => Promise<unknown[]>;
-    onChange?: (item: unknown) => void;
-    disabled?: boolean;
-  }) => {
-    useEffect(() => {
-      void lookupFunction('');
-    }, [lookupFunction]);
+function MockComboBox({
+  placeholder = '',
+  lookupFunction,
+  onChange,
+  disabled = false,
+}: {
+  placeholder?: string;
+  lookupFunction: (query: string) => Promise<unknown[]>;
+  onChange?: (item: unknown) => void;
+  disabled?: boolean;
+}) {
+  useEffect(() => {
+    void lookupFunction('');
+  }, [lookupFunction]);
 
-    return (
-      <button
-        type="button"
-        data-testid={placeholder}
-        disabled={disabled}
-        onClick={() => {
-          if (placeholder.includes('projeto')) {
-            onChange?.({ id: 123, label: 'Projeto X', fluxo: 'SUPER' });
-            return;
-          }
-          onChange?.({ id: 456, label: 'Fortaleza - CE' });
-        }}
-      >
-        {placeholder}
-      </button>
-    );
-  },
+  return (
+    <button
+      type="button"
+      data-testid={placeholder}
+      disabled={disabled}
+      onClick={() => {
+        if (placeholder.includes('projeto')) {
+          onChange?.({ id: 123, label: 'Projeto X', fluxo: 'SUPER' });
+          return;
+        }
+        onChange?.({ id: 456, label: 'Fortaleza - CE' });
+      }}
+    >
+      {placeholder}
+    </button>
+  );
+}
+
+vi.mock('../../../components/ComboBox', () => ({
+  default: MockComboBox,
 }));
 
 import NewSolicitacaoWizard from '../NewSolicitacaoWizard';


### PR DESCRIPTION
## Summary

Resgata o trabalho de **acessibilidade** que estava órfão na branch `fix/frontend-react-router-...` (PR #1388, fechada — as partes de deps/react-doctor-gate já entraram na main via #1390). Aqui só as melhorias de a11y, rebaseadas limpas sobre a main (verificado: nenhum dos 16 arquivos mudou na main desde o fork `0243cad`, sem reverter trabalho novo).

## Mudanças (react-doctor a11y)
- **fontSize 11 → 12** em ~13 componentes (legibilidade) — AppHeader, DAT pages, MapaBrasil, PreAgenda, GCalDashboard, etc.
- **`Cadastros/columns.tsx`**: célula clicável de status (bare `onClick` div) → `role="button"` + `tabIndex={0}` + `onKeyDown` (Enter/Espaço) — **navegável por teclado**.
- **React keys estáveis**: `key={index}` → `key={step.title}` no `NewSolicitacaoWizard` (+ teste atualizado).
- **Labels associados**: `htmlFor`/`id` nos campos do `FiltersBar` de Disponibilidade.

## Verificação local
- `npm run lint` → 0 issues.
- `npm run build` (tsc + vite) → ✓ built.
- `npx vitest run` → **454 passed**.

## Notes
- Sem mudança de deps (já na main). Após o merge, a branch antiga `fix/frontend-react-router-...` fica totalmente subsumida e pode ser deletada.

## Staging Gate (antes de Ready)

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

> Rodado por etapas (precheck/build/up/test/down) no worktree do PR (bug `$(MAKE)` GnuWin32). Equivalente ao pipeline completo.

```
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS
ALL 8 CHECKS PASSED
```
