### PR TITLE
perf(backend): MD5PasswordHasher sob a flag TESTING (#1393)

### DIFF
--- a/v2/backend/apps/core/tests/test_admin_api.py
+++ b/v2/backend/apps/core/tests/test_admin_api.py
@@ -479,7 +479,8 @@ class TestUsuarioAdminAPI:
 
         user = Usuario.objects.get(username="test_hash")
         assert user.password != "SecurePass456!"  # senha não em plaintext
-        assert user.password.startswith("pbkdf2_")  # formato Django hash
+        assert user.has_usable_password()  # armazenada como hash (independe do algoritmo)
+        assert user.check_password("SecurePass456!")  # hash válido e verificável
 
     def test_controle_cannot_create_usuario(self, api_client, usuario_controle):
         """Controle NÃO pode criar usuário"""

--- a/v2/backend/config/settings.py
+++ b/v2/backend/config/settings.py
@@ -34,6 +34,12 @@ DEBUG = os.getenv("DEBUG", "0") == "1"
 # Detect if running under pytest (for disabling debug toolbar during tests)
 TESTING = "pytest" in sys.modules or "PYTEST_CURRENT_TEST" in os.environ
 
+if TESTING:
+    # Hashing rápido apenas em teste. PBKDF2 (default de produção) custa
+    # centenas de ms por create_user/set_password — chamado em ~141 arquivos
+    # de teste. Gated pela flag TESTING; produção/staging mantêm PBKDF2.
+    PASSWORD_HASHERS = ["django.contrib.auth.hashers.MD5PasswordHasher"]
+
 print("Aprender Sistema Inicializado")
 # ================================================================
 # SECRET KEY


### PR DESCRIPTION
## Contexto

Closes #1393 (M1 Quick Wins — maior ROI da suíte de testes).

`PASSWORD_HASHERS` não tinha override: ~141 dos 196 arquivos de teste do core chamam `create_user`/`set_password`, cada um pagando **PBKDF2** completo (centenas de ms). A flag `TESTING` (`config/settings.py:35`) já existia, usada só para gating do debug-toolbar.

## Mudança

- **`config/settings.py`**: dentro de `if TESTING:`, define `PASSWORD_HASHERS = ["django.contrib.auth.hashers.MD5PasswordHasher"]`. Gated pela flag → **produção/staging mantêm PBKDF2** (verificado: `TESTING=False` → `PBKDF2PasswordHasher`).
- **`apps/core/tests/test_admin_api.py`**: o único assert que amarrava ao algoritmo (`user.password.startswith("pbkdf2_")`) foi trocado por `has_usable_password()` + `check_password(...)` — valida o mesmo intent (senha hasheada e verificável) de forma independente do hasher.

## Verificação

| Hasher | 59 testes auth-pesados |
|--------|------------------------|
| PBKDF2 (baseline) | 20.51s |
| **MD5 (TESTING)** | **14.12s** (−31%) |

- `apps/core/tests` completa: **2711 passed, 43 skipped** ✅
- `black`/`isort`/`flake8` nos arquivos tocados: limpos
- Grep confirmou: nenhum outro teste asserta o algoritmo do hash (demais usos são `check_password`, agnósticos)

## Definition of Done (#1393)

- [x] `PASSWORD_HASHERS` definido **apenas** sob `if TESTING:`
- [x] Nenhum teste asserta o algoritmo do hash
- [x] Suíte `apps/core/tests` verde
- [x] Tempo reduzido (−31% medido em subset auth-pesado)
- [x] Produção/staging inalterados (PBKDF2 fora de TESTING)

## Staging Gate — Evidência

Rodado localmente via `make staging-full` (precheck → build → up → test → down):

```
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS
ALL 8 CHECKS PASSED
```

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

## Nota (fora de escopo)

`test_pr_security_url_substring.py` falha na **coleta apenas no container dev** (calcula `parents[4]/infra`, mas `v2/infra` não é montado em `/app`). Em CI o repo inteiro existe e o teste passa. Pré-existente, documentado, não tocado aqui.