### PR TITLE
ci(dependabot): pip → /v2/backend + composite actions (#1391)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,14 @@ updates:
   # PYTHON DEPENDENCIES
   # ================================
   - package-ecosystem: "pip"
-    directory: "/"
+    # NOTE: os requirements de backend vivem em /v2/backend (requirements*.txt), NAO na raiz.
+    # Com `directory: "/"` (antigo) o Dependabot so encontrava /requirements-docs.txt e NUNCA
+    # abria PR de dep de backend — gap que custou bumps manuais de Django 5.2.15, cryptography
+    # 48.0.1 e pyarrow. `directories` (plural) cobre os dois: backend + docs (raiz), sem
+    # regressao na cobertura dos docs. Ver memoria dependabot-pip-directory.
+    directories:
+      - "/v2/backend"
+      - "/"
     schedule:
       interval: "weekly"
       day: "tuesday"
@@ -141,7 +148,14 @@ updates:
   # GITHUB ACTIONS
   # ================================
   - package-ecosystem: "github-actions"
-    directory: "/.github/workflows"
+    # `/` cobre .github/workflows (comportamento padrao do ecossistema github-actions).
+    # Glob NAO e suportado p/ github-actions, entao as 2 composite actions em
+    # .github/actions/<nome>/action.yml entram como diretorios explicitos — senao os SHAs
+    # dessas actions internas envelhecem em silencio (ficam fora do auto-update).
+    directories:
+      - "/"
+      - "/.github/actions/setup-node-deps"
+      - "/.github/actions/setup-python-deps"
     schedule:
       # `day` aceita SOMENTE nome de dia da semana (monday..sunday); "first-wednesday"
       # quebrava o parser do Dependabot e invalidava o arquivo INTEIRO (todos os blocos).


### PR DESCRIPTION
## Contexto

Closes #1391 (M1 Quick Wins — fecha gap de descoberta de segurança).

O bloco **pip** usava `directory: "/"`. Como os manifests de backend (`requirements*.txt`) vivem em `/v2/backend`, o Dependabot só encontrava `/requirements-docs.txt` na raiz e **nunca abria PR de dependência de backend** — gap que custou os bumps manuais de **Django 5.2.15, cryptography 48.0.1 e pyarrow** na sessão anterior.

## Mudança

**pip** → `directories: ["/v2/backend", "/"]`
- `/v2/backend` restaura a descoberta de deps de backend (os groups django/database/dev-tools/google voltam a funcionar).
- `/` mantém a cobertura de `requirements-docs.txt` (**sem regressão** nos docs — foi de onde vieram os PRs #1409-1412 consolidados em #1423).

**github-actions** → `directories: ["/", "/.github/actions/setup-node-deps", "/.github/actions/setup-python-deps"]`
- `/` cobre `.github/workflows` (comportamento padrão do ecossistema).
- As 2 composite actions ficam em subpastas. Os docs do GitHub são explícitos: **glob (`*`) não é suportado para github-actions** — cada subdir precisa ser listado. Sem isso, os `uses:` SHA-pinados dentro das composite actions envelhecem em silêncio.

## Verificação

- `yaml.safe_load` OK — 3 ecossistemas resolvendo: pip→`[/v2/backend, /]`, docker→`[/v2/infra, /v2/frontend]`, github-actions→`[/, /.github/actions/setup-node-deps, /.github/actions/setup-python-deps]`.
- Sintaxe segue o schema documentado (`directories` plural é suportado; para github-actions usei paths explícitos, não glob).

## Definition of Done (#1391)

- [x] `directory` do pip aponta para `/v2/backend` (via `directories`, + raiz p/ docs)
- [x] github-actions cobre `/` e as composite actions de `.github/actions`
- [ ] Insights → Dependency graph lista deps de backend *(verificável só pós-merge)*
- [ ] Dependabot abre ≥1 PR de backend em 24h / "Check for updates" *(pós-merge)*
- [x] Sem regressão nos demais ecossistemas (npm intacto; docs preservados via raiz)

## Nota

Mudança **config-only** (`.github/dependabot.yml`) — fora do regex runtime-impact, então o staging gate é dispensado. Validação real do schema acontece quando o GitHub re-parseia pós-merge; vou confirmar que nenhum erro de config aparece e disparar "Check for updates".