### PR TITLE
perf(ci): remover --no-cache-dir do setup-python-deps (#1392)

### DIFF
--- a/.github/actions/setup-python-deps/action.yml
+++ b/.github/actions/setup-python-deps/action.yml
@@ -31,6 +31,9 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
+        # Sem --no-cache-dir: o setup-python (cache: 'pip') restaura o cache de
+        # download e o pip o reutiliza no hit, evitando recompilar wheels pesados
+        # (pandas/pyarrow/cryptography) a cada job. O flag antigo anulava esse cache.
         for req in ${{ inputs.requirements }}; do
-          pip install --no-cache-dir -r "$req"
+          pip install -r "$req"
         done


### PR DESCRIPTION
## Contexto

Closes #1392 (M1 Quick Wins).

A composite action `setup-python-deps` habilita o cache do pip via `actions/setup-python` (`cache: 'pip'`, l.26), mas instalava com `pip install --no-cache-dir`, **anulando o cache restaurado**. Resultado: 4-5 jobs Python por PR recompilavam wheels pesados (pandas, pyarrow, cryptography) do zero a cada execução.

## Mudança

`.github/actions/setup-python-deps/action.yml` — removido `--no-cache-dir` do step de install. O pip volta a reutilizar o cache de download restaurado pelo setup-python no cache hit.

### Por que NÃO toquei o `ci.yaml`

`ci.yaml:629/631` também usa `--no-cache-dir`, **mas em contexto diferente**: dentro de um `docker run --rm` (job docker-parity), num container efêmero construído do zero a cada run. Não há cache de pip persistente ali para aproveitar, e `--no-cache-dir` evita escrever arquivos de cache que seriam descartados no `--rm`. Remover não traria ganho — então fica.

## Verificação

- `yaml.safe_load` da action: OK
- Composite action usada por: `ci.yaml`, `security-scan.yml`, `architecture-guardrails.yml`, `backend-xdist-canary.yml`, `docs.yml` — todos passam a aproveitar o cache.

## Definition of Done (#1392)

- [x] `--no-cache-dir` removido do step de install (composite action)
- [ ] Log do job mostra cache hit do pip em re-runs *(verificável após merge, em re-run)*
- [ ] Tempo de setup reduzido *(medível após 1º run popular o cache)*
- [x] Sem regressão na instalação de dependências (instala os mesmos requirements; só reusa cache)

## Nota

Config/CI-only (`.github/actions/`) — fora do regex runtime-impact, staging gate dispensado.