### PR TITLE
security(ci): safety lê SAFETY_API_KEY do env (parte do #1394)

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -60,7 +60,9 @@ jobs:
 
           if [ -n "${SAFETY_API_KEY:-}" ]; then
             set +e
-            safety --key "$SAFETY_API_KEY" scan --target . --output json > safety-report.json
+            # safety 3.x le SAFETY_API_KEY do ambiente (setado no env: do step) —
+            # dispensa --key na linha de comando, que expunha a chave em /proc/<pid>/cmdline.
+            safety scan --target . --output json > safety-report.json
             safety_exit=$?
             set -e
 


### PR DESCRIPTION
## Contexto

Aborda **parte** de #1394 (a issue **permanece aberta** para a parte do `deploy.yaml`).

`security-scan.yml:63` passava a chave como argumento de CLI — `safety --key "$SAFETY_API_KEY"` — visível em `/proc/<pid>/cmdline` durante a execução. O `safety` 3.x lê `SAFETY_API_KEY` do ambiente (já definido no `env:` do step), então o `--key` é dispensável.

## Mudança

`.github/workflows/security-scan.yml` — removido `--key "$SAFETY_API_KEY"` do `safety scan`. A chave continua vindo do `env:` do step (auto-mascarada no log); agora sem aparecer no process listing.

## Verificação

- `yaml.safe_load`: OK
- `grep` confirma: nenhum `--key`/`safety --key` restante em `.github/`
- Lógica preservada: guard `[ -n "${SAFETY_API_KEY:-}" ]` (skip se não configurada), captura de exit code, `pip-audit` segue como gate bloqueante de CVE

## Escopo deferido (deploy.yaml) — por que NÃO está aqui

O header `X-API-KEY` do Portainer aparece em **7 curls / 3 steps** do `deploy.yaml` (Step A=deploy 🔴 bloqueante; Steps B/C=verificação/cleanup 🟢 não-bloqueantes). Mover para `curl --config` é mecânica de baixo risco, mas:
- `deploy.yaml` é o **único caminho de prod** e **não há staging env** para exercitar antes.
- A lógica fire-and-forget do Step A (trata timeout como "aceito") poderia **mascarar** uma falha de auth como sucesso → deploy falso.

Decisão: tratar a parte do Portainer em **PR dedicado, validado por um deploy de teste** (`workflow_dispatch`). Risco residual da exposição atual é 🟡 baixo (token mascarado no log, sem `set -x`, runner efêmero). Refs #1394.

## Nota

Config/CI-only — fora do regex runtime-impact, staging gate dispensado.