### PR TITLE
ci: trunk-based trigger cleanup + prefixo docs job (#1395)

### DIFF
--- a/.github/workflows/agent-browser-smoke.yml
+++ b/.github/workflows/agent-browser-smoke.yml
@@ -2,7 +2,7 @@ name: agent-browser-smoke
 
 on:
   pull_request:
-    branches: [main, feat/dashboard-compras-etl]
+    branches: [main]
     paths:
       - "v2/frontend/**"
       - ".github/workflows/agent-browser-smoke.yml"

--- a/.github/workflows/architecture-guardrails.yml
+++ b/.github/workflows/architecture-guardrails.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - develop
   pull_request:
     branches:
       - main

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,9 +2,9 @@ name: CI – Continuous Integration
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main ]
   pull_request:
-    branches: [ main, feat/dashboard-compras-etl ]
+    branches: [ main ]
 
 permissions:
   contents: read

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,6 +33,7 @@ concurrency:
 
 jobs:
   build:
+    name: "[info] documentation build"
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -2,13 +2,13 @@ name: frontend-ci
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main ]
     paths:
       - 'v2/frontend/**'
       - '.github/workflows/frontend-ci.yml'
       - '.github/actions/setup-node-deps/**'
   pull_request:
-    branches: [ main, feat/dashboard-compras-etl ]
+    branches: [ main ]
     # Removed path filters for pull_request to ensure required check always runs
     # This is needed because the ruleset requires "frontend-ci" as a status check
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contribuindo — Aprender Sistema v2
+
+## Modelo de branches (trunk-based)
+
+O projeto é **trunk-based**: `main` é a única branch de longa duração e a base de
+integração. Feature branches curtas no padrão `type/nome` (ex.: `feat/gcal-sync`,
+`fix/availability-buffer`) saem de `main` e voltam por **Pull Request com squash-merge**
+(CP-05/CP-06). **Não há branch `develop`** nem fluxo gitflow. Como `main` é a única base de
+PR, gatear `pull_request` → `main` cobre todo o fluxo de integração — não existe branch
+intermediária ungated. **Merge na `main` dispara deploy de produção**, então cada PR passa
+pela suíte completa de CI antes do merge.
+
+## Convenções
+
+- **Commits**: Conventional Commits — `type(scope): mensagem` (`feat`, `fix`, `chore`,
+  `docs`, `test`, `refactor`, `perf`, `ci`, `security`).
+- **PRs**: base `main`, CI verde, squash-and-merge. Mudanças com impacto em runtime exigem
+  evidência do staging gate no corpo do PR (ver `v2/infra` `make staging-full`).
+
+## Gating de CI
+
+Os workflows disparam em `push` para `main` e `pull_request` → `main`. O prefixo no nome do
+job indica a criticidade:
+
+- `[required]` — check obrigatório no ruleset; **bloqueia o merge** se falhar.
+- `[info]` — informativo (ex.: build de documentação, e2e journeys, lighthouse); roda e
+  reporta, mas não bloqueia.


### PR DESCRIPTION
## Contexto

Closes #1395 (M1 Quick Wins — higiene de CI).

Quatro workflows mantinham o target obsoleto `feat/dashboard-compras-etl` em `pull_request`, e três disparavam em `push` para `develop`. **Nenhuma das duas branches existe** (o repo é trunk-based: só `main`, squash-merge). O `docs.yml` era o único job sem prefixo de criticidade.

## Mudança

**Triggers (remoção de config morta):**
- `feat/dashboard-compras-etl` removida de `pull_request.branches`: `ci.yaml`, `frontend-ci.yml`, `agent-browser-smoke.yml` → `[ main ]`.
- `develop` removida de `push.branches`: `ci.yaml`, `frontend-ci.yml`, `architecture-guardrails.yml` → só `main`.

**Decisão sobre `develop` (DoD "develop gateado OU decisão documentada"):** o projeto é **trunk-based**. Adicionar gating de PR para `develop` seria config morta para um branch que não existe. Em vez disso, removo os triggers mortos e **documento o modelo** — não há branch intermediária ungated porque não há branch intermediária.

**Prefixo de job:**
- `docs.yml`: job `build` → `name: "[info] documentation build"`. Era o único sem prefixo; build de docs é validação (não bloqueia). **Não está nos 9 required checks**, então renomear é seguro.

**Documentação:**
- Novo `CONTRIBUTING.md`: modelo trunk-based (`main` = única base de PR e gatilho de deploy; sem `develop`/gitflow), conventional commits, e a convenção de prefixos `[required]`/`[info]`.

## Verificação

Auditoria adversarial independente (read-only) confirmou:
- ✅ docs `build` **não** é um dos 9 required checks → rename seguro; nenhum required check renomeado.
- ✅ **Zero** refs residuais a `develop`/`feat/dashboard-compras-etl` em todo o `.github/`, scripts e docs.
- ✅ Todos os **29 jobs** dos workflows têm prefixo `[required]`/`[info]`/`[ops]` (docs era o último faltando).
- ✅ Todos os workflows seguem gateando `pull_request → main`; nenhum ficou órfão.
- ✅ `deploy.yaml` dispara em `push: [main]` + `workflow_dispatch` — **não** dependia de `develop`.
- ✅ YAML válido nos 5 arquivos.

## Definition of Done (#1395)

- [x] Branch obsoleta removida de todos os triggers
- [x] `develop` — decisão documentada (trunk-based; sem branch intermediária ungated)
- [x] `docs.yml` com prefixo de criticidade (`[info]`)
- [x] Modelo de branches documentado (`CONTRIBUTING.md`)

## Nota

Config/CI-only — fora do regex runtime-impact, staging gate dispensado.