### PR TITLE
security(deploy): X-API-KEY do Portainer via curl --config (#1394)

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -573,13 +573,19 @@ jobs:
             curl_opts+=(--insecure)
           fi
 
+          # API key via curl --config (arquivo mode 600): mantém o token fora de
+          # argv (/proc/<pid>/cmdline). A requisição HTTP enviada é idêntica. #1394.
+          portainer_hdr_file="$(mktemp)"
+          chmod 600 "$portainer_hdr_file"
+          printf 'header = "X-API-KEY: %s"\n' "$portainer_access_token" > "$portainer_hdr_file"
+          trap 'rm -f "$portainer_hdr_file"' EXIT
+          curl_opts+=(--config "$portainer_hdr_file")
+
           # --- Read current stack state ---
           stack_json="$(curl "${curl_opts[@]}" \
-            -H "X-API-KEY: ${portainer_access_token}" \
             "${portainer_url}/api/stacks/${PORTAINER_STACK_ID}")"
 
           stack_file_json="$(curl "${curl_opts[@]}" \
-            -H "X-API-KEY: ${portainer_access_token}" \
             "${portainer_url}/api/stacks/${PORTAINER_STACK_ID}/file")"
 
           stack_file_content="$(printf '%s' "$stack_file_json" | jq -r '.StackFileContent')"
@@ -627,7 +633,6 @@ jobs:
               -o /tmp/portainer-stack-update-response.json \
               -w '%{http_code}' \
               -X PUT \
-              -H "X-API-KEY: ${portainer_access_token}" \
               -H "Content-Type: application/json" \
               "${portainer_url}/api/stacks/${PORTAINER_STACK_ID}?endpointId=${PORTAINER_ENDPOINT_ID}" \
               --data-raw "$payload" || true)"
@@ -848,9 +853,14 @@ jobs:
             if [ "${PORTAINER_SKIP_TLS_VERIFY:-}" = "true" ]; then
               portainer_curl_opts+=(--insecure)
             fi
+            # API key via curl --config (mode 600), fora do argv. #1394.
+            portainer_hdr_file="$(mktemp)"
+            chmod 600 "$portainer_hdr_file"
+            printf 'header = "X-API-KEY: %s"\n' "$PORTAINER_ACCESS_TOKEN" > "$portainer_hdr_file"
+            trap 'rm -f "$portainer_hdr_file"' EXIT
+            portainer_curl_opts+=(--config "$portainer_hdr_file")
 
             containers_json="$(curl "${portainer_curl_opts[@]}" \
-              -H "X-API-KEY: ${PORTAINER_ACCESS_TOKEN}" \
               "${PORTAINER_URL}/api/endpoints/${PORTAINER_ENDPOINT_ID}/docker/containers/json?all=true&filters=%7B%22label%22%3A%5B%22com.docker.compose.project%3Daprender_prod%22%5D%7D" 2>/dev/null || echo "[]")"
 
             web_state="$(printf '%s' "$containers_json" | jq -r '[.[] | select(.Names[] | contains("web"))] | .[0].State // "unknown"' 2>/dev/null || echo "unknown")"
@@ -944,14 +954,18 @@ jobs:
           if [ "${PORTAINER_SKIP_TLS_VERIFY:-false}" = "true" ]; then
             curl_opts+=(--insecure)
           fi
+          # API key via curl --config (arquivo mode 600), fora do argv. #1394.
+          portainer_hdr_file="$(mktemp)"
+          chmod 600 "$portainer_hdr_file"
+          printf 'header = "X-API-KEY: %s"\n' "$portainer_access_token" > "$portainer_hdr_file"
+          trap 'rm -f "$portainer_hdr_file"' EXIT
+          curl_opts+=(--config "$portainer_hdr_file")
 
           docker_api_base="${portainer_url}/api/endpoints/${PORTAINER_ENDPOINT_ID}/docker"
 
           containers_json="$(curl "${curl_opts[@]}" \
-            -H "X-API-KEY: ${portainer_access_token}" \
             "${docker_api_base}/containers/json?all=1" || true)"
           images_json="$(curl "${curl_opts[@]}" \
-            -H "X-API-KEY: ${portainer_access_token}" \
             "${docker_api_base}/images/json?all=1" || true)"
 
           if [ -z "$containers_json" ] || [ -z "$images_json" ]; then
@@ -1003,7 +1017,6 @@ jobs:
                 -o /tmp/portainer-image-delete-response.json \
                 -w '%{http_code}' \
                 -X DELETE \
-                -H "X-API-KEY: ${portainer_access_token}" \
                 "${docker_api_base}/images/${encoded_ref}?force=false&noprune=false" || true)"
 
               if [[ "$http_code" =~ ^[0-9]+$ ]] && [ "$http_code" -ge 200 ] && [ "$http_code" -lt 300 ]; then


### PR DESCRIPTION
## Contexto

Completa a **2ª metade do #1394** (a 1ª — `safety --key`→env — foi #1428). `Closes #1394`.

Os 7 curls para a API do Portainer no `deploy.yaml` passavam o token como `-H "X-API-KEY: $token"`, visível em `/proc/<pid>/cmdline` durante a execução. Em **3 steps** (deploy, verificação-fallback, cleanup de imagens).

## Mudança

Cada step agora escreve o header num arquivo temporário (`mktemp`, **mode 600**) e usa `curl --config "$file"` via o array `curl_opts`/`portainer_curl_opts`; os `-H "X-API-KEY"` foram removidos. `trap 'rm -f ...' EXIT` limpa o arquivo. **A requisição HTTP enviada ao Portainer é idêntica** — só muda o mecanismo local de passar o header (token sai do argv).

- Step A (deploy): GET stack, GET file, PUT stack update.
- Step B (verificação fallback): GET containers.
- Step C (cleanup): GET containers/images, DELETE image.

## Validação (estática + local)

- ✅ `grep`: **0** `-H "X-API-KEY"` restantes em argv; 3 `--config`, 3 `printf header`, 3 `trap`.
- ✅ `yaml.safe_load`: deploy.yaml válido.
- ✅ `bash -n` nos 3 run-blocks editados: **0 erros de sintaxe**.
- ✅ **Smoke local do mecanismo**: `curl --config <file>` com `header = "X-API-KEY: SECRET"` → servidor HTTP recebeu o header corretamente, e o argv do `curl` continha **apenas o path do arquivo** (token ausente do cmdline).

## Pendente antes do merge (opção 3)

- [ ] **Deploy de teste via `workflow_dispatch`** para exercitar os curls Portainer de verdade (round-trip real), antes de confiar — combinado com o autor.

## Nota

`.github/workflows/deploy.yaml` está **fora** do regex runtime-impact do staging gate → gate dispensado. Risco residual fechado: token no process listing de runner efêmero (🟡 baixo).