### PR TITLE
test(core): reabilitar AuditLog de edição de Solicitação (#1382)

### DIFF
--- a/v2/backend/apps/core/tests/test_solicitacao_edit.py
+++ b/v2/backend/apps/core/tests/test_solicitacao_edit.py
@@ -383,14 +383,11 @@ class TestSolicitacaoEditBusinessRules:
 class TestSolicitacaoEditAuditLog:
     """Testes de audit log para edições."""
 
-    @pytest.mark.skip(reason="AuditLog para edições em investigação - funcionalidade principal de edição funciona")
     def test_edit_creates_audit_log(self, api_client, usuario_owner, solicitacao_editavel):
-        """Edição cria registro no AuditLog com campos alterados.
+        """Edição via PATCH cria registro no AuditLog com campos alterados (PA-05).
 
-        Nota: O AuditLog é criado no perform_update() do ViewSet quando
-        há campos alterados. Este teste verifica que o mecanismo funciona.
-
-        TODO: Investigar por que perform_update não está gerando AuditLog em testes.
+        O AuditLog é criado no perform_update() do ViewSet quando
+        há campos alterados.
         """
         api_client.force_authenticate(user=usuario_owner)
 
@@ -429,6 +426,9 @@ class TestSolicitacaoEditAuditLog:
         assert log.usuario == usuario_owner
         assert log.details["solicitacao_id"] == solicitacao_editavel.id
         assert "local" in log.details["changed_fields"]
+        assert "observacoes" in log.details["changed_fields"]
+        assert log.details["changed_fields"]["local"]["old"] == "Local Original"
+        assert log.details["changed_fields"]["local"]["new"] == "Novo Local para Audit"
 
     def test_no_audit_log_when_no_changes(self, api_client, usuario_owner, solicitacao_editavel):
         """Não cria AuditLog quando não há mudanças."""


### PR DESCRIPTION
## Contexto

Fecha #1382. A 3ª validação adversarial apontou uma lacuna em **PA-05/CP-02**: o teste de AuditLog para edição de `Solicitacao` estava `@pytest.mark.skip`.

## Causa raiz

O skip era **órfão**. A lógica de AuditLog em `SolicitacaoViewSet.perform_update()` (`views_solicitacao.py:400-487`) já registra `action=UPDATE` com `changed_fields` desde o PR #332 — o teste apenas nunca foi reabilitado após a "investigação" original. Confirmado: `test_owner_can_edit_own_solicitacao` (mesmo PATCH) já exercita o caminho há tempos.

## Mudança

- Remove o `@pytest.mark.skip` de `test_edit_creates_audit_log` e o TODO obsoleto.
- Reforça asserts para cobrir o critério "campos alterados": verifica `old`/`new` de `local` e presença de `observacoes` em `changed_fields`.
- Diff é **test-only** (6+/6−), nenhuma mudança de produção.

## Critérios de aceite (todos ✅)

- [x] Teste não está mais skipado
- [x] PATCH com mudança real cria AuditLog `UPDATE`
- [x] PATCH sem mudança não cria log falso (`test_no_audit_log_when_no_changes`, já existente)
- [x] Log contém usuário, solicitação e campos alterados
- [x] Testes existentes continuam verdes

## Verificação local (Docker dev)

- Alvo: `TestSolicitacaoEditAuditLog` → **2 passed**
- Arquivo inteiro `test_solicitacao_edit.py` → **32 passed**
- Regressão `-k "audit or Audit"` → **93 passed**
- `black --check` / `isort --check` / `flake8` → limpos

> Nota: a coleta de `test_pr_security_url_substring.py` falha por `ModuleNotFoundError: validate_oauth_config` — **pré-existente e não relacionado** a este diff (problema de PYTHONPATH daquele teste de OAuth).