### PR TITLE
perf(ci): coverage via sysmon (Python 3.12) (#1399)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -291,6 +291,10 @@ jobs:
         mkdir -p "$GITHUB_WORKSPACE/v2/backend/data/csv-import"
 
     - name: Run core tests with coverage
+      env:
+        # Backend sys.monitoring do Python 3.12: coverage muito mais leve que o
+        # C-trace (~30-50% menos overhead), mantendo --cov e o gate de 85%. #1399.
+        COVERAGE_CORE: sysmon
       run: |
         cd v2/backend
         echo "🧪 Running backend core suite (serial)"
@@ -403,6 +407,9 @@ jobs:
         mkdir -p "$GITHUB_WORKSPACE/v2/backend/data/csv-import"
 
     - name: Run ingest/devtools tests with coverage
+      env:
+        # Backend sys.monitoring do Python 3.12 (ver step core). #1399.
+        COVERAGE_CORE: sysmon
       run: |
         cd v2/backend
         echo "🧪 Running backend ingest/devtools suite (serial)"


### PR DESCRIPTION
## Contexto

Closes #1399 (M2 — Estabilidade/perf).

Os jobs backend de coleta de cobertura (`ci.yaml`: core l.293-301 + ingest/devtools l.405-413) usam o backend **C-trace** do coverage.py (~30-50% de overhead). Python 3.12 oferece o backend `sys.monitoring` (`COVERAGE_CORE=sysmon`), muito mais leve, mantendo `--cov` e o gate de 85%.

## Mudança

`COVERAGE_CORE: sysmon` adicionado ao `env:` dos **2 steps de coleta** (pytest `--cov`). O step de `coverage combine`/`report --fail-under=85` **não coleta** — só agrega o `.coverage` já gerado — então não precisa do flag (e lê os dados igual).

## Verificação (local, container dev)

| | Tempo | Cobertura reportada |
|--|------|---------------------|
| C-trace (default) | 26.13s | `38585 / 36937` |
| **sysmon** | **21.03s** (−20%) | `38585 / 36937` (**idêntica**) |

- `coverage` 7.14.0 + Python 3.12.13 → sysmon suportado.
- `yaml.safe_load`: ci.yaml válido.
- Cobertura **idêntica** entre os dois backends → DoD "mesmo número reportado" ✓. Gate 85% e upload Codecov inalterados (combine/report intactos).

## Definition of Done (#1399)

- [x] `COVERAGE_CORE=sysmon` nos jobs com `--cov` (os 2 de coleta)
- [x] Gate 85% válido (combine/report inalterados; cobertura idêntica)
- [x] Tempo reduzido (−20% medido no subset; full-suite na CI deste PR)
- [x] Codecov segue recebendo o relatório (step inalterado)

## Nota

CI-only (`.github/workflows/ci.yaml`, sem tocar runtime) → staging gate dispensado.