### PR TITLE
perf(ci): path filters em architecture-guardrails (#1400)

### DIFF
--- a/.github/workflows/architecture-guardrails.yml
+++ b/.github/workflows/architecture-guardrails.yml
@@ -1,12 +1,25 @@
 name: Architecture Guardrails
 
 on:
+  # Guardrails de arquitetura (import-linter backend + dependency-cruiser frontend)
+  # so importam quando o codigo muda. Path filters evitam runs em PRs so-docs.
+  # NAO e required check (nem ruleset nem branch protection), entao skip nao trava merge.
   push:
     branches:
       - main
+    paths:
+      - 'v2/backend/**'
+      - 'v2/frontend/**'
+      - '.github/workflows/architecture-guardrails.yml'
+      - '.github/actions/setup-node-deps/**'
   pull_request:
     branches:
       - main
+    paths:
+      - 'v2/backend/**'
+      - 'v2/frontend/**'
+      - '.github/workflows/architecture-guardrails.yml'
+      - '.github/actions/setup-node-deps/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Contexto

Closes #1400 (M2 — Estabilidade/perf).

`architecture-guardrails.yml` rodava import-linter (backend) + dependency-cruiser (frontend) em **todo** PR/push, inclusive PRs que só tocam documentação.

## Mudança

Path filters no trigger (`push` + `pull_request`): o guardrail só dispara quando muda código relevante:
- `v2/backend/**` (import-linter)
- `v2/frontend/**` (dependency-cruiser)
- `.github/workflows/architecture-guardrails.yml`
- `.github/actions/setup-node-deps/**` (usada pelo guard frontend)

**Seguro pular em PR só-docs:** confirmei que o check **não é required** — ausente do ruleset (`required_status_checks`) e da branch protection clássica de `main`. Logo, um PR só-docs que não dispara o guardrail **não trava em "expected"**.

## Sobre a DoD "setup via composite"

Mantive o `pip install "import-linter==2.6"` direto **de propósito**: a composite `setup-python-deps` instala o `requirements-dev.txt` **inteiro** (pytest, black, flake8, locust, …) só para rodar uma ferramenta → seria **mais lento**. O `actions/setup-python` atual já usa `cache: pip`, então o `import-linter` já é cacheado. O ganho real da issue (evitar runs em PR só-docs) está entregue.

## Verificação

- `yaml.safe_load`: OK; `pull_request.paths` com 4 entradas.
- Não-required confirmado via `gh api` (ruleset + branch protection).

## Definition of Done (#1400)

- [x] PR só-docs **não** dispara o guardrail (path filters; não-required → sem trava)
- [x] PR de código continua gateado (paths cobrem backend/frontend)
- [~] Setup com cache — já cacheado via `setup-python` `cache: pip`; composite evitada (instalaria deps demais). Justificado acima.

## Nota

CI-only (`.github/`) → staging gate dispensado.