### PR TITLE
perf(ci): cache gha nos docker builds (docker-parity + security-scan) (#1398)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -581,9 +581,21 @@ jobs:
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
     - name: Build backend image (Dockerfile.prod)
-      run: |
-        docker build -f v2/infra/Dockerfile.prod -t aprender-backend:ci-parity-${{ github.sha }} v2
+      uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+      with:
+        context: ./v2
+        file: ./v2/infra/Dockerfile.prod
+        push: false
+        load: true
+        tags: aprender-backend:ci-parity-${{ github.sha }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        build-args: |
+          GIT_SHA=${{ github.sha }}
 
     - name: Run smoke checks inside container
       env:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -123,14 +123,34 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
       - name: Build backend image
-        run: |
-          cd v2
-          docker build -f infra/Dockerfile.prod -t aprender-backend:scan .
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        with:
+          context: ./v2
+          file: ./v2/infra/Dockerfile.prod
+          push: false
+          load: true
+          tags: aprender-backend:scan
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            GIT_SHA=${{ github.sha }}
 
       - name: Build frontend image
-        run: |
-          docker build -f v2/frontend/Dockerfile.prod -t aprender-frontend:scan v2/frontend
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        with:
+          context: ./v2/frontend
+          file: ./v2/frontend/Dockerfile.prod
+          push: false
+          load: true
+          tags: aprender-frontend:scan
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            GIT_SHA=${{ github.sha }}
 
       - name: Run Trivy (backend JSON report)
         uses: aquasecurity/trivy-action@476e4fdcdc675b65ce75e8c3440b48d7a494f0e5 # 0.34.1


### PR DESCRIPTION
## Contexto

Closes #1398 (M2 — Estabilidade/perf).

`docker-parity` (`ci.yaml`) e o scan do `security-scan.yml` faziam `docker build` **puro** (sem buildx, sem cache `type=gha`), enquanto o `deploy.yaml` **já** usa o padrão buildx + `build-push-action` + cache gha. Builds Docker repetidos sem cache custam minutos por PR.

## Mudança

Alinha os dois jobs ao padrão do `deploy.yaml`:
- `docker/setup-buildx-action@8d2750c…` + `docker/build-push-action@ca052bb…`
- `push: false`, `load: true` (imagem fica disponível localmente p/ o Trivy e o `docker run` da parity)
- `cache-from: type=gha` + `cache-to: type=gha,mode=max`
- `build-args: GIT_SHA=${{ github.sha }}` (consistência + cache-bust do layer apt/apk)
- **Tags preservadas**: `aprender-backend:scan`/`aprender-frontend:scan` (refs dos steps Trivy) e `aprender-backend:ci-parity-<sha>` (ref do `docker run` da parity).

## Por que NÃO removi o `pip install` do docker-parity

A issue sugeria remover o `pip install` "redundante", mas a imagem buildada é a **PROD** (`Dockerfile.prod` → `requirements-prod.txt`), que **não contém pytest**. O `pip install -r requirements-dev.txt` dentro do container é justamente o que traz o pytest para rodar os 2 testes (`test_modular_imports`, `test_auth_backends`). **Removê-lo quebraria o job.** A premissa da issue estava incorreta nessa parte; o ganho real (cache gha no build) está entregue.

## Verificação

- `yaml.safe_load`: ambos OK.
- Tags batem com os consumidores (Trivy `image-ref`, `docker run`).
- Cache hit em re-runs será visível no log da CI deste PR (segunda execução).

## Definition of Done (#1398)

- [x] Ambos os jobs usam buildx + `cache-from/to: type=gha`
- [x] Cache hit visível em re-runs (validável no log da CI)
- [N/A] Remover `pip install` do docker-parity — **não aplicável** (imagem prod não tem pytest; quebraria). Justificado.

## Nota

CI-only (`.github/`) → staging gate dispensado.