### PR TITLE
reliability(deploy): confirmar IMAGE_TAG após timeout 000 (#1396)

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -653,11 +653,29 @@ jobs:
               break
             fi
 
-            # Timeout (000) = firewall dropped the response, but Portainer likely received the request
+            # Timeout (000): o firewall pode ter dropado a RESPOSTA mas o Portainer
+            # recebeu o PUT — OU o PUT nao chegou (deploy fantasma). NAO assumir sucesso
+            # cego: confirmar via GET que o stack realmente recebeu a IMAGE_TAG nova.
+            # Fail-fast (#1396): se nao confirmar, faz retry; se esgotar, deploy_sent
+            # fica false -> exit 1 abaixo (em vez de depender so do timeout de 360s).
             if [ "$http_code" = "000" ]; then
-              echo "Portainer request timed out (attempt ${attempt}/${max_attempts}). Treating as fire-and-forget — post-deploy verification will confirm."
-              deploy_sent=true
-              break
+              echo "Portainer PUT timed out (attempt ${attempt}/${max_attempts}). Confirming stack IMAGE_TAG before assuming success..."
+              confirm_json="$(curl "${curl_opts[@]}" --max-time 30 \
+                "${portainer_url}/api/stacks/${PORTAINER_STACK_ID}" 2>/dev/null || true)"
+              live_tag="$(printf '%s' "$confirm_json" | jq -r '([.Env[]? | select(.name == "IMAGE_TAG") | .value] | first) // ""' 2>/dev/null || true)"
+              if [ "$live_tag" = "$RELEASE_VERSION" ]; then
+                echo "Confirmed: stack IMAGE_TAG=${RELEASE_VERSION} despite the timeout. Treating as sent."
+                deploy_sent=true
+                break
+              fi
+              echo "Not confirmed: stack IMAGE_TAG='${live_tag:-unknown}' != '${RELEASE_VERSION}' after timeout."
+              if [ "$attempt" -lt "$max_attempts" ]; then
+                echo "Retrying PUT in ${retry_sleep}s... (${attempt}/${max_attempts})"
+                sleep "$retry_sleep"
+                continue
+              fi
+              echo "Exhausted ${max_attempts} attempts after timeout without IMAGE_TAG confirmation." >&2
+              # deploy_sent permanece false -> exit 1 logo abaixo.
             fi
 
             # Server errors are retryable


### PR DESCRIPTION
## Contexto

Closes #1396 (M2 — Estabilidade/reliability).

**Achado importante:** a verificação pós-deploy **já era** version-aware (exige `RELEASE_VERSION` no endpoint público OU no fallback do Portainer), então o risco de deploy fantasma já estava bastante mitigado. Esta mudança adiciona um **hardening fail-fast** no caminho do timeout 000, em vez de depender só do timeout de 360s.

## Mudança

No loop do PUT ao Portainer, ao receber **HTTP 000** (timeout): em vez de `deploy_sent=true` cego, faz um **GET rápido do stack** e só aceita se `IMAGE_TAG == RELEASE_VERSION` (o PUT pode ter aplicado mesmo com a resposta perdida no firewall). Se não confirmar → **retry**; se esgotar as tentativas → `deploy_sent` fica `false` → **`exit 1`** (falha rápido). A verificação pós-deploy de 360s segue como rede de segurança (defesa em profundidade).

## Verificação (local)

- `yaml.safe_load`: OK · `bash -n` no run-block do deploy: OK.
- **Simulação da decisão do 000** (mock do GET de confirmação), 4 casos:

| Caso | Resultado |
|------|-----------|
| 000 + `IMAGE_TAG` bate (deploy real, resposta perdida) | **ACCEPT** (`deploy_sent=true`) |
| 000 + `IMAGE_TAG` antigo, última tentativa (**fantasma**) | **FAIL → exit 1** |
| 000 + Portainer inalcançável (vazio), última tentativa | **FAIL → exit 1** |
| 000 + antigo, tentativa 1/3 | **RETRY** |

## Pendente antes do merge

- [ ] **Deploy de teste via `workflow_dispatch`** (happy path: PUT real → 2xx; regressão do step) — combinado com o autor.

## Definition of Done (#1396)

- [x] HTTP 000 sem confirmação ⇒ o job **falha** (não avança) — provado (casos B/C)
- [x] Confirmação pós-000 compara `IMAGE_TAG` corrente do stack (`.Env[] IMAGE_TAG == RELEASE_VERSION`)
- [x] Fallback exige `healthy` + `IMAGE_TAG` correta (**já existente**, l.872-874; documentado)
- [ ] Deploy real continua passando (deploy de teste)
- [x] Caminho 000 simulado falha como esperado (simulação local)

## Nota

`deploy.yaml` está **fora** do regex runtime-impact do staging gate → gate dispensado.