### PR TITLE
security(ci): least-privilege das permissões do GITHUB_TOKEN (#1397)

### DIFF
--- a/.github/workflows/backend-xdist-canary.yml
+++ b/.github/workflows/backend-xdist-canary.yml
@@ -19,8 +19,9 @@ on:
       - "docs/operations/ci-check-policy.md"
 
 permissions:
+  # `issues: write` movido p/ o job canary-report (unico que comenta na issue);
+  # o job de matriz de testes herda so `contents: read`. #1397.
   contents: read
-  issues: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -167,6 +168,10 @@ jobs:
   canary-report:
     name: "[ops] backend xdist canary summary"
     runs-on: ubuntu-latest
+    permissions:
+      # Unico job que comenta na issue 677 — issues:write vive aqui. #1397.
+      contents: read
+      issues: write
     needs:
       - xdist-canary
     if: always()

--- a/.github/workflows/dependency-review-scorecard.yml
+++ b/.github/workflows/dependency-review-scorecard.yml
@@ -103,9 +103,9 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     permissions:
+      # publish_results:false + so upload-artifact (sem upload-sarif) -> os escopos
+      # security-events:write e id-token:write ficavam ociosos. Removidos. #1397.
       contents: read
-      security-events: write
-      id-token: write
       actions: read
     # Fork PRs can have restricted token permissions for Scorecard internals.
     if: github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -29,8 +29,9 @@ env:
   FRONTEND_IMAGE: norjosamatheus/aprender-frontend
 
 permissions:
+  # Default minimo herdado por todos os jobs; quem precisa de mais declara o seu.
+  # `deployments: write` era ocioso (nenhum step cria Deployment via API). #1397.
   contents: read
-  deployments: write
 
 concurrency:
   group: deploy-${{ github.event_name == 'push' && 'staging' || github.event.inputs.target_environment || 'production' }}
@@ -40,6 +41,7 @@ jobs:
   prepare:
     name: Prepare release context
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
       target_environment: ${{ steps.compute.outputs.target_environment }}
       release_mode: ${{ steps.compute.outputs.release_mode }}
@@ -149,7 +151,10 @@ jobs:
     needs: prepare
     if: needs.prepare.outputs.should_build == 'true'
     permissions:
-      contents: write
+      # build/push de imagem NAO precisa escrever no repo. O git tag + gh release
+      # foram movidos p/ o job `tag_and_release` (desacopla contents:write de um
+      # alvo classico de supply-chain: o job que builda/pusha imagem). #1397.
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
@@ -265,6 +270,20 @@ jobs:
           build-args: |
             GIT_SHA=${{ github.sha }}
 
+  tag_and_release:
+    name: Tag and GitHub Release
+    runs-on: ubuntu-latest
+    needs: [prepare, build_and_push]
+    if: needs.build_and_push.result == 'success'
+    permissions:
+      # Unico job com contents:write — exclusivo p/ git tag + gh release. #1397.
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
+        with:
+          fetch-depth: 0
+
       - name: Create git tag if missing
         env:
           RELEASE_VERSION: ${{ needs.prepare.outputs.release_version }}
@@ -318,6 +337,8 @@ jobs:
   validate_existing_tag:
     name: Validate immutable tag exists (promotion/rollback)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: prepare
     if: needs.prepare.outputs.should_build != 'true'
     steps:
@@ -350,6 +371,8 @@ jobs:
   deploy:
     name: Deploy via Portainer CE API
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     environment:
       name: ${{ needs.prepare.outputs.target_environment }}
     needs:


### PR DESCRIPTION
## Contexto

Closes #1397 (M2 — Estabilidade/security). Princípio do menor privilégio nos escopos de escrita do `GITHUB_TOKEN`.

## Mudanças

### `deploy.yaml` (split estrutural)
- **top**: remove `deployments: write` **ocioso** (nenhum step cria Deployment via API) → default mínimo `contents: read`.
- **prepare**: `permissions: {}` (só computa outputs).
- **build_and_push**: `contents: write` → **`contents: read`**. O `git tag` + `gh release` foram **movidos** para um job novo **`tag_and_release`** (`contents: write` exclusivo), desacoplando escrita-no-repo do job que builda/pusha imagem (alvo clássico de supply-chain).
- **validate_existing_tag** / **deploy**: `contents: read` explícito.

**Grafo de jobs resultante:**
```
prepare {} ─┬─ build_and_push (read) ─┬─ tag_and_release (write)  [git tag + gh release]
            │                          └─ deploy (read)            [Portainer]
            └─ validate_existing_tag (read)
```
`tag_and_release` e `deploy` rodam em **paralelo** (ambos `needs: build_and_push`). Como o `deploy` **não** depende do tag/release, uma falha de tag não bloqueia mais o deploy real — **melhoria** (deploy > metadado de release); o run geral ainda sinaliza falha se o tag falhar.

### `dependency-review-scorecard.yml`
- **scorecard**: remove `security-events: write` + `id-token: write` **ociosos** (`publish_results: false` + só `upload-artifact`, sem `upload-sarif`). Mantém `contents: read` + `actions: read`.

### `backend-xdist-canary.yml`
- `issues: write` movido do **topo** para o job **`canary-report`** (único que comenta na issue 677); a matriz de testes herda só `contents: read`.

### Mantido (legítimo)
`slsa-provenance.yml` usa `id-token: write` + `attestations: write` corretamente (Cosign keyless + attest-build-provenance) — **não tocado**.

## Verificação

- **actionlint** nos 3 arquivos: **sem erros** nas mudanças (job split, refs `needs`, expressões, sintaxe de permissões). Os 3 warnings shellcheck restantes (SC2129/SC2086) são **pré-existentes** em run-blocks não tocados.
- YAML + grafo de jobs conferidos (parse + needs/permissions por job).

## Pendente antes do merge

- [ ] **Deploy de teste via `workflow_dispatch`** (exercita build_and_push read → tag_and_release write + deploy read end-to-end) — combinado com o autor.

## Definition of Done (#1397)

- [x] `deployments: write` ocioso removido do topo
- [x] `contents: write` isolado em `tag_and_release` (build/push com `contents: read`)
- [x] scorecard sem `security-events`/`id-token` ociosos
- [x] canary `issues: write` só no job que comenta
- [x] `slsa-provenance` preservado
- [ ] Deploy real continua passando (deploy de teste)

## Nota

`.github/` (fora do regex runtime-impact) → staging gate dispensado.