### PR TITLE
ci(backend): reusable workflow para setup de teste (#1401)

### DIFF
--- a/.github/workflows/_backend-test.yml
+++ b/.github/workflows/_backend-test.yml
@@ -48,6 +48,10 @@ on:
         description: "Se != '', redireciona o pytest para esse log + tail (canary)"
         type: string
         default: ""
+      fail_on_test_error:
+        description: "Se true, o job falha quando o pytest falha (gates core/ingest). O canary usa false (non-blocking): exit real fica no metadata/report."
+        type: boolean
+        default: true
       emit_canary_metadata:
         description: "Se true, escreve xdist-canary-metadata.json (canary)"
         type: boolean
@@ -173,6 +177,7 @@ jobs:
           PYTEST_EXTRA_ARGS: ${{ inputs.pytest_extra_args }}
           COVERAGE_FILE_INPUT: ${{ inputs.coverage_file }}
           CAPTURE_LOG_FILE: ${{ inputs.capture_log_file }}
+          FAIL_ON_TEST_ERROR: ${{ inputs.fail_on_test_error }}
           SUMMARY_TITLE: ${{ inputs.summary_title }}
           EMIT_CANARY_METADATA: ${{ inputs.emit_canary_metadata }}
           WORKERS: ${{ inputs.matrix_workers }}
@@ -235,7 +240,12 @@ jobs:
             echo "- Exit code: ${TEST_EXIT}"
           } >> "${GITHUB_STEP_SUMMARY}"
 
-          exit "${TEST_EXIT}"
+          # core/ingest sao gates reais (falham quando o pytest falha). O canary e
+          # non-blocking (fail_on_test_error=false): o exit real vive no metadata/report
+          # da issue #677 e o job segue verde, preservando o contrato original.
+          if [ "${FAIL_ON_TEST_ERROR}" = "true" ]; then
+            exit "${TEST_EXIT}"
+          fi
 
       - name: Upload test artifact
         if: always()

--- a/.github/workflows/_backend-test.yml
+++ b/.github/workflows/_backend-test.yml
@@ -1,0 +1,249 @@
+# Reusable workflow: backend test job (SSOT de infra de teste).
+#
+# Centraliza o setup duplicado dos jobs backend (#1401):
+#   - services postgres/redis  (bump de versao = 1 edicao, aqui)
+#   - 19 env vars de teste      (idem)
+#   - manage.py migrate         (idem)
+#   - prepare runtime dirs/symlinks
+#   - run pytest (parametrizado: paths, coverage, xdist, junit, log, metadata)
+#   - upload de artifact
+#
+# Consumido por:
+#   - ci.yaml: backend-tests-core, backend-tests-ingest-devtools
+#   - backend-xdist-canary.yml: xdist-canary (via strategy.matrix no caller)
+#
+# Fora de escopo (carve-out documentado): ci.yaml::docker-parity-backend usa env/topologia
+# de container (host.docker.internal, REQUIRE_DOCKER=1, migrate in-container) e nao consome
+# este reusable; ao bumpar postgres/redis aqui, sincronizar tambem o services de la.
+name: Backend Test (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      runner_timeout:
+        description: "Job timeout em minutos"
+        type: number
+        default: 35
+      pytest_paths:
+        description: "Paths/targets do pytest (separados por espaco)"
+        type: string
+        default: "apps"
+      pytest_extra_args:
+        description: "Args extras do pytest (xdist, junit, dispatch passthrough)"
+        type: string
+        default: ""
+      coverage_file:
+        description: "Se != '', exporta COVERAGE_FILE e adiciona --cov=apps --cov-report=term"
+        type: string
+        default: ""
+      validate_test_paths:
+        description: "Roda o guard de paths '/app' hardcoded (so o core precisa)"
+        type: boolean
+        default: false
+      summary_title:
+        description: "Titulo do bloco no GITHUB_STEP_SUMMARY"
+        type: string
+        default: "Backend tests"
+      capture_log_file:
+        description: "Se != '', redireciona o pytest para esse log + tail (canary)"
+        type: string
+        default: ""
+      emit_canary_metadata:
+        description: "Se true, escreve xdist-canary-metadata.json (canary)"
+        type: boolean
+        default: false
+      matrix_workers:
+        description: "Valor de matrix.workers (para o metadata do canary)"
+        type: string
+        default: ""
+      matrix_dist:
+        description: "Valor de matrix.dist (para o metadata do canary)"
+        type: string
+        default: ""
+      artifact_name:
+        description: "Nome do artifact de saida"
+        type: string
+        required: true
+      artifact_paths:
+        description: "Path(s) do artifact (newline-separated)"
+        type: string
+        required: true
+      artifact_if_no_files:
+        description: "if-no-files-found do upload (error|warn|ignore)"
+        type: string
+        default: "warn"
+      artifact_retention_days:
+        description: "Retencao do artifact em dias"
+        type: number
+        default: 7
+
+permissions:
+  contents: read
+
+jobs:
+  backend-test:
+    name: "[info] backend test"
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ inputs.runner_timeout }}
+
+    services:
+      # SSOT: bump de versao aqui cobre core/ingest/canary (#1401).
+      postgres:
+        image: postgres:15.13
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: test_aprender
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+      redis:
+        image: redis:7.4
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379
+
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
+
+      - uses: ./.github/actions/setup-python-deps
+        with:
+          requirements: 'requirements.txt requirements-dev.txt'
+
+      - name: Set up environment variables
+        run: |
+          echo "DJANGO_SETTINGS_MODULE=config.settings" >> "$GITHUB_ENV"
+          echo "ENVIRONMENT=testing" >> "$GITHUB_ENV"
+          echo "DEBUG=0" >> "$GITHUB_ENV"
+          echo "SECRET_KEY=test-secret-key-for-ci-only" >> "$GITHUB_ENV"
+          echo "DB_HOST=localhost" >> "$GITHUB_ENV"
+          echo "DB_PORT=5432" >> "$GITHUB_ENV"
+          echo "DB_NAME=test_aprender" >> "$GITHUB_ENV"
+          echo "DB_USER=postgres" >> "$GITHUB_ENV"
+          echo "DB_PASSWORD=postgres" >> "$GITHUB_ENV"
+          echo "REDIS_HOST=localhost" >> "$GITHUB_ENV"
+          echo "REDIS_PORT=6379" >> "$GITHUB_ENV"
+          echo "TZ=America/Fortaleza" >> "$GITHUB_ENV"
+          echo "REQUIRE_DOCKER=0" >> "$GITHUB_ENV"
+          echo "GCAL_CLIENT=fake" >> "$GITHUB_ENV"
+          echo "GCAL_SEND_UPDATES=none" >> "$GITHUB_ENV"
+          echo "FEATURE_AUTO_APPLY_ENABLED=false" >> "$GITHUB_ENV"
+          echo "ETL_OUTPUT_DIR=${{ github.workspace }}/v2/backend/out_etl" >> "$GITHUB_ENV"
+          echo "ETL_DATA_DIR=${{ github.workspace }}/v2/backend/data/csv-import" >> "$GITHUB_ENV"
+          echo "PYTHONDONTWRITEBYTECODE=1" >> "$GITHUB_ENV"
+
+      - name: Validate test paths (no /app hardcoded)
+        if: ${{ inputs.validate_test_paths }}
+        run: |
+          cd v2/backend
+          if grep -R --line-number '"/app' apps/core/tests apps/dev_tools/tests 2>/dev/null | grep -v "Binary file" | grep -v '"/api/'; then
+            echo "❌ Found '/app' hardcoded in tests. Use Path(settings.BASE_DIR) instead." >&2
+            exit 1
+          fi
+          echo "✅ No hardcoded '/app' paths found in tests"
+
+      - name: Run migrations
+        run: |
+          cd v2/backend
+          python manage.py migrate --noinput
+
+      - name: Prepare runtime dirs and symlinks
+        run: |
+          sudo mkdir -p /app
+          mkdir -p "$GITHUB_WORKSPACE/v2/backend/.agents/outbox"
+          sudo rm -rf /app/.agents || true
+          sudo ln -s "$GITHUB_WORKSPACE/v2/backend/.agents" /app/.agents
+          mkdir -p "$GITHUB_WORKSPACE/v2/backend/out_etl"
+          mkdir -p "$GITHUB_WORKSPACE/v2/backend/data/csv-import"
+
+      - name: Run tests
+        env:
+          # Backend sys.monitoring do Python 3.12: coverage muito mais leve que o C-trace
+          # (no-op quando nao ha --cov). #1399.
+          COVERAGE_CORE: sysmon
+          PYTEST_PATHS: ${{ inputs.pytest_paths }}
+          PYTEST_EXTRA_ARGS: ${{ inputs.pytest_extra_args }}
+          COVERAGE_FILE_INPUT: ${{ inputs.coverage_file }}
+          CAPTURE_LOG_FILE: ${{ inputs.capture_log_file }}
+          SUMMARY_TITLE: ${{ inputs.summary_title }}
+          EMIT_CANARY_METADATA: ${{ inputs.emit_canary_metadata }}
+          WORKERS: ${{ inputs.matrix_workers }}
+          DIST_MODE: ${{ inputs.matrix_dist }}
+        run: |
+          cd v2/backend
+          echo "🧪 ${SUMMARY_TITLE}"
+          START_TS=$(date +%s)
+
+          # Monta o argv do pytest a partir dos inputs (array evita eval / word-splitting inseguro).
+          read -ra _paths <<< "${PYTEST_PATHS}" || true
+          read -ra _extra <<< "${PYTEST_EXTRA_ARGS}" || true
+          pytest_cmd=(pytest -q --tb=short "${_paths[@]}" "${_extra[@]}")
+          if [ -n "${COVERAGE_FILE_INPUT}" ]; then
+            export COVERAGE_FILE="${COVERAGE_FILE_INPUT}"
+            pytest_cmd+=(--cov=apps --cov-report=term)
+          fi
+
+          set +e
+          if [ -n "${CAPTURE_LOG_FILE}" ]; then
+            "${pytest_cmd[@]}" > "${CAPTURE_LOG_FILE}" 2>&1
+            TEST_EXIT=$?
+          else
+            "${pytest_cmd[@]}"
+            TEST_EXIT=$?
+          fi
+          set -e
+
+          END_TS=$(date +%s)
+          DURATION_SEC=$((END_TS - START_TS))
+
+          if [ -n "${CAPTURE_LOG_FILE}" ]; then
+            tail -n 120 "${CAPTURE_LOG_FILE}" || true
+          fi
+          ls -la .coverage* 2>/dev/null || true
+
+          if [ "${EMIT_CANARY_METADATA}" = "true" ]; then
+          TEST_EXIT="${TEST_EXIT}" DURATION_SEC="${DURATION_SEC}" python - <<'PY'
+          import json
+          import os
+
+          payload = {
+              "workers": os.environ.get("WORKERS", ""),
+              "dist": os.environ.get("DIST_MODE", ""),
+              "exit_code": int(os.environ["TEST_EXIT"]),
+              "duration_seconds": int(os.environ["DURATION_SEC"]),
+              "repository": os.environ.get("GITHUB_REPOSITORY", ""),
+              "run_id": os.environ.get("GITHUB_RUN_ID", ""),
+              "run_attempt": os.environ.get("GITHUB_RUN_ATTEMPT", ""),
+          }
+          with open("xdist-canary-metadata.json", "w", encoding="utf-8") as file:
+              json.dump(payload, file, indent=2, sort_keys=True)
+              file.write("\n")
+          PY
+          fi
+
+          {
+            echo "### ${SUMMARY_TITLE}"
+            echo "- Duration (seconds): ${DURATION_SEC}"
+            echo "- Exit code: ${TEST_EXIT}"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+          exit "${TEST_EXIT}"
+
+      - name: Upload test artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
+        continue-on-error: true
+        with:
+          name: ${{ inputs.artifact_name }}
+          path: ${{ inputs.artifact_paths }}
+          if-no-files-found: ${{ inputs.artifact_if_no_files }}
+          include-hidden-files: true
+          retention-days: ${{ inputs.artifact_retention_days }}

--- a/.github/workflows/backend-xdist-canary.yml
+++ b/.github/workflows/backend-xdist-canary.yml
@@ -47,6 +47,8 @@ jobs:
         --junitxml=xdist-canary-junit.xml ${{ github.event.inputs.extra_pytest_args || '' }}
       summary_title: xdist canary run
       capture_log_file: xdist-canary-pytest.log
+      # non-blocking: falhas xdist vivem no report/issue #677, job segue verde (#1401).
+      fail_on_test_error: false
       emit_canary_metadata: true
       matrix_workers: ${{ matrix.workers }}
       matrix_dist: ${{ matrix.dist }}

--- a/.github/workflows/backend-xdist-canary.yml
+++ b/.github/workflows/backend-xdist-canary.yml
@@ -13,6 +13,7 @@ on:
     branches: [ main ]
     paths:
       - ".github/workflows/backend-xdist-canary.yml"
+      - ".github/workflows/_backend-test.yml"
       - "v2/scripts/xdist_canary_report.py"
       - "docs/operations/ci-backend-xdist-canary.md"
       - "docs/operations/ci-backend-xdist-stabilization-backlog.md"
@@ -30,140 +31,32 @@ concurrency:
 jobs:
   xdist-canary:
     name: "[info] backend xdist canary (w=${{ matrix.workers }},dist=${{ matrix.dist }})"
-    runs-on: ubuntu-latest
-    timeout-minutes: 40
     strategy:
       fail-fast: false
       matrix:
         workers: ["2", "auto"]
         dist: ["loadscope", "loadfile"]
-
-    services:
-      postgres:
-        image: postgres:15.13
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: test_aprender
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
-
-      redis:
-        image: redis:7.4
-        options: >-
-          --health-cmd "redis-cli ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 6379:6379
-
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
-
-      - uses: ./.github/actions/setup-python-deps
-        with:
-          requirements: 'requirements.txt requirements-dev.txt'
-
-      - name: Set up environment variables
-        run: |
-          echo "DJANGO_SETTINGS_MODULE=config.settings" >> "$GITHUB_ENV"
-          echo "ENVIRONMENT=testing" >> "$GITHUB_ENV"
-          echo "DEBUG=0" >> "$GITHUB_ENV"
-          echo "SECRET_KEY=test-secret-key-for-ci-only" >> "$GITHUB_ENV"
-          echo "DB_HOST=localhost" >> "$GITHUB_ENV"
-          echo "DB_PORT=5432" >> "$GITHUB_ENV"
-          echo "DB_NAME=test_aprender" >> "$GITHUB_ENV"
-          echo "DB_USER=postgres" >> "$GITHUB_ENV"
-          echo "DB_PASSWORD=postgres" >> "$GITHUB_ENV"
-          echo "REDIS_HOST=localhost" >> "$GITHUB_ENV"
-          echo "REDIS_PORT=6379" >> "$GITHUB_ENV"
-          echo "TZ=America/Fortaleza" >> "$GITHUB_ENV"
-          echo "REQUIRE_DOCKER=0" >> "$GITHUB_ENV"
-          echo "GCAL_CLIENT=fake" >> "$GITHUB_ENV"
-          echo "GCAL_SEND_UPDATES=none" >> "$GITHUB_ENV"
-          echo "FEATURE_AUTO_APPLY_ENABLED=false" >> "$GITHUB_ENV"
-          echo "ETL_OUTPUT_DIR=${{ github.workspace }}/v2/backend/out_etl" >> "$GITHUB_ENV"
-          echo "ETL_DATA_DIR=${{ github.workspace }}/v2/backend/data/csv-import" >> "$GITHUB_ENV"
-          echo "PYTHONDONTWRITEBYTECODE=1" >> "$GITHUB_ENV"
-
-      - name: Run migrations
-        run: |
-          cd v2/backend
-          python manage.py migrate --noinput
-
-      - name: Prepare runtime dirs and symlinks
-        run: |
-          sudo mkdir -p /app
-          mkdir -p "$GITHUB_WORKSPACE/v2/backend/.agents/outbox"
-          sudo rm -rf /app/.agents || true
-          sudo ln -s "$GITHUB_WORKSPACE/v2/backend/.agents" /app/.agents
-          mkdir -p "$GITHUB_WORKSPACE/v2/backend/out_etl"
-          mkdir -p "$GITHUB_WORKSPACE/v2/backend/data/csv-import"
-
-      - name: Run xdist canary suite (non-blocking)
-        env:
-          WORKERS: ${{ matrix.workers }}
-          DIST_MODE: ${{ matrix.dist }}
-          EXTRA_PYTEST_ARGS: ${{ github.event.inputs.extra_pytest_args || '' }}
-        run: |
-          cd v2/backend
-          echo "🧪 Running xdist canary (workers=${WORKERS}, dist=${DIST_MODE})"
-          START_TS=$(date +%s)
-
-          set +e
-          pytest -q --tb=short -n "${WORKERS}" --dist "${DIST_MODE}" --max-worker-restart=0 \
-            --junitxml=xdist-canary-junit.xml ${EXTRA_PYTEST_ARGS} apps > xdist-canary-pytest.log 2>&1
-          TEST_EXIT=$?
-          set -e
-
-          END_TS=$(date +%s)
-          DURATION_SEC=$((END_TS - START_TS))
-
-          TEST_EXIT="${TEST_EXIT}" DURATION_SEC="${DURATION_SEC}" python - <<'PY'
-          import json
-          import os
-
-          payload = {
-              "workers": os.environ["WORKERS"],
-              "dist": os.environ["DIST_MODE"],
-              "exit_code": int(os.environ["TEST_EXIT"]),
-              "duration_seconds": int(os.environ["DURATION_SEC"]),
-              "repository": os.environ.get("GITHUB_REPOSITORY", ""),
-              "run_id": os.environ.get("GITHUB_RUN_ID", ""),
-              "run_attempt": os.environ.get("GITHUB_RUN_ATTEMPT", ""),
-          }
-          with open("xdist-canary-metadata.json", "w", encoding="utf-8") as file:
-              json.dump(payload, file, indent=2, sort_keys=True)
-              file.write("\n")
-          PY
-
-          tail -n 120 xdist-canary-pytest.log || true
-
-          {
-            echo "### xdist canary run"
-            echo "- workers: ${WORKERS}"
-            echo "- dist: ${DIST_MODE}"
-            echo "- duration (seconds): ${DURATION_SEC}"
-            echo "- exit code: ${TEST_EXIT}"
-            echo "- mode: non-blocking canary"
-          } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Upload xdist canary artifact
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
-        with:
-          name: xdist-canary-${{ matrix.workers }}w-${{ matrix.dist }}
-          path: |
-            v2/backend/xdist-canary-pytest.log
-            v2/backend/xdist-canary-junit.xml
-            v2/backend/xdist-canary-metadata.json
-          if-no-files-found: warn
-          retention-days: 30
+    # Setup (services/env/migrate/dirs) centralizado no reusable; matrix fica aqui no
+    # caller e passa workers/dist via inputs. #1401.
+    uses: ./.github/workflows/_backend-test.yml
+    with:
+      runner_timeout: 40
+      pytest_paths: apps
+      pytest_extra_args: >-
+        -n ${{ matrix.workers }} --dist ${{ matrix.dist }} --max-worker-restart=0
+        --junitxml=xdist-canary-junit.xml ${{ github.event.inputs.extra_pytest_args || '' }}
+      summary_title: xdist canary run
+      capture_log_file: xdist-canary-pytest.log
+      emit_canary_metadata: true
+      matrix_workers: ${{ matrix.workers }}
+      matrix_dist: ${{ matrix.dist }}
+      artifact_name: xdist-canary-${{ matrix.workers }}w-${{ matrix.dist }}
+      artifact_paths: |
+        v2/backend/xdist-canary-pytest.log
+        v2/backend/xdist-canary-junit.xml
+        v2/backend/xdist-canary-metadata.json
+      artifact_if_no_files: warn
+      artifact_retention_days: 30
 
   canary-report:
     name: "[ops] backend xdist canary summary"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,7 +76,7 @@ jobs:
 
         # Conservative impact patterns to prevent false green:
         # includes backend app, backend runtime infra, backend tests and this CI workflow itself.
-        BACKEND_IMPACT_REGEX='^(v2/backend/|v2/infra/|v2/tests/|v2/.dockerignore$|\.github/workflows/ci\.yaml$)'
+        BACKEND_IMPACT_REGEX='^(v2/backend/|v2/infra/|v2/tests/|v2/.dockerignore$|\.github/workflows/ci\.yaml$|\.github/workflows/_backend-test\.yml$)'
         BACKEND_MATCHED_FILES="$(printf '%s\n' "$CHANGED_FILES" | grep -E "$BACKEND_IMPACT_REGEX" || true)"
         BACKEND_MATCHED_COUNT="$(printf '%s\n' "$BACKEND_MATCHED_FILES" | sed '/^$/d' | wc -l | tr -d ' ')"
 
@@ -208,240 +208,39 @@ jobs:
   # ----------------------------------------------------------------
   backend-tests-core:
     name: "[info] backend tests core (runner)"
-    runs-on: ubuntu-latest
-    timeout-minutes: 35
     needs:
       - backend-impact
     if: needs.backend-impact.outputs.backend_changed == 'true'
-
-    services:
-      postgres:
-        image: postgres:15.13
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: test_aprender
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
-
-      redis:
-        image: redis:7.4
-        options: >-
-          --health-cmd "redis-cli ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 6379:6379
-
-    steps:
-    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
-
-    - uses: ./.github/actions/setup-python-deps
-      with:
-        requirements: 'requirements.txt requirements-dev.txt'
-
-    - name: Set up environment variables
-      run: |
-        echo "DJANGO_SETTINGS_MODULE=config.settings" >> $GITHUB_ENV
-        echo "ENVIRONMENT=testing" >> $GITHUB_ENV
-        echo "DEBUG=0" >> $GITHUB_ENV
-        echo "SECRET_KEY=test-secret-key-for-ci-only" >> $GITHUB_ENV
-        echo "DB_HOST=localhost" >> $GITHUB_ENV
-        echo "DB_PORT=5432" >> $GITHUB_ENV
-        echo "DB_NAME=test_aprender" >> $GITHUB_ENV
-        echo "DB_USER=postgres" >> $GITHUB_ENV
-        echo "DB_PASSWORD=postgres" >> $GITHUB_ENV
-        echo "REDIS_HOST=localhost" >> $GITHUB_ENV
-        echo "REDIS_PORT=6379" >> $GITHUB_ENV
-        echo "TZ=America/Fortaleza" >> $GITHUB_ENV
-        echo "REQUIRE_DOCKER=0" >> $GITHUB_ENV
-        echo "GCAL_CLIENT=fake" >> $GITHUB_ENV
-        echo "GCAL_SEND_UPDATES=none" >> $GITHUB_ENV
-        echo "FEATURE_AUTO_APPLY_ENABLED=false" >> $GITHUB_ENV
-        echo "ETL_OUTPUT_DIR=${{ github.workspace }}/v2/backend/out_etl" >> $GITHUB_ENV
-        echo "ETL_DATA_DIR=${{ github.workspace }}/v2/backend/data/csv-import" >> $GITHUB_ENV
-        echo "PYTHONDONTWRITEBYTECODE=1" >> $GITHUB_ENV
-
-    - name: Validate test paths (no /app hardcoded)
-      run: |
-        cd v2/backend
-        if grep -R --line-number '"/app' apps/core/tests apps/dev_tools/tests 2>/dev/null | grep -v "Binary file" | grep -v '"/api/'; then
-          echo "❌ Found '/app' hardcoded in tests. Use Path(settings.BASE_DIR) instead." >&2
-          exit 1
-        fi
-        echo "✅ No hardcoded '/app' paths found in tests"
-
-    - name: Run migrations
-      run: |
-        cd v2/backend
-        python manage.py migrate --noinput
-
-    - name: Prepare runtime dirs and symlinks
-      run: |
-        sudo mkdir -p /app
-        mkdir -p "$GITHUB_WORKSPACE/v2/backend/.agents/outbox"
-        sudo rm -rf /app/.agents || true
-        sudo ln -s "$GITHUB_WORKSPACE/v2/backend/.agents" /app/.agents
-        mkdir -p "$GITHUB_WORKSPACE/v2/backend/out_etl"
-        mkdir -p "$GITHUB_WORKSPACE/v2/backend/data/csv-import"
-
-    - name: Run core tests with coverage
-      env:
-        # Backend sys.monitoring do Python 3.12: coverage muito mais leve que o
-        # C-trace (~30-50% menos overhead), mantendo --cov e o gate de 85%. #1399.
-        COVERAGE_CORE: sysmon
-      run: |
-        cd v2/backend
-        echo "🧪 Running backend core suite (serial)"
-        START_TS=$(date +%s)
-
-        set +e
-        COVERAGE_FILE=".coverage.core" \
-        pytest -q --tb=short apps/core/tests --cov=apps --cov-report=term
-        TEST_EXIT=$?
-        set -e
-        ls -la .coverage* || true
-
-        END_TS=$(date +%s)
-        DURATION_SEC=$((END_TS - START_TS))
-        {
-          echo "### Backend Core Tests Runtime"
-          echo "- Duration (seconds): ${DURATION_SEC}"
-          echo "- Exit code: ${TEST_EXIT}"
-        } >> "${GITHUB_STEP_SUMMARY}"
-
-        exit ${TEST_EXIT}
-
-    - name: Upload core coverage artifact
-      if: always()
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
-      continue-on-error: true
-      with:
-        name: backend-coverage-core
-        path: v2/backend/.coverage.core
-        if-no-files-found: error
-        include-hidden-files: true
-        retention-days: 7
+    # Setup (services/env/migrate/dirs) centralizado no reusable. #1401.
+    uses: ./.github/workflows/_backend-test.yml
+    with:
+      runner_timeout: 35
+      pytest_paths: apps/core/tests
+      coverage_file: .coverage.core
+      validate_test_paths: true
+      summary_title: Backend Core Tests Runtime
+      artifact_name: backend-coverage-core
+      artifact_paths: v2/backend/.coverage.core
+      artifact_if_no_files: error
 
   # ----------------------------------------------------------------
   # Job 2b: Backend tests - ingest/devtools suite (serial)
   # ----------------------------------------------------------------
   backend-tests-ingest-devtools:
     name: "[info] backend tests ingest/devtools (runner)"
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
     needs:
       - backend-impact
     if: needs.backend-impact.outputs.backend_changed == 'true'
-
-    services:
-      postgres:
-        image: postgres:15.13
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: test_aprender
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
-
-      redis:
-        image: redis:7.4
-        options: >-
-          --health-cmd "redis-cli ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 6379:6379
-
-    steps:
-    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
-
-    - uses: ./.github/actions/setup-python-deps
-      with:
-        requirements: 'requirements.txt requirements-dev.txt'
-
-    - name: Set up environment variables
-      run: |
-        echo "DJANGO_SETTINGS_MODULE=config.settings" >> $GITHUB_ENV
-        echo "ENVIRONMENT=testing" >> $GITHUB_ENV
-        echo "DEBUG=0" >> $GITHUB_ENV
-        echo "SECRET_KEY=test-secret-key-for-ci-only" >> $GITHUB_ENV
-        echo "DB_HOST=localhost" >> $GITHUB_ENV
-        echo "DB_PORT=5432" >> $GITHUB_ENV
-        echo "DB_NAME=test_aprender" >> $GITHUB_ENV
-        echo "DB_USER=postgres" >> $GITHUB_ENV
-        echo "DB_PASSWORD=postgres" >> $GITHUB_ENV
-        echo "REDIS_HOST=localhost" >> $GITHUB_ENV
-        echo "REDIS_PORT=6379" >> $GITHUB_ENV
-        echo "TZ=America/Fortaleza" >> $GITHUB_ENV
-        echo "REQUIRE_DOCKER=0" >> $GITHUB_ENV
-        echo "GCAL_CLIENT=fake" >> $GITHUB_ENV
-        echo "GCAL_SEND_UPDATES=none" >> $GITHUB_ENV
-        echo "FEATURE_AUTO_APPLY_ENABLED=false" >> $GITHUB_ENV
-        echo "ETL_OUTPUT_DIR=${{ github.workspace }}/v2/backend/out_etl" >> $GITHUB_ENV
-        echo "ETL_DATA_DIR=${{ github.workspace }}/v2/backend/data/csv-import" >> $GITHUB_ENV
-        echo "PYTHONDONTWRITEBYTECODE=1" >> $GITHUB_ENV
-
-    - name: Run migrations
-      run: |
-        cd v2/backend
-        python manage.py migrate --noinput
-
-    - name: Prepare runtime dirs and symlinks
-      run: |
-        sudo mkdir -p /app
-        mkdir -p "$GITHUB_WORKSPACE/v2/backend/.agents/outbox"
-        sudo rm -rf /app/.agents || true
-        sudo ln -s "$GITHUB_WORKSPACE/v2/backend/.agents" /app/.agents
-        mkdir -p "$GITHUB_WORKSPACE/v2/backend/out_etl"
-        mkdir -p "$GITHUB_WORKSPACE/v2/backend/data/csv-import"
-
-    - name: Run ingest/devtools tests with coverage
-      env:
-        # Backend sys.monitoring do Python 3.12 (ver step core). #1399.
-        COVERAGE_CORE: sysmon
-      run: |
-        cd v2/backend
-        echo "🧪 Running backend ingest/devtools suite (serial)"
-        START_TS=$(date +%s)
-
-        set +e
-        COVERAGE_FILE=".coverage.ingest_devtools" \
-        pytest -q --tb=short apps/dev_tools/tests --cov=apps --cov-report=term
-        TEST_EXIT=$?
-        set -e
-        ls -la .coverage* || true
-
-        END_TS=$(date +%s)
-        DURATION_SEC=$((END_TS - START_TS))
-        {
-          echo "### Backend Ingest/DevTools Tests Runtime"
-          echo "- Duration (seconds): ${DURATION_SEC}"
-          echo "- Exit code: ${TEST_EXIT}"
-        } >> "${GITHUB_STEP_SUMMARY}"
-
-        exit ${TEST_EXIT}
-
-    - name: Upload ingest/devtools coverage artifact
-      if: always()
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
-      continue-on-error: true
-      with:
-        name: backend-coverage-ingest-devtools
-        path: v2/backend/.coverage.ingest_devtools
-        if-no-files-found: error
-        include-hidden-files: true
-        retention-days: 7
+    # Setup (services/env/migrate/dirs) centralizado no reusable. #1401.
+    uses: ./.github/workflows/_backend-test.yml
+    with:
+      runner_timeout: 30
+      pytest_paths: apps/dev_tools/tests
+      coverage_file: .coverage.ingest_devtools
+      summary_title: Backend Ingest/DevTools Tests Runtime
+      artifact_name: backend-coverage-ingest-devtools
+      artifact_paths: v2/backend/.coverage.ingest_devtools
+      artifact_if_no_files: error
 
   # ----------------------------------------------------------------
   # Job 2c: Backend coverage combine + required backend tests gate
@@ -561,6 +360,10 @@ jobs:
       - backend-impact
     if: needs.backend-impact.outputs.backend_changed == 'true'
 
+    # Carve-out do reusable _backend-test.yml (#1401): topologia de container
+    # (host.docker.internal, REQUIRE_DOCKER=1, migrate in-container, build buildx)
+    # diverge do setup de runner. Ao bumpar postgres/redis aqui, sincronizar com o
+    # services do reusable (SSOT das versoes).
     services:
       postgres:
         image: postgres:15.13


### PR DESCRIPTION
## Contexto

Fecha **#1401** (último item do M2 — Estabilidade do roadmap CI/CD). Os jobs de teste backend
duplicavam o mesmo setup de infra em 4 lugares — `services` postgres/redis (×4), ~20 env vars
(×3) e `manage.py migrate` (×3) — então um bump de versão exigia até 4 edições sincronizadas
(drift provável). Nenhum workflow usava `workflow_call`.

## Mudança

Novo **`.github/workflows/_backend-test.yml`** (reusable, `workflow_call`) é o **SSOT** do setup
de teste backend: `services` + env (19 vars) + `migrate` + prepare dirs + `pytest` parametrizado
+ upload de artifact. Consumido por:

- `ci.yaml`: `backend-tests-core` e `backend-tests-ingest-devtools` viram callers `uses:` finos
- `backend-xdist-canary.yml`: `xdist-canary` vira caller `uses:` (a `strategy.matrix` workers×dist
  fica no caller e passa via inputs)

`docker-parity-backend` fica **fora** (carve-out documentado): topologia de container
(`host.docker.internal`, `REQUIRE_DOCKER=1`, migrate in-container, build buildx) diverge do setup
de runner. Comentário no job aponta o SSOT das versões.

### DoD (#1401)
- [x] Setup backend (env + services + migrate) centralizado num único lugar
- [x] `ci.yaml` e `backend-xdist-canary.yml` consomem o mesmo bloco
- [x] Bump de postgres/redis/env = **1 edição** (no reusable)
- [x] Todos os jobs backend continuam verdes

## Decisão de design

**Reusable workflow** (não composite action): composite **não pode declarar `services:`** (é
job-level), então só o reusable cumpre o checkbox "bump de postgres = 1 edição". Custo: a lógica
de teste migra pra dentro do reusable e os jobs viram `uses:` (mais invasivo, mas é o único
mecanismo que DRY-a os `services`).

## Inalterado (sem risco de gate)
- Required checks `[required] tests` (agregador) e `[required] lint` — nomes e lógica mantidos.
  Nenhum job convertido é required por nome (são `[info]`/`[ops]` ou alimentam o agregador via
  `needs.<job>.result`, que funciona igual em job `uses:`).
- `backend-tests` (combine/coverage/codecov), `docker-parity-backend`, `backend-typecheck`,
  `canary-report` — intactos. CODECOV_TOKEN segue no combine (reusable não usa secrets).
- Least-privilege preservado (#1397): reusable declara `permissions: contents: read`.

## Validação
- **actionlint** (via docker `rhysd/actionlint`) nos 3 arquivos: estrutura limpa (schema
  `workflow_call`, refs de matrix, `uses:`/`with`, permissões). Só restam `SC2129` (style/info)
  pré-existentes nas etapas `>> $GITHUB_ENV`/`$GITHUB_OUTPUT` — agora consolidadas de 3× para 1×.
- **CI deste PR**: jobs backend (core/ingest via reusable, combine, docker-parity, typecheck)
  exercitados — o regex de impacto passou a incluir o reusable.
- **Canary** (não roda em PR): validado via `workflow_dispatch` no branch.

CI-only (não toca `deploy.yaml`) → sem deploy. Staging gate dispensado (mudança só em `.github/`).