### PR TITLE
perf(test): estabilizar suite backend sob pytest-xdist (#1402)

### DIFF
--- a/v2/backend/apps/core/tests/test_import_job_integration.py
+++ b/v2/backend/apps/core/tests/test_import_job_integration.py
@@ -24,7 +24,6 @@ from rest_framework.test import APIClient
 import pytest
 
 from apps.core.models import AvailabilityBlock, ImportJob
-from apps.core.services.functional_permissions_seed import seed_functional_permissions
 
 User = get_user_model()
 
@@ -33,10 +32,8 @@ UPLOAD_URL = "/api/imports/bloqueios/"
 
 @pytest.fixture
 def controle_user(db):
-    # Testes com transaction=True truncam entre cases; re-semeia a ligacao
-    # PermissaoFuncional <-> Group que o conftest de sessao criou.
-    seed_functional_permissions(assign_default_groups=True)
-
+    # O seed RBAC (incl. pos-truncate de transaction=True) e garantido globalmente
+    # pela fixture autouse `ensure_rbac_seed` (conftest raiz, #1402).
     user = User.objects.create_user(
         username="ctrl_intg",
         email="ctrl_intg@test.com",

--- a/v2/backend/config/settings.py
+++ b/v2/backend/config/settings.py
@@ -257,6 +257,28 @@ CACHES = {
     }
 }
 
+if TESTING:
+    # xdist: isola o cache Redis por worker usando um DB index distinto. Sem isso,
+    # todos os workers batem no mesmo DB 0 → o `cache.clear()`/FLUSHDB (ou a
+    # invalidação) de um worker apaga o keyspace dos outros mid-test, causando a
+    # flakiness paralelo-insegura sob `-n auto` (sessões em cache, contagens e
+    # caches de permissão vazando entre workers). #1402.
+    #
+    # Mantemos o backend django_redis real (NÃO LocMemCache): o código de
+    # invalidação usa `cache.keys("static_endpoint:*")` + `delete_many` — APIs
+    # específicas do django_redis que o LocMemCache não possui (o `hasattr` falha
+    # e a invalidação vira no-op, quebrando os testes de invalidação). As sessões
+    # (SESSION_ENGINE=cache, abaixo) também ficam isoladas por worker.
+    #
+    # Mapa: serial/master → DB 0 (status quo); gwN → DB (N % 16). No runner
+    # ubuntu-latest (`-n auto` = 4 cores) usa DBs 0–3; Redis tem 16 DBs (0–15).
+    _xdist_worker = os.environ.get("PYTEST_XDIST_WORKER", "")  # "gw0".."gwN" ou "" (serial)
+    _test_redis_db = int(_xdist_worker[2:]) % 16 if _xdist_worker[2:].isdigit() else 0
+    CACHES["default"]["LOCATION"] = (
+        f"redis://:{os.getenv('REDIS_PASSWORD', '')}@"
+        f"{os.getenv('REDIS_HOST', 'redis')}:{os.getenv('REDIS_PORT', '6379')}/{_test_redis_db}"
+    )
+
 # ================================================================
 # SESSION BACKEND (CP2 - Redis Sessions)
 # ================================================================

--- a/v2/backend/conftest.py
+++ b/v2/backend/conftest.py
@@ -18,13 +18,45 @@ import pytest
 
 
 @pytest.fixture(autouse=True, scope="function")
-def default_test_user(db):
+def ensure_rbac_seed(db):
+    """
+    Garante o seed de RBAC (grupos + PermissaoFuncional + ligacoes group x capability)
+    presente em CADA teste, mesmo sob pytest-xdist. #1402.
+
+    Por que: os testes `@pytest.mark.django_db(transaction=True)` usam semantica
+    TransactionTestCase e fazem TRUNCATE/flush do DB no teardown, apagando o seed de
+    RBAC (vindo das migrations RunPython e do fixture de sessao). O runner nativo do
+    Django reordena TransactionTestCase para o FIM, entao serial nunca perde o seed no
+    meio. Mas pytest-xdist NAO reordena: sob `-n auto`, um teste-truncate roda no meio
+    do worker e TODOS os testes seguintes naquele worker perdem o seed -> a resolucao de
+    capability (`PermissaoFuncional.objects.filter(groups__user__id=...)`) retorna vazio
+    -> 403 PERMISSION_DENIED em cascata (centenas de falhas, nao-deterministicas).
+
+    Guarda de 1 query: no-op quando o seed ja existe (caso comum -> sem overhead). So
+    re-semeia (idempotente) quando o vinculo group x capability sumiu (pos-truncate).
+    """
+    from apps.core.models import PermissaoFuncional
+    from apps.core.services.functional_permissions_seed import seed_functional_permissions
+
+    if not PermissaoFuncional.objects.filter(groups__isnull=False).exists():
+        seed_functional_permissions(assign_default_groups=True)
+        # O groups.set do seed dispara m2m_changed e popula o buffer de auditoria de
+        # capability; essas mudancas sao infraestrutura de teste (nao operacoes
+        # auditaveis) -> limpar para nao contaminar contagens de AuditLog.
+        from apps.core.signals import _PENDING_GROUP_CAP_DELTAS
+
+        _PENDING_GROUP_CAP_DELTAS.clear()
+
+
+@pytest.fixture(autouse=True, scope="function")
+def default_test_user(db, ensure_rbac_seed):
     """
     Create unique test user for each test function.
 
     - Unique CPF/username via uuid4 (xdist-safe)
     - Added to Coordenador group
     - autouse=True ensures DB is available for all tests
+    - depends on ensure_rbac_seed so o grupo/seed RBAC exista antes do groups.add
 
     Available as explicit fixture: `def test_x(default_test_user):`
     """


### PR DESCRIPTION
## Contexto

Fecha #1402. A issue dizia "6 testes flaky por cache Redis compartilhado". A investigação (canary completa + probes + leitura de código) provou que era **muito maior e por outra causa**: ~**537 testes distintos** falhavam por run de canary sob xdist (`-n 2/auto × loadscope/loadfile`), enquanto serial é verde.

### Causa-raiz (confirmada empiricamente no CI)
Os 12 testes `@pytest.mark.django_db(transaction=True)` (5 arquivos) usam semântica `TransactionTestCase` → fazem **TRUNCATE/flush** do DB no teardown, apagando o seed de RBAC (grupos + `PermissaoFuncional` + ligações group×capability das migrations RunPython e do fixture de sessão). Sem `serialized_rollback`, não é restaurado. O runner nativo do Django **reordena `TransactionTestCase` pro fim** (serial nunca perde o seed no meio); o **pytest-xdist NÃO reordena** → sob `-n auto` um truncate roda no meio do worker e **todos os testes seguintes naquele worker perdem o seed** → `get_user_functional_permissions()` retorna vazio → **403 PERMISSION_DENIED em cascata** (não-determinístico; explica `loadscope ≠ loadfile`).

**Prova:** deselecionar os 5 arquivos `transaction=True` na canary → **0 falhas nas 4 células** (era 537), 0 residual ⇒ causa única confirmada.

## Mudanças
1. **`ensure_rbac_seed`** (fixture autouse function-scoped, `conftest.py` raiz): guarda de 1 query (no-op quando o seed existe → sem overhead no caso comum); re-semeia idempotente (`seed_functional_permissions`) quando o vínculo group×capability sumiu (pós-truncate) e limpa o buffer de auditoria de capability. `default_test_user` passa a depender dela.
2. **Isolação de cache/sessão Redis por worker** (`config/settings.py`, sob `TESTING`): DB index por `PYTEST_XDIST_WORKER` (serial → DB 0 = status quo). Mantém django_redis real (a invalidação usa `cache.keys()`/`delete_many`, que LocMemCache não tem). Corrige o subconjunto `SessionInterrupted`.
3. Remove o workaround manual de re-seed em `test_import_job_integration.py` (agora coberto globalmente).

Test-only: ambas as mudanças são gated por `TESTING`/fixtures → **zero impacto em runtime/produção**. Não toca o gate (`ci.yaml`); a promoção de `-n auto` ao gate é o #1403 (PR separado).

## Validação
- **Canary CI (autoritativo):** suíte completa sob xdist → **0/4 células** (run [27831983087](https://github.com/matheusnorjosa/aprender_sistema/actions/runs/27831983087)); 2ª run consecutiva em andamento (critério do `ci-backend-xdist-canary.md`).
- **Local:** `pytest apps/core/tests -n 4 --create-db` → 110 → **0** falhas com o fix.
- **Serial sem regressão:** a fixture é no-op em serial (seed presente); gate `[required] tests` segue verde.

---

## Evidência de Staging Gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Resultado local (`make -C v2/infra staging-precheck → build → up → test → down`, RC=0; smokes 1–8 incl. health/version/frontend root-div):

ALL 8 CHECKS PASSED

Observação: a mudança é test-only (gated por `TESTING`/fixtures, zero impacto em runtime/prod), mas `config/settings.py` casa o regex de runtime-impact do gate, então a evidência é fornecida.
