### PR TITLE
docs(sdd): auditoria documental + Fase 0 da migracao SDD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -588,11 +588,10 @@ v2/frontend/validate-*.json
 v2/frontend/playwright-report/
 v2/frontend/test-results/
 
-# Observability stack (opcional - não utilizado atualmente)
+# Observability stack: configs de infra local opcionais (o doc v2/docs/OBSERVABILITY.md E versionado)
 v2/infra/docker-compose.observability.yml
 v2/infra/prometheus.yml
 v2/infra/grafana/
-v2/docs/OBSERVABILITY.md
 
 # Continuous Claude cache (local only)
 .claude/cache/

--- a/v2/OAUTH_ENV_VARIABLES.md
+++ b/v2/OAUTH_ENV_VARIABLES.md
@@ -188,5 +188,4 @@ docker compose restart web worker beat
 
 - [Google Calendar API - OAuth 2.0](https://developers.google.com/calendar/api/guides/auth)
 - [Fernet (Cryptography)](https://cryptography.io/en/latest/fernet/)
-- [fechar_plano_gcal.md](../docs/fechar_plano_gcal.md) - Plano completo OAuth
-- [GUIDE_GCAL.md](../docs/GUIDE_GCAL.md) - Guia de configuração GCal
+- [GUIDE_GCAL.md](docs/GUIDE_GCAL.md) - Guia de configuração GCal

--- a/v2/docs/INDEX_DOCUMENTACAO.md
+++ b/v2/docs/INDEX_DOCUMENTACAO.md
@@ -223,7 +223,6 @@
 **Arquivos**:
 - [LOGGING.md](./LOGGING.md) - Structured logging
 - [OBSERVABILITY.md](./OBSERVABILITY.md) - Métricas e monitoramento
-- [ENV_VARS_ETL.md](./ENV_VARS_ETL.md) - Variáveis de ambiente
 
 ---
 

--- a/v2/docs/OBSERVABILITY.md
+++ b/v2/docs/OBSERVABILITY.md
@@ -4,6 +4,7 @@ status: active
 last_verified: 2026-06-19
 sources_of_truth:
   - v2/backend/config/settings.py
+  - v2/backend/config/urls.py
   - v2/infra/docker-compose.yml
   - v2/infra/Makefile
 owner: infra
@@ -15,24 +16,35 @@ related:
 
 # Observabilidade (v2)
 
-Documento-índice da observabilidade do AS v2. Consolida os ponteiros para a stack real de métricas,
-logging e alertas. Para o guia narrativo publicado no MkDocs, ver [observability.md](../../docs/guides/observability.md).
+> **Dev × Produção (importante):** a stack de **coleta e painéis (Prometheus + Grafana) é local/opcional e NÃO
+> roda em produção.** Em prod, o app apenas **expõe `/metrics`** (instrumentação `django-prometheus`) para
+> scraping por um serviço externo do provedor, e envia erros ao **Sentry somente se `SENTRY_DSN` estiver
+> configurado**. Fonte autoritativa: comentário em `v2/infra/docker-compose.yml` — a stack foi movida para
+> `docker-compose.observability.yml` (Issue #234): *"Em produção, use o serviço de observabilidade do provedor.
+> O endpoint /metrics do Django permanece disponível para scraping."*
 
-> Nota: este arquivo foi criado em 2026-06-19 (Fase 0 do plano SDD) para resolver ponteiros que apontavam
-> para um `v2/docs/OBSERVABILITY.md` inexistente (README, INDEX_DOCUMENTACAO, LOGGING). Ver
-> [plano SDD](./plans/PLAN_sdd_migration_2026-06-19.md) e [auditoria](./reports/AUDITORIA_DOCUMENTAL_2026-06-19.md).
+Documento-índice criado em 2026-06-19 (Fase 0 do plano SDD) para resolver ponteiros que apontavam para um
+`v2/docs/OBSERVABILITY.md` inexistente (README, INDEX_DOCUMENTACAO, LOGGING). Ver
+[plano SDD](./plans/PLAN_sdd_migration_2026-06-19.md) e [auditoria](./reports/AUDITORIA_DOCUMENTAL_2026-06-19.md).
 
-## Stack real
+## O que existe em cada ambiente
 
-| Camada | Tecnologia | Onde está |
+| Componente | Dev/local | Produção |
 |---|---|---|
-| Erros/tracing | Sentry SDK | bloco `SENTRY` em `config/settings.py` (ativado por `SENTRY_DSN`) |
-| Métricas | `django-prometheus` (`/metrics`) | `INSTALLED_APPS`/`MIDDLEWARE` em `config/settings.py` |
-| Coleta/painéis | Prometheus + Grafana | `v2/infra/docker-compose.yml` (perfil de observabilidade) |
-| Subir local | `make up-obs` | `v2/infra/Makefile` |
+| Instrumentação `django-prometheus` (middleware) | ✅ | ✅ (sempre ativa; em `INSTALLED_APPS`/`MIDDLEWARE`) |
+| Endpoint `/metrics` | ✅ | ✅ **gated** — só staff / IP interno (`config/urls.py`, SEC-RECON-02) |
+| Prometheus + Grafana (coleta + painéis) | ✅ opcional via `make up-obs` | ❌ **não roda em prod** — design é scraping externo do `/metrics` pelo provedor |
+| Sentry (erros/tracing) | se `SENTRY_DSN` setado | se `SENTRY_DSN` setado (secret do Portainer — **status não verificado**) |
 
-> As versões exatas (django-prometheus, sentry-sdk, Prometheus, Grafana) são definidas em
-> `v2/backend/requirements.txt` e nas imagens do compose — consultá-las lá para evitar drift de versão.
+> Os arquivos da stack local (`docker-compose.observability.yml`, `prometheus.yml`, `grafana/`) são **locais e
+> não versionados** (gitignored). `docker-compose.prod.yml` não contém nenhum serviço de Prometheus/Grafana.
+
+## Stack local (opcional)
+
+```bash
+make up-obs     # docker-compose.yml + docker-compose.observability.yml (Prometheus + Grafana)
+make down-obs
+```
 
 ## Logging
 
@@ -41,12 +53,11 @@ logging e alertas. Para o guia narrativo publicado no MkDocs, ver [observability
 ### MP2 — Structured Logging
 
 O logging estruturado (JSON) e as práticas de log (níveis, contexto, dados sensíveis) estão documentados em
-[LOGGING.md](./LOGGING.md). Logs de produção são coletados pela stack do container; eventos de erro também
-chegam ao Sentry quando `SENTRY_DSN` está configurado.
+[LOGGING.md](./LOGGING.md). Em produção, os erros chegam ao Sentry apenas quando `SENTRY_DSN` está configurado.
 
 ## SLOs e alertas
 
-Os objetivos de nível de serviço (latência, disponibilidade, taxa de erro) e a política de alertas estão em
+Os objetivos de nível de serviço (latência, disponibilidade, taxa de erro) estão em
 [SLO_DEFINITIONS.md](./SLO_DEFINITIONS.md).
 
 ## Análise histórica

--- a/v2/docs/OBSERVABILITY.md
+++ b/v2/docs/OBSERVABILITY.md
@@ -1,0 +1,62 @@
+---
+title: Observabilidade (v2)
+status: active
+last_verified: 2026-06-19
+sources_of_truth:
+  - v2/backend/config/settings.py
+  - v2/infra/docker-compose.yml
+  - v2/infra/Makefile
+owner: infra
+related:
+  - ./LOGGING.md
+  - ./SLO_DEFINITIONS.md
+  - ../../docs/guides/observability.md
+---
+
+# Observabilidade (v2)
+
+Documento-índice da observabilidade do AS v2. Consolida os ponteiros para a stack real de métricas,
+logging e alertas. Para o guia narrativo publicado no MkDocs, ver [observability.md](../../docs/guides/observability.md).
+
+> Nota: este arquivo foi criado em 2026-06-19 (Fase 0 do plano SDD) para resolver ponteiros que apontavam
+> para um `v2/docs/OBSERVABILITY.md` inexistente (README, INDEX_DOCUMENTACAO, LOGGING). Ver
+> [plano SDD](./plans/PLAN_sdd_migration_2026-06-19.md) e [auditoria](./reports/AUDITORIA_DOCUMENTAL_2026-06-19.md).
+
+## Stack real
+
+| Camada | Tecnologia | Onde está |
+|---|---|---|
+| Erros/tracing | Sentry SDK | bloco `SENTRY` em `config/settings.py` (ativado por `SENTRY_DSN`) |
+| Métricas | `django-prometheus` (`/metrics`) | `INSTALLED_APPS`/`MIDDLEWARE` em `config/settings.py` |
+| Coleta/painéis | Prometheus + Grafana | `v2/infra/docker-compose.yml` (perfil de observabilidade) |
+| Subir local | `make up-obs` | `v2/infra/Makefile` |
+
+> As versões exatas (django-prometheus, sentry-sdk, Prometheus, Grafana) são definidas em
+> `v2/backend/requirements.txt` e nas imagens do compose — consultá-las lá para evitar drift de versão.
+
+## Logging
+
+<a id="mp2"></a>
+
+### MP2 — Structured Logging
+
+O logging estruturado (JSON) e as práticas de log (níveis, contexto, dados sensíveis) estão documentados em
+[LOGGING.md](./LOGGING.md). Logs de produção são coletados pela stack do container; eventos de erro também
+chegam ao Sentry quando `SENTRY_DSN` está configurado.
+
+## SLOs e alertas
+
+Os objetivos de nível de serviço (latência, disponibilidade, taxa de erro) e a política de alertas estão em
+[SLO_DEFINITIONS.md](./SLO_DEFINITIONS.md).
+
+## Análise histórica
+
+Para o levantamento de gaps de observabilidade/infra (datado), ver
+[analysis/phase-07-infra-observability-backup-dr.md](./analysis/phase-07-infra-observability-backup-dr.md).
+
+## Relacionados
+
+- [LOGGING.md](./LOGGING.md) — logging estruturado
+- [SLO_DEFINITIONS.md](./SLO_DEFINITIONS.md) — SLOs e alertas
+- [observability.md (MkDocs)](../../docs/guides/observability.md) — guia narrativo
+- [BACKUP_OPERATIONS.md](./BACKUP_OPERATIONS.md) — operações de backup/DR

--- a/v2/docs/plans/PLAN_sdd_migration_2026-06-19.md
+++ b/v2/docs/plans/PLAN_sdd_migration_2026-06-19.md
@@ -1,0 +1,188 @@
+# Plano de Migração SDD (Spec-Driven Development) — 2026-06-19
+
+> Status: plano ativo (não-iniciado) · Base: [`../reports/AUDITORIA_DOCUMENTAL_2026-06-19.md`](../reports/AUDITORIA_DOCUMENTAL_2026-06-19.md)
+> Regra deste plano: **nenhum arquivo é movido nesta etapa**. Isto descreve a estrutura-alvo e as fases.
+
+## 1. Objetivo
+
+Transformar um acervo de **326 `.md`** (210 versionados, 116 locais) — hoje sem sinalização de canonicidade,
+com 21 docs `stale` e 31 links quebrados — num modelo **Spec-Driven Development**: cada módulo/contrato vivo tem
+uma **spec versionada, datada e rastreável ao código**, claramente separada de runbooks, ADRs, planos e histórico.
+
+Resultado esperado: ler qualquer doc e saber, sem ambiguidade, **se é verdade hoje**, **qual código é a fonte**, e
+**quando foi verificado pela última vez**.
+
+## 2. Princípios
+
+1. **Spec = contrato vivo, código = implementação.** A spec descreve o comportamento esperado; o código é o SSOT
+   técnico. Toda spec aponta para os arquivos de código que a realizam (`sources_of_truth`).
+2. **Canonicidade explícita.** Todo doc vivo declara `status` no frontmatter. Sem frontmatter ⇒ tratar como histórico.
+3. **`last_verified` obrigatório.** Doc sem verificação recente é candidato a `stale`, não a `canonical`.
+4. **Uma verdade por tópico.** Um SSOT por domínio; os demais docs *linkam*, não duplicam (evita drift de contagens).
+5. **Histórico é imutável e isolado.** `analysis/`, `_archive/`, planos concluídos e relatórios datados não se "corrigem" —
+   ficam como registro, fora da navegação viva.
+6. **Nada crítico fora do git.** Contratos *enforced* (CP-01..08, RBAC) vivem em docs versionados, não em `.claude/`.
+7. **Gerar em vez de copiar.** Tabelas que derivam do código (setores/funções, endpoints) são geradas (ex.: `rbac_matrix_doc`),
+   não transcritas à mão.
+8. **Migração sem perda.** Não apagar; mover para `_archive/` preservando histórico git; corrigir links no mesmo passo.
+
+## 3. Estrutura-alvo
+
+Camada de specs **nova e versionada**, sob `v2/docs/specs/` (sob `v2/docs/`, que é versionado — **não** usar `specs/` na
+raiz, que é ambíguo/inexistente). Os diretórios existentes permanecem; o conteúdo migra por fases.
+
+```text
+v2/docs/
+  specs/                      # NOVO — specs vivas (SSOT por domínio), com frontmatter obrigatório
+    domain/                   # regras de negócio (contratos imutáveis)
+      clausulas-petreas.spec.md      # CP-01..CP-08 (inclui CP-07/CP-08 hoje fora do git)
+      regras-disponibilidade.spec.md # RD-01..RD-08
+      politica-aprovacao.spec.md     # PA-01..PA-07
+      requisitos-funcionais.spec.md  # RF-xx
+    backend/
+      rbac.spec.md            availability.spec.md      solicitacao-approval.spec.md
+      gcal.spec.md            imports.spec.md           backup-dr.spec.md
+      dat.spec.md             notificacoes.spec.md      deslocamento.spec.md   # GAP hoje
+    frontend/
+      pages.spec.md           hooks-rbac.spec.md        api-clients.spec.md
+    infra/
+      deploy.spec.md          environments.spec.md      ci.spec.md
+  decisions/                  # ADRs (hoje em docs/architecture/project-decisions/) — alvo de consolidação
+  runbooks/                   # operacional vivo: RUNBOOK, BACKUP_OPERATIONS, DISASTER_RECOVERY, SCALING
+  reference/                  # API_REFERENCE, RBAC_NAMING, SLO_DEFINITIONS, TESTING_MSW
+  reports/                    # relatórios datados (esta auditoria mora aqui)
+  plans/                      # planos ativos (este plano mora aqui)
+  _archive/                   # histórico (analysis/, planos concluídos, snapshots)
+```
+
+> Nota de transição: na Fase 1, `specs/` é criada e os docs canônicos existentes **passam a ser linkados** a partir
+> dela (índice), sem mover. Os moves físicos para `runbooks/`/`reference/`/`decisions/` só ocorrem nas Fases 5-6,
+> sempre corrigindo os links no mesmo commit.
+
+## 4. Metadados mínimos por documento vivo (frontmatter)
+
+Todo doc em `specs/`, `runbooks/`, `reference/` e `decisions/` deve começar com:
+
+```yaml
+---
+title: Disponibilidade (RD-01..08)
+status: canonical          # canonical | active | draft | stale | historical
+last_verified: 2026-06-19  # data da última checagem contra o código
+sources_of_truth:          # arquivos de código que esta spec descreve
+  - v2/backend/apps/core/services/availability_service.py
+  - v2/backend/apps/core/views_availability.py
+owner: backend             # área responsável
+supersedes: []             # docs que esta spec substitui (a serem arquivados)
+related:                   # links a specs/ADRs relacionados
+  - ../infra/deploy.spec.md
+---
+```
+
+Regra de lint (Fase 6): doc vivo sem `status`/`last_verified` falha o gate; `last_verified` > 180 dias vira aviso.
+
+## 5. Template de documentação por módulo (`*.spec.md`)
+
+```markdown
+# <Módulo> — Spec
+<frontmatter acima>
+
+## Propósito
+O que este módulo faz e por que existe (1-2 parágrafos).
+
+## Fonte de verdade no código
+Arquivos/serviços que implementam (com caminhos clicáveis).
+
+## Contratos e invariantes
+Regras que NÃO podem ser violadas (RD/PA/CP aplicáveis; limites; idempotência).
+
+## API / Interface
+Endpoints, comandos, ou props públicas (linkar API_REFERENCE quando houver).
+
+## Fluxos principais
+Passo-a-passo dos caminhos felizes + erros relevantes.
+
+## Decisões relacionadas (ADRs)
+Links para decisions/.
+
+## Testes que cobrem
+Arquivos de teste que provam os contratos acima.
+
+## Pontos de atenção / dívidas conhecidas
+Gaps, TOCTOU, itens de backlog (linkar issues).
+```
+
+## 6. Lista de módulos a documentar (do mapa de módulos)
+
+Prioridade por lacuna/risco (do relatório §8):
+
+| Spec-alvo | Estado hoje | Ação |
+|---|---|---|
+| `backend/deslocamento.spec.md` | **Sem doc** (GAP) | **Criar do zero** (view 10.5K + import + página FE). |
+| `frontend/hooks-rbac.spec.md` | **Sem doc** (GAP) | **Criar** (`usePermissions`/`useCanAccess`/`useGoogleGuard`/polling). |
+| `infra/deploy.spec.md` | `infrastructure.md` stale ("GitHub Pages") | Reescrever via ADR-010 (Portainer→prod). |
+| `backend/rbac.spec.md` | `docs/guides/rbac.md` stale (anti-padrão) | Reescrever via `RBAC_NAMING`/`apps/core/rbac`. |
+| `backend/imports.spec.md` | `docs/guides/etl.md` stale (21 cmds) | Substituir ETL por imports DRF (`v2/docs/imports/`). |
+| `domain/clausulas-petreas.spec.md` | versionado só CP-01..06 | Adicionar CP-07/CP-08 (hoje só em `.claude/`). |
+| `backend/{availability,gcal,approval,backup-dr,dat}.spec.md` | doc canônico existe | Migrar conteúdo + frontmatter (Fase 3). |
+| `frontend/pages.spec.md` | 6/14 documentadas | Completar + corrigir "45+ pages". |
+| `apps.dev_tools` (catálogo seed) | só plano `_archive` | Catálogo versionado dos 15 commands. |
+
+## 7. Fases de execução
+
+> Cada fase = 1 PR (CP-06, squash). Nenhum move sem correção de links no mesmo commit.
+
+- **Fase 0 — Fundação (sem mover):** criar `v2/docs/specs/` + `INDEX_SDD.md` (índice vivo) + convenção de frontmatter.
+  Corrigir os **8 links quebrados** de canonical/active (fantasmas `OBSERVABILITY.md`/`ENV_VARS_ETL.md`, `OAUTH_ENV_VARIABLES`,
+  `infra/README`). **Saída:** esqueleto + zero link quebrado em canonical/active.
+- **Fase 1 — Contratos para o git:** promover **CP-07/CP-08** ao `clausulas-petreas.md`; decidir `.gitignore` de
+  `CLAUDE.md`/`AGENTS.md` (escopar para `/.claude/`); ADR de "documentação SDD".
+- **Fase 2 — Reconciliar stale crítico:** reescrever/deprecar `docs/guides/etl.md`, `docs/guides/rbac.md`,
+  `docs/architecture/backend.md`, `infrastructure.md`, `overview.md`, `INDEX_DOCUMENTACAO.md`; corrigir versões
+  (`TESTING_POLICY` 3.12; `index.md` DRF 3.17; staging vs ADR-010).
+- **Fase 3 — Specs canônicas:** migrar conteúdo dos canônicos vivos (rbac, gcal, availability, approval, imports,
+  backup-dr, dat) para `specs/` com frontmatter; deixar redirects/links nos antigos (ainda sem deletar).
+- **Fase 4 — Preencher gaps:** `deslocamento.spec.md`, `hooks-rbac.spec.md`, catálogo dev_tools, pages restantes.
+- **Fase 5 — Histórico:** mover `analysis/` + planos concluídos para `_archive/`; corrigir os 22 links de
+  `rbac_system_inventory.md`; isolar histórico da nav viva.
+- **Fase 6 — Automação:** gate CI de **links relativos quebrados** (reusar o script da auditoria) + lint de
+  frontmatter (`status`/`last_verified`) + geração de tabelas RBAC a partir de `constants.py`.
+
+## 8. Backlog inicial (acionável)
+
+1. [F0] Criar `v2/docs/specs/INDEX_SDD.md` + 4 subdirs.
+2. [F0] Remover/recriar refs a `v2/docs/OBSERVABILITY.md` (README + INDEX + LOGGING) — decidir: criar a spec de
+   observability ou apontar para `docs/guides/observability.md`.
+3. [F0] Remover ref a `v2/docs/ENV_VARS_ETL.md` no INDEX (resíduo de ETL removido).
+4. [F0] Corrigir `OAUTH_ENV_VARIABLES.md` (2 links: `../docs/`→`docs/`; remover `fechar_plano_gcal.md`).
+5. [F0] Repontar `v2/infra/README.md` → `../docs/_archive/plans/PLAN_infrastructure_scaling.md`.
+6. [F1] Adicionar CP-07 e CP-08 a `docs/business-rules/clausulas-petreas.md`.
+7. [F1] Escopar `.gitignore` (`/.claude/` em vez de bare `CLAUDE.md`/`AGENTS.md`) **ou** documentar local-only.
+8. [F2] Deprecar/reescrever `docs/guides/etl.md` e `docs/guides/rbac.md`.
+9. [F2] Corrigir árvore de apps (remover `dat_ingest`) em `overview.md`/`backend.md`/INDEX; deploy em `infrastructure.md`.
+10. [F2] Sincronizar 13 setores / 5 funções em INDEX/MAPEAMENTO.
+11. [F4] **Criar `deslocamento.spec.md`** e **`hooks-rbac.spec.md`** (gaps).
+12. [F6] Job CI de links quebrados + lint de frontmatter.
+
+## 9. Riscos
+
+- **Docs locais não existem em outras máquinas** (`.claude/`, `.agents/`): qualquer plano que dependa deles quebra num
+  clone limpo. Mitigação: Fase 1 leva os contratos para o git.
+- **Mover arquivos quebra links** (MkDocs nav, links relativos): mitigação — mover + corrigir no mesmo commit; gate de links na Fase 6.
+- **Drift de contagens** (setores/funções/endpoints) reaparece se transcrito à mão: mitigação — gerar do código.
+- **Sobre-engenharia**: SDD com fricção demais para um dev solo. Mitigação — frontmatter mínimo (3 campos) e specs só para
+  módulos vivos, não para histórico.
+- **MkDocs nav** (`mkdocs.yml`) precisa acompanhar moves para não publicar links mortos.
+
+## 10. Critérios de conclusão
+
+- [ ] Todo módulo backend/frontend/infra **vivo** tem uma `*.spec.md` com `status` + `last_verified` + `sources_of_truth`.
+- [ ] **0** docs `stale` em posição canonical/active (os 21 atuais reconciliados ou arquivados).
+- [ ] **0** links relativos quebrados em docs canonical/active (e gate de CI impedindo regressão).
+- [ ] **CP-01..CP-08** definidos no SSOT versionado (`clausulas-petreas.md`).
+- [ ] Contagens (setores/funções) **geradas** do código, não transcritas.
+- [ ] Histórico (`analysis/`/`_archive/`/planos concluídos) isolado da navegação viva e sinalizado.
+- [ ] `CLAUDE.md`/`AGENTS.md`: decisão explícita (versionar ou local-only documentado).
+
+---
+
+_Plano derivado da auditoria de 2026-06-19. Execução por fases, 1 PR por fase (CP-06), sem mover arquivos fora de um commit que também corrige os links afetados._

--- a/v2/docs/plans/README.md
+++ b/v2/docs/plans/README.md
@@ -4,6 +4,7 @@ Esta pasta concentra planos tecnicos ativos (nao arquivados).
 
 ## Prioritarios
 
+- `PLAN_sdd_migration_2026-06-19.md` — migracao da documentacao para modelo SDD (Spec-Driven Development); base em `../reports/AUDITORIA_DOCUMENTAL_2026-06-19.md`
 - `PLAN_API_CANONICA_DEFINITIVA_2026-03-09.md`
 - `PLAN_cybersecurity_hardening_2026-03-09.md`
 

--- a/v2/docs/reports/AUDITORIA_DOCUMENTAL_2026-06-19.md
+++ b/v2/docs/reports/AUDITORIA_DOCUMENTAL_2026-06-19.md
@@ -1,0 +1,194 @@
+# Auditoria Documental Completa — 2026-06-19
+
+> Status: report (datado) · Repo @ `cbf10a7` (branch `main`) · Método: auditoria multi-agente read-only (14 agentes)
+> Escopo: todos os `.md` versionados e locais. Nenhum arquivo foi movido, apagado ou reescrito.
+> Documento-irmão: plano de migração em [`../plans/PLAN_sdd_migration_2026-06-19.md`](../plans/PLAN_sdd_migration_2026-06-19.md).
+
+## 1. Resumo executivo
+
+A documentação do projeto é **abundante e, nos pilares arquiteturais, de alta qualidade** (RBAC, GCal,
+disponibilidade, aprovação, imports, backup/DR, CI/deploy têm SSOT claro e alinhado ao código). O problema
+não é falta de docs — é **canonicidade ambígua**: 326 arquivos `.md` reais sem metadados que distingam o que
+é fonte de verdade viva do que é registro histórico ou já desatualizado.
+
+Achados de maior impacto:
+
+1. **21 documentos `stale`** (desatualizados e *não* marcados como históricos) — alguns em posição canônica/ativa,
+   logo enganosos se lidos hoje. Os piores: `docs/guides/etl.md` (ensina 21 comandos ETL que não existem),
+   `docs/guides/rbac.md` (ensina o anti-padrão banido e omite o SSOT `apps/core/rbac`), `INDEX_DOCUMENTACAO.md`
+   (declara 33 models incluindo `dat_ingest` removido), `docs/architecture/backend.md` e `infrastructure.md`.
+2. **31 links markdown relativos quebrados** (de 223 checados); 8 deles em docs canonical/active — destaque para
+   `v2/docs/OBSERVABILITY.md` e `v2/docs/ENV_VARS_ETL.md`, arquivos **fantasmas** referenciados por README + INDEX + LOGGING.
+3. **Conhecimento crítico vive fora do git**: `CP-07` e `CP-08` (cláusulas pétreas *enforced* por hook/settings)
+   só têm definição completa em `.claude/CLAUDE.md`, que é **gitignored**. Pior: o `.gitignore` tem padrões *bare*
+   `CLAUDE.md`/`AGENTS.md` que ignoram também o `CLAUDE.md` da raiz e `v2/docs/AGENTS.md` — somem em qualquer clone novo.
+4. **`specs/CONSTITUTION.md` não é fonte canônica**: `specs/` não existe nem é versionado (`git ls-files specs` = 0)
+   e nenhum doc versionado o referencia. Confirmado e descartado como SSOT.
+5. **Lacunas de documentação** em módulos reais: `core.deslocamento` (código substancial, zero doc dedicado) e os
+   hooks RBAC do frontend (`usePermissions`/`useCanAccess`, sem doc).
+
+A recomendação é adotar um modelo **SDD (Spec-Driven Development)**: uma camada de *specs* vivas, versionada, com
+metadados mínimos (`status` + `last_verified` + `sources_of_truth`), separada de runbooks, ADRs, planos e histórico.
+O plano está no documento-irmão.
+
+## 2. Escopo e números do inventário
+
+| Métrica | Valor | Fonte |
+|---|---:|---|
+| Total `.md` reais (excl. vendor) | **326** | git |
+| — `.md` **versionados** | **210** | `git ls-files '*.md'` |
+| — `.md` **locais/ignorados** (não-vendor) | **116** | `git ls-files --others --ignored` |
+| — `.md` **untracked** (não-ignorados) | **0** | `git ls-files --others --exclude-standard` |
+| `.md` em vendor (node_modules/.venv) — fora de escopo | 1065 | git |
+| Links relativos checados | **223** | script |
+| Links relativos **quebrados** | **31** | script |
+
+Distribuição dos 210 versionados:
+
+| Diretório | Qtd | Diretório | Qtd |
+|---|---:|---|---:|
+| `v2/docs/` (raiz) | 47 | `docs/architecture/` (inc. ADRs) | 24 |
+| `v2/docs/analysis/` | 28 | `docs/` (operations/guides/business-rules/...) | 22 |
+| `v2/docs/plans/` | 22 | `v2/backend|frontend|infra|tests/` | 14 |
+| `v2/docs/_archive/` | 20 | raiz (README/SECURITY/CONTRIBUTING/...) | 5 |
+| `v2/docs/issues/` | 13 | `v2/docs/imports/` | 7 |
+| `v2/docs/reports/` | 6 | `v2/docs/audits|adr/` | 2 |
+
+Os **116 locais/ignorados** são quase todos ferramental de agente: `.claude/` (57: CLAUDE.md, commands, cheatsheets,
+agents, skills) e `.agents/skills/` (~33). São **regra operacional local**, não contrato versionado.
+
+## 3. Classificação por canonicidade (210 versionados)
+
+| Classe | Qtd | Definição |
+|---|---:|---|
+| `canonical` | 34 | Fonte única de verdade, autoritativa hoje, casa com o código. |
+| `active` | 59 | Útil/atual e mantido, mas não é o SSOT. |
+| `historical` | 96 | Arquivo intencional (`_archive/`, `analysis/`, planos concluídos, relatórios datados). |
+| `stale` | 21 | Desatualizado/contradiz o código e **não** marcado como histórico → enganoso. |
+| `local` | (116) | Não versionado / máquina-específico (`.claude/`, `.agents/`). |
+
+> Observação: **46% do acervo versionado é histórico** (`analysis/` + `_archive/` + planos concluídos). Isso é
+> saudável como registro, mas hoje está misturado com o conteúdo vivo no mesmo nível de navegação, sem sinalização.
+
+## 4. Fontes canônicas atuais (SSOT por domínio)
+
+| Domínio | Documento(s) canônico(s) | Casa com código? |
+|---|---|---|
+| RBAC | `v2/docs/RBAC_NAMING.md`, `v2/docs/rbac_authorization_matrix.md`, `v2/backend/apps/core/rbac/README.md` | Sim (HasPerm/Policy) |
+| Google Calendar | `v2/docs/GUIDE_GCAL.md`, ADR-008 | Sim |
+| Disponibilidade (RD-01..08) | `v2/docs/GUIDE_AVAILABILITY.md`, `docs/business-rules/regras-disponibilidade.md`, ADR-003 | Sim |
+| Aprovação (PA-01..07) | `docs/business-rules/politica-aprovacao.md`, ADR-002 | Sim |
+| Imports | `v2/backend/apps/core/imports/README.md`, `v2/docs/imports/*`, ADR-012 (SHA-1) | Sim |
+| Backup/DR | `v2/docs/BACKUP_OPERATIONS.md`, `GUIDE_DR.md`, `DISASTER_RECOVERY.md` | Sim |
+| Concorrência | `v2/docs/ACID_POLICY.md`, `RUNBOOK_concurrency.md` | Sim |
+| Testes | `v2/docs/TESTING_MSW.md`, `analysis/COVERAGE_POLICY.md` | Sim |
+| DAT | `v2/docs/SPEC_DAT_REGISTROS.md` | Sim |
+| Infra/Deploy | ADR-001 (Docker-only), ADR-010 (Portainer→prod), `v2/infra/ENVIRONMENTS.md`, `RUNBOOK.md` | Parcial (ver §6) |
+| Decisões | `docs/architecture/project-decisions/ADR-001..014` | Sim |
+| Cláusulas pétreas | `docs/business-rules/clausulas-petreas.md` | **Incompleto: só CP-01..06** (ver §6) |
+
+## 5. Documentos locais ou não canônicos
+
+- **`.claude/` (gitignored, `.gitignore:570`)** — 57 `.md`. Contém `CLAUDE.md` (índice operacional do projeto),
+  `CLAUDE-principles.md`, commands, cheatsheets, agents, skills. **Risco:** carrega contratos que não existem
+  versionados (CP-07/CP-08; ver §6). Um exemplo "Bom" em `CLAUDE-principles.md` ainda ensina o anti-padrão
+  `user.groups.filter(name=...)` (banido por `scripts/rbac_lint.py`).
+- **`.agents/skills/` (gitignored)** — ~33 `.md`. **Não é espelho** de `.claude/skills/`: 7 SKILL.md divergem em
+  conteúdo + 8 `source-command-*` só existem aqui. Duplicação local divergente.
+- **`specs/`** — **inexistente e não versionado**. `specs/CONSTITUTION.md` **não deve ser tratado como fonte
+  canônica** (não existe). Nenhum doc versionado o referencia (sem risco de link quebrado em outra máquina).
+
+## 6. Achados de staleness (os 21 `stale` + divergências)
+
+### 6.1 Críticos (canonical/active, enganam se lidos hoje)
+
+| Doc | Problema | Recomendação |
+|---|---|---|
+| `docs/guides/etl.md` | Documenta **21 comandos ETL** (`import_usuarios/formadores/projetos/solicitacoes`...) que **não existem**; único command real é `import_export_contract`. ETL backend (`dat_ingest`) foi removido (#967/#971). Está na nav do MkDocs. | Reescrever apontando para imports via endpoints DRF (`v2/docs/imports/`) ou remover da nav + banner de deprecação. |
+| `docs/guides/rbac.md` | Ensina modelo **legacy** (grupos + `views_basic.py`), **omite o SSOT** `apps/core/rbac` (HasPerm/Policy). Lista 9 setores/4 funções (real: 13/5). | Reescrever para HasPerm/Policy; apontar `RBAC_NAMING.md`; sincronizar contagens com `constants.py`. |
+| `v2/docs/INDEX_DOCUMENTACAO.md` | Declara "33 models (28 core + **5 dat_ingest**)" e lista `dat_ingest` como app vivo; "9 setores"; métricas datadas. + 2 links quebrados (§7). | Atualizar para apps reais (core + dev_tools), 13 setores; corrigir links. |
+| `docs/architecture/backend.md` | Cita `models/availability.py` (inexistente — vive em `organizacao.py`/`agenda.py`), `approval_service.py` (real: `solicitacao_approval.py`), "rotinas ETL". | Corrigir nomes de arquivos; remover ETL. |
+| `docs/architecture/infrastructure.md` | Diz que o deploy é "**GitHub Pages**"; real é Portainer→prod (ADR-010); omite `deploy.yaml`. | Reescrever a seção de deploy citando ADR-010. |
+| `docs/architecture/overview.md` | Mostra `dat_ingest/` na árvore de apps. | Remover a linha; deixar core + dev_tools. |
+| `docs/architecture/dependency-guardrails.md` / `ADR-012-dependency-guardrails.md` | Referenciam `dat_ingest` como guardrail vivo. | Marcar a parte de `dat_ingest` como histórica (módulo removido). |
+
+### 6.2 Divergências de versão/stack
+
+A grande maioria está **correta** (React 18 consistente — *nenhum* "React 19"; PostgreSQL 15, Redis 7, Vite 7, Antd 5,
+Node 20, Django 5.2, MSW 2.x fiéis). Divergências reais:
+
+- `v2/docs/TESTING_POLICY.md` diz **Python 3.11** no CI; real é **3.12** (todos os workflows + Dockerfiles). *(médio)*
+- `deploy.md` / `RUNBOOK.md` / `DEPLOY_CHECKLIST.md` descrevem **staging remoto** via Portainer, contradizendo
+  **ADR-010** (Accepted: sem staging remoto; merge=prod). O `deploy.yaml` de fato seta `target_environment=staging`
+  no push — então os docs casam com o *workflow* mas batem de frente com o ADR + realidade. **Reconciliar.** *(médio)*
+- `docs/index.md`: "DRF 3.16" (real 3.17.1); `RUNBOOK.md`: "Django 5.2.1" (real 5.2.15). *(baixo)*
+- `docs/guides/observability.md`: stack real (Sentry + django-prometheus + Grafana), só versões defasadas. *(baixo)*
+- `BACKLOG_MAPA_BRASIL.md`: snippet com `jest.fn()` (projeto usa Vitest/MSW); `BACKLOG_FRONTEND_CODE_SPLITTING.md`
+  sugere `manualChunks` (anti-padrão que quebrou prod). *(baixo, são backlogs datados)*
+
+### 6.3 Divergências entre camadas (`.claude` × `docs` × `v2/docs`)
+
+- **CP-07/CP-08 fora do git** *(alto):* `docs/business-rules/clausulas-petreas.md` para em **CP-06**. CP-07 (no push main)
+  e CP-08 (`INCLUDE_DEV_TOOLS=false`) só têm texto completo em `.claude/CLAUDE.md` (gitignored). ADR-004 e INDEX os
+  *citam* sem definir. **Promover CP-07/CP-08 ao SSOT versionado.**
+- **`.gitignore` bare `CLAUDE.md`/`AGENTS.md`** *(alto):* ignora também o `CLAUDE.md` da raiz e `v2/docs/AGENTS.md`.
+  Decidir: versionar (escopar ignore para `/.claude/`) ou migrar o conteúdo crítico para docs versionados.
+- **Funções 5 vs 4** *(médio):* `constants.py` tem 5 (`FUNCAO_GROUPS`, inclui "Assistente Administrativo"); `.claude/CLAUDE.md`
+  e INDEX dizem 4. **Setores 13 vs 9** *(médio):* código/`.claude` = 13; INDEX/MAPEAMENTO ainda dizem 9.
+- **RBAC_NAMING importa de caminhos legados** *(médio):* ensina `from apps.core.permissions import HasPerm` e
+  `apps.core.rbac_helpers`, enquanto o SSOT declarado é `apps.core.rbac` (os legados ainda existem como shim).
+
+## 7. Links quebrados relevantes (8 de 31, em canonical/active)
+
+| Origem | Alvo | Diagnóstico |
+|---|---|---|
+| `v2/README.md` | `docs/OBSERVABILITY.md` | Alvo **inexistente** (`v2/docs/OBSERVABILITY.md`). |
+| `v2/docs/INDEX_DOCUMENTACAO.md` | `./OBSERVABILITY.md` | Mesmo arquivo fantasma. |
+| `v2/docs/INDEX_DOCUMENTACAO.md` | `./ENV_VARS_ETL.md` | Fantasma; provável resíduo da remoção do ETL. |
+| `v2/docs/LOGGING.md` | `./OBSERVABILITY.md` (x2) | Mesmo fantasma. |
+| `v2/OAUTH_ENV_VARIABLES.md` | `../docs/GUIDE_GCAL.md` | Um `../` a mais — alvo real é `docs/GUIDE_GCAL.md` (= `v2/docs/`). |
+| `v2/OAUTH_ENV_VARIABLES.md` | `../docs/fechar_plano_gcal.md` | Inexistente em todo o repo. |
+| `v2/infra/README.md` | `../docs/PLAN_infrastructure_scaling.md` | Movido para `v2/docs/_archive/plans/`. |
+
+Os outros 23 são históricos: 1 em `PLANO_MELHORIAS_DETALHADO.md` e **22 em `v2/docs/analysis/rbac_system_inventory.md`**
+(todos com o mesmo bug de profundidade `../` — faltou um nível; os arquivos-alvo existem). Correção mecânica única.
+
+## 8. Mapa dos módulos reais × documentação
+
+**Backend real = APENAS `apps/core` (28 models) + `apps/dev_tools`.** `apps.dat_ingest` foi removido; `INCLUDE_ETL` é ignorado.
+
+| Camada | Módulo/subsistema | Doc? | Observação |
+|---|---|:--:|---|
+| Backend | RBAC, GCal, Disponibilidade, Aprovação, Imports, Backup/DR, DAT, Concorrência | ✅ | Cobertura canônica forte, casa com código. |
+| Backend | **`core.deslocamento`** | ❌ | **GAP**: `views_deslocamento.py` (10.5K) + import service + página FE dedicada; **zero** doc, zero menção no `API_REFERENCE`. |
+| Backend | `core.acoes_notificacao` | ⚠️ | Só `PLANO_NOTIFICACOES_TIMING.md` (plano, não runbook). |
+| Backend | `apps.dev_tools` (15 seed commands) | ⚠️ | Design só em plano `_archive`; sem catálogo versionado por comando. |
+| Frontend | 14 pages | ⚠️ | `frontend.md` cobre ~6/14; CLAUDE.md diz "45+ lazy pages" (real: 14 dirs → número inflado/stale). |
+| Frontend | 14 hooks (`usePermissions`/`useCanAccess`...) | ❌ | **GAP**: hooks RBAC-críticos sem doc. |
+| Frontend | ~21 components | ⚠️ | Só `RemoteSelect`/`MeetLink` documentados. |
+| Frontend | 15 api clients | ✅ | Contrato via `API_REFERENCE` + ADR-013 (axios→fetch). |
+| Infra | compose/docker, scripts/systemd, CI workflows | ✅ | `RUNBOOK.md` (42.9K), `ENVIRONMENTS.md`, ADRs, docs xdist-canary frescos (2026-06). |
+
+**Docs que descrevem o inexistente:** `docs/guides/etl.md`, `INDEX_DOCUMENTACAO.md`, `docs/architecture/backend.md`,
+`docs/architecture/infrastructure.md` (ver §6). Menções a `dat_ingest` em `_archive/`, `analysis/`, `PLAN_remove_etl_backend`,
+`RELEASE_NOTES`, `ADR-012` são **históricas/intencionais** — não acionáveis.
+
+## 9. Recomendações operacionais
+
+Prioridade (alta → baixa):
+
+1. **Corrigir os fantasmas + stale crítico** (alto): criar/remover refs a `OBSERVABILITY.md`/`ENV_VARS_ETL.md`;
+   reescrever ou deprecar `docs/guides/etl.md` e `docs/guides/rbac.md`; corrigir `backend.md`/`infrastructure.md`/`overview.md`/INDEX.
+2. **Versionar os contratos críticos** (alto): promover **CP-07/CP-08** para `docs/business-rules/clausulas-petreas.md`;
+   decidir o destino de `CLAUDE.md`/`AGENTS.md` (escopar `.gitignore`).
+3. **Adotar metadados de canonicidade** (alto): frontmatter `status` + `last_verified` + `sources_of_truth` em todo doc vivo.
+4. **Preencher gaps** (médio): spec de `core.deslocamento`; doc dos hooks RBAC do frontend; catálogo de seed commands.
+5. **Sincronizar contagens** (médio): 13 setores / 5 funções (gerar a partir de `constants.py`/`rbac_matrix_doc`).
+6. **Automatizar** (médio): gate de **links relativos quebrados** no CI (o script desta auditoria é reaproveitável).
+7. **Separar histórico do vivo** (baixo): consolidar `analysis/` + planos concluídos sob `_archive/` e sinalizar na nav.
+
+A execução estruturada está no plano SDD: [`../plans/PLAN_sdd_migration_2026-06-19.md`](../plans/PLAN_sdd_migration_2026-06-19.md).
+
+---
+
+_Gerado por auditoria read-only (14 agentes; ~1M tokens). Nenhum arquivo de documentação existente foi alterado por esta auditoria além da criação deste relatório, do plano-irmão e da atualização dos índices `reports/README.md` e `plans/README.md`._

--- a/v2/docs/reports/README.md
+++ b/v2/docs/reports/README.md
@@ -3,11 +3,16 @@
 Esta pasta concentra relatorios tecnicos e analises consolidadas.
 
 ## Arquivos atuais
+- `AUDITORIA_DOCUMENTAL_2026-06-19.md` — auditoria completa dos `.md` (210 versionados + 116 locais); base do plano SDD
 - `BACKLOG_QUALIDADE_SISTEMA_2026-03-06.md`
 - `ESTIMATIVAS_PRAZOS_QUALIDADE_2026-03-06.md`
 - `RELATORIO_TECNICO_ARQUITETURA_2026-03-06.md`
 - `CLASSIFICACAO_PUBLICO_PRIVADO_2026-03-09.md`
 - `relatorio_deploy.md`
+
+## Auditoria documental / SDD
+- Relatorio: `AUDITORIA_DOCUMENTAL_2026-06-19.md`
+- Plano de migracao: `../plans/PLAN_sdd_migration_2026-06-19.md`
 
 ## Relacao com planos de seguranca
 - Plano: `v2/docs/plans/PLAN_cybersecurity_hardening_2026-03-09.md`

--- a/v2/docs/specs/INDEX_SDD.md
+++ b/v2/docs/specs/INDEX_SDD.md
@@ -1,0 +1,58 @@
+---
+title: Índice SDD (Spec-Driven Development)
+status: active
+last_verified: 2026-06-19
+owner: docs
+related:
+  - ../plans/PLAN_sdd_migration_2026-06-19.md
+  - ../reports/AUDITORIA_DOCUMENTAL_2026-06-19.md
+---
+
+# Índice SDD — Specs vivas do AS v2
+
+Esta pasta (`v2/docs/specs/`) é a camada de **specs vivas** do modelo Spec-Driven Development: cada módulo ou
+contrato em produção tem (ou terá) uma spec versionada, datada e rastreável ao código. O racional, a estrutura-alvo
+e as fases estão no [plano SDD](../plans/PLAN_sdd_migration_2026-06-19.md), apoiado na
+[auditoria documental 2026-06-19](../reports/AUDITORIA_DOCUMENTAL_2026-06-19.md).
+
+> Estado: **esqueleto (Fase 0)**. As specs por módulo ainda não foram escritas — esta estrutura existe para
+> receber a migração das Fases 3-4. Os ponteiros abaixo marcam o que está planejado.
+
+## Convenção de frontmatter (obrigatória em todo doc vivo)
+
+Todo arquivo em `specs/`, `runbooks/`, `reference/` e `decisions/` começa com:
+
+```yaml
+---
+title: <nome legível>
+status: canonical | active | draft | stale | historical
+last_verified: YYYY-MM-DD     # data da última checagem contra o código
+sources_of_truth:             # arquivos de código que esta spec descreve
+  - v2/backend/apps/core/...
+owner: backend | frontend | infra | docs | domain
+supersedes: []                # docs que esta spec substitui (a arquivar)
+related: []                   # links a specs/ADRs relacionados
+---
+```
+
+## Legenda de `status`
+
+| status | significado |
+|---|---|
+| `canonical` | fonte única de verdade, autoritativa hoje, casa com o código |
+| `active` | útil/atual e mantido, mas não é o SSOT |
+| `draft` | em construção, ainda não confiável |
+| `stale` | desatualizado/contradiz o código (a reconciliar) |
+| `historical` | registro datado/arquivado (não se "corrige") |
+
+## Áreas
+
+- [`domain/`](./domain/README.md) — regras de negócio (CP, RD, PA, RF)
+- [`backend/`](./backend/README.md) — subsistemas de `apps/core` + `apps/dev_tools`
+- [`frontend/`](./frontend/README.md) — pages, hooks, api clients
+- [`infra/`](./infra/README.md) — deploy, ambientes, CI
+
+## Template de spec por módulo
+
+O template canônico de `*.spec.md` está na seção 5 do
+[plano SDD](../plans/PLAN_sdd_migration_2026-06-19.md).

--- a/v2/docs/specs/backend/README.md
+++ b/v2/docs/specs/backend/README.md
@@ -1,0 +1,28 @@
+---
+title: Specs de Backend
+status: active
+last_verified: 2026-06-19
+owner: backend
+related:
+  - ../INDEX_SDD.md
+---
+
+# Specs de Backend (`apps/core` + `apps/dev_tools`)
+
+Backend real = **apenas** `apps/core` (28 models) + `apps/dev_tools`. Voltar ao [índice SDD](../INDEX_SDD.md).
+
+## Specs planejadas (Fase 3-4)
+
+| Spec | Estado da doc hoje | Fonte canônica / código |
+|---|---|---|
+| `deslocamento.spec.md` | **GAP — sem doc** | `apps/core/views_deslocamento.py`, `services/deslocamentos_import.py` |
+| `rbac.spec.md` | reescrever (`docs/guides/rbac.md` é stale) | `apps/core/rbac/`, `RBAC_NAMING.md` |
+| `imports.spec.md` | reescrever (`docs/guides/etl.md` é stale) | `apps/core/imports/`, `v2/docs/imports/` |
+| `availability.spec.md` | migrar | `services/availability_service.py`, `GUIDE_AVAILABILITY.md` |
+| `solicitacao-approval.spec.md` | migrar | `services/solicitacao_approval.py`, `IMPLEMENTACAO_PA.md` |
+| `gcal.spec.md` | migrar | `services/gcal/`, `GUIDE_GCAL.md` |
+| `backup-dr.spec.md` | migrar | `tasks_backup.py`, `BACKUP_OPERATIONS.md` |
+| `dat.spec.md` | migrar | `views/dat_module.py`, `SPEC_DAT_REGISTROS.md` |
+| `notificacoes.spec.md` | consolidar | `services/notificacoes_acoes_service.py`, `PLANO_NOTIFICACOES_TIMING.md` |
+
+> Status: esqueleto. Nenhuma spec escrita ainda (Fase 0).

--- a/v2/docs/specs/domain/README.md
+++ b/v2/docs/specs/domain/README.md
@@ -1,0 +1,23 @@
+---
+title: Specs de Domínio
+status: active
+last_verified: 2026-06-19
+owner: domain
+related:
+  - ../INDEX_SDD.md
+---
+
+# Specs de Domínio (regras de negócio)
+
+Contratos imutáveis do negócio. Voltar ao [índice SDD](../INDEX_SDD.md).
+
+## Specs planejadas (Fase 3-4)
+
+| Spec | Conteúdo | Fonte canônica atual |
+|---|---|---|
+| `clausulas-petreas.spec.md` | CP-01..CP-08 (inclui CP-07/CP-08 hoje só em `.claude/`) | `docs/business-rules/clausulas-petreas.md` (só CP-01..06) |
+| `regras-disponibilidade.spec.md` | RD-01..RD-08 | `docs/business-rules/regras-disponibilidade.md`, ADR-003 |
+| `politica-aprovacao.spec.md` | PA-01..PA-07 | `docs/business-rules/politica-aprovacao.md`, ADR-002 |
+| `requisitos-funcionais.spec.md` | RF-xx | `docs/business-rules/requisitos-funcionais.md` |
+
+> Status: esqueleto. Nenhuma spec escrita ainda (Fase 0).

--- a/v2/docs/specs/frontend/README.md
+++ b/v2/docs/specs/frontend/README.md
@@ -1,0 +1,22 @@
+---
+title: Specs de Frontend
+status: active
+last_verified: 2026-06-19
+owner: frontend
+related:
+  - ../INDEX_SDD.md
+---
+
+# Specs de Frontend (`v2/frontend/src`)
+
+Voltar ao [índice SDD](../INDEX_SDD.md).
+
+## Specs planejadas (Fase 3-4)
+
+| Spec | Estado da doc hoje | Código |
+|---|---|---|
+| `hooks-rbac.spec.md` | **GAP — sem doc** | `hooks/usePermissions`, `useCanAccess`, `useGoogleGuard`, `usePolling` |
+| `pages.spec.md` | parcial (6/14 documentadas) | `src/pages/` (14 dirs reais; rever "45+ pages") |
+| `api-clients.spec.md` | contrato via `API_REFERENCE` + ADR-013 | `src/api/` (15 módulos) |
+
+> Status: esqueleto. Nenhuma spec escrita ainda (Fase 0).

--- a/v2/docs/specs/infra/README.md
+++ b/v2/docs/specs/infra/README.md
@@ -13,11 +13,11 @@ Voltar ao [índice SDD](../INDEX_SDD.md).
 
 ## Specs planejadas (Fase 3-4)
 
-| Spec | Estado da doc hoje | Fonte canônica / código |
+| Spec | Estado | Fonte canônica / código |
 |---|---|---|
-| `deploy.spec.md` | reescrever (`docs/architecture/infrastructure.md` diz "GitHub Pages") | ADR-010, `.github/workflows/deploy.yaml` |
-| `environments.spec.md` | migrar | `v2/infra/ENVIRONMENTS.md`, `docker-compose*.yml` |
-| `ci.spec.md` | consolidar | `.github/workflows/`, `docs/operations/ci-*.md` |
+| [`deploy.spec.md`](./deploy.spec.md) | ✅ **escrita** (2026-06-19, verificada contra a stack viva do Portainer) | `docker-compose.prod.yml`, `deploy.yaml`, ADR-010 |
+| `environments.spec.md` | planejado (migrar) | `v2/infra/ENVIRONMENTS.md`, `docker-compose*.yml` |
+| `ci.spec.md` | planejado (consolidar) | `.github/workflows/`, `docs/operations/ci-*.md` |
 
-> Status: esqueleto. Nenhuma spec escrita ainda (Fase 0).
+> Status: esqueleto (Fase 0) + `deploy.spec.md` já preenchida a partir da verificação dev × prod de 2026-06-19.
 > Lembrete (auditoria): o deploy é Portainer→prod (ADR-010), **sem staging remoto**; merge na main = deploy em produção.

--- a/v2/docs/specs/infra/README.md
+++ b/v2/docs/specs/infra/README.md
@@ -1,0 +1,23 @@
+---
+title: Specs de Infra
+status: active
+last_verified: 2026-06-19
+owner: infra
+related:
+  - ../INDEX_SDD.md
+---
+
+# Specs de Infra (deploy, ambientes, CI)
+
+Voltar ao [índice SDD](../INDEX_SDD.md).
+
+## Specs planejadas (Fase 3-4)
+
+| Spec | Estado da doc hoje | Fonte canônica / código |
+|---|---|---|
+| `deploy.spec.md` | reescrever (`docs/architecture/infrastructure.md` diz "GitHub Pages") | ADR-010, `.github/workflows/deploy.yaml` |
+| `environments.spec.md` | migrar | `v2/infra/ENVIRONMENTS.md`, `docker-compose*.yml` |
+| `ci.spec.md` | consolidar | `.github/workflows/`, `docs/operations/ci-*.md` |
+
+> Status: esqueleto. Nenhuma spec escrita ainda (Fase 0).
+> Lembrete (auditoria): o deploy é Portainer→prod (ADR-010), **sem staging remoto**; merge na main = deploy em produção.

--- a/v2/docs/specs/infra/deploy.spec.md
+++ b/v2/docs/specs/infra/deploy.spec.md
@@ -1,0 +1,98 @@
+---
+title: Deploy & Produção (spec)
+status: canonical
+last_verified: 2026-06-19
+sources_of_truth:
+  - v2/infra/docker-compose.prod.yml
+  - v2/infra/Dockerfile.prod
+  - v2/frontend/Dockerfile.prod
+  - .github/workflows/deploy.yaml
+  - v2/infra/Makefile
+owner: infra
+related:
+  - ../INDEX_SDD.md
+  - ../../OBSERVABILITY.md
+  - ../../reports/AUDITORIA_DOCUMENTAL_2026-06-19.md
+---
+
+# Deploy & Produção
+
+> **Verificado em 2026-06-19** contra a stack viva no Portainer (aba Editor + Environment variables) e contra o
+> repositório. **Drift funcional: zero** — o compose vivo é idêntico ao `v2/infra/docker-compose.prod.yml` (só
+> diferem 2-3 linhas de comentário). Esta spec descreve o que **de fato** roda em produção.
+
+## Qual arquivo vai para produção
+
+| Artefato | Produção | Observação |
+|---|---|---|
+| Compose | **`v2/infra/docker-compose.prod.yml`** (standalone) | Usado **sozinho** (`-f docker-compose.prod.yml`), **não** mergeia o `docker-compose.yml` base — ver `Makefile` `PROD_COMPOSE`. |
+| Imagem backend | **`v2/infra/Dockerfile.prod`** → `norjosamatheus/aprender-backend:${IMAGE_TAG}` | `deploy.yaml` |
+| Imagem frontend | **`v2/frontend/Dockerfile.prod`** → `norjosamatheus/aprender-frontend:${IMAGE_TAG}` | `deploy.yaml` |
+| Env | `stack.env` no Portainer (`APP_ENV_FILE`) | **não** é o `.env.production` do repo (que é template) |
+
+**NÃO vão para produção:** `docker-compose.yml` (base; dev+staging), `docker-compose.override.yml` (dev,
+auto-load), `docker-compose.staging-gate.yml` (gate), `docker-compose.observability.yml` (local, gitignored),
+`Dockerfile.dev`, `v2/frontend/Dockerfile`.
+
+## Mecanismo de deploy (e risco de drift)
+
+`deploy.yaml` (GitHub Actions): build/push das imagens no Docker Hub → atualiza **apenas o `IMAGE_TAG`** da stack
+via **Portainer CE API**. **O corpo do compose NÃO é enviado no deploy** — ele vive dentro da stack no Portainer e
+só muda por edição **manual** no Editor (CP do hook: *"Compose changes require manual Portainer Editor update"*).
+
+> **Risco de drift:** `docker-compose.prod.yml` no repo é a *intenção*; a verdade é o Editor do Portainer. Em
+> 2026-06-19 estavam idênticos (verificado), mas mudanças no repo não propagam sozinhas — re-verificar a cada
+> alteração estrutural de infra.
+
+## Produção vs Local (estado verificado 2026-06-19)
+
+| Componente | Produção | Local/dev |
+|---|---|---|
+| Stack | 5 serviços: web, redis, worker, beat, frontend | idem + override de dev |
+| Observabilidade (Prometheus/Grafana) | **NÃO roda** | opcional via `make up-obs` (compose gitignored) |
+| `/metrics` (django-prometheus) | exposto, **gated** (staff/IP interno, SEC-RECON-02) | exposto |
+| Sentry | **DESLIGADO** — `SENTRY_DSN` ausente no stack.env | off (salvo se setar DSN) |
+| Backup Celery | **morto e silencioso** — ver abaixo | grava em `backup_data:/backups` (base) |
+| Redis auth | **ATIVO** — `REDIS_PASSWORD` preenchido; isolado em `backend-internal` sem porta no host | conforme `.env` |
+| Migrations | **manuais** — nenhum serviço roda `migrate` (web=gunicorn, worker/beat=celery) | idem |
+| Guards de prod | **OK** — `ALLOWED_HOSTS`, `CSRF_TRUSTED_ORIGINS`, `SECRET_KEY`, `SECURE_SSL_REDIRECT`, `DB_SSLMODE` setados | guards não se aplicam |
+| GCal | **configurado** (`GCAL_*` completos) | conforme `.env` |
+| dev_tools (CP-08) | **off** — `INCLUDE_DEV_TOOLS` ausente → default `false` | on em dev |
+
+### Backup: por que está "morto e silencioso"
+
+- `worker` e `beat` são `read_only: true`; `tmpfs` só em `/tmp,/run,/home/appuser,/app/out_etl`; **nenhum volume
+  `/backups`** (único volume nomeado é `redis_data`). O default `BACKUP_DIR=/backups` cai em filesystem read-only
+  → **EROFS** → a task Celery falha e não gera nenhum arquivo.
+- `BACKUP_AGE_RECIPIENT` **está setado** (backup encriptado *pretendido*), mas como nada é escrito, a encriptação
+  nunca acontece.
+- Com **Sentry off**, a falha não gera alerta → silenciosa. A única proteção de dados possível é o cron na **VM02**
+  (#376, WAL archiving) — **fora desta stack**, não verificável pelo Portainer/repo (exige SSH na VM02).
+- Rastreado em **#1455** (mount `/backups`) e **#1457**/**#1456** (Redis guard / migrations).
+
+## Variáveis de ambiente em produção (stack.env)
+
+Presentes (valores no Portainer; secrets marcados `[s]`): `DB_HOST`, `DB_NAME`, `DB_USER`, `DB_PASSWORD`[s],
+`DB_PORT`, `DB_SSLMODE`, `DATABASE_URL`[s], `REDIS_HOST`, `REDIS_PORT`, `REDIS_PASSWORD`[s], `REDIS_URL`[s],
+`SECRET_KEY`[s], `DEBUG`, `ALLOWED_HOSTS`, `ENVIRONMENT`, `CSRF_TRUSTED_ORIGINS`, `SECURE_SSL_REDIRECT`,
+`VITE_API_URL`, `FRONTEND_URL`, `DOCKER_HUB_TOKEN`[s], `GCAL_CLIENT`, `GCAL_AUTH_MODE`, `GCAL_CALENDAR_ID`,
+`GCAL_OAUTH_CLIENT_ID`, `GCAL_OAUTH_CLIENT_SECRET`[s], `GCAL_OAUTH_REDIRECT_URI`, `GCAL_ENCRYPTION_KEY`[s],
+`GCAL_ALLOWED_DOMAIN`, `BACKUP_AGE_RECIPIENT`, `IMAGE_TAG`.
+
+**Ausentes (significativo):** `SENTRY_DSN` (→ Sentry off), `BACKUP_DIR` (→ default `/backups`, EROFS),
+`INCLUDE_DEV_TOOLS`/`INCLUDE_ETL` (→ defaults off, correto).
+
+> **Redundância a revisar (não-bug):** coexistem `DATABASE_URL` e `DB_*`, e `REDIS_URL` e `REDIS_*`. Conferir qual
+> o `config/settings.py` realmente consome para não haver duas fontes divergentes.
+
+## Como re-verificar (read-only)
+
+1. Portainer → Stacks → stack de prod → **Editor** (compose vivo) e **Environment variables** (valores reais).
+2. (Opcional) VM01 via SSH: `docker ps`, `docker inspect <svc>` (mounts/read_only/env). **Nunca** reiniciar
+   Docker/containers (Kaspersky/KESL derruba o site).
+
+## Gaps abertos relacionados
+
+- **#1455** — backup Celery sem `/backups` gravável em prod (agravado: Sentry off → silencioso).
+- **#1456** — deploy não aplica migrations + CI sem `makemigrations --check`.
+- **#1457** — guard de `REDIS_PASSWORD` obrigatório (em prod está setado; falta o fail-fast preventivo).

--- a/v2/docs/specs/infra/deploy.spec.md
+++ b/v2/docs/specs/infra/deploy.spec.md
@@ -20,6 +20,9 @@ related:
 > **Verificado em 2026-06-19** contra a stack viva no Portainer (aba Editor + Environment variables) e contra o
 > repositório. **Drift funcional: zero** — o compose vivo é idêntico ao `v2/infra/docker-compose.prod.yml` (só
 > diferem 2-3 linhas de comentário). Esta spec descreve o que **de fato** roda em produção.
+>
+> **Pré-go-live:** em 2026-06-19 produção está **sem dados e sem usuários** — isso reduz a urgência dos gaps
+> abaixo (não são emergência), mas todos devem ser fechados **antes do go-live**.
 
 ## Qual arquivo vai para produção
 
@@ -69,6 +72,23 @@ só muda por edição **manual** no Editor (CP do hook: *"Compose changes requir
 - Com **Sentry off**, a falha não gera alerta → silenciosa. A única proteção de dados possível é o cron na **VM02**
   (#376, WAL archiving) — **fora desta stack**, não verificável pelo Portainer/repo (exige SSH na VM02).
 - Rastreado em **#1455** (mount `/backups`) e **#1457**/**#1456** (Redis guard / migrations).
+
+## Topologia do Redis: container na VM01 (decisão 2026-06-19)
+
+**Realidade:** o Redis roda como **container na VM01** (serviço `redis` no `docker-compose.prod.yml`, rede
+`backend-internal`), **não** numa VM03 dedicada. O app conecta via `REDIS_HOST` (default `redis` → o container);
+cache (`/0`), Celery broker (`/1`) e sessões (`SESSION_ENGINE=cache`) usam esse Redis.
+
+**Decisão: manter na VM01.** Latência localhost (<1ms — sessão bate no Redis a cada request autenticado), seguro
+(senha + `backend-internal` sem porta no host), cabe nos recursos (2g de 16g). O downside (restart da VM01 =
+re-login + perda de tasks Celery em voo) é irrelevante pré-go-live e aceitável no volume previsto.
+**Rejeitado:** Redis grátis externo (latência por-request + rate-limit de free tier para sessão/cache/broker).
+VM03 dedicada só se **HA** virar requisito.
+
+**Docs a reconciliar (Fase 2 — hoje afirmam VM03, divergindo do compose):** `v2/infra/ENVIRONMENTS.md:19/74`
+("Redis externo VM03"), `v2/infra/README.md:170` (tabela "VM03_Redis"), `.claude/CLAUDE.md` (tabela prod).
+Vestigiais (não montados pelo container, que usa `--requirepass` inline): `v2/infra/configs/vm03/redis.conf`,
+`v2/infra/redis/redis.conf`. **VM03 provavelmente está ociosa** (nota de inventário/custo).
 
 ## Variáveis de ambiente em produção (stack.env)
 

--- a/v2/infra/README.md
+++ b/v2/infra/README.md
@@ -171,6 +171,6 @@ DOCKER_HUB_TOKEN=your-docker-hub-token
 
 ## Related Documentation
 
-- [PLAN_infrastructure_scaling.md](../docs/PLAN_infrastructure_scaling.md)
+- [PLAN_infrastructure_scaling.md](../docs/_archive/plans/PLAN_infrastructure_scaling.md)
 - [DEPLOY_CHECKLIST.md](../docs/DEPLOY_CHECKLIST.md)
 - [GUIDE_DR.md](../docs/GUIDE_DR.md) - Disaster Recovery & Backup


### PR DESCRIPTION
## O que

Auditoria documental completa + início da migração para **SDD (Spec-Driven Development)** + **primeira spec
verificada contra produção**. Documentação apenas — nenhum arquivo movido ou apagado.

## Commits

1. **Auditoria + plano** — `AUDITORIA_DOCUMENTAL_2026-06-19.md`, `PLAN_sdd_migration_2026-06-19.md`, índices.
2. **Fase 0** — esqueleto `v2/docs/specs/` (INDEX_SDD + frontmatter + READMEs domain/backend/frontend/infra),
   cria `v2/docs/OBSERVABILITY.md`, **corrige 8 links quebrados** de canonical/active. Causa-raiz: `OBSERVABILITY.md`
   estava banido no `.gitignore` (removida a linha; configs de infra local seguem ignorados).
3. **Correção OBSERVABILITY.md** — Prometheus/Grafana são **locais**, não prod (revisão de precisão).
4. **`infra/deploy.spec.md`** — primeira spec SDD real, **verificada 2026-06-19 contra a stack viva do Portainer**.

## Realidade de produção verificada (Portainer: Editor + Environment variables)

- **Drift funcional ZERO** entre o repo (`docker-compose.prod.yml`) e a stack viva.
- **Compose que vai p/ prod:** `v2/infra/docker-compose.prod.yml` (standalone) + `Dockerfile.prod` backend/frontend.
- **Observabilidade (Prometheus/Grafana): NÃO roda em prod** (local-only via `make up-obs`).
- **Sentry: DESLIGADO** (`SENTRY_DSN` ausente) → erros e falhas não geram alerta.
- **Backup Celery: morto e silencioso** (`/backups` em fs read-only = EROFS; `BACKUP_DIR` ausente;
  `BACKUP_AGE_RECIPIENT` setado mas nunca executa). → reforça **#1455**.
- **Redis auth: ATIVO** (`REDIS_PASSWORD` preenchido) → **#1457** não se concretiza (vira hardening preventivo).
- **Migrations: manuais** (nenhum serviço roda `migrate`) → **#1456**.
- **Guards/TLS/GCal/CP-08: OK.**

## Validações

- `git diff --check`: limpo.
- Links relativos: **0 quebrados** (os 8 canonical/active quebrados agora resolvem; novos docs checados).
- Whitespace: sem BOM/trailing/tabs nos arquivos novos.

## Escopo / deploy

- **Docs-only**: nenhum arquivo casa o `runtime_regex` do `staging-gate-audit` → gate **skipped**.
- Próximas fases (reconciliar stale crítico, demais specs por módulo, gaps) virão em PRs separados.
