### PR TITLE
docs(sdd): fase 2 - reconciliar docs stale com o codigo

### DIFF
--- a/docs/architecture/backend.md
+++ b/docs/architecture/backend.md
@@ -16,7 +16,7 @@ apps/core/
 ├── models/           # Modelos Django
 │   ├── usuario.py
 │   ├── solicitacao.py
-│   ├── availability.py
+│   ├── agenda.py     # AvailabilityBlock (disponibilidade)
 │   └── ...
 ├── serializers/      # DRF Serializers
 ├── views/            # DRF ViewSets
@@ -70,7 +70,7 @@ O sistema possui dois domínios distintos de compras e eles não devem ser confu
 
 - `core_compra`
   - leitura: Controle e Superintendência
-  - escrita: pipelines/importações de controle e rotinas ETL
+  - escrita: pipelines/importações de controle (`services/controle_imports.py`)
 - `core_dat_compra`
   - leitura/escrita: DAT e Superintendência (CRUD operacional DAT)
 
@@ -85,7 +85,7 @@ A lógica de negócio está isolada em services:
 
 - `availability_service.py`: Verificação de conflitos
 - `gcal_sync_service.py`: Sincronização com Google Calendar
-- `approval_service.py`: Fluxo de aprovação
+- `solicitacao_approval.py`: Fluxo de aprovação
 
 ## Type Hints
 

--- a/docs/architecture/infrastructure.md
+++ b/docs/architecture/infrastructure.md
@@ -54,8 +54,8 @@ docker compose -f v2/infra/docker-compose.yml exec web pytest
 
 ## CI/CD
 
-O projeto usa GitHub Actions para CI:
+O projeto usa GitHub Actions para CI/CD:
 
 - **Lint**: Black, isort, flake8, Pyright
 - **Testes**: pytest com coverage (threshold 85%)
-- **Deploy**: GitHub Pages (documentação)
+- **Deploy**: Merge na `main` dispara o workflow `.github/workflows/deploy.yaml` ("Deploy (Portainer CE)"), que faz build + scan + push da imagem Docker com tag imutável `vYYYY.MM.DD-<sha>` e atualiza a stack na VM de produção via Portainer CE API (ver [ADR-010](project-decisions/ADR-010-deploy-portainer-direct-to-prod.md)). Não há ambiente de staging remoto; a validação pré-merge é o staging gate local (`make staging-full`).

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -60,7 +60,7 @@ v2/
 │   │   │   ├── views/     # ViewSets DRF
 │   │   │   ├── services/  # Lógica de negócio
 │   │   │   └── tests/     # Testes
-│   │   └── dat_ingest/    # ETL e importação
+│   │   └── dev_tools/     # Seeds (desabilitado em prod)
 │   ├── config/            # Configurações Django
 │   └── manage.py
 ├── frontend/

--- a/docs/business-rules/clausulas-petreas.md
+++ b/docs/business-rules/clausulas-petreas.md
@@ -51,3 +51,16 @@ Ordem obrigatória para agentes autônomos:
 **Branches**: `<type>/<nome>`
 
 **PRs**: Require 1+ approval, CI verde
+
+## CP-07: Nunca Push Direto na main
+
+- **Push direto na `main` é proibido** — sempre via branch + Pull Request
+- Merge por **squash-merge** após CI verde
+- Enforced por hook local `PreToolUse` (`.claude/settings.json`) que bloqueia `git push origin main`
+- ⚠️ O hook vive em `.claude/` (gitignored) → enforcement local não é herdado por um clone novo; o backstop real é o **ruleset de branch protection** da `main` no GitHub (PR obrigatório)
+
+## CP-08: dev_tools Desabilitado em Produção
+
+- **`apps.dev_tools` (seeds/backfills/cleanup) NÃO deve rodar em produção** — definir `INCLUDE_DEV_TOOLS=false`
+- Mecanismo: `config/settings.py` inclui `apps.dev_tools` apenas se `INCLUDE_DEV_TOOLS != "false"`
+- ⚠️ **Default é `true`** (conveniência de dev) e **não há guard por `ENVIRONMENT`** → produção PRECISA setar `INCLUDE_DEV_TOOLS=false` explicitamente; se a variável não existir no `stack.env`, o app de dev é carregado (CP-08 violado)

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ O **Aprender Sistema (AS) v2** substitui planilhas Google/Excel por uma platafor
 
 | Camada | Tecnologias |
 |--------|-------------|
-| **Backend** | Python 3.12, Django 5.2 LTS, DRF 3.16, Celery |
+| **Backend** | Python 3.12, Django 5.2 LTS, DRF 3.17, Celery |
 | **Frontend** | React (Vite), Tailwind CSS, Ant Design |
 | **Banco de Dados** | PostgreSQL 15 |
 | **Cache/Filas** | Redis 7 |

--- a/v2/docs/INDEX_DOCUMENTACAO.md
+++ b/v2/docs/INDEX_DOCUMENTACAO.md
@@ -8,7 +8,7 @@
 
 | Métrica | Valor |
 |---------|-------|
-| **Models** | 33 (28 core + 5 dat_ingest) |
+| **Models** | 28 (core) |
 | **API Endpoints** | 87+ |
 | **Testes** | 1.707 (130 arquivos) |
 | **Type Hints** | 100% (Pyright strict) |
@@ -51,7 +51,7 @@
 **Quando usar**: Entender grupos, permissões, páginas acessíveis.
 
 **Conteúdo**:
-- 9 setores + 4 funções
+- 13 setores + 5 funções
 - Permissões Django granulares
 - Páginas acessíveis por perfil
 - Regra de aprovação SUPER
@@ -258,12 +258,11 @@
 
 ## 📋 Referência de Arquitetura
 
-### Backend (33 Models)
+### Backend (28 Models)
 
 | App | Models | Arquivos |
 |-----|--------|----------|
 | **core** | 28 | Usuario, Solicitacao, AvailabilityBlock, Municipio, Projeto, Gerencia, TipoEvento, Produto, Participation, Compra, Deslocamento, AcaoControle, AcaoDAT, Config, AuditLog, GoogleOAuthCredential, DATRegistro, DATArea, DATCoordenador, DATAcao, DATCompra, DATCadastro, DATFormacao, PlanoFormacoes, Formacao, Acompanhamento, Prova, ProjetoGeral |
-| **dat_ingest** | 5 | ImportLog, StgUsuario, StgMunicipio, StgProjeto, StgTipoEvento |
 | **dev_tools** | 0 | - |
 
 ---
@@ -289,7 +288,6 @@
 | App | Commands | Exemplos |
 |-----|----------|----------|
 | **core** | 4 | preagenda_to_gcal, compliance_audit, lgpd_export |
-| **dat_ingest** | 21 | etl_all, etl_upsert_*, import_* |
 | **dev_tools** | 15 | seed_*, backfill_*, cleanup_* |
 
 ---
@@ -339,7 +337,6 @@ aprender_sistema/
 │   ├── backend/
 │   │   ├── apps/
 │   │   │   ├── core/          # App principal (28 models)
-│   │   │   ├── dat_ingest/    # ETL (5 models)
 │   │   │   └── dev_tools/     # Seeds (prod disabled)
 │   │   └── config/            # Django settings
 │   ├── frontend/

--- a/v2/docs/TESTING_POLICY.md
+++ b/v2/docs/TESTING_POLICY.md
@@ -4,7 +4,7 @@ Este documento consolida práticas e contratos adotados nos testes para manter o
 
 ## Ambiente de CI
 
-- **Runtime**: Python 3.11, PostgreSQL 15, Redis 7, TZ `America/Fortaleza`
+- **Runtime**: Python 3.12, PostgreSQL 15, Redis 7, TZ `America/Fortaleza`
 - **Settings**: `DJANGO_SETTINGS_MODULE=config.settings`, `ENVIRONMENT=testing`, `REQUIRE_DOCKER=0`
 - **Integrações externas**:
   - `GCAL_CLIENT=fake`, `GCAL_SEND_UPDATES=none`

--- a/v2/infra/ENVIRONMENTS.md
+++ b/v2/infra/ENVIRONMENTS.md
@@ -16,7 +16,7 @@ Fonte operacional oficial para evitar confusao de contexto no fluxo solo.
 | dev | Desenvolvimento local | `docker-compose.yml + docker-compose.override.yml` | `.env.dev` | `aprender_dev` | `8002` | `5173` | `5434` | `6380` |
 | staging | Homologacao local | `docker-compose.yml` | `.env.staging` | `aprender_staging` | `18002` | `15173` | `15434` | `16380` |
 | prod-like | Validacao local fiel ao compose de producao | `docker-compose.prod.yml` | `.env.prodlike.local` | `aprender_prod_like` | `28000` | `18081` | externo | interno |
-| producao | Runtime final (VM01) | `docker-compose.prod.yml` | `stack.env`/`.env.production` | `aprender_prod` | `8000` | `81` | VM02 | VM03 |
+| producao | Runtime final (VM01) | `docker-compose.prod.yml` | `stack.env`/`.env.production` | `aprender_prod` | `8000` | `81` | VM02 | interno (VM01) |
 
 ## 3) Comandos Oficiais
 
@@ -71,7 +71,7 @@ make build-prod-image
 6. `staging/producao` devem usar imagem publicada gerada com `Dockerfile.prod`.
 7. `staging` e `producao` exigem `IMAGE_TAG` explicita e imutavel (`vYYYY.MM.DD-<sha-or-id>`); `latest` nao e permitido em promocao/rollback de producao.
 8. Em `staging/producao`, `docker-compose.override.yml` nao e aplicado.
-9. Em producao Golden Cloud (3-VMs), `docker-compose.prod.yml` usa DB/Redis externos (VM02/VM03); a stack da VM01 sobe `web/worker/beat/frontend`.
+9. Em producao Golden Cloud, `docker-compose.prod.yml` usa DB externo (VM02); o Redis e container local da stack (servico `redis`), e a stack da VM01 sobe `web/worker/beat/frontend/redis`.
 10. O `docker-compose.yml` base e prod-like: binds de codigo do frontend (`src/public`) ficam apenas no `docker-compose.override.yml` (dev-only).
 
 ## 5) Staging Gate — Validacao Local Pre-Merge

--- a/v2/infra/README.md
+++ b/v2/infra/README.md
@@ -167,7 +167,7 @@ DOCKER_HUB_TOKEN=your-docker-hub-token
 |----|------|-----|-------|
 | VM01_App | App + Workers (Docker) | <VM01_IP_PRIVADO> | 8000 (web), 81 (frontend), 80/443 (via NPM) |
 | VM02_Banco | PostgreSQL 15 (servico nativo) | <VM02_IP_PRIVADO> | 5432 |
-| VM03_Redis | Redis 7 (servico nativo) | <VM03_IP_PRIVADO> | 6379 |
+| VM01_App (Redis) | Redis 7 (container na stack da VM01, servico `redis`) | <VM01_IP_PRIVADO> | interno (rede `backend-internal`, sem porta no host) |
 
 ## Related Documentation
 


### PR DESCRIPTION
## O que

**Fase 2 do SDD** — reconciliar os docs `stale` com o código real (o grupo crítico da auditoria 2026-06-19).
Docs-only, correções cirúrgicas verificadas por workflow read-only contra o código.

## Mudanças (9 docs)

- **dat_ingest removido** (app não existe mais) de `docs/architecture/overview.md` (árvore de apps),
  `v2/docs/INDEX_DOCUMENTACAO.md` (5 pontos: "33 models", linha do app, commands, árvore) e `backend.md`.
- **`backend.md`** — arquivos inexistentes corrigidos: `models/availability.py` → `agenda.py` (AvailabilityBlock),
  `approval_service.py` → `solicitacao_approval.py`, "rotinas ETL" → `services/controle_imports.py`.
- **`infrastructure.md`** — deploy "GitHub Pages" → **Portainer CE → prod** (cita ADR-010).
- **Versões:** `TESTING_POLICY.md` Python 3.11 → **3.12**; `docs/index.md` DRF 3.16 → **3.17**.
- **RBAC counts:** `INDEX_DOCUMENTACAO.md` "9 setores + 4 funções" → **13 setores + 5 funções** (SSOT `constants.py`).
- **Redis topologia:** `ENVIRONMENTS.md` + `infra/README.md` — VM03 dedicada → **container na VM01** (decisão registrada em `deploy.spec.md`).
- **CP-07 e CP-08 versionadas** em `docs/business-rules/clausulas-petreas.md` (antes só em `.claude/`, gitignored).

## ⚠️ Achado durante a verificação: CP-08 provavelmente violada em produção

Ao versionar a CP-08 descobri que **`INCLUDE_DEV_TOOLS` tem default `true`** (`settings.py:113`) e **não há guard por
`ENVIRONMENT`** em `dev_tools/apps.py`. Como o `stack.env` de produção **não define `INCLUDE_DEV_TOOLS`**, o app
**`apps.dev_tools` (15 comandos seed/backfill/cleanup) está carregado em produção** — CP-08 violado. Pré-go-live é
baixo risco (sem dados/usuários; comandos exigem exec no container, não são HTTP), mas deve ser corrigido:
setar `INCLUDE_DEV_TOOLS=false` no Portainer **e** (ideal) adicionar um guard rígido em código (recusar `dev_tools`
se `ENVIRONMENT=production`). Sugiro abrir issue. A CP-08 no doc já documenta esse footgun.

## Validações

- `git diff --check`: limpo. Links relativos: **0 quebrados** (65 checados, incl. novo link ADR-010). Sem trailing whitespace.

## Fora de escopo (próxima onda)

- 2 refs a `dat_ingest` ainda em `dependency-guardrails.md` e `ADR-012` (ADR é registro histórico).
- Rewrites maiores de `docs/guides/etl.md` e `docs/guides/rbac.md` (precisam reescrita de conteúdo).
- **Docs-only** → `staging-gate-audit` pula (sem runtime impact).
