### PR TITLE
docs(sdd): substituir docs do ETL legado removido por ponteiros ao pipeline real

### DIFF
--- a/docs/guides/etl.md
+++ b/docs/guides/etl.md
@@ -1,141 +1,14 @@
-# ETL e Importação de Dados
+# Importação de Dados
 
-Guia para importação de dados das planilhas originais.
+> **Atualizado (SDD 2026-06).** O antigo pipeline ETL (`apps.dat_ingest`, ~21 comandos `import_usuarios`/`import_formadores`/`import_projetos`/`import_solicitacoes`/…) foi **removido** (#967/#971). Aquele guia não reflete mais o sistema — o único management command de import real hoje é `import_export_contract`.
 
-## Visão Geral
+A importação de dados agora usa o **pipeline export-contract** (`apps/core/imports/`), com idempotência por `external_hash` SHA1 (ADR-012) e os contratos documentados no SSOT:
 
-O sistema possui 21 comandos ETL para importação de dados:
+> **[v2/docs/imports/README.md](https://github.com/matheusnorjosa/aprender_sistema/blob/main/v2/docs/imports/README.md)** — contratos por entidade (usuários, disponibilidade, agenda/solicitações, produtos/controle), ordem de importação e contrato de resposta de dry-run.
 
-```bash
-# Listar comandos disponíveis
-docker compose exec web python manage.py --help | grep import
-```
+Mecanismos:
 
-## Comandos Principais
+- **Endpoints DRF**: `POST /api/<recurso>/import/` (síncrono) ou `POST /api/imports/<tipo>/` (assíncrono, ASQ-005).
+- **Management command**: `python manage.py import_export_contract` (dry-run por padrão; `--apply` exige allowlist e nunca sobrescreve campos protegidos).
 
-### Usuários
-
-```bash
-python manage.py import_usuarios --dry-run
-python manage.py import_usuarios --apply
-```
-
-### Formadores
-
-```bash
-python manage.py import_formadores --dry-run
-python manage.py import_formadores --apply
-```
-
-### Municípios
-
-```bash
-python manage.py import_municipios --dry-run
-python manage.py import_municipios --apply
-```
-
-### Projetos
-
-```bash
-python manage.py import_projetos --dry-run
-python manage.py import_projetos --apply
-```
-
-### Solicitações
-
-```bash
-python manage.py import_solicitacoes --dry-run
-python manage.py import_solicitacoes --apply
-```
-
-## Princípios ETL
-
-### 1. Idempotência
-
-- Comandos podem ser executados múltiplas vezes
-- Usa `update_or_create` para evitar duplicatas
-- Chave única: campos de identificação natural
-
-### 2. Dry-Run Obrigatório
-
-```bash
-# SEMPRE rodar dry-run primeiro
-python manage.py import_dados --dry-run
-
-# Verificar output, depois aplicar
-python manage.py import_dados --apply
-```
-
-### 3. Quality Gates
-
-- Validação de campos obrigatórios
-- Normalização de dados (trim, lowercase)
-- Tratamento de valores nulos
-
-### 4. Relatórios
-
-Cada comando gera relatório JSON:
-
-```json
-{
-  "command": "import_usuarios",
-  "mode": "apply",
-  "started_at": "2025-01-15T10:00:00Z",
-  "finished_at": "2025-01-15T10:01:00Z",
-  "stats": {
-    "total_rows": 150,
-    "created": 145,
-    "updated": 5,
-    "skipped": 0,
-    "errors": 0
-  },
-  "errors": []
-}
-```
-
-## Estrutura de Arquivos
-
-```
-v2/backend/data/csv-import/
-├── Acompanhamento de Agenda _ 2025.xlsx
-├── Disponibilidade _ 2025.xlsx
-├── Planilha de Controle - 2025.xlsx
-└── Usuários.xlsx
-```
-
-## Fluxo Recomendado
-
-1. **Municípios** (sem dependências)
-2. **Projetos** (sem dependências)
-3. **Usuários** (requer grupos)
-4. **Formadores** (requer usuários)
-5. **Solicitações** (requer formadores, projetos, municípios)
-6. **Bloqueios** (requer formadores)
-
-## Troubleshooting
-
-### Erro de Encoding
-
-```bash
-# Converter arquivo para UTF-8
-iconv -f ISO-8859-1 -t UTF-8 arquivo.csv > arquivo_utf8.csv
-```
-
-### Erro de Formato de Data
-
-O sistema espera datas no formato ISO 8601 ou DD/MM/YYYY:
-
-```python
-# Formatos aceitos
-"2025-01-15"
-"2025-01-15T10:00:00"
-"15/01/2025"
-```
-
-### Linhas Ignoradas
-
-Verifique o relatório JSON para detalhes:
-
-```bash
-cat import_report_*.json | jq '.errors'
-```
+Regra de ouro: todo import roda **dry-run por padrão**; só aplica com autorização explícita.

--- a/v2/README.md
+++ b/v2/README.md
@@ -49,8 +49,7 @@ docker compose up -d
 v2/
 ├── backend/              # Django + DRF
 │   ├── apps/
-│   │   ├── core/         # Domínio principal (28 models)
-│   │   └── dat_ingest/   # ETL (21 comandos)
+│   │   └── core/         # Domínio principal (28 models; imports em core/imports/)
 │   └── config/           # Settings, URLs, Celery
 │
 ├── frontend/             # React + Vite
@@ -89,17 +88,19 @@ cd frontend && npx playwright test
 
 ---
 
-## ETL
+## Importação de Dados
+
+O antigo pipeline ETL (`apps.dat_ingest`, ~21 comandos `import_*`) foi **removido** (#967/#971). A importação
+hoje usa o pipeline **export-contract** (`apps/core/imports/`), idempotente por `external_hash` SHA1 (ADR-012),
+**dry-run por padrão**:
 
 ```bash
-# Dry-run (simulação)
-docker compose exec web python manage.py import_usuarios --dry-run
-
-# Executar
-docker compose exec web python manage.py import_usuarios --apply
+# Único command de import real (dry-run por padrão)
+docker compose exec web python manage.py import_export_contract --dry-run
 ```
 
-**Comandos disponíveis**: 21 (import_usuarios, import_municipios, import_dat_acoes, etc.)
+Também há endpoints DRF (`POST /api/<recurso>/import/`). Contratos por entidade e ordem de importação em
+`v2/docs/imports/README.md`.
 
 ---
 

--- a/v2/docs/PROJETO_ORIGEM.md
+++ b/v2/docs/PROJETO_ORIGEM.md
@@ -115,27 +115,17 @@ O sistema original funcionava integralmente sobre planilhas Google/Excel, que ac
 | `AuditLog` | Log de auditoria (todas operações críticas) |
 | `GoogleOAuthCredential` | Credenciais OAuth criptografadas |
 
-### 2.4 ETLs Disponíveis (21 comandos)
+### 2.4 Importação de Dados
 
-```bash
-# Importação de dados base
-import_municipios, import_projetos, import_tipos_evento, import_usuarios
+> **Atualizado (SDD 2026-06).** O antigo pipeline ETL (`apps.dat_ingest`, ~21 comandos `import_*` como
+> `import_municipios`/`import_usuarios`/`import_dat_*`) foi **removido** (#967/#971). Aquela lista não reflete
+> mais o sistema.
 
-# Acompanhamento e Agenda
-import_acompanhamento, import_disponibilidade, import_deslocamentos
+A importação hoje usa o pipeline **export-contract** (`apps/core/imports/`), idempotente por `external_hash`
+SHA1 (ADR-012), **dry-run por padrão**. Único management command real: `import_export_contract`. Também há
+endpoints DRF (`POST /api/<recurso>/import/`).
 
-# Módulo DAT
-import_dat_acoes, import_dat_registros, import_dat_cadastros
-import_dat_compras, import_dat_coordenadores, import_dat_formacoes
-
-# Controle
-import_acoes_controle, import_compras
-
-# Utilitários
-backfill_user_groups, fix_duplicate_users, validate_data
-```
-
-Todos suportam `--dry-run` e geram relatórios em `out_etl/*.json`.
+Contratos por entidade e ordem de importação: `v2/docs/imports/README.md`.
 
 ---
 


### PR DESCRIPTION
## Matar a documentação do ETL legado removido

O ETL legado (`apps.dat_ingest`, ~21 comandos `import_*`) foi removido (#967/#971). Confirmado nesta sessão: `**/management/commands/etl_*.py` = **0 arquivos**; único import real = `import_export_contract`. Três docs **vivos** ainda ensinavam os comandos fantasma:

- **`docs/guides/etl.md`** (página na nav MkDocs) → stub apontando ao SSOT `v2/docs/imports/README.md` + `import_export_contract` + endpoints DRF.
- **`v2/README.md`** → seção "ETL" (`import_usuarios --dry-run/--apply`, "21 comandos") e árvore (`dat_ingest/`) corrigidas.
- **`v2/docs/PROJETO_ORIGEM.md` §2.4** → lista de 21 comandos fantasma substituída por ponteiro ao pipeline atual.

### Resíduo rastreado (não-doc) — issue #1470

Os alvos do **Makefile** `etl-acomp-dry/apply` e `etl-desloc-dry/apply` chamam `etl_upsert_acompanhamento`/`etl_upsert_deslocamento` (inexistentes) → `make` falha. Mais RUNBOOK + Quick Reference do `.claude/CLAUDE.md`. É código + ops e precisa de decisão remove-vs-repoint → fora deste PR docs-only.

### Validação

- Link-checker (python): **0 quebras vivas** (`docs/` e `v2/docs/`).
- `git diff --check` limpo.
- **Docs-only** → `[required] staging gate evidence` deve ficar `skipped`.

Parte da migração SDD (memória `sdd-doc-program-2026-06-19`).
