### PR TITLE
docs(sdd): fases 1+3+4 - ADR-017 + 19 specs vivas por modulo

### DIFF
--- a/docs/architecture/project-decisions/ADR-017-spec-driven-documentation.md
+++ b/docs/architecture/project-decisions/ADR-017-spec-driven-documentation.md
@@ -1,0 +1,64 @@
+# ADR-017: Documentação Spec-Driven (SDD)
+
+**Status:** Accepted
+**Date:** 2026-06-19
+**Decider:** Matheus Norjosa
+
+## Context
+
+O acervo de documentação chegou a ~326 arquivos `.md` (210 versionados + 116 locais) sem sinalização de
+canonicidade: 21 docs `stale` (ensinavam comportamento que não existe mais — ex.: 21 comandos ETL do
+`apps.dat_ingest` removido), contagens divergentes (setores/funções/models transcritas à mão e desatualizadas)
+e dezenas de links quebrados. Ler um doc não dizia **se ele é verdade hoje**, **qual código é a fonte**, nem
+**quando foi verificado**.
+
+Agravante: contratos críticos (CP-07 "nunca push na main", CP-08 "dev_tools off em prod") viviam só em
+`.claude/CLAUDE.md` — um arquivo **local**, que não existe num clone limpo. Qualquer regra que dependesse de
+`.claude/` ou `.agents/` quebrava fora da máquina do dev.
+
+## Decision
+
+Adotar **Spec-Driven Development (SDD)** para a documentação, com uma camada de specs vivas versionada em
+[`v2/docs/specs/`](https://github.com/matheusnorjosa/aprender_sistema/blob/main/v2/docs/specs/INDEX_SDD.md):
+
+1. **Frontmatter obrigatório** em todo doc vivo (`specs/`, `runbooks/`, `reference/`, `decisions/`): `status`
+   (`canonical|active|draft|stale|historical`), `last_verified` (data da última checagem contra o código) e
+   `sources_of_truth` (arquivos de código que a spec descreve). Sem frontmatter ⇒ tratar como histórico.
+2. **Uma verdade por tópico.** Um SSOT por domínio; os demais docs **linkam**, não duplicam (evita drift de
+   contagens). A spec é um contrato conciso que aponta para o guia detalhado + o código.
+3. **Spec = contrato vivo, código = implementação.** Toda spec lista `sources_of_truth` reais e verificados.
+4. **Gerar em vez de copiar.** Tabelas derivadas do código (setores/funções, capability×grupo) são geradas
+   (`python manage.py rbac_matrix_doc`), não transcritas.
+5. **Histórico é imutável e isolado.** `_archive/`, `analysis/`, planos concluídos e relatórios datados ficam
+   fora da navegação viva e **não se "corrigem"**.
+6. **Nada crítico fora do git.** Os contratos *enforced* (CP-01..08, RD-01..08, PA-01..07, RF) passam a viver em
+   docs versionados: `docs/business-rules/clausulas-petreas.md` (CP-07/CP-08 já promovidos) + as specs em
+   [`specs/domain/`](https://github.com/matheusnorjosa/aprender_sistema/blob/main/v2/docs/specs/domain/).
+
+### Decisão sobre `CLAUDE.md` / `AGENTS.md` / `.claude/`
+
+Mantidos **local-only** (gitignored) **de forma intencional**. Como os contratos agora estão em git (item 6),
+**nenhum comportamento crítico depende de `.claude/` num clone limpo** — esses arquivos são *tooling* de
+conveniência do dev (instruções de agente, skills locais), não fonte de verdade. Não versionar evita ruído e
+vazamento de configuração local. Critério de conclusão "decisão explícita sobre CLAUDE.md/AGENTS.md" do plano
+SDD: **satisfeito por esta ADR** (local-only documentado).
+
+## Consequences
+
+- Todo módulo vivo (backend/frontend/infra) e contrato (domain) ganha uma `*.spec.md` com `status` +
+  `last_verified` + `sources_of_truth`.
+- **Proibido**: documento vivo sem frontmatter; transcrever tabelas que o código gera; "corrigir" arquivos em
+  `_archive/`; mover arquivo sem corrigir os links no mesmo commit.
+- **Gate de CI** (Fase 6) passa a barrar links relativos quebrados em docs canonical/active e frontmatter
+  ausente — impedindo regressão.
+- Specs novas em `v2/docs/specs/` **não** entram na nav do MkDocs (que publica só `docs/`); são referência
+  interna versionada. Links de páginas MkDocs para `v2/docs/*` usam URL absoluta (`blob/main`), pois caminho
+  relativo cross-tree quebra `mkdocs build --strict`.
+
+## References
+
+- Plano: `v2/docs/plans/PLAN_sdd_migration_2026-06-19.md`
+- Auditoria: `v2/docs/reports/AUDITORIA_DOCUMENTAL_2026-06-19.md`
+- Índice de specs: `v2/docs/specs/INDEX_SDD.md`
+- Contratos: `docs/business-rules/clausulas-petreas.md` (CP-01..08)
+- [ADR-010](ADR-010-deploy-portainer-direct-to-prod.md) (deploy), [ADR-012](ADR-012-dependency-guardrails.md) (guardrails)

--- a/docs/architecture/project-decisions/README.md
+++ b/docs/architecture/project-decisions/README.md
@@ -24,6 +24,7 @@ Cada ADR documenta: contexto (problema), decisão (o que foi escolhido e por qu�
 | [ADR-014](ADR-014-stateless-horizontal-scaling.md) | Arquitetura Stateless para Scaling | Accepted | 2026-01-12 |
 | [ADR-015](ADR-015-testing-policy.md) | Política de Testes | Accepted | 2026-02-24 |
 | [ADR-016](ADR-016-asymmetric-crypto-strategy.md) | Estratégia de Criptografia Assimétrica | Accepted | 2026-04-13 |
+| [ADR-017](ADR-017-spec-driven-documentation.md) | Documentação Spec-Driven (SDD) | Accepted | 2026-06-19 |
 
 ## Como Adicionar um Novo ADR
 

--- a/v2/docs/specs/INDEX_SDD.md
+++ b/v2/docs/specs/INDEX_SDD.md
@@ -15,8 +15,9 @@ contrato em produção tem (ou terá) uma spec versionada, datada e rastreável 
 e as fases estão no [plano SDD](../plans/PLAN_sdd_migration_2026-06-19.md), apoiado na
 [auditoria documental 2026-06-19](../reports/AUDITORIA_DOCUMENTAL_2026-06-19.md).
 
-> Estado: **esqueleto (Fase 0)**. As specs por módulo ainda não foram escritas — esta estrutura existe para
-> receber a migração das Fases 3-4. Os ponteiros abaixo marcam o que está planejado.
+> Estado: **specs escritas (Fases 3-4, 2026-06-19)**. Cada spec abaixo foi autorada e verificada contra o
+> código (`sources_of_truth` confirmados). O modelo SDD está formalizado na
+> [ADR-017](../../../docs/architecture/project-decisions/ADR-017-spec-driven-documentation.md).
 
 ## Convenção de frontmatter (obrigatória em todo doc vivo)
 
@@ -45,12 +46,50 @@ related: []                   # links a specs/ADRs relacionados
 | `stale` | desatualizado/contradiz o código (a reconciliar) |
 | `historical` | registro datado/arquivado (não se "corrige") |
 
-## Áreas
+## Specs por área
 
-- [`domain/`](./domain/README.md) — regras de negócio (CP, RD, PA, RF)
-- [`backend/`](./backend/README.md) — subsistemas de `apps/core` + `apps/dev_tools`
-- [`frontend/`](./frontend/README.md) — pages, hooks, api clients
-- [`infra/`](./infra/README.md) — deploy, ambientes, CI
+### `domain/` — regras de negócio (contratos imutáveis)
+
+| Spec | Cobre | Status |
+|---|---|---|
+| [clausulas-petreas.spec.md](./domain/clausulas-petreas.spec.md) | CP-01..CP-08 (enforcement real) | canonical |
+| [regras-disponibilidade.spec.md](./domain/regras-disponibilidade.spec.md) | RD-01..RD-08 | canonical |
+| [politica-aprovacao.spec.md](./domain/politica-aprovacao.spec.md) | PA-01..PA-07 | canonical |
+| [requisitos-funcionais.spec.md](./domain/requisitos-funcionais.spec.md) | RF01..RF08 (índice) | canonical |
+
+### `backend/` — subsistemas de `apps/core` + `apps/dev_tools`
+
+| Spec | Cobre | Status |
+|---|---|---|
+| [rbac.spec.md](./backend/rbac.spec.md) | HasPerm, policies, matriz, lint | canonical |
+| [availability.spec.md](./backend/availability.spec.md) | serviço de disponibilidade (RD) | canonical |
+| [solicitacao-approval.spec.md](./backend/solicitacao-approval.spec.md) | fluxo de aprovação (PA/RF04) | canonical |
+| [gcal.spec.md](./backend/gcal.spec.md) | Google Calendar + Meet (RF05/06) | canonical |
+| [imports.spec.md](./backend/imports.spec.md) | pipeline export-contract | canonical |
+| [backup-dr.spec.md](./backend/backup-dr.spec.md) | backup & disaster recovery (dívida #1455) | active |
+| [dat.spec.md](./backend/dat.spec.md) | módulo DAT (ações/cadastros/registros) | canonical |
+| [notificacoes.spec.md](./backend/notificacoes.spec.md) | sistema 32 Passos | canonical |
+| [deslocamento.spec.md](./backend/deslocamento.spec.md) | deslocamento (GAP preenchido) | active |
+| [dev-tools.spec.md](./backend/dev-tools.spec.md) | catálogo de seeds (CP-08) | canonical |
+
+### `frontend/` — pages, hooks, api clients
+
+| Spec | Cobre | Status |
+|---|---|---|
+| [pages.spec.md](./frontend/pages.spec.md) | páginas React (rotas + guards) | canonical |
+| [hooks-rbac.spec.md](./frontend/hooks-rbac.spec.md) | hooks de RBAC/guards (GAP preenchido) | canonical |
+| [api-clients.spec.md](./frontend/api-clients.spec.md) | clientes axios/fetch | canonical |
+
+### `infra/` — deploy, ambientes, CI
+
+| Spec | Cobre | Status |
+|---|---|---|
+| [deploy.spec.md](./infra/deploy.spec.md) | deploy → Portainer (prod verificado) | canonical |
+| [environments.spec.md](./infra/environments.spec.md) | dev / staging / prod-like | canonical |
+| [ci.spec.md](./infra/ci.spec.md) | GitHub Actions, gates, deploy | canonical |
+
+> READMEs de área: [`domain/`](./domain/README.md) · [`backend/`](./backend/README.md) ·
+> [`frontend/`](./frontend/README.md) · [`infra/`](./infra/README.md).
 
 ## Template de spec por módulo
 

--- a/v2/docs/specs/backend/README.md
+++ b/v2/docs/specs/backend/README.md
@@ -11,7 +11,7 @@ related:
 
 Backend real = **apenas** `apps/core` (28 models) + `apps/dev_tools`. Voltar ao [índice SDD](../INDEX_SDD.md).
 
-## Specs planejadas (Fase 3-4)
+## Specs (escritas em 2026-06-19) — origem de cada uma
 
 | Spec | Estado da doc hoje | Fonte canônica / código |
 |---|---|---|
@@ -25,4 +25,4 @@ Backend real = **apenas** `apps/core` (28 models) + `apps/dev_tools`. Voltar ao 
 | `dat.spec.md` | migrar | `views/dat_module.py`, `SPEC_DAT_REGISTROS.md` |
 | `notificacoes.spec.md` | consolidar | `services/notificacoes_acoes_service.py`, `PLANO_NOTIFICACOES_TIMING.md` |
 
-> Status: esqueleto. Nenhuma spec escrita ainda (Fase 0).
+> Status: **specs escritas** (Fase 3-4, 2026-06-19) — links vivos no [índice SDD](../INDEX_SDD.md).

--- a/v2/docs/specs/backend/availability.spec.md
+++ b/v2/docs/specs/backend/availability.spec.md
@@ -1,0 +1,108 @@
+---
+title: Disponibilidade (serviço)
+status: canonical
+last_verified: 2026-06-19
+sources_of_truth:
+  - v2/backend/apps/core/services/availability_service.py
+  - v2/backend/apps/core/views_availability.py
+  - v2/backend/apps/core/views_availability_monthly.py
+  - v2/backend/apps/core/models/agenda.py
+  - v2/backend/apps/core/utils/cache_utils.py
+  - v2/backend/apps/core/urls.py
+  - v2/docs/GUIDE_AVAILABILITY.md
+owner: backend
+supersedes:
+  - v2/docs/GUIDE_AVAILABILITY.md
+related:
+  - ../domain/regras-disponibilidade.spec.md
+  - ./solicitacao-approval.spec.md
+  - ../../../../docs/architecture/project-decisions/ADR-003-availability-rules-timezone.md
+  - ../../../../docs/business-rules/regras-disponibilidade.md
+---
+
+# Disponibilidade (serviço)
+
+## Propósito
+
+O módulo de disponibilidade calcula, de forma **consultiva**, se um formador/coordenador pode atender um novo evento num intervalo `(inicio, fim)`, aplicando as regras RD-01 a RD-08 (não-sobreposição, bloqueios total/parcial, buffer de deslocamento entre municípios, capacidade diária e timezone-aware). É a implementação de software das regras de negócio de agenda: substitui a planilha manual em que a Superintendência conferia conflitos à mão.
+
+O coração é um **serviço puro, sem efeitos colaterais** (`check_conflicts`): não grava, não aprova e não muda estado — apenas retorna uma lista estruturada de conflitos. A aprovação em si fica no fluxo de solicitação (ver [solicitacao-approval.spec](./solicitacao-approval.spec.md)). Sobre o serviço existem três superfícies HTTP: check pontual, check em lote e a grade mensal usada pela UI da Superintendência.
+
+## Fonte de verdade no código
+
+- [`services/availability_service.py`](../../../backend/apps/core/services/availability_service.py) — `check_conflicts(*, usuario, inicio, fim, municipio=None) -> CheckResult`; dataclasses `Conflict` (code/title/detail/ref_id) e `CheckResult` (ok/conflicts); helpers `to_local`, `same_day_local`, `_fmt_interval_local`. **SSOT das RD-01 a RD-08.**
+- [`views_availability.py`](../../../backend/apps/core/views_availability.py) (raiz de `apps/core/` — **arquivo ativo**) — `AvailabilityBlockViewSet`, `AvailabilityCheckView`, `AvailabilityCheckManyView` + helpers `is_privileged_user`, `can_check_availability_for_others`, `get_user_gerencias_ids`.
+- [`views_availability_monthly.py`](../../../backend/apps/core/views_availability_monthly.py) — `MonthlyAvailabilityView` (grade mensal; delega para `services/monthly_grid_service.build_monthly_grid`).
+- [`models/agenda.py`](../../../backend/apps/core/models/agenda.py) — `AvailabilityBlock` (`tipo` T/P, `status` aprovado, `inicio`/`fim` UTC; check constraints `fim>inicio` e `tipo in {T,P}`).
+- [`utils/cache_utils.py`](../../../backend/apps/core/utils/cache_utils.py) — decorator `cache_availability_check` + `invalidate_availability_cache` (versionamento por usuário no Redis).
+- [`urls.py`](../../../backend/apps/core/urls.py) — registro das rotas sob `/api/`.
+- Guia detalhado (grade multi-setor, permissões, exemplos de payload): [`GUIDE_AVAILABILITY.md`](../../GUIDE_AVAILABILITY.md).
+
+> Nota: existe um arquivo órfão `apps/core/views/availability.py` que **não** é roteado — `urls.py` importa de `views_availability` (raiz). Não editar o órfão.
+
+## Contratos e invariantes
+
+- **RD-01 (X)** — sobreposição com evento aprovado: overlap `inicio__lt=fim & fim__gt=inicio` ≥ 1 min gera conflito; intervalos **adjacentes** (`fim == inicio`) **não** conflitam.
+- **RD-02 (T)** — bloqueio total aprovado que intersecta o intervalo impede qualquer evento.
+- **RD-03 (P)** — bloqueio parcial aprovado impede só dentro do subintervalo.
+- **RD-04 (D)** — buffer de deslocamento entre municípios distintos: exige `>= TRAVEL_BUFFER_MINUTES` (default 120). `municipio=None` é tratado como **cidade diferente** (fix #588) → exige buffer. Buffer **exato** (`== buffer`) passa; só `< buffer` conflita.
+- **RD-05 (M)** — capacidade diária: soma das durações (eventos do dia + novo intervalo) não pode exceder `AVAILABILITY_DAILY_LIMIT_HOURS` (default 8h). Janela do dia calculada por **range de datetime em UTC** derivado do dia local (issue #249), não por `.date()`.
+- **RD-06 (timezone)** — armazenamento em UTC; comparações de "mesmo dia" e formatação em `America/Fortaleza` (`settings.TZ_PROJECT`). Datas naive recebidas são tratadas como UTC.
+- **RD-07** — reporta **todos** os conflitos encontrados (sem short-circuit); `ok = (len(conflicts) == 0)`.
+- **RD-08** — cada `Conflict` carrega `code`, `title`, `detail` (com formador/intervalo formatado) e `ref_id` quando aplicável.
+- **Sem efeito colateral**: `check_conflicts` nunca grava nem aprova. Decisão de aprovação é externa.
+- **Multi-formador**: considera eventos onde o usuário é `usuario` OU participante (`participations__usuario`).
+- **Idempotência/cache**: resultado é cacheado por 5 min (TTL + jitter ≤30s) com chave versionada por usuário; mudanças nos dados do usuário fazem `invalidate_availability_cache(usuario_id)` bumpar a versão (miss natural, sem scan de Redis).
+- **CP-03 (timezone Fortaleza)** e configuração via `config_service.get_cfg("availability", ...)` com fallback para `settings` — limites são **configuráveis**, não hardcoded.
+
+## API / Interface
+
+Todas montadas sob `/api/` (`config/urls.py` → `apps.core.urls`). Catálogo completo de payloads em [`GUIDE_AVAILABILITY.md`](../../GUIDE_AVAILABILITY.md) e `v2/docs/API_REFERENCE.md`.
+
+| Método/rota | View | Permissão | Função |
+|---|---|---|---|
+| `GET /api/availability/check/` | `AvailabilityCheckView` | `HasPerm("view_all_availability") \| HasPerm("create_solicitation") \| HasPerm("approve_solicitation_batch")` + filtro runtime (próprio vs outros) | Check pontual de 1 usuário. Params: `usuario_id`, `inicio`, `fim` (ISO8601), `municipio_id?`. Resposta `{ok, conflicts[]}`. Throttle `availability_check` (60/min prod). |
+| `POST /api/availability/check-many/` | `AvailabilityCheckManyView` | idem | Check em lote. Body `{usuarios_ids[], inicio, fim, municipio_id?}`. Resposta `{ok, results[]}`. |
+| `GET /api/availability/monthly/` | `MonthlyAvailabilityView` | superuser OU `view_all_availability` OU escopo por `EquipeGerencia` | Grade mensal por gerência/setor. Params `year`, `month`, `role` (FORMADOR/COORDENADOR), `gerencia_id?`, `sector?`, `q?`. Cache Redis 5 min. |
+| `GET/POST/PATCH/DELETE /api/availability-blocks/` | `AvailabilityBlockViewSet` | `IsAuthenticated` (escopo via queryset) | CRUD de bloqueios. Formador cria os próprios (auto `status="aprovado"`); delegação para outro Formador exige `user_can_delegate_availability_block` (+ AuditLog `DELEGATE_BLOCK_CREATE`). |
+
+Idioma RBAC canônico: `permission_classes=[HasPerm("codename")]` (grupos diretos banidos por `scripts/rbac_lint.py`).
+
+## Fluxos principais
+
+**Check de conflito (`check_conflicts`)**
+1. Valida intervalo (`fim > inicio`); inválido → `CheckResult(ok=False)` com `Conflict("X", "Intervalo inválido", ...)`.
+2. Carrega `TRAVEL_BUFFER_MINUTES` e `AVAILABILITY_DAILY_LIMIT_HOURS` (config → fallback settings).
+3. **RD-02/03**: bloqueios aprovados que intersectam → conflito T ou P por `tipo`.
+4. **RD-01**: eventos aprovados que sobrepõem → conflito X (`distinct()` por causa do JOIN de participação).
+5. **RD-04**: evento imediatamente anterior/posterior; se cidade distinta e gap `< buffer` → conflito D.
+6. **RD-05**: soma durações do dia (range UTC do dia local) + novo intervalo; se `> limite` → conflito M.
+7. **RD-07**: retorna `CheckResult(ok=len==0, conflicts=[...])`.
+
+**Endpoint de check pontual** — valida `usuario_id`/datas (400 em entrada inválida; 404 se usuário não existe); 403 se consultar outro usuário sem `can_check_availability_for_others`; força timezone-aware (RD-06); chama o serviço; serializa conflitos via `c.__dict__`.
+
+**Criação de bloqueio** — sem `usuario_id` (ou self): `usuario=created_by=request.user`, `status="aprovado"`. Com `usuario_id` de terceiro: 403 **antes** de qualquer lookup (anti-enumeração); depois valida target ativo + Função Formador (400 senão), salva e grava AuditLog.
+
+## Decisões relacionadas (ADRs)
+
+- [ADR-003 — Availability rules & timezone](../../../../docs/architecture/project-decisions/ADR-003-availability-rules-timezone.md) (UTC storage + America/Fortaleza).
+- Regra de negócio canônica: [`docs/business-rules/regras-disponibilidade.md`](../../../../docs/business-rules/regras-disponibilidade.md) (indexada por [regras-disponibilidade.spec](../domain/regras-disponibilidade.spec.md)).
+- ASQ-007 (#780): invalidação granular de cache por versionamento (sem `cache.keys` pattern delete).
+
+## Testes que cobrem
+
+- [`tests/test_availability_service.py`](../../../backend/apps/core/tests/test_availability_service.py) — RD-01..08: overlap total/parcial, adjacência permitida, T/P, buffer entre cidades, mesma cidade buffer-zero, capacidade M, timezone Fortaleza, fronteira de meia-noite, multi-formador, mensagens com código/intervalo; endpoint check (auth, validações, lote, permissão self-vs-privileged).
+- [`tests/test_d9_availability_check.py`](../../../backend/apps/core/tests/test_d9_availability_check.py) — composição de permissão D9 (check de terceiros por Coord/Gerente Sup/Controle).
+- [`tests/test_availability_batch.py`](../../../backend/apps/core/tests/test_availability_batch.py) — check-many.
+- [`tests/test_api_availability_blocks.py`](../../../backend/apps/core/tests/test_api_availability_blocks.py), [`tests/test_availability_block_idor.py`](../../../backend/apps/core/tests/test_availability_block_idor.py), [`tests/test_availability_block_autoapproval.py`](../../../backend/apps/core/tests/test_availability_block_autoapproval.py), [`tests/test_pr13_delegated_availability_blocks.py`](../../../backend/apps/core/tests/test_pr13_delegated_availability_blocks.py) — CRUD de bloqueios, escopo IDOR, auto-aprovação, delegação.
+- [`tests/test_availability_monthly_api.py`](../../../backend/apps/core/tests/test_availability_monthly_api.py), [`tests/test_availability_monthly_rbac.py`](../../../backend/apps/core/tests/test_availability_monthly_rbac.py) — grade mensal e RBAC por gerência.
+- [`tests/test_cache_availability.py`](../../../backend/apps/core/tests/test_cache_availability.py) — cache versionado e invalidação.
+
+## Pontos de atenção / dívidas conhecidas
+
+- **Arquivo órfão**: `apps/core/views/availability.py` é cópia não roteada (`urls.py` usa `views_availability.py` raiz). Risco de drift se alguém editar o errado — candidato a remoção.
+- **TOCTOU**: o check é consultivo e cacheado (5 min); entre o check e a gravação da solicitação o estado pode mudar (novo evento/bloqueio concorrente). A garantia real de não-conflito é da camada de aprovação de solicitação, não deste serviço.
+- **`municipio=None` = cidade diferente** (RD-04): chamadas sem `municipio_id` disparam buffer; intencional (fix #588), mas pode gerar conflito D inesperado quando o município simplesmente não foi informado.
+- **Permissão por composition OR** nos endpoints de check (3 caps) é tática; se a matriz crescer, migrar para Policy class (ver `feedback_composition_or_is_tactical`).
+- **Grade mensal**: legenda/células dependem de `monthly_grid_service`; este spec cobre o contrato HTTP, não o algoritmo da grade (ver `GUIDE_AVAILABILITY.md`).
+- Throttle dev relaxado (`600/min`) vs prod (`60/min`) — não confundir limites em testes locais.

--- a/v2/docs/specs/backend/backup-dr.spec.md
+++ b/v2/docs/specs/backend/backup-dr.spec.md
@@ -1,0 +1,115 @@
+---
+title: Backup & Disaster Recovery
+status: canonical
+last_verified: 2026-06-19
+sources_of_truth:
+  - v2/backend/apps/core/tasks_backup.py
+  - v2/backend/config/celery.py
+  - v2/infra/scripts/backup_db.sh
+  - v2/infra/scripts/restore_db.sh
+  - v2/infra/scripts/verify_backup.sh
+  - v2/infra/scripts/test_dr.sh
+  - v2/infra/configs/vm02/postgresql.conf
+  - v2/infra/docker-compose.prod.yml
+  - v2/backend/apps/core/tests/test_celery_backup.py
+  - v2/docs/BACKUP_OPERATIONS.md
+  - v2/docs/DISASTER_RECOVERY.md
+  - v2/docs/GUIDE_DR.md
+owner: backend
+supersedes:
+  - v2/docs/BACKUP_OPERATIONS.md
+  - v2/docs/DISASTER_RECOVERY.md
+related:
+  - v2/docs/specs/infra/deploy.spec.md
+  - v2/docs/GUIDE_DR.md
+  - v2/docs/SLO_DEFINITIONS.md
+---
+
+# Backup & Disaster Recovery
+
+## Proposito
+
+Garantir que o estado do AS v2 (banco PostgreSQL, fonte de verdade de ~82k formulas migradas) seja recuperavel apos corrupcao, perda de servidor ou comprometimento de credenciais. O modulo cobre dois eixos: (1) **backup automatizado** do PostgreSQL via `pg_dump` agendado pelo Celery Beat (Docker) ou cron (VM), com retencao, upload S3 opcional e criptografia `age` opcional (SEC-017); e (2) **recovery** — procedimentos operacionais de restore para cada cenario de desastre.
+
+Esta spec e o **indice canonico** do tema. Os parametros e procedimentos detalhados vivem em [`BACKUP_OPERATIONS.md`](../../BACKUP_OPERATIONS.md) (SSOT de operacoes/parametros) e [`DISASTER_RECOVERY.md`](../../DISASTER_RECOVERY.md) (cenarios de recovery em Docker); para VM de producao, [`GUIDE_DR.md`](../../GUIDE_DR.md). Aqui ficam o **contrato** e os **invariantes** — nao se duplica o passo-a-passo dos guias.
+
+> **AVISO DE REALIDADE (2026-06):** o backup automatizado esta **morto/silencioso em producao** (issue #1455). As secoes abaixo descrevem o **contrato-alvo**; onde o estado real diverge, esta sinalizado. Trate a cobertura como aspiracional ate o job ser ressuscitado e validado por um restore drill real.
+
+## Fonte de verdade no codigo
+
+- **Tasks Celery** — [`v2/backend/apps/core/tasks_backup.py`](../../../backend/apps/core/tasks_backup.py)
+  - `backup.perform_database_backup(backup_type="full")` — invoca o script, `max_retries=3`, `default_retry_delay=300`, `timeout=3600`, backoff exponencial; alerta Sentry se `SENTRY_DSN` setado.
+  - `backup.verify_backup_health()` — health check semanal (3 checks: dir gravavel, backup recente < 25h, conectividade S3 se configurado).
+- **Schedule (beat)** — [`v2/backend/config/celery.py`](../../../backend/config/celery.py)
+  - `daily-database-backup` — `crontab(hour=2, minute=0)`, args `("full",)`, `expires=3600`.
+  - `weekly-backup-health-check` — `crontab(hour=3, minute=0, day_of_week=0)` (domingos).
+- **Script de backup** — [`v2/infra/scripts/backup_db.sh`](../../../infra/scripts/backup_db.sh) — `pg_dump | gzip [| age]`, nomenclatura `backup_full_YYYYMMDD_HHMMSS.sql.gz[.age]`, retencao `find -mtime +$BACKUP_RETENTION_DAYS -delete`, upload S3 opcional. Mesmo script para Docker e VM (muda so a chamada e os defaults das env vars).
+- **Script de restore** — [`v2/infra/scripts/restore_db.sh`](../../../infra/scripts/restore_db.sh) — interativo (exige `yes`), verifica integridade (`gzip -t`), termina conexoes, drop+create do DB, restaura (suporta `.age`), valida contagem de tabelas.
+- **Scripts auxiliares** — [`verify_backup.sh`](../../../infra/scripts/verify_backup.sh) (health check VM), [`test_dr.sh`](../../../infra/scripts/test_dr.sh) (drill mensal).
+- **WAL archiving (RPO)** — [`v2/infra/configs/vm02/postgresql.conf`](../../../infra/configs/vm02/postgresql.conf): `archive_mode=on`, `archive_timeout=300`, `archive_command` para `/var/lib/postgresql/wal_archive/`.
+
+## Contratos e invariantes
+
+| Parametro | Valor | Fonte |
+|---|---|---|
+| **RPO** | 5 min | `archive_timeout=300` (WAL contínuo na VM02) |
+| **RTO** | 1 h (restore + migrations + smoke) | SSOT `BACKUP_OPERATIONS.md` |
+| **Retencao** | 7 dias (`BACKUP_RETENTION_DAYS`) | `backup_db.sh` |
+| **Frequencia** | 1x/dia (02:00 Docker / 03:00 VM, `America/Fortaleza`) | `celery.py` / cron |
+| **Health check** | semanal (domingos 03:00) | `verify_backup_health` |
+
+Invariantes que NAO podem ser violados:
+
+- **Nomenclatura fixa**: `backup_full_*.sql.gz[.age]`. O health check faz glob exatamente por `backup_full_*.sql.gz`; arquivos com outro nome sao **invisiveis** (provado em teste). Mudar o prefixo quebra a deteccao de "backup recente".
+- **Restore e destrutivo e irreversivel**: dropa o DB alvo. Em modo interativo exige confirmacao literal `yes`. Producao deve parar `web`/`worker`/`beat` antes (prevenir escrita concorrente).
+- **Idempotencia de retencao**: a limpeza so apaga `backup_full_*` mais velhos que a janela; nunca toca arquivos fora do padrao.
+- **Credencial nunca logada**: `PGPASSWORD` e exportado para o `pg_dump`, jamais ecoado. Secrets reais de prod vivem no Portainer, nao no repo.
+- **Cobertura = somente PostgreSQL**: uploads/media e secrets NAO tem backup automatizado (apenas procedimento manual documentado). Redis nao e persistido (cache/sessions/broker efemero).
+- **`age` opcional (SEC-017)**: se `BACKUP_AGE_RECIPIENT` setado, o dump e criptografado em repouso; restore exige `BACKUP_AGE_KEY`.
+
+## API / Interface
+
+Nao expoe endpoints HTTP. Interface = tasks Celery + scripts CLI + env vars.
+
+**Disparo manual (Docker):**
+```bash
+# backup full
+docker compose exec web /app/infra/scripts/backup_db.sh full
+# via Celery
+docker compose exec web python manage.py shell -c \
+  "from apps.core.tasks_backup import perform_database_backup; perform_database_backup.delay('full')"
+# restore (DESTRUTIVO)
+docker compose exec web /app/infra/scripts/restore_db.sh /backups/backup_full_<ts>.sql.gz
+```
+
+**Env vars (contrato `tasks_backup.py` -> `backup_db.sh`):** `DB_HOST/DB_PORT/DB_USER/DB_PASSWORD/DB_NAME`, `BACKUP_DIR` (default `/backups`), `BACKUP_RETENTION_DAYS` (7), `BACKUP_S3_BUCKET` (opcional), `BACKUP_AGE_RECIPIENT` (opcional), `SENTRY_DSN`. Tabela completa de variaveis e setup S3 em [`BACKUP_OPERATIONS.md`](../../BACKUP_OPERATIONS.md#configuration).
+
+## Fluxos principais
+
+**Backup (caminho feliz):** Beat dispara 02:00 -> `perform_database_backup("full")` valida que `/app/infra/scripts/backup_db.sh` existe -> monta env do `settings.DATABASES` -> `subprocess.run` (timeout 1h) -> script faz `pg_dump | gzip [| age]` em `$BACKUP_DIR` -> verifica arquivo nao-vazio -> upload S3 (se `BACKUP_S3_BUCKET`) -> retencao -> task parseia o path do stdout e retorna `{status: success, ...}`.
+
+**Erros:** timeout -> `self.retry` (countdown 300); `CalledProcessError` -> log + Sentry + retry com backoff exponencial; retries esgotados -> excecao propaga (deveria alertar via Sentry).
+
+**Restore (cenario 1 — corrupcao de DB):** parar `web/worker/beat` -> listar backups -> `restore_db.sh <file>` (verifica integridade, termina conexoes, drop/create, restaura, valida contagem) -> reiniciar -> validar `/healthz/detailed/`. Cenarios completos (perda total do servidor, credenciais comprometidas, GCal indisponivel) em [`DISASTER_RECOVERY.md` §2](../../DISASTER_RECOVERY.md).
+
+## Decisoes relacionadas (ADRs)
+
+- MP5 — Automated Backup System (issue #169, PR #186) — origem do sistema.
+- SEC-017 — criptografia `age` opcional em repouso para backups.
+- Issue #562 (C-05) / #563 (C-06) — script unificado Docker+VM e testes.
+- Spec de deploy/infra relacionada: [`deploy.spec.md`](../infra/deploy.spec.md).
+
+## Testes que cobrem
+
+- [`v2/backend/apps/core/tests/test_celery_backup.py`](../../../backend/apps/core/tests/test_celery_backup.py)
+  - `TestVerifyBackupHealth` — degraded sem backups; healthy com backup recente; warning com backup > 25h; warning com dir inexistente; **glob so casa `backup_full_*.sql.gz`** (nome divergente = invisivel).
+  - `TestPerformDatabaseBackupScriptPath` — task registrada com nome `backup.perform_database_backup`; `max_retries=3`, `default_retry_delay=300`.
+- Sem cobertura de integracao real do `pg_dump`/restore (exige Docker); drill via [`test_dr.sh`](../../../infra/scripts/test_dr.sh) e manual/mensal.
+
+## Pontos de atencao / dividas conhecidas
+
+- **CRITICO — job morto/silencioso em prod (issue #1455).** O Beat esta agendado, mas a execucao em producao nao produz backups verificaveis. Causa estrutural confirmada no codigo: [`docker-compose.prod.yml`](../../../infra/docker-compose.prod.yml) define `worker`/`beat` mas **nao monta o volume `backup_data` (`/backups`) nem o diretorio `infra/scripts` (`/app/infra/scripts`)** — ao contrario do compose de dev/staging. A task hardcoda `Path("/app/infra/scripts/backup_db.sh")`; sem o mount, `script_path.exists()` falha (`FileNotFoundError`) ou, na melhor hipotese, escreve em path efemero perdido no restart. Sem `SENTRY_DSN` ativo em prod, a falha e **silenciosa**. Acao: montar volume + scripts no `worker`/`beat` de prod, garantir `SENTRY_DSN`/alerta, e validar com restore drill.
+- **Sem alerta de "backup ausente"**: o health check semanal so emite warning ao Sentry; se Sentry estiver OFF (estado prod atual), `degraded` nao chega a ninguem.
+- **RPO 5 min depende do WAL na VM02**, nao do `pg_dump` (diario). Em ambiente Docker sem `archive_mode`, o RPO efetivo regride para ~24h (ultimo dump).
+- **Sem backup de media/uploads e secrets** automatizado — so procedimento manual. Estrategia 3-2-1 e aspiracional (sem copia offsite ativa).
+- **Restore drill mensal nao automatizado em CI** — `test_dr.sh` existe mas a execucao recorrente nao esta garantida.

--- a/v2/docs/specs/backend/dat.spec.md
+++ b/v2/docs/specs/backend/dat.spec.md
@@ -1,0 +1,134 @@
+---
+title: Módulo DAT
+status: canonical
+last_verified: 2026-06-19
+sources_of_truth:
+  - v2/backend/apps/core/models/dat_acao.py
+  - v2/backend/apps/core/models/dat_cadastro.py
+  - v2/backend/apps/core/models/dat_compra.py
+  - v2/backend/apps/core/models/dat_coordenador.py
+  - v2/backend/apps/core/models/dat_formacao.py
+  - v2/backend/apps/core/models/dat_registro.py
+  - v2/backend/apps/core/models/workflow.py
+  - v2/backend/apps/core/views/dat_module.py
+  - v2/backend/apps/core/views/dat.py
+  - v2/backend/apps/core/views_controle_dat.py
+  - v2/backend/apps/core/urls.py
+  - v2/backend/apps/core/services/dat_cadastros_import.py
+  - v2/backend/apps/core/rbac/matrix.py
+  - v2/backend/apps/core/rbac/policies.py
+owner: backend
+supersedes:
+  - v2/docs/_archive/SPEC_DAT_REGISTROS.md
+related:
+  - v2/docs/specs/backend/rbac.spec.md
+  - v2/docs/API_REFERENCE.md
+  - v2/docs/RBAC_NAMING.md
+---
+
+# Módulo DAT
+
+## Propósito
+
+O módulo DAT (Departamento de Apoio Técnico/Tecnologia) gerencia o ciclo operacional de implantação dos projetos nos municípios: o acompanhamento da chegada do projeto (ações em 4 etapas), o cadastro de turmas/cursos nas plataformas externas **FORMAR** e **AVALIAR**, as formações/treinamentos dados aos professores, as compras de materiais e o cadastro dos coordenadores responsáveis. É o "back-office" transversal que dá suporte a todos os setores de produto.
+
+No código convivem **dois conjuntos de models** com a mesma origem de dados (planilha DAT), mas finalidades diferentes — o que segue a distinção legacy×operacional do projeto:
+
+- **Operacional (UI/CRUD via DRF):** `DATAcao`, `DATCadastro`, `DATCompra`, `DATFormacao`, `DATCoordenador`/`DATArea`, `DATRegistro` (tabelas `core_dat_*`). É o que esta spec governa.
+- **Legacy (histórico de import ETL):** `AcaoDAT` + `TipoAcaoDAT` em [`workflow.py`](../../../backend/apps/core/models/workflow.py) (tabela `core_acao_dat`). Alimentado por importação por `external_hash`; não é o caminho de edição da UI nova.
+
+## Fonte de verdade no código
+
+Models operacionais (um arquivo por entidade):
+
+- [`models/dat_acao.py`](../../../backend/apps/core/models/dat_acao.py) — `DATAcao` (ciclo de 4 etapas).
+- [`models/dat_cadastro.py`](../../../backend/apps/core/models/dat_cadastro.py) — `DATCadastro` (FORMAR/AVALIAR).
+- [`models/dat_compra.py`](../../../backend/apps/core/models/dat_compra.py) — `DATCompra` (materiais/estoque).
+- [`models/dat_formacao.py`](../../../backend/apps/core/models/dat_formacao.py) — `DATFormacao` (formações/calendário).
+- [`models/dat_coordenador.py`](../../../backend/apps/core/models/dat_coordenador.py) — `DATArea` (referência) + `DATCoordenador`.
+- [`models/dat_registro.py`](../../../backend/apps/core/models/dat_registro.py) — `DATRegistro` (acompanhamento de turmas FORMAR/AVALIAR; depende de `ProjetoGeral`).
+
+Model legacy:
+
+- [`models/workflow.py`](../../../backend/apps/core/models/workflow.py) — `AcaoDAT` + `TipoAcaoDAT`.
+
+ViewSets / Views:
+
+- [`views/dat_module.py`](../../../backend/apps/core/views/dat_module.py) — `DATArea/DATCoordenador/DATAcao/DATCompra/DATCadastro/DATFormacao` ViewSets.
+- [`views/dat.py`](../../../backend/apps/core/views/dat.py) — `DATRegistroViewSet` + `ProjetoGeralViewSet`.
+- [`views_controle_dat.py`](../../../backend/apps/core/views_controle_dat.py) — `DATAcoesListCreateView` (legacy `AcaoDAT`).
+
+Roteamento: [`urls.py`](../../../backend/apps/core/urls.py). Serviço de import legacy: [`services/dat_cadastros_import.py`](../../../backend/apps/core/services/dat_cadastros_import.py).
+
+## Contratos e invariantes
+
+- **Unicidade (constraints de BD, não podem ser violadas):**
+  - `DATAcao`: único por `(municipio, projeto)` — `unique_dat_acao_municipio_projeto`.
+  - `DATCadastro`: único por `(municipio, projeto_geral, plataforma)` — `unique_dat_cadastro_mun_proj_plat`.
+  - `DATRegistro`: único por `(municipio, projeto_geral, projeto)`; `external_hash` é unique (idempotência de import).
+  - `AcaoDAT` (legacy): `external_hash` unique = `SHA1(municipio_id|projeto_id|tipo_acao|responsavel_id)`.
+- **Campos derivados em `DATRegistro.save()` (sempre recalculados):** `usa_avaliar` espelha `projeto_geral.usa_avaliar`; `nr_codigos` é calculado por `tipo_calculo_codigos` (`por_aluno` = ceil(alunos/divisor), `por_professor` = ceil(profs*mult), `nao_aplicavel` = None); se `usa_avaliar=False`, os 3 status AVALIAR viram `nao_aplicavel`. UI/import nunca devem gravar esses campos manualmente.
+- **Auto-status em `DATCompra.save()`:** `status_uso` é derivado de quantidades (`>= adquirida` → `esgotado`; `> 0` → `em_uso`; senão `disponivel`). `disponivel = max(0, quantidade - quantidade_utilizada)`.
+- **Workflow de 4 etapas (`DATAcao`):** Carta → Contato → Reunião → Entrega. Cada etapa tem status `pendente|em_andamento|concluido|cancelado`. `progresso` e `etapa_atual` são derivados (primeira não concluída).
+- **Auditoria obrigatória:** todos os models gravam `created_by` (PROTECT) e `updated_by` via `perform_create`/`perform_update`; FKs para `Municipio`/`Projeto`/`ProjetoGeral` são `PROTECT` (não deletar mestre com dependentes).
+- **CP-08 / SEC-007:** export CSV de `DATRegistro` passa por `sanitize_csv_value` (anti CSV-injection). Não remover.
+- **Disciplina de import (CP / memória do projeto):** o caminho de import real é via `import_export_contract` (dry-run por padrão; `--apply` exige allowlist). Re-import cego sobrescreveria data-fixes manuais — **não importar dados reais sem dry-run verde + autorização**.
+
+## API / Interface
+
+Rotas DRF (prefixo `/api/`, registradas em [`urls.py`](../../../backend/apps/core/urls.py)). Detalhe consolidado: [`API_REFERENCE.md`](../../API_REFERENCE.md).
+
+| Recurso | Rota | ViewSet/View | Extras |
+|---|---|---|---|
+| Áreas (ref.) | `dat/areas/` | `DATAreaViewSet` (ReadOnly) | `?minimal=true` |
+| Coordenadores | `dat/coordenadores/` | `DATCoordenadorViewSet` | `@action alocacoes` |
+| Ações (ciclo) | `dat/acoes-ciclo/` | `DATAcaoViewSet` | `@action stats` |
+| Compras/materiais | `dat/compras-materiais/` | `DATCompraViewSet` | `@action stats / dashboard / pendencias` |
+| Cadastros FORMAR/AVALIAR | `dat/cadastros/` | `DATCadastroViewSet` | `@action stats / etapa` |
+| Formações | `dat/formacoes/` | `DATFormacaoViewSet` | `@action stats / calendario` |
+| Registros (turmas) | `dat/registros/` | `DATRegistroViewSet` | `@action export(CSV) / stats` |
+| Projetos Gerais | `projetos-gerais/` | `ProjetoGeralViewSet` | `@action projetos` |
+| Ações DAT (legacy) | `dat/acoes/` | `DATAcoesListCreateView` | model `AcaoDAT` |
+
+**RBAC (idioma `permission_classes=[HasPerm("codename")]`; ver [rbac.spec](rbac.spec.md)):**
+
+- Leitura/escrita do CRUD operacional: `HasPerm("manage_admin_registries") | HasPerm("run_daily_operations")` (DAT + Controle/Assistente; composition OR, issue #1220).
+- `destroy`: `HasPerm("execute_restricted_operations")` (Superintendência/superuser).
+- Compras têm Policies dedicadas: `CanViewComprasStats` (stats), `CanViewComprasDashboard` (dashboard executivo — Diretoria), `CanViewComprasPendencias` (operacional). Ver [`rbac/policies.py`](../../../backend/apps/core/rbac/policies.py) e [`rbac/matrix.py`](../../../backend/apps/core/rbac/matrix.py).
+- `DATRegistro`/`DATCadastro` usam só `manage_admin_registries` (sem `run_daily_operations`).
+
+## Fluxos principais
+
+**Ação DAT (ciclo de implantação):** cria-se `DATAcao` para `(municipio, projeto)` → preenche as 4 etapas (status + data + observação) → `progresso`/`etapa_atual` refletem o avanço → `stats` agrega por etapa/projeto/coordenador. A constraint impede duplicar a mesma dupla município/projeto.
+
+**Cadastro de plataforma:** cria-se `DATCadastro` para `(municipio, projeto_geral, plataforma)` → workflow FORMAR (Criação Curso → Chaves → Instruções → Envio) ou AVALIAR (Recebimento → Validação → Importação) → `POST {id}/etapa/` atualiza uma etapa específica (`etapa` inválida → **400**) → `progresso` por plataforma.
+
+**Registro de turma:** cria-se `DATRegistro` → `save()` deriva `usa_avaliar`/`nr_codigos` → seções FORMAR e (condicionalmente) AVALIAR → `status_geral` = `completo | pendente_formar | pendente_avaliar` → `export/` gera CSV sanitizado.
+
+**Formação:** cria-se `DATFormacao` (data/horário/modalidade/participantes/docs) → `calendario/` exige `data_inicio`+`data_fim` (faltando → **400**) → `taxa_presenca`/`documentacao_completa` derivados.
+
+**Erros relevantes:** sem permissão → **403**; etapa/parâmetro inválido → **400**; violação de unicidade → **IntegrityError** (400/409).
+
+## Decisões relacionadas (ADRs)
+
+- Issue #1220 — Controle edita ações/formações/coordenadores DAT via `run_daily_operations` (composition OR).
+- Issues #1222/#1233 (Epic 4.2.b1) — `pendencias` é operacional; `dashboard` agregado fica restrito (Diretoria); cada action mapeada para Policy nomeada de Compras.
+- PR #1361 — `stats_qs = qs.order_by()` antes de `values_list().annotate(Count())` para evitar fragmentação de GROUP BY (aplicado a todos os `stats` do módulo).
+- Pipeline export-contract — `dat_acao` + `plano_formacao` no importer dedicado (PR #1384, dry-run); ver [export-contract](../../../backend/apps/core/services/export_contract_importer.py).
+
+## Testes que cobrem
+
+- [`tests/test_dat_module.py`](../../../backend/apps/core/tests/test_dat_module.py) — models + serializers + ViewSets das 6 entidades operacionais.
+- [`tests/test_dat_registros.py`](../../../backend/apps/core/tests/test_dat_registros.py) — `DATRegistro`/`ProjetoGeral` (cálculo de códigos, `usa_avaliar`, stats, export).
+- [`tests/test_controle_dat_api.py`](../../../backend/apps/core/tests/test_controle_dat_api.py) — RBAC e filtros de `/api/dat/acoes/` (legacy `AcaoDAT`).
+- [`tests/test_dat_tipo_acao_choices.py`](../../../backend/apps/core/tests/test_dat_tipo_acao_choices.py) — choices/normalização de `TipoAcaoDAT` + data migration `0057`.
+- [`tests/test_etl_dat_cadastros.py`](../../../backend/apps/core/tests/test_etl_dat_cadastros.py) — import legacy idempotente.
+- [`tests/test_dat_imports_dat_only.py`](../../../backend/apps/core/tests/test_dat_imports_dat_only.py) — escopo de import restrito a DAT.
+
+## Pontos de atenção / dívidas conhecidas
+
+- **Dois `DATAcao`/`AcaoDAT` coexistentes:** operacional (`core_dat_acao`, `dat/acoes-ciclo/`) vs legacy (`core_acao_dat`, `dat/acoes/`). Não confundir ao escrever queries/migrações; ver memória "Legacy vs Operational models".
+- **`DATCoordenador.area` é `CharField` livre**, não FK para `DATArea` (a tabela de referência existe mas não é amarrada). Divergência de grafia silenciosa é possível.
+- **REGIAO_UFS duplicado:** o mapa em [`views/dat.py`](../../../backend/apps/core/views/dat.py) deve casar com `REGIAO_UFS` do frontend (`DATModule/DATRegistros/constants.tsx`); divergência quebra o filtro `regiao`.
+- **Doc detalhado arquivado:** `SPEC_DAT_REGISTROS.md` está em `v2/docs/_archive/` (não atualizado com o estado atual); esta spec passa a ser o índice canônico do módulo, mas o detalhe de Registros ainda referencia o arquivo arquivado.
+- **`DAT-01..DAT-04` não são IDs formais** de RD/PA/CP no código — são rótulos descritivos do escopo (workflow / registros / cadastros FORMAR-AVALIAR / coordenadores-áreas). Não citar como cláusula imutável.

--- a/v2/docs/specs/backend/deslocamento.spec.md
+++ b/v2/docs/specs/backend/deslocamento.spec.md
@@ -1,0 +1,116 @@
+---
+title: Deslocamento (GAP — criar)
+status: active
+last_verified: 2026-06-19
+sources_of_truth:
+  - v2/backend/apps/core/models/workflow.py
+  - v2/backend/apps/core/migrations/0016_create_deslocamento.py
+  - v2/backend/apps/core/views_deslocamento.py
+  - v2/backend/apps/core/serializers/workflow.py
+  - v2/backend/apps/core/views_import_deslocamentos.py
+  - v2/backend/apps/core/services/deslocamentos_import.py
+  - v2/backend/apps/core/services/monthly_grid_service.py
+  - v2/backend/apps/core/services/availability_service.py
+  - v2/backend/apps/core/urls.py
+  - v2/backend/apps/core/admin.py
+  - v2/backend/apps/core/models/auditoria.py
+  - v2/backend/apps/core/rbac/matrix.py
+  - v2/frontend/src/pages/Deslocamentos/DeslocamentosPage.tsx
+owner: backend
+supersedes: []
+related:
+  - v2/docs/specs/backend/availability.spec.md
+  - v2/docs/specs/backend/rbac.spec.md
+  - v2/docs/GUIDE_AVAILABILITY.md
+  - v2/docs/rbac_authorization_matrix.md
+---
+
+# Deslocamento
+
+## Proposito
+
+O modulo de **Deslocamento** registra periodos em que um usuario (tipicamente formador/coordenador) esta em transito entre municipios — origem, destino e o intervalo de datas (`start_date`..`end_date`). Existe para tornar visivel, na **grade mensal de disponibilidade**, os dias em que a pessoa esta viajando: a grade emite o codigo `D` (deslocamento sem evento/bloqueio) ou `D1` (evento + deslocamento) para esses dias, evitando que o operador agende formacoes para alguem que ja esta em deslocamento.
+
+E um cadastro operacional simples (CRUD + import em massa), sem fluxo de aprovacao. **Nota de escopo importante:** o modelo `Deslocamento` *informa* a grade mensal, mas **nao** alimenta o motor de conflitos da disponibilidade. A regra **RD-04** ("buffer de viagem entre municipios") e implementada separadamente em [`availability_service.py`](../../../backend/apps/core/services/availability_service.py) calculando o `TRAVEL_BUFFER_MINUTES` entre os municipios de *eventos* consecutivos — ela nao le registros de `Deslocamento`. Os dois compartilham o tema "viagem", mas sao mecanismos distintos.
+
+## Fonte de verdade no codigo
+
+- **Model**: [`apps/core/models/workflow.py`](../../../backend/apps/core/models/workflow.py) — classe `Deslocamento` (tabela `core_deslocamento`).
+- **Migration de criacao**: [`apps/core/migrations/0016_create_deslocamento.py`](../../../backend/apps/core/migrations/0016_create_deslocamento.py).
+- **ViewSet CRUD**: [`apps/core/views_deslocamento.py`](../../../backend/apps/core/views_deslocamento.py) — `DeslocamentoViewSet` (+ `DeslocamentoPagination`, `_get_client_ip`).
+- **Serializer**: [`apps/core/serializers/workflow.py`](../../../backend/apps/core/serializers/workflow.py) — `DeslocamentoSerializer`.
+- **Import (endpoint)**: [`apps/core/views_import_deslocamentos.py`](../../../backend/apps/core/views_import_deslocamentos.py) — `ImportDeslocamentosView`.
+- **Import (service)**: [`apps/core/services/deslocamentos_import.py`](../../../backend/apps/core/services/deslocamentos_import.py) — `import_deslocamentos_from_file()`.
+- **Consumo na grade mensal**: [`apps/core/services/monthly_grid_service.py`](../../../backend/apps/core/services/monthly_grid_service.py) — distribui deslocamentos por dia/pessoa e gera codigos `D`/`D1`.
+- **Rotas**: [`apps/core/urls.py`](../../../backend/apps/core/urls.py) — router `deslocamentos` + rota `deslocamentos/import/`.
+- **AuditLog actions**: [`apps/core/models/auditoria.py`](../../../backend/apps/core/models/auditoria.py) — `CREATE_DESLOCAMENTO`, `UPDATE_DESLOCAMENTO`, `DELETE_DESLOCAMENTO`.
+- **Admin**: [`apps/core/admin.py`](../../../backend/apps/core/admin.py) — `DeslocamentoAdmin`.
+- **RBAC (cobertura)**: [`apps/core/rbac/matrix.py`](../../../backend/apps/core/rbac/matrix.py) — resource `deslocamentos` mapeado para `_ALL_AUTH`.
+- **Frontend**: [`v2/frontend/src/pages/Deslocamentos/DeslocamentosPage.tsx`](../../../frontend/src/pages/Deslocamentos/DeslocamentosPage.tsx).
+
+### Campos do model
+
+`usuario` (FK `Usuario`, `on_delete=PROTECT`, `related_name="deslocamentos"`), `origem` (CharField 200), `destino` (CharField 200), `start_date` (DateField), `end_date` (DateField), `observacao` (TextField, opcional), `external_hash` (CharField 64, `unique=True`, `db_index`, idempotencia de import), `created_at`, `updated_at`. Indices em `(usuario, start_date, end_date)` e `(external_hash)`.
+
+> **Inexistente / nao usar:** nao ha management command de import (so o endpoint DRF). A funcao legada `etl_upsert_deslocamento` **nao existe** no codigo atual — o import passa exclusivamente por `import_deslocamentos_from_file` + `ImportDeslocamentosView`.
+
+## Contratos e invariantes
+
+- **Validacao de datas** (serializer): exige `end_date > start_date` (estrito; `end_date <= start_date` -> 400 em `end_date`). Suporta PATCH parcial (usa o valor da instancia para o campo ausente).
+- **Origem != destino** (serializer): comparacao case-insensitive (`.strip().lower()`); igual -> 400 em `destino`.
+- **Idempotencia de import**: `external_hash = SHA1(usuario_id|origem|destino|start_iso|end_iso)` via `stable_import_hash` (byte-equivalente ao formato historico). Re-import do mesmo registro nao duplica; so `observacao` e atualizada quando muda (never-overwrite dos demais campos). `unique=True` no `external_hash` e a barreira de banco.
+- **Dry-run por padrao no import**: `dry_run=true` faz `transaction.set_rollback(True)`; nada e persistido. `dry_run=false` exige `HasPerm("import_spreadsheet")` (DAT ou superuser). Isolamento savepoint-por-linha (ASQ-016): uma linha ruim nao derruba o lote.
+- **Scope RBAC (Onda 1 C2, 2026-04-27)** no `get_queryset`:
+  - Superuser **ou** capability `view_all_availability` (Controle/Gerente via seed 0078) -> ve todos os deslocamentos.
+  - Demais autenticados (Coord/Apoio/DAT) -> veem **apenas** deslocamentos de usuarios em gerencias vinculadas via `EquipeGerencia`. Sem vinculo -> **0 resultados** (fail-safe).
+- **Auditoria obrigatoria**: todo CREATE/UPDATE/DELETE grava `AuditLog` com `usuario`, IP (X-Forwarded-For -> X-Real-IP -> REMOTE_ADDR), user-agent (truncado 200) e diff dos campos (no UPDATE). DELETE registra antes de deletar.
+- **CP**: roda apenas em Docker (CP-01); idioma RBAC e `permission_classes=[HasPerm("...")]` (CP — grupos diretos banidos por `scripts/rbac_lint.py`).
+- **Codigos de grade** (precedencia `X > D1 > 2 > E > T/P > D`): `D` = deslocamento sem evento/bloqueio; `D1` = evento + deslocamento sem bloqueio. Definidos em `monthly_grid_service.py`.
+
+## API / Interface
+
+CRUD (router DRF, basename `deslocamento`):
+
+- `GET /api/deslocamentos/` — lista paginada (50/pagina, `page_size` ate 100), ordenada por `-start_date`.
+- `GET /api/deslocamentos/{id}/`, `POST /api/deslocamentos/`, `PUT/PATCH /api/deslocamentos/{id}/`, `DELETE /api/deslocamentos/{id}/`.
+- **Permissao do ViewSet**: `[IsAuthenticated]` + scope no queryset (nao `HasPerm` no nivel de classe; o controle e por *visibilidade* via `EquipeGerencia`).
+- **Filtros** (query params, aplicados manualmente em `get_queryset`): `usuario_id` (exato), `data_inicio` (`start_date >=`), `data_fim` (`end_date <=`), `origem` (`icontains`), `destino` (`icontains`). **Nao ha `FilterSet`/`filterset_fields` declarado** — `DjangoFilterBackend` esta em `filter_backends` mas o filtro real e o codigo manual; `OrderingFilter` cobre `start_date|end_date|origem|destino`.
+
+Import em massa:
+
+- `POST /api/deslocamentos/import/` — `ImportDeslocamentosView`. Permissao `[IsAuthenticated, HasPerm("import_spreadsheet")]` (DAT ou superuser). Query `dry_run=true|false` (default `true`). Body multipart `file` (CSV/XLSX). Validacao de upload (tamanho/MIME/magic bytes) e temp-file sanitizado (path-injection mitigado). Retorna `{stats:{created,updated,unchanged,skipped}, pendencias:{usuarios,dates,outros}, dry_run, file}`. Colunas aceitas com headers flexiveis (`usuario|email|nome`, `origem`, `destino`, `data_inicio`, `data_fim`, `observacao`); datas parseadas em ISO, `dd/mm/yyyy` e serial Excel.
+
+Schema detalhado/exemplos: ver `API_REFERENCE` quando disponivel.
+
+## Fluxos principais
+
+**Lancamento manual (UI dedicada)**: operador abre `DeslocamentosPage`, filtra por usuario/datas/origem/destino, cria/edita via modal -> `POST`/`PUT` -> serializer valida (datas, origem!=destino) -> `perform_create/update` grava registro + `AuditLog`. `external_hash` so e setado pelo import (CRUD manual deixa null).
+
+**Import em massa (caminho feliz)**: DAT envia planilha -> `dry_run=true` retorna `stats`/`pendencias` para revisao -> apos validacao, `dry_run=false` persiste create-only (atualiza so `observacao`). Idempotente por `external_hash`.
+
+**Erros relevantes do import**: usuario nao resolvido (email>nome) -> `skipped.usuario` + `pendencias.usuarios`; origem/destino ausentes -> `skipped.other`; data invalida ou `data_fim < data_inicio` -> `skipped.dates`; qualquer excecao de linha e isolada por savepoint e some em `pendencias.outros` (o lote continua).
+
+**Reflexo na disponibilidade**: a grade mensal carrega os deslocamentos do mes, distribui por dia/pessoa e aplica precedencia, emitindo `D`/`D1`. Nao bloqueia agendamento por si so — e sinalizacao visual.
+
+## Decisoes relacionadas (ADRs)
+
+- Idempotencia de import via SHA1 — ADR-012 (hashing `apps/core/imports/hashing.py`), reutilizada por `_compute_external_hash`.
+- Scope C2 de Deslocamentos (Coord/Apoio/DAT scoped via `EquipeGerencia`, Controle/Gerente full) — decisao de stakeholder 2026-04-27, documentada em [`rbac_authorization_matrix.md`](../../rbac_authorization_matrix.md) (§3) e PR #1250.
+- Centralizacao DAT-only do import (`HasPerm("import_spreadsheet")`) — PR-A1 DAT-Imports (2026-04-29).
+
+## Testes que cobrem
+
+- [`apps/core/tests/test_deslocamento_api.py`](../../../backend/apps/core/tests/test_deslocamento_api.py) — CRUD, filtros, validacoes (datas, origem!=destino), AuditLog.
+- [`apps/core/tests/test_deslocamento_rbac.py`](../../../backend/apps/core/tests/test_deslocamento_rbac.py) — scope C2 (Coord/DAT veem so a propria gerencia; sem vinculo -> 0; Controle/Gerente full).
+- [`apps/core/tests/test_import_deslocamentos.py`](../../../backend/apps/core/tests/test_import_deslocamentos.py) — service + view + RBAC `import_spreadsheet` + idempotencia.
+- [`apps/core/tests/test_monthly_with_deslocamento.py`](../../../backend/apps/core/tests/test_monthly_with_deslocamento.py) — codigos `D`/`D1` e precedencia na grade.
+- [`apps/core/tests/test_rbac_matrix_endpoint_coverage.py`](../../../backend/apps/core/tests/test_rbac_matrix_endpoint_coverage.py) / [`test_rbac_matrix_living.py`](../../../backend/apps/core/tests/test_rbac_matrix_living.py) — `deslocamentos` na matriz viva (`_ALL_AUTH`).
+
+## Pontos de atencao / dividas conhecidas
+
+- **GAP de documentacao**: este modulo nao tinha spec/doc canonico ate aqui (criada do zero). Confirmar dono de produto da regra de negocio de viagem.
+- **RD-04 vs Deslocamento**: facil confundir. RD-04 (buffer entre municipios) le municipios de *eventos*, **nao** o modelo `Deslocamento`. Nao assumir que cadastrar um deslocamento gera buffer no motor de conflitos — hoje **nao gera**. Avaliar se essa desconexao e intencional ou divida.
+- **`DjangoFilterBackend` decorativo**: esta em `filter_backends` mas sem `filterset_class`/`filterset_fields`; o filtro efetivo e manual em `get_queryset`. Remover o backend ocioso ou migrar para `FilterSet` (alinhar com a convencao do resto do app; cuidado com sufixo `_id` — ver memoria de FilterSet naming).
+- **`external_hash` nulo no CRUD manual**: registros criados pela UI nao tem hash; um import posterior com os mesmos campos-chave criaria uma 2a linha (hash so e calculado no import). Possivel duplicacao cruzada UI x import.
+- **`origem`/`destino` sao texto livre** (CharField, nao FK `Municipio`) — sem normalizacao canonica de nomes de municipio; risca consistencia com o resto do dominio.
+- **Import e sincrono** (nao usa ImportJob/Celery do ASQ-005); planilhas grandes ocupam o request. Avaliar migracao para import assincrono.

--- a/v2/docs/specs/backend/dev-tools.spec.md
+++ b/v2/docs/specs/backend/dev-tools.spec.md
@@ -1,0 +1,122 @@
+---
+title: dev_tools — Catálogo de Seeds
+status: canonical
+last_verified: 2026-06-19
+sources_of_truth:
+  - v2/backend/apps/dev_tools/__init__.py
+  - v2/backend/apps/dev_tools/apps.py
+  - v2/backend/config/settings.py
+  - v2/backend/apps/dev_tools/management/commands/seed_rbac.py
+  - v2/backend/apps/dev_tools/management/commands/seed_e2e_users.py
+  - v2/backend/apps/dev_tools/management/commands/seed_frontend_contract_data.py
+  - v2/backend/apps/dev_tools/management/commands/seed_gerencias.py
+  - v2/backend/apps/dev_tools/management/commands/seed_gerentes.py
+  - v2/backend/apps/dev_tools/management/commands/seed_produtos.py
+  - v2/backend/apps/dev_tools/management/commands/seed_tipos_evento.py
+  - v2/backend/apps/dev_tools/management/commands/seed_projetos_fluxo_from_csv.py
+  - v2/backend/apps/dev_tools/management/commands/seed_projetos_fluxo_from_sheets.py
+  - v2/backend/apps/dev_tools/management/commands/link_projetos_gerencias.py
+  - v2/backend/apps/dev_tools/management/commands/fix_projetos_gerencia.py
+  - v2/backend/apps/dev_tools/management/commands/migrate_rbac_groups.py
+  - v2/backend/apps/dev_tools/management/commands/backfill_is_online.py
+  - v2/backend/apps/dev_tools/management/commands/populate_municipio_coords.py
+  - v2/backend/apps/dev_tools/management/commands/cleanup_e2e_data.py
+  - v2/backend/apps/dev_tools/middleware/freeze_time.py
+  - v2/backend/apps/dev_tools/tests/test_optional_dev_tools.py
+  - v2/backend/apps/dev_tools/tests/test_seed_e2e_users.py
+  - v2/backend/apps/dev_tools/tests/test_seed_gerentes.py
+  - v2/backend/apps/dev_tools/tests/test_seed_frontend_contract_data.py
+  - v2/backend/apps/dev_tools/tests/test_projetos_fluxo_seed.py
+  - v2/backend/apps/dev_tools/tests/test_freeze_time_middleware.py
+owner: backend
+supersedes: []
+related:
+  - v2/docs/specs/infra/deploy.spec.md
+  - v2/docs/RBAC_NAMING.md
+---
+
+# dev_tools — Catálogo de Seeds
+
+## Propósito
+
+`apps.dev_tools` concentra todas as ferramentas de desenvolvimento do AS v2 — seeds (dados iniciais), backfills (migrações de dados pontuais), fixups (correções únicas) e cleanup de dados de teste E2E — fora do app de produção `apps.core`. Existe para popular bancos de dev, CI e E2E de forma idempotente sem misturar esse código com o domínio operacional, e para garantir que nenhum management command de seed vaze para produção.
+
+O app é **condicional**: só entra em `INSTALLED_APPS` quando `INCLUDE_DEV_TOOLS=true` (default em dev/CI). Em produção, a Cláusula Pétrea CP-08 exige `INCLUDE_DEV_TOOLS=false`, removendo o app inteiro — e com ele todos os comandos `seed_*`, `backfill_*`, `fix_*`, `cleanup_*` e o `FreezeTimeMiddleware`.
+
+## Fonte de verdade no código
+
+- Gate de inclusão (CP-08): [`v2/backend/config/settings.py`](../../../backend/config/settings.py) — `INCLUDE_DEV_TOOLS = os.getenv("INCLUDE_DEV_TOOLS", "true").lower() == "true"`; o app só é anexado via `if INCLUDE_DEV_TOOLS: INSTALLED_APPS.append("apps.dev_tools")`.
+- AppConfig: [`v2/backend/apps/dev_tools/apps.py`](../../../backend/apps/dev_tools/apps.py) (`DevToolsConfig`, sem lógica de gate — o gate vive em `settings.py`).
+- Pacote: [`v2/backend/apps/dev_tools/__init__.py`](../../../backend/apps/dev_tools/__init__.py).
+- Management commands: `v2/backend/apps/dev_tools/management/commands/*.py` — **15 comandos** (16 arquivos `.py`, descontando `__init__.py`).
+- Middleware auxiliar E2E: [`v2/backend/apps/dev_tools/middleware/freeze_time.py`](../../../backend/apps/dev_tools/middleware/freeze_time.py) (`FreezeTimeMiddleware`, gate duplo `DEBUG_E2E` + `INCLUDE_DEV_TOOLS`).
+
+### Catálogo: comando → o que semeia
+
+| Comando | O que semeia / faz |
+|---------|--------------------|
+| `seed_rbac` | Grupos (13 setores + 4 funções) e permissões mínimas. Idempotente; é a base do RBAC. |
+| `seed_e2e_users` | 4 usuários (coord, super, controle, formador) + grupos, 1 município (Salvador/BA), 1 projeto (`TESTE E2E`, fluxo SUPER). Idempotente. |
+| `seed_frontend_contract_data` | Dados determinísticos da matriz funcional crítica frontend↔backend (checklist Playwright): usuários, municípios, projetos, compras, solicitações. |
+| `seed_gerencias` | Seed inicial de gerências (7 registros). |
+| `seed_gerentes` | Vincula gerentes ao grupo função Gerente + `EquipeGerencia.papel=GERENTE`. |
+| `seed_produtos` | Seed inicial dos principais produtos. |
+| `seed_tipos_evento` | `TipoEvento` com os tipos padrão. Idempotente. |
+| `seed_projetos_fluxo_from_csv` | Popula `Projeto.fluxo` a partir de CSV. Idempotente. |
+| `seed_projetos_fluxo_from_sheets` | Popula `Projeto.fluxo` a partir de planilhas XLSX. Idempotente. |
+| `link_projetos_gerencias` | Vincula projetos existentes às gerências. |
+| `fix_projetos_gerencia` | Corrige vinculação de projetos a gerências. Idempotente (fixup). |
+| `migrate_rbac_groups` | Migra usuários para a estrutura RBAC atual (Setor + Função). Backfill. |
+| `backfill_is_online` | Backfill de `Solicitacao.tipo` a partir da coluna G da planilha original. |
+| `populate_municipio_coords` | Popula latitude/longitude de `Municipio` a partir de CSV. |
+| `cleanup_e2e_data` | Remove os dados E2E criados por `seed_e2e_users` (Playwright). |
+
+## Contratos e invariantes
+
+- **CP-08 (imutável)**: produção roda com `INCLUDE_DEV_TOOLS=false`. Sem o app, **nenhum** comando de seed/backfill/fix/cleanup fica disponível e `FreezeTimeMiddleware` não é instalado.
+- **Default perigoso**: `INCLUDE_DEV_TOOLS` tem default `true` por conveniência de dev e **não há guard por `ENVIRONMENT`**. Produção PRECISA setar `INCLUDE_DEV_TOOLS=false` explicitamente; se a variável faltar no `stack.env`, o app de dev é carregado e CP-08 é violado. Ver [deploy.spec.md](../infra/deploy.spec.md).
+- **Idempotência**: seeds usam `get_or_create` / lógica idempotente — rodar N vezes não duplica dados. É invariante esperada de todo `seed_*` (validada nos testes).
+- **Separação de domínio**: `apps.core` (produção) NÃO depende de `apps.dev_tools`. Toda lógica de produção precisa viver fora deste app, pois ele desaparece em prod.
+- **RBAC**: seeds criam grupos por nome, mas a autorização em runtime continua via `permission_classes=[HasPerm("codename")]` — grupos diretos (`user.groups.filter(name=...)`) são banidos por `scripts/rbac_lint.py` fora do código de seed. Ver [RBAC_NAMING.md](../../RBAC_NAMING.md).
+- **FreezeTimeMiddleware (gate duplo)**: só ativo com `DEBUG_E2E=true` **e** `INCLUDE_DEV_TOOLS=true`; levanta `RuntimeError` se invocado sem `INCLUDE_DEV_TOOLS`.
+
+## API / Interface
+
+Não há endpoints HTTP — a interface pública são os **management commands** Django:
+
+```bash
+# dev / CI (INCLUDE_DEV_TOOLS=true)
+docker exec aprender_dev-web-1 python manage.py seed_rbac
+docker exec aprender_dev-web-1 python manage.py seed_e2e_users
+docker exec aprender_dev-web-1 python manage.py cleanup_e2e_data
+```
+
+Em CI o E2E roda com `INCLUDE_DEV_TOOLS=true` + `DEBUG_E2E=true` (ver `.github/workflows/frontend-ci.yml`). O `FreezeTimeMiddleware` congela `timezone.now()` quando a request envia o header `X-E2E-Frozen-Time` (consumido pela fixture `v2/frontend/e2e/fixtures/time.ts`).
+
+## Fluxos principais
+
+1. **Bootstrap de dev** (caminho feliz): `make up` → aplica migrações → roda a sequência canônica de seeds (`seed_rbac` antes de tudo, depois masters como `seed_gerencias`/`seed_produtos`/`seed_tipos_evento`, vínculos `seed_gerentes`/`link_projetos_gerencias`, e fixos como `fix_projetos_gerencia`). Idempotente: re-rodar não duplica.
+2. **E2E (Playwright)**: `seed_rbac` → `seed_e2e_users` (ou `seed_frontend_contract_data` para a matriz de contrato) → suíte roda → `cleanup_e2e_data` remove o que `seed_e2e_users` criou.
+3. **Backfill pontual**: `migrate_rbac_groups` / `backfill_is_online` / `populate_municipio_coords` rodam uma vez para corrigir/preencher dados existentes.
+4. **Erro esperado em prod**: com `INCLUDE_DEV_TOOLS=false`, `manage.py seed_rbac` falha com "Unknown command" — o app não está em `INSTALLED_APPS`. Esse é o comportamento desejado (CP-08).
+
+## Decisões relacionadas (ADRs)
+
+- CP-08 (Cláusula Pétrea) — `INCLUDE_DEV_TOOLS=false` em produção. Texto canônico em `docs/business-rules/clausulas-petreas.md`.
+- Histórico de design do app: `v2/docs/_archive/plans/PLAN_dev_tools_app.md` (arquivado).
+
+## Testes que cobrem
+
+- [`tests/test_optional_dev_tools.py`](../../../backend/apps/dev_tools/tests/test_optional_dev_tools.py) — prova o gate: default `True`, app em `INSTALLED_APPS` quando ligado, comandos disponíveis/indisponíveis conforme `INCLUDE_DEV_TOOLS` (CP-08).
+- [`tests/test_seed_e2e_users.py`](../../../backend/apps/dev_tools/tests/test_seed_e2e_users.py) — idempotência e dados criados pelo seed E2E.
+- [`tests/test_seed_gerentes.py`](../../../backend/apps/dev_tools/tests/test_seed_gerentes.py) — vínculo Gerente + `EquipeGerencia`.
+- [`tests/test_seed_frontend_contract_data.py`](../../../backend/apps/dev_tools/tests/test_seed_frontend_contract_data.py) — matriz de contrato funcional.
+- [`tests/test_projetos_fluxo_seed.py`](../../../backend/apps/dev_tools/tests/test_projetos_fluxo_seed.py) — `seed_projetos_fluxo_from_csv`/`_from_sheets`.
+- [`tests/test_freeze_time_middleware.py`](../../../backend/apps/dev_tools/tests/test_freeze_time_middleware.py) — gate duplo `DEBUG_E2E`+`INCLUDE_DEV_TOOLS` e `RuntimeError` sem o flag.
+
+## Pontos de atenção / dívidas conhecidas
+
+- **Default `true` sem guard de ambiente**: maior risco do módulo. CP-08 depende de uma variável de ambiente correta no `stack.env` de produção; falta um failsafe que bloqueie `INCLUDE_DEV_TOOLS=true` quando `ENVIRONMENT=production`. Auditar via [deploy.spec.md](../infra/deploy.spec.md).
+- **Gate fora do app**: o gate vive em `config/settings.py`, não em `apps/dev_tools/apps.py` — quem audita o app precisa olhar settings. (Esta spec corrige a expectativa de que o gate estaria em `apps.py`.)
+- **Comandos não-seed na mesma pasta**: `backfill_*`, `fix_*`, `migrate_rbac_groups` e `populate_municipio_coords` são one-shot/legados; alguns dependem de planilhas/CSV externos (ex.: `backfill_is_online` lê coluna G da planilha original) e podem estar obsoletos após os data-fixes manuais do golden dataset. Confirmar relevância antes de rodar.
+- **`seed_rbac` é pré-requisito**: várias suítes e seeds assumem grupos/permissões já criados; rodar seeds dependentes antes de `seed_rbac` falha. A sequência canônica está documentada na memória de seed order do projeto.

--- a/v2/docs/specs/backend/gcal.spec.md
+++ b/v2/docs/specs/backend/gcal.spec.md
@@ -1,0 +1,129 @@
+---
+title: Integração Google Calendar + Meet
+status: canonical
+last_verified: 2026-06-19
+sources_of_truth:
+  - v2/backend/apps/core/services/gcal_client_factory.py
+  - v2/backend/apps/core/services/gcal_google_client.py
+  - v2/backend/apps/core/services/gcal_oauth_client.py
+  - v2/backend/apps/core/services/gcal_fake_client.py
+  - v2/backend/apps/core/services/gcal_sync_service.py
+  - v2/backend/apps/core/services/gcal/sync.py
+  - v2/backend/apps/core/services/gcal/payload.py
+  - v2/backend/apps/core/services/gcal/client.py
+  - v2/backend/apps/core/services/oauth/oauth_flow.py
+  - v2/backend/apps/core/services/oauth/token_manager.py
+  - v2/backend/apps/core/services/google_oauth.py
+  - v2/backend/apps/core/services/solicitacao_publish.py
+  - v2/backend/apps/core/tasks.py
+  - v2/backend/apps/core/views_solicitacao.py
+  - v2/backend/apps/core/views_oauth.py
+  - v2/backend/apps/core/urls.py
+  - v2/backend/apps/core/models/integracao.py
+  - v2/backend/apps/core/models/auditoria.py
+  - v2/backend/apps/core/rbac/policies.py
+  - v2/backend/apps/core/management/commands/preagenda_to_gcal.py
+  - v2/backend/apps/core/management/commands/rotate_gcal_encryption_key.py
+owner: backend
+supersedes:
+  - v2/docs/GUIDE_GCAL.md
+related:
+  - v2/docs/specs/backend/rbac.spec.md
+  - v2/docs/RBAC_NAMING.md
+  - v2/docs/rbac_authorization_matrix.md
+---
+
+# Integração Google Calendar + Meet
+
+## Propósito
+
+Publica eventos de formações aprovadas no Google Calendar e gera links Google Meet para eventos online (RF05/RF06). A integração é acionada a partir da Pré-agenda: quando uma `Solicitacao` está `aprovado`, um operador de Controle/Superintendência publica, re-sincroniza ou cancela o evento correspondente no Calendar. O `meet_link` resultante é persistido e exposto na API/UI.
+
+O módulo isola o acesso à Google Calendar API atrás de um adaptador único (`CalendarClientAdapter`), com três implementações intercambiáveis selecionadas por configuração: `fake` (in-memory, default seguro), `google` via Service Account e `google` via OAuth 2.0 por usuário. Toda escrita real no Calendar passa por idempotência (event id derivado da solicitação), retry com backoff e auditoria.
+
+## Fonte de verdade no código
+
+- Guia operacional detalhado (setup Google Cloud, troubleshooting): [`v2/docs/GUIDE_GCAL.md`](../../GUIDE_GCAL.md). Esta spec é o índice/contrato; o guia mantém os passos de configuração.
+- Seleção de cliente: [`gcal_client_factory.py`](../../../backend/apps/core/services/gcal_client_factory.py) — `get_gcal_client_and_calendar_id()` (service account / fake) e `get_oauth_client_for_user(user)` (OAuth).
+- Clientes (implementam o adaptador [`gcal/client.py`](../../../backend/apps/core/services/gcal/client.py)):
+  - [`gcal_google_client.py`](../../../backend/apps/core/services/gcal_google_client.py) — Service Account.
+  - [`gcal_oauth_client.py`](../../../backend/apps/core/services/gcal_oauth_client.py) — OAuth por usuário.
+  - [`gcal_fake_client.py`](../../../backend/apps/core/services/gcal_fake_client.py) — fake in-memory.
+- Sincronização (pacote modular): [`gcal/sync.py`](../../../backend/apps/core/services/gcal/sync.py) (`apply_one_solicitacao`, `upsert_one`, `resync_solicitacao`, `cancel_solicitacao`) e [`gcal/payload.py`](../../../backend/apps/core/services/gcal/payload.py) (`build_event_payload`, `build_preview_for_solicitacao`). O módulo legado [`gcal_sync_service.py`](../../../backend/apps/core/services/gcal_sync_service.py) é apenas um *re-export facade* para o pacote `gcal/`.
+- Camada de serviço dos endpoints: [`solicitacao_publish.py`](../../../backend/apps/core/services/solicitacao_publish.py) (`publish_to_gcal`, `preview_gcal`, `resync_to_gcal`, `cancel_from_gcal`, `_check_google_oauth`).
+- Tasks Celery: [`tasks.py`](../../../backend/apps/core/tasks.py) — `task_publish_solicitacao_to_gcal`, `task_cancel_solicitacao_from_gcal`, `preview_then_apply_gcal` (beat).
+- OAuth 2.0 (fluxo + tokens): [`oauth/oauth_flow.py`](../../../backend/apps/core/services/oauth/oauth_flow.py) e [`oauth/token_manager.py`](../../../backend/apps/core/services/oauth/token_manager.py), re-exportados por [`google_oauth.py`](../../../backend/apps/core/services/google_oauth.py). Modelo: [`models/integracao.py`](../../../backend/apps/core/models/integracao.py) (`GoogleOAuthCredential`).
+- Endpoints: [`views_solicitacao.py`](../../../backend/apps/core/views_solicitacao.py) (ações GCal) e [`views_oauth.py`](../../../backend/apps/core/views_oauth.py) (fluxo OAuth) — roteados em [`urls.py`](../../../backend/apps/core/urls.py).
+
+## Contratos e invariantes
+
+- **Modo de cliente vs modo de auth são variáveis distintas**: `GCAL_CLIENT` ∈ `{fake, google}` decide cliente real vs in-memory; `GCAL_AUTH_MODE` ∈ `{service_account, oauth}` decide a autenticação no modo real. **Não existe `GCAL_CLIENT_MODE`.** Default: `GCAL_CLIENT=fake`, `GCAL_AUTH_MODE=service_account`.
+- **Governança de escrita real**: publicação real só ocorre com `GCAL_CLIENT=google`. Com `GCAL_CLIENT != "google"`, `apply_blocked=false` e `dry_run=false`, o serviço retorna **409 Conflict** (`code=gcal_client_not_configured`) e não persiste nada. `apply_blocked=true` força via cliente fake (somente testes).
+- **Pré-condição de publicação**: apenas `Solicitacao.status == "aprovado"` pode publicar/re-sincronizar (`code=not_approved` caso contrário).
+- **OAuth obrigatório por usuário**: em `GCAL_AUTH_MODE=oauth`, o operador precisa de `GoogleOAuthCredential`. Sem credencial, publish/resync/cancel retornam **403 Forbidden** (`code=google_not_connected`); com credencial, a task recebe `operator_user_id` e a resposta é **202 Accepted**.
+- **Domínio restrito (OAuth)**: o callback só aceita contas `@{GCAL_ALLOWED_DOMAIN}` (default `aprendereditora.com.br`); outras levantam erro na troca de código.
+- **Idempotência**: o event id é derivado da solicitação; `insert`/`update`/`delete` são idempotentes. `delete`/`cancel` tratam **404 como sucesso** (evento já removido). `cancel_solicitacao` exige evento publicado, senão `ValueError` (→ **409** no endpoint).
+- **Modalidade (`is_online`)**: `conferenceData`/`requestId` (`conferenceSolutionKey=hangoutsMeet`) só é incluído quando `is_online=true`; `conferenceDataVersion=1` é obrigatório no `insert`/`patch` para o Meet ser criado. Eventos presenciais nunca geram nem persistem `meet_link`.
+- **Persistência de `meet_link` apenas em APPLY real**: preview, `dry_run=true` e o caminho bloqueado (409) **não** persistem `meet_link`/`external_event_id`/`gcal_payload_hash`.
+- **`GCAL_SEND_UPDATES`** ∈ `{none, all, externalOnly}` (default `none`) é validado *fail-fast* no boot (`sys.exit(1)` em valor inválido) e repassado como `sendUpdates` em insert/update/delete.
+- **Tokens OAuth criptografados em repouso** (Fernet, AES-128-CBC + HMAC-SHA256) via `GCAL_ENCRYPTION_KEY`. Em produção a chave é **obrigatória** (ausência → `ValueError`); em dev/staging há fallback derivado de `SECRET_KEY` com warning. Refresh é thread-safe (`select_for_update` + double-check). `invalid_grant` no refresh remove a credencial e exige reconexão.
+- **RBAC**: todas as ações GCal usam `permission_classes=[CanUseGcal]` (Policy `use_gcal` = `operate_preagenda | approve_solicitation`, ou seja Controle + Superintendência). Nenhum acesso a grupo direto (banido por `scripts/rbac_lint.py`). Endpoints OAuth também exigem autenticação + RBAC e têm rate limit (`UserRateThrottle`, ~10/h no start).
+- **Auditoria obrigatória (PA-05)**: cada operação grava `AuditLog` — ações `PREVIEW_GCAL`, `PUBLISH_GCAL_REQUESTED`/`PUBLISH_GCAL`/`PUBLISH_GCAL_ERROR`, `RESYNC_GCAL_REQUESTED`, `CANCEL_GCAL_REQUESTED`/`CANCEL_GCAL`, `GCAL_ENCRYPTION_KEY_ROTATION`, `GOOGLE_CONNECT`/`GOOGLE_DISCONNECT`/`GOOGLE_REFRESH_TOKEN`.
+
+## API / Interface
+
+Ações sobre `Solicitacao` (DRF `@action`, todas `CanUseGcal`):
+
+- `POST /api/solicitacoes/{id}/preview-gcal/` → payload simulado, sem persistir (200).
+- `POST /api/solicitacoes/{id}/publish/` — corpo `{dry_run?, apply_blocked?}` → enfileira `task_publish_solicitacao_to_gcal` (202 `task_id`); 409 se bloqueado; 403 se OAuth sem conexão.
+- `POST /api/solicitacoes/{id}/resync-gcal/` → força UPDATE (reseta `gcal_payload_hash`), enfileira publish (202).
+- `POST /api/solicitacoes/{id}/cancel-gcal/` → enfileira `task_cancel_solicitacao_from_gcal`; deleta evento e limpa campos (202); 409 se não publicado.
+- `meet_link` é exposto nos serializers de detalhe e lista de `Solicitacao`.
+
+Fluxo OAuth (em [`urls.py`](../../../backend/apps/core/urls.py), sob prefixo `/api/`):
+
+- `GET /api/oauth/google/start/?return_to=…` → redireciona para o consent do Google (state CSRF em cache, TTL 10min).
+- `GET /api/oauth/google/callback/` → troca código por tokens, cria `GoogleOAuthCredential`.
+- `GET /api/integrations/google/status/`, `POST .../disconnect/`, `GET .../calendars/`, `POST .../select-calendar/`, `GET .../events/`.
+
+Comandos de gestão:
+
+- `python manage.py preagenda_to_gcal [--dry-run] [--client=fake|google] [--ids …] [--since/--until …]` — sync em lote da Pré-agenda (substitui a referência stale a `sync_calendar` no guia).
+- `python manage.py rotate_gcal_encryption_key --old-key … --new-key …` — rotação zero-downtime da chave Fernet.
+
+Beat automático: `preview_then_apply_gcal` (CELERY_BEAT_SCHEDULE, quando habilitado).
+
+## Fluxos principais
+
+1. **Publicação (service account)**: solicitação aprovada → `POST /publish/` → `publish_to_gcal` valida status/governança → marca `gcal_status=PENDING` → `task_publish_solicitacao_to_gcal.delay()` → `apply_one_solicitacao` monta payload (com `conferenceData` se `is_online`), faz upsert via factory (`fake`/`google`), persiste `external_event_id`/`meet_link`/hash e marca `PUBLISHED`. Erro → `ERROR` + `PUBLISH_GCAL_ERROR`.
+2. **Publicação (OAuth)**: idêntico, mas `_check_google_oauth` injeta `operator_user_id`; a task instancia `OAuthCalendarClient` via `get_oauth_client_for_user` (refresh de token se expirado) e usa o calendário preferido do usuário. Sem credencial → 403 antes de enfileirar.
+3. **Resync**: `resync-gcal` zera `gcal_payload_hash` para forçar UPDATE e reutiliza o caminho de publish.
+4. **Cancel**: `cancel-gcal` valida publicação → `task_cancel_solicitacao_from_gcal` → `client.delete` (404 = sucesso) → limpa `external_event_id`/`meet_link`/`gcal_payload_hash`, marca `gcal_status=NONE`, `last_sync_action=DELETE`.
+5. **Preview**: `preview-gcal` sempre permitido; retorna payload e (se online) `meet_link` simulado, sem persistir.
+6. **Conexão OAuth**: `start` → consent Google → `callback` valida state/domínio, troca código, criptografa e salva tokens; `disconnect` revoga no Google e remove a credencial.
+
+## Decisões relacionadas (ADRs)
+
+- SEC-011 — criptografia de tokens OAuth (Fernet + `GCAL_ENCRYPTION_KEY`, rotação zero-downtime). Detalhes na seção 8 de [`GUIDE_GCAL.md`](../../GUIDE_GCAL.md).
+- Epic #459 (§1/§7) — extração da camada de serviço de publicação e modularização OAuth (`oauth/oauth_flow.py`, `oauth/token_manager.py`).
+- Issue #1233 (Epic 4.2.a) — operações GCal encapsuladas na Policy `use_gcal` (`CanUseGcal`); ver [`rbac.spec`](rbac.spec.md).
+
+## Testes que cobrem
+
+- [`test_gcal_publish_apply_blocked.py`](../../../backend/apps/core/tests/test_gcal_publish_apply_blocked.py) — matriz governança (409 vs publish; preview sempre permitido).
+- [`test_gcal_meet_link_persist.py`](../../../backend/apps/core/tests/test_gcal_meet_link_persist.py) / [`test_gcal_meet_link_by_mode.py`](../../../backend/apps/core/tests/test_gcal_meet_link_by_mode.py) — persistência de `meet_link` só em apply real e por modo.
+- [`test_gcal_conference_version.py`](../../../backend/apps/core/tests/test_gcal_conference_version.py) — `conferenceDataVersion=1` + `conferenceData` condicionado a `is_online`.
+- [`test_gcal_send_updates.py`](../../../backend/apps/core/tests/test_gcal_send_updates.py) — `sendUpdates` em insert/update/delete.
+- [`test_gcal_retry_backoff.py`](../../../backend/apps/core/tests/test_gcal_retry_backoff.py) / [`test_gcal_retry_audit.py`](../../../backend/apps/core/tests/test_gcal_retry_audit.py) — retry 429/5xx e auditoria.
+- [`test_gcal_cancel_resync.py`](../../../backend/apps/core/tests/test_gcal_cancel_resync.py) / [`test_gcal_publish_resync.py`](../../../backend/apps/core/tests/test_gcal_publish_resync.py) — resync/cancel (helpers, tasks, endpoints; 404 idempotente; 403/409).
+- [`test_gcal_oauth_mode.py`](../../../backend/apps/core/tests/test_gcal_oauth_mode.py) — roteamento OAuth (403 sem credencial, 202 com).
+- [`test_google_oauth.py`](../../../backend/apps/core/tests/test_google_oauth.py), [`test_pr_security_oauth_hardening.py`](../../../backend/apps/core/tests/test_pr_security_oauth_hardening.py), [`test_pr_security_oauth_authorize_url.py`](../../../backend/apps/core/tests/test_pr_security_oauth_authorize_url.py) — encrypt/decrypt/rotation, open-redirect, rate limit, HTTPS, validação de domínio/state.
+- [`test_gcal_google_client.py`](../../../backend/apps/core/tests/test_gcal_google_client.py), [`test_gcal_sync_dryrun.py`](../../../backend/apps/core/tests/test_gcal_sync_dryrun.py), [`test_gcal_hash_drift.py`](../../../backend/apps/core/tests/test_gcal_hash_drift.py), [`test_gcal_endpoints.py`](../../../backend/apps/core/tests/test_gcal_endpoints.py).
+
+## Pontos de atenção / dívidas conhecidas
+
+- **Doc canônico com referência stale**: a seção 5 de [`GUIDE_GCAL.md`](../../GUIDE_GCAL.md) cita `manage.py sync_calendar`, mas o comando real é `preagenda_to_gcal`. Atualizar o guia.
+- **Nome de módulo na seção OAuth do guia**: a seção 1 sugere que `gcal_oauth_client` lê tokens via `oauth/token_manager`; no código o cliente importa de [`google_oauth.py`](../../../backend/apps/core/services/google_oauth.py) (que re-exporta `oauth/token_manager`). Mesmo destino, caminho indireto.
+- **Mismatch `GCAL_CLIENT` configurado vs valor**: `apply_one_solicitacao` libera escrita quando `settings.GCAL_CLIENT is not None` (qualquer valor), mas a factory só instancia cliente real com `=="google"`. Com `GCAL_CLIENT=fake` a guarda passa e cai no fake client — comportamento intencional para testes, porém a governança 409 fica concentrada em `publish_to_gcal`/`apply_blocked`, não no `apply_one`. Atenção ao chamar `apply_one_solicitacao` fora do fluxo de endpoint.
+- **Fallback de chave em dev/staging**: tokens cifrados com chave derivada de `SECRET_KEY` ficam ilegíveis se `SECRET_KEY` mudar; em produção `GCAL_ENCRYPTION_KEY` é mandatória. Rotação exige restart dos containers (web, worker, beat).
+- **TOCTOU brando no cancel**: validação de "publicado" no endpoint e o `delete` na task são separados; concorrência é mitigada por idempotência (404 = sucesso), não por lock.

--- a/v2/docs/specs/backend/imports.spec.md
+++ b/v2/docs/specs/backend/imports.spec.md
@@ -1,0 +1,130 @@
+---
+title: Importação de Dados (export-contract)
+status: canonical
+last_verified: 2026-06-19
+sources_of_truth:
+  - v2/backend/apps/core/imports/__init__.py
+  - v2/backend/apps/core/imports/hashing.py
+  - v2/backend/apps/core/imports/normalization.py
+  - v2/backend/apps/core/services/usuarios_import.py
+  - v2/backend/apps/core/services/municipios_import.py
+  - v2/backend/apps/core/services/controle_imports.py
+  - v2/backend/apps/core/services/export_contract_importer.py
+  - v2/backend/apps/core/services/export_contract_projeto_resolver.py
+  - v2/backend/apps/core/management/commands/import_export_contract.py
+  - v2/backend/apps/core/views_import_usuarios.py
+  - v2/backend/apps/core/views_controle_imports.py
+  - v2/backend/apps/core/views/imports.py
+  - v2/backend/apps/core/models/import_job.py
+  - v2/backend/apps/core/rbac/policies.py
+  - v2/backend/apps/core/urls.py
+owner: backend
+supersedes:
+  - v2/docs/imports/README.md
+  - v2/docs/imports/usuarios.md
+  - v2/docs/imports/disponibilidade.md
+  - v2/docs/imports/produtos_controle.md
+  - v2/docs/imports/agenda_solicitacoes.md
+  - v2/docs/imports/ordem_de_importacao.md
+  - v2/docs/imports/dry_run_response_contract.md
+related:
+  - v2/docs/adr/ADR-012-sha1-idempotency-hashes.md
+  - v2/docs/specs/backend/rbac.spec.md
+  - v2/docs/API_REFERENCE.md
+---
+
+# Importação de Dados (export-contract)
+
+## Propósito
+
+Este módulo importa dados da planilha consolidada externa (`sheets.banco`, materializada como `export-contract`) para o PostgreSQL de `apps.core`, substituindo a digitação manual e as fórmulas Excel pela origem operacional do sistema. Cobre dois caminhos complementares: (1) os **services de import por entidade** (`*_import.py`) expostos como endpoints DRF síncronos e — para `bloqueios` — assíncronos via `ImportJob`/Celery; e (2) o **importer dedicado do export-contract** (`import_export_contract`), um pipeline dry-run-first que classifica linhas de um diretório de export contra o estado atual do banco.
+
+A regra de ouro é a segurança contra reimportação cega: todo import valida em **dry-run** antes de qualquer escrita, é **idempotente** por `external_hash`, e **nunca** sobrescreve campos protegidos ou dispara efeitos colaterais perigosos (GCal, aprovação, atribuição de grupos privilegiados). O ETL legado `apps.dat_ingest` foi **removido**; não existem mais management commands `etl_*.py`/`import_*.py` históricos — o import real é `import_export_contract` + os endpoints DRF.
+
+## Fonte de verdade no código
+
+- Pacote canônico de helpers puros: [`apps/core/imports/`](../../../backend/apps/core/imports/) — [`hashing.py`](../../../backend/apps/core/imports/hashing.py) (`stable_import_hash`, `hash_event_v2`) e [`normalization.py`](../../../backend/apps/core/imports/normalization.py) (SSOT de normalização: `normalize_blank`, `normalize_cpf_digits`, `normalize_active_flag`, datas/horas/email/setor). Sem I/O, sem ORM.
+- Services por entidade em `apps/core/services/*_import.py`: [`usuarios_import.py`](../../../backend/apps/core/services/usuarios_import.py), [`municipios_import.py`](../../../backend/apps/core/services/municipios_import.py), [`produtos_import.py`](../../../backend/apps/core/services/produtos_import.py), [`colecoes_import.py`](../../../backend/apps/core/services/colecoes_import.py), [`equipe_gerencia_import.py`](../../../backend/apps/core/services/equipe_gerencia_import.py), [`eventos_import.py`](../../../backend/apps/core/services/eventos_import.py), [`bloqueios_import.py`](../../../backend/apps/core/services/bloqueios_import.py), [`controle_imports.py`](../../../backend/apps/core/services/controle_imports.py) (alimenta `Compra`), [`controle_acoes_import.py`](../../../backend/apps/core/services/controle_acoes_import.py), [`dat_cadastros_import.py`](../../../backend/apps/core/services/dat_cadastros_import.py), [`deslocamentos_import.py`](../../../backend/apps/core/services/deslocamentos_import.py).
+- Importer do export-contract: [`apps/core/services/export_contract_importer.py`](../../../backend/apps/core/services/export_contract_importer.py) (`ExportContractImporter`, `diff_and_classify`, `PROTECTED_FIELDS`, `IMPLEMENTED`) + resolver [`export_contract_projeto_resolver.py`](../../../backend/apps/core/services/export_contract_projeto_resolver.py) + command [`management/commands/import_export_contract.py`](../../../backend/apps/core/management/commands/import_export_contract.py).
+- Views DRF síncronas: [`views_import_usuarios.py`](../../../backend/apps/core/views_import_usuarios.py), [`views_controle_imports.py`](../../../backend/apps/core/views_controle_imports.py), [`views_import_municipios.py`](../../../backend/apps/core/views_import_municipios.py), [`views_import_produtos.py`](../../../backend/apps/core/views_import_produtos.py), [`views_import_colecoes.py`](../../../backend/apps/core/views_import_colecoes.py), [`views_import_equipe_gerencia.py`](../../../backend/apps/core/views_import_equipe_gerencia.py), [`views_import_eventos.py`](../../../backend/apps/core/views_import_eventos.py), [`views_import_bloqueios.py`](../../../backend/apps/core/views_import_bloqueios.py), [`views_import_deslocamentos.py`](../../../backend/apps/core/views_import_deslocamentos.py).
+- Caminho assíncrono (ASQ-005): [`views/imports.py`](../../../backend/apps/core/views/imports.py) + model [`models/import_job.py`](../../../backend/apps/core/models/import_job.py).
+- Roteamento: [`apps/core/urls.py`](../../../backend/apps/core/urls.py).
+- Detalhe de cada contrato de planilha (colunas, normalizações, gates): doc canônico [`v2/docs/imports/README.md`](../../imports/README.md) e arquivos por tipo (`usuarios.md`, `disponibilidade.md`, `produtos_controle.md`, `agenda_solicitacoes.md`).
+
+## Contratos e invariantes
+
+- **Dry-run obrigatório antes de apply**. Endpoints síncronos aceitam `?dry_run=true|false` (default `true`); o importer do export-contract é dry-run salvo `--apply`. Dry-run valida e retorna preview sem persistir (rollback via `transaction.atomic`).
+- **Idempotência via `external_hash` (SHA1, ADR-012)**. `stable_import_hash(*parts)` = `hashlib.sha1("|".join(parts), usedforsecurity=False).hexdigest()`. O algoritmo, encoding (UTF-8) e delimitador (`|`) são **congelados** — alterá-los quebra os hashes históricos gravados em `Compra`, `Solicitacao`, `Deslocamento`, `AcaoControle`, `AcaoDAT`, `Acompanhamento`. `controle_imports.sha1_str` delega a `stable_import_hash`. Reimportar o mesmo arquivo não duplica linhas.
+- **`--apply` sem allowlist é BLOQUEADO** no `import_export_contract`: sem `--allow-entity`, `report["apply_blocked"]` é verdadeiro e nada é escrito. Modo `create-only`: só insere `would_create`, nunca faz update.
+- **Never-overwrite de campos protegidos** (`PROTECTED_FIELDS`): `Solicitacao.status`, `Formacao.data_formacao`, `Acompanhamento.{data_acompanhamento,realizado}`. Linha que diverge num campo protegido vira `protected_diff` e fica para decisão humana — jamais sobrescrita.
+- **Nenhum efeito colateral perigoso** (CP-02/PA-01): import NUNCA publica no Google Calendar, NUNCA aprova solicitação SUPER, NUNCA atribui grupos `Gerente`/`Superintendência`, NUNCA cria `is_superuser=True`. RBAC é admin-driven (D17): import não roda `seed_rbac` nem concede capabilities.
+- **RBAC por capability, não por grupo** (`scripts/rbac_lint.py` bane grupos diretos): gates via `permission_classes=[HasPerm("import_spreadsheet")]` ou `HasPerm("manage_admin_registries")`; o upload assíncrono usa a Policy `CanImportGenericSpreadsheet` (`import_spreadsheet` OU `run_daily_operations` — Controle/DAT).
+- **Timezone** (RD-06): datas de calendário armazenadas em UTC, interpretadas como `America/Fortaleza`. Datas do CSV (`dd/mm/yyyy`) são local Fortaleza antes de virar UTC.
+- **Sem PII no relatório** do export-contract: só counts e nomes de entidade.
+
+## API / Interface
+
+Endpoints síncronos (`{stats, pendencias, dry_run, file}`; todos com `?dry_run`, default `true`). Detalhes em [`API_REFERENCE.md`](../../API_REFERENCE.md):
+
+| Endpoint | Gate |
+|---|---|
+| `POST /api/usuarios/import/` | `HasPerm("manage_admin_registries")` |
+| `POST /api/municipios/import/` | `HasPerm("manage_admin_registries")` |
+| `POST /api/colecoes/import/` | `HasPerm("manage_admin_registries")` |
+| `POST /api/equipe-gerencia/import/` | `HasPerm("manage_admin_registries")` |
+| `POST /api/dat/import-cadastros/` | `HasPerm("manage_admin_registries")` |
+| `POST /api/produtos/import/` | `HasPerm("import_spreadsheet")` |
+| `POST /api/solicitacoes/import/` | `HasPerm("import_spreadsheet")` (com PA-01) |
+| `POST /api/disponibilidade/import-bloqueios/` | `HasPerm("import_spreadsheet")` |
+| `POST /api/controle/import-compras/` | `HasPerm("import_spreadsheet")` |
+| `POST /api/controle/import-acoes/` | `HasPerm("import_spreadsheet")` |
+
+Endpoints assíncronos (ASQ-005 Fase 1 — só `bloqueios`):
+
+- `POST /api/imports/bloqueios/` — cria `ImportJob` (status `QUEUED`) + despacha Celery `task_run_import_job`; retorna `202 Accepted` com o job serializado. Gate: `IsAuthenticated + CanImportGenericSpreadsheet`.
+- `GET /api/imports/<id>/` — estado do job (owner ou superuser).
+- `GET /api/imports/` — lista jobs do usuário (filtros `type=`, `status=`).
+
+Management command:
+
+```bash
+# dry-run (default — só classifica, nada escrito):
+python manage.py import_export_contract --path <dir-com-manifest.json>
+
+# apply create-only de entidades explicitamente permitidas:
+python manage.py import_export_contract --path <dir> --apply --allow-entity municipio
+```
+
+Entidades implementadas no importer (`IMPLEMENTED`): `municipio`, `projeto_geral`, `produto`, `usuario`, `gerencia`, `tipo_evento`, `dat_coordenador`, `dat_area`, `dat_acao`, `plano_formacao`. Demais (`solicitacao`, `formacao`, `acompanhamento`, ...) → `not_implemented` (só count reportado).
+
+## Fluxos principais
+
+**Import síncrono por endpoint (caminho feliz)**: cliente faz `POST .../import/?dry_run=true` (multipart `file`) → view valida upload (`validate_upload`, magic bytes) e grava temp seguro → service `import_<entidade>_from_file(path, dry_run=True)` normaliza linhas (helpers de `apps/core/imports/normalization.py`), reconcilia FKs e calcula `external_hash` → retorna `{stats, pendencias, dry_run, file}` sob `transaction.atomic` revertido. Operador revisa `pendencias`; sem erros bloqueantes, repete com `?dry_run=false` para persistir + grava `AuditLog`.
+
+**Import assíncrono de bloqueios**: `POST /api/imports/bloqueios/` cria `ImportJob` (arquivo em `imports/%Y/%m/%d/`), retorna `202` imediato; Celery transiciona `QUEUED→RUNNING→SUCCESS|FAILED` (`mark_running/success/failed`), preenchendo `stats`/`pendencias`/`duration_ms`. Cliente faz polling em `GET /api/imports/<id>/`. `error_traceback` fica só em log, nunca na API.
+
+**Importer do export-contract**: `ExportContractImporter.run()` lê `manifest.json` + CSVs do diretório, e por entidade chama `diff_and_classify(existing, export, protected)` → tally `{would_create, would_update, would_skip_same, protected_diff, would_reject}`. Sem `--apply` o relatório só classifica; com `--apply` + allowlist, escreve apenas `would_create` (create-only).
+
+**Erros relevantes**: linha sem chave natural (ex.: `nome` vazio) → `would_reject` / `pendencias`; FK não resolvida (município/projeto) → pendência (resolver de Projeto canonicaliza & vs E, hífen, prefixo PROJETO, aliases); upload inválido (mime/magic) → `400`; `--apply` sem allowlist → bloqueado, nada escrito.
+
+## Decisões relacionadas (ADRs)
+
+- [ADR-012 — SHA1 idempotency hashes](../../adr/ADR-012-sha1-idempotency-hashes.md): `external_hash` é SHA1 congelado; migração para SHA256 é proibida.
+- ASQ-005 (async `ImportJob` + Celery, Fase 1 `bloqueios`; #778/#1162) e ASQ-016 (savepoint-per-row) — referenciados no código dos services e do model.
+- D17 (RBAC admin-driven): import não atribui capabilities — ver [`rbac.spec.md`](./rbac.spec.md).
+
+## Testes que cobrem
+
+- [`tests/test_imports_hashing.py`](../../../backend/apps/core/tests/test_imports_hashing.py) e [`tests/test_imports_normalization.py`](../../../backend/apps/core/tests/test_imports_normalization.py) — congelam `stable_import_hash`/normalizadores.
+- [`tests/test_export_contract_importer.py`](../../../backend/apps/core/tests/test_export_contract_importer.py) e [`tests/test_export_contract_projeto_resolver.py`](../../../backend/apps/core/tests/test_export_contract_projeto_resolver.py) — classificação dry-run + apply-blocked + resolver de Projeto.
+- [`tests/test_import_usuarios.py`](../../../backend/apps/core/tests/test_import_usuarios.py), [`tests/test_import_compras.py`](../../../backend/apps/core/tests/test_import_compras.py), [`tests/test_import_deslocamentos.py`](../../../backend/apps/core/tests/test_import_deslocamentos.py), [`tests/test_import_produtos.py`](../../../backend/apps/core/tests/test_import_produtos.py), [`tests/test_import_colecoes.py`](../../../backend/apps/core/tests/test_import_colecoes.py), [`tests/test_import_equipe_gerencia.py`](../../../backend/apps/core/tests/test_import_equipe_gerencia.py), [`tests/test_import_bloqueios.py`](../../../backend/apps/core/tests/test_import_bloqueios.py), [`tests/test_import_eventos.py`](../../../backend/apps/core/tests/test_import_eventos.py), [`tests/test_municipios_import_service.py`](../../../backend/apps/core/tests/test_municipios_import_service.py) — services por entidade (idempotência + dry-run).
+- [`tests/test_import_endpoints.py`](../../../backend/apps/core/tests/test_import_endpoints.py) e [`tests/test_dat_imports_dat_only.py`](../../../backend/apps/core/tests/test_dat_imports_dat_only.py) — gates RBAC dos endpoints.
+- [`tests/test_import_job_model.py`](../../../backend/apps/core/tests/test_import_job_model.py), [`tests/test_import_job_task.py`](../../../backend/apps/core/tests/test_import_job_task.py), [`tests/test_import_job_endpoints.py`](../../../backend/apps/core/tests/test_import_job_endpoints.py), [`tests/test_import_job_integration.py`](../../../backend/apps/core/tests/test_import_job_integration.py) — ciclo async.
+
+## Pontos de atenção / dívidas conhecidas
+
+- **ImportJob cobre só `bloqueios`** (Fase 1). Os outros 9 imports (usuários, compras, ações, deslocamentos, eventos, produtos, municípios, coleções, equipe_gerência) seguem síncronos; migração para async é Fase 2 (ASQ-005, ver `import_job.py`).
+- **Importer do export-contract não importou dados reais**: `--apply` permanece bloqueado por allowlist. Regra operacional: NÃO importar de verdade até um dry-run real do `--apply` passar verde + autorização — reimport cego sobrescreveria data-fixes manuais (D2/C3-A/C4.4).
+- **Reconciliação de `Usuario` por nome** em Agenda (Formador 1..5) é fuzzy (CPF não aparece na planilha de agenda) — risco de match errado; ver pendências em [`v2/docs/imports/README.md`](../../imports/README.md) §6.
+- **Shape de retorno dos services não é 100% uniforme** historicamente — contrato-alvo em [`dry_run_response_contract.md`](../../imports/dry_run_response_contract.md).
+- **Documentação histórica menciona `make etl-*` e management commands `etl_*.py`**: não existem mais (`apps.dat_ingest` removido). Os targets de Makefile que sobrevivem chamam os endpoints HTTP via `curl`.

--- a/v2/docs/specs/backend/notificacoes.spec.md
+++ b/v2/docs/specs/backend/notificacoes.spec.md
@@ -1,0 +1,110 @@
+---
+title: Notificações (32 Passos)
+status: canonical
+last_verified: 2026-06-19
+sources_of_truth:
+  - v2/backend/apps/core/models/acoes_notificacao.py
+  - v2/backend/apps/core/services/prazo_engine_service.py
+  - v2/backend/apps/core/services/notificacoes_acoes_service.py
+  - v2/backend/apps/core/services/business_calendar_service.py
+  - v2/backend/apps/core/services/acoes_notificacao_seed.py
+  - v2/backend/apps/core/management/commands/seed_acoes_notificacao.py
+  - v2/backend/apps/core/views/acoes_notificacao.py
+  - v2/backend/apps/core/serializers/acoes_notificacao.py
+  - v2/backend/apps/core/urls.py
+  - v2/backend/apps/core/tasks.py
+  - v2/backend/config/celery.py
+  - v2/backend/apps/core/rbac/matrix.py
+  - v2/backend/apps/core/migrations/0060_seed_acoes_notificacao_templates.py
+  - v2/backend/apps/core/migrations/0079_add_manage_internal_actions.py
+owner: backend
+supersedes:
+  - v2/docs/_archive/PLANO_NOTIFICACOES_TIMING.md
+related:
+  - ../INDEX_SDD.md
+  - ./README.md
+  - ./rbac.spec.md
+  - ../../RBAC_NAMING.md
+---
+
+# Notificações (32 Passos)
+
+## Propósito
+
+O módulo de "Ações Internas / Notificações" (codinome **32 Passos**) modela o ciclo operacional de 32 ações que cada par **Projeto × Município** percorre em um semestre — da entrega de materiais ao último feedback da equipe técnica. Para cada ação há uma regra de prazo em **dias úteis** ancorada num evento (entrega, formação, marco de calendário, ou conclusão da ação anterior). Um processador diário avalia os prazos e gera **notificações in-app** em cascata hierárquica (responsável → coordenador → gerente → DAT), com lembretes pré-vencimento e escalonamento pós-vencimento.
+
+O objetivo é substituir o acompanhamento manual de prazos por uma régua determinística de cobrança: cada ação tem âncora, vencimento calculado sobre o calendário útil de Fortaleza/CE/Brasil, e estado operacional (`AGUARDANDO_ANCORA` → `EM_ANDAMENTO`/`ATRASADA` → `CONCLUIDA`). A feature está **em desenvolvimento** (CRUD de ciclos/ações é superuser-only por enquanto); a inbox de notificações já é exposta a qualquer usuário autenticado.
+
+> ⚠️ NÃO confundir com o plano arquivado [`PLANO_NOTIFICACOES_TIMING.md`](../../_archive/PLANO_NOTIFICACOES_TIMING.md), que propunha os models `EtapaProjeto`/`CicloFormacao`/`Notification` — **nunca implementados**. O sistema vivo usa `AcaoTemplate`/`CicloAcoes`/`AcaoInstancia`/`NotificacaoInterna`.
+
+## Fonte de verdade no código
+
+- **Models** — [`apps/core/models/acoes_notificacao.py`](../../../backend/apps/core/models/acoes_notificacao.py): `AcaoTemplate`, `AcaoTemplateExecutor`, `CicloAcoes`, `AcaoInstancia`, `RegistroAncora`, `RegistroConclusaoAcao`, `FeriadoLocal`, `NotificacaoInterna` + enums (`TipoAncoraChoices`, `SemestreChoices`, `EstadoAcaoChoices`, `TipoNotificacaoChoices`, `NivelNotificacaoChoices`, `PrioridadeNotificacaoChoices`).
+- **Engine de prazo** — [`services/prazo_engine_service.py`](../../../backend/apps/core/services/prazo_engine_service.py) (`PrazoEngineService`): resolve âncora, calcula vencimento e estado, e propaga recálculo a dependentes.
+- **Calendário útil** — [`services/business_calendar_service.py`](../../../backend/apps/core/services/business_calendar_service.py) (`BusinessCalendarService`): feriados nacionais/CE/Fortaleza (móveis via Páscoa) + `FeriadoLocal` do DB; `add_business_days`, `business_days_between`.
+- **Processador / escalonamento** — [`services/notificacoes_acoes_service.py`](../../../backend/apps/core/services/notificacoes_acoes_service.py): `EscalonamentoService` (régua D-7…D+3), `NotificationService` (resolução de destinatários + dedup), `AcoesNotificacaoDailyService.run()`.
+- **Seed dos 32 templates** — [`services/acoes_notificacao_seed.py`](../../../backend/apps/core/services/acoes_notificacao_seed.py) + comando [`management/commands/seed_acoes_notificacao.py`](../../../backend/apps/core/management/commands/seed_acoes_notificacao.py) + migration de dados [`0060_seed_acoes_notificacao_templates.py`](../../../backend/apps/core/migrations/0060_seed_acoes_notificacao_templates.py).
+- **API** — [`views/acoes_notificacao.py`](../../../backend/apps/core/views/acoes_notificacao.py) + [`serializers/acoes_notificacao.py`](../../../backend/apps/core/serializers/acoes_notificacao.py) + rotas em [`urls.py`](../../../backend/apps/core/urls.py).
+- **Agendamento** — task [`apps/core/tasks.py::processar_notificacoes_acoes_diarias`](../../../backend/apps/core/tasks.py) + Celery beat em [`config/celery.py`](../../../backend/config/celery.py).
+- **RBAC** — capability `manage_internal_actions` (key de matriz `ciclos_acoes`) em [`rbac/matrix.py`](../../../backend/apps/core/rbac/matrix.py) + migration [`0079_add_manage_internal_actions.py`](../../../backend/apps/core/migrations/0079_add_manage_internal_actions.py).
+
+## Contratos e invariantes
+
+- **32 ações exatas**: o seed valida `ordens == 1..32` sem gaps; cada ação tem ≥1 grupo executor. Templates são idempotentes (`update_or_create` por `ordem`).
+- **Âncoras (`TipoAncoraChoices`)**: `EVENTO_EXTERNO` exige `ref_evento_externo` não-vazio (data manual via `data_ancora`); `ACAO_ANTERIOR` exige `ref_acao_template` (âncora = `data_realizacao` da ação referenciada no mesmo ciclo); `MARCO_CALENDARIO` ancora no início do semestre (`1S` → 01/03, `2S` → 01/08). CheckConstraints no DB reforçam `ancora_acao_requer_ref` e `ancora_evento_requer_ref`.
+- **Prazo em dias úteis**: vencimento = `add_business_days(âncora, dias_prazo_uteis)`. `dias_prazo_uteis > 0` (CheckConstraint). Calendário útil = fins de semana + feriados nacionais/CE/Fortaleza + `FeriadoLocal` ativos. Timezone do projeto: **America/Fortaleza**.
+- **Unicidade de ciclo**: um único `CicloAcoes` por `(projeto, municipio, semestre, ano)`; `ano >= 2020`. Ao criar o ciclo, gera-se uma `AcaoInstancia` por template ativo (`unique (ciclo, ordem)` e `unique (ciclo, template)`); `instancia.ordem == template.ordem` (validado em `clean()`).
+- **Conclusão irreversível (MVP)**: `concluir()` exige `observacao` não-vazia e `data_realizacao` (CheckConstraints `concluida_requer_observacao`/`concluida_requer_data_realizacao`); cria `RegistroConclusaoAcao` (OneToOne) — **reabertura não permitida**. Concluir dispara `recalculate_dependents` (recálculo das ações que ancoram nesta, com proteção contra ciclo via `visited`). Não é permitido registrar/alterar âncora de ação já concluída.
+- **Idempotência de notificação**: `NotificacaoInterna` tem `unique (destinatario, acao_instancia, fase_disparo, referencia_data)`; o `get_or_create` + tratamento de `IntegrityError` garantem que rodar o processador N vezes no mesmo dia não duplica (contabilizado como `deduplicated`). O processador ignora ações `CONCLUIDA` e ciclos não `EM_ANDAMENTO`.
+- **Acesso (CP-02/RBAC)**: ciclos e ações exigem `permission_classes = [HasPerm("manage_internal_actions")]`. No seed essa capability **não recebe grupos** → na prática **somente superuser** passa (matriz `ciclos_acoes`: SUPERUSER=ALLOW, todos os demais DENY). A inbox (`NotificacaoInterna`) é `IsAuthenticated` e escopada ao `destinatario == request.user` (cada um só vê o próprio inbox).
+
+## API / Interface
+
+Rotas DRF (router em [`urls.py`](../../../backend/apps/core/urls.py); prefixo `/api/`):
+
+- `ciclos-acoes/` — `CicloAcoesViewSet` (CRUD; cria as 32 instâncias no `create`). Action extra `GET ciclos-acoes/{id}/acoes/`. Filtros: `projeto, municipio, semestre, ano, status`.
+- `acoes-instancia/` — `AcaoInstanciaViewSet` (read-only) + comandos `POST acoes-instancia/{id}/registrar-ancora/` (`data_ancora`, `observacao?`; usa `select_for_update`) e `POST acoes-instancia/{id}/concluir/` (`data_realizacao`, `observacao` obrigatória).
+- `notificacoes-internas/` — `NotificacaoInternaViewSet` (read-only, inbox do usuário) + `POST {id}/marcar-lida/`, `GET unread-count/`, `POST marcar-todas-lidas/`. Filtros: `lida, tipo, nivel, fase_disparo, referencia_data`.
+
+Operações administrativas:
+
+- `python manage.py seed_acoes_notificacao [--verbose]` — semeia/atualiza os 32 templates + executores (idempotente).
+- Task Celery `apps.core.tasks.processar_notificacoes_acoes_diarias(reference_date_iso?)` — beat diário às **08:00** (`config/celery.py`, key `acoes-notificacoes-diarias`). Retorna métricas (`actions_evaluated/triggered`, `notifications_created/deduplicated`, `fallback_actions`, `phases`) e grava `AuditLog` (`ACOES_NOTIFICACOES_DAILY`).
+
+Toda mutação relevante grava `AuditLog`: `CICLO_ACOES_CREATE`, `ACAO_REGISTRAR_ANCORA`, `ACAO_CONCLUIR`.
+
+## Fluxos principais
+
+1. **Provisionamento**: `seed_acoes_notificacao` cria os 32 `AcaoTemplate` + grupos executores (ação 1 → Logística Galpão; ação 2 → Comercial/Relacionamento/DAT; ações 3–32 → Coordenador/Gerente).
+2. **Abertura de ciclo**: `POST ciclos-acoes/` → cria `CicloAcoes` + 32 `AcaoInstancia` (`AGUARDANDO_ANCORA`).
+3. **Registro de âncora**: `POST .../registrar-ancora/` → `PrazoEngineService.recalculate_action` resolve âncora, calcula `data_vencimento` em dias úteis e move o estado para `EM_ANDAMENTO`/`ATRASADA`. Grava `RegistroAncora` (histórico).
+4. **Processamento diário** (`AcoesNotificacaoDailyService.run`): para cada ação de ciclo `EM_ANDAMENTO` com vencimento e não concluída → recalcula estado → `EscalonamentoService.resolve_rule` mapeia a distância em dias úteis até o vencimento para uma fase (**D-7** lembrete/responsável, **D-3**/**D-1** alta, **D0** vencimento/crítica, **D+1** escala p/ coordenador, **D+3** escala p/ gerente) → `NotificationService.dispatch_for_action` resolve destinatários (executores ∩ papel do nível) e cria notificações dedup.
+5. **Conclusão**: `POST .../concluir/` → estado `CONCLUIDA`, `RegistroConclusaoAcao` único, e recálculo das ações dependentes (que ancoram nesta).
+6. **Erros relevantes**: âncora/conclusão em ação já concluída → 400 (ValidationError); conclusão sem observação → 400; recriação de conclusão → erro; sem destinatários elegíveis → notificação não criada, registrada em `fallback_actions`.
+
+**Fallback determinístico de destinatário** (`_resolve_recipients`): se não houver executor+papel, tenta gerente do mesmo executor (para D+1) → gerentes globais → DAT como último recurso. Nota RBAC: os filtros `groups__name__in` aqui são **data-scope** (whitelistados no `rbac_lint`), não autorização.
+
+## Decisões relacionadas (ADRs)
+
+- RBAC: capability hardcoded + atribuição group×capability admin-driven — ver [`rbac.spec.md`](./rbac.spec.md) e [`RBAC_NAMING.md`](../../RBAC_NAMING.md). A feature segue o padrão "capability sem grupos no seed = superuser-only" até maturar.
+- Issues de origem: `#870` (engine de prazo/calendário), `#871` (processador diário/escalonamento + beat), `#872` (API). Capability `manage_internal_actions` introduzida na Onda 1 C3 (migration `0079`).
+- Sem ADR formal dedicado; o plano antigo [`PLANO_NOTIFICACOES_TIMING.md`](../../_archive/PLANO_NOTIFICACOES_TIMING.md) está arquivado e foi superado por esta implementação.
+
+## Testes que cobrem
+
+- [`tests/test_acoes_notificacao_models.py`](../../../backend/apps/core/tests/test_acoes_notificacao_models.py) — models, constraints, `registrar_ancora`/`concluir`.
+- [`tests/test_prazo_engine_service.py`](../../../backend/apps/core/tests/test_prazo_engine_service.py) — resolução de âncora, vencimento, estados, dependentes.
+- [`tests/test_business_calendar_service.py`](../../../backend/apps/core/tests/test_business_calendar_service.py) — feriados, dias úteis, distância assinada.
+- [`tests/test_notificacoes_acoes_service.py`](../../../backend/apps/core/tests/test_notificacoes_acoes_service.py) — régua de escalonamento, destinatários, dedup, métricas da task.
+- [`tests/test_api_acoes_notificacao.py`](../../../backend/apps/core/tests/test_api_acoes_notificacao.py) — endpoints (ciclos/ações/inbox) + RBAC superuser-only.
+- [`tests/test_seed_acoes_notificacao.py`](../../../backend/apps/core/tests/test_seed_acoes_notificacao.py) — idempotência do seed e validação 1..32.
+- [`tests/test_celery_notificacoes_schedule.py`](../../../backend/apps/core/tests/test_celery_notificacoes_schedule.py) e `test_celery_task_suite.py` — agendamento e execução da task.
+
+## Pontos de atenção / dívidas conhecidas
+
+- **Feature superuser-only**: `manage_internal_actions` não tem grupos no seed; nenhum papel operacional acessa ciclos/ações pela UI hoje. Maturar = admin atribui grupo via interface (sem code change).
+- **Sem reabertura de ação concluída** (decisão MVP): conclusões são irreversíveis; correções exigem intervenção manual/admin.
+- **Cache de feriados com TTL**: `BusinessCalendarService` cacheia `FeriadoLocal` por 300s por ano; mudanças em feriados só refletem após `invalidate_cache()` ou expiração — relevante ao editar `FeriadoLocal` perto de um vencimento.
+- **Régua de notificação discreta**: o processador só dispara nas distâncias exatas {7,3,1,0,-1,-3} dias úteis; se o beat falhar/pular um dia, aquela fase específica não é reemitida (a janela é por dia, não acumulativa).
+- **`registrar_ancora` faz `select_for_update`, `concluir` não**: a conclusão não trava a linha; concorrência alta poderia gerar corrida, mitigada pela OneToOne de conclusão e pelo `unique (ciclo, template)`.
+- **Texto do seed**: alguns `nome`/`descricao_prazo` carregam typos do material de negócio (ex.: "inicío", relatórios duplicados nas ações 14/21) — preservados como fonte de negócio, não normalizados.

--- a/v2/docs/specs/backend/rbac.spec.md
+++ b/v2/docs/specs/backend/rbac.spec.md
@@ -1,0 +1,113 @@
+---
+title: RBAC — Controle de Acesso
+status: canonical
+last_verified: 2026-06-19
+sources_of_truth:
+  - v2/backend/apps/core/rbac/__init__.py
+  - v2/backend/apps/core/rbac/permissions.py
+  - v2/backend/apps/core/rbac/policies.py
+  - v2/backend/apps/core/rbac/matrix.py
+  - v2/backend/apps/core/rbac/helpers.py
+  - v2/backend/apps/core/rbac/constants.py
+  - v2/backend/apps/core/constants.py
+  - v2/backend/apps/core/services/rbac_permissions.py
+  - v2/backend/apps/core/services/functional_permissions_seed.py
+  - v2/backend/apps/core/views/me.py
+  - v2/backend/apps/core/signals.py
+  - v2/backend/scripts/rbac_lint.py
+owner: backend
+supersedes:
+  - v2/docs/RBAC_NAMING.md
+  - v2/docs/rbac_authorization_matrix.md
+  - v2/docs/GUIA_ADMIN_RBAC.md
+related:
+  - v2/docs/specs/backend/approvals.spec.md
+  - v2/docs/specs/backend/availability.spec.md
+---
+
+# RBAC — Controle de Acesso
+
+## Propósito
+
+O módulo `apps.core.rbac` é o SSOT da autorização do Aprender Sistema v2. Implementa o modelo NIST RBAC de 3 camadas — `User → Roles (Groups Django) → Capabilities (PermissaoFuncional) ← Policies (CanXxx) ← Views` — separando **o que** a pessoa pode fazer (capability) de **quem** ela é organizacionalmente (setor/função). A consequência prática: se a organização reestrutura (DAT vira "Operações Administrativas"), só muda `Group.name`; zero linha de código de autorização muda.
+
+Existem três conceitos ortogonais: **capability** (autorização binária por feature), **scope** (filtragem de dados — vê só o próprio setor/gerência/queryset) e **policy** (composição declarativa de capabilities exposta como classe `CanXxx`). Autorização passa SEMPRE por `HasPerm(codename)` / `user.has_perm()` / `user_has_any_perm` — nunca por nome de grupo, padrão banido pelo lint (ver §Contratos).
+
+## Fonte de verdade no código
+
+- [`v2/backend/apps/core/rbac/__init__.py`](../../../backend/apps/core/rbac/__init__.py) — superfície pública do módulo (re-exporta classes, helpers e a matriz de policies).
+- [`v2/backend/apps/core/rbac/permissions.py`](../../../backend/apps/core/rbac/permissions.py) — classes DRF: `HasPerm` (paramétrica), `HasFunctionalPermission` (base) e as 3 classes não-reduzíveis + 1 composite (`IsGerenteSuperintendencia`, `IsOwnerOrPrivileged`, `HasSectorAccess`, `IsAssistenteAdministrativoControle`). Aplica o monkey-patch de `permissions.OR/AND/NOT.__call__` que habilita composition em instâncias.
+- [`v2/backend/apps/core/rbac/policies.py`](../../../backend/apps/core/rbac/policies.py) — Capability Policy Layer: matriz `ACCESS_POLICIES` (policy key → frozenset de capabilities elegíveis, semântica OR), classes `Can*`, `PUBLIC_POLICY_KEYS`, e os SSOT `user_has_policy` / `resolve_public_policies`.
+- [`v2/backend/apps/core/rbac/matrix.py`](../../../backend/apps/core/rbac/matrix.py) — Matriz Viva `ACCESS_MATRIX` (10 atores × recursos discriminantes → status HTTP esperado) para testes parametrizados.
+- [`v2/backend/apps/core/rbac/helpers.py`](../../../backend/apps/core/rbac/helpers.py) — `user_has_any_perm`, `user_has_all_perms`, `user_is_assistente_administrativo_controle`.
+- [`v2/backend/apps/core/rbac/constants.py`](../../../backend/apps/core/rbac/constants.py) — constantes de **data scope** (`COORDENADOR_ROLE_GROUPS`, `FORMADOR_ROLE_GROUPS`) — usadas para filtrar queryset, não para autorizar.
+- [`v2/backend/apps/core/constants.py`](../../../backend/apps/core/constants.py) — `SETOR_GROUPS` (13 setores), `FUNCAO_GROUPS` (5 funções), `ALLOWED_USER_GROUPS`, `RESERVED_GROUPS`.
+- [`v2/backend/apps/core/services/rbac_permissions.py`](../../../backend/apps/core/services/rbac_permissions.py) — `get_user_functional_permissions` (resolução cache-aware das capabilities do usuário) + helpers de invalidação por usuário/grupo.
+- [`v2/backend/apps/core/services/functional_permissions_seed.py`](../../../backend/apps/core/services/functional_permissions_seed.py) — `FUNCTIONAL_PERMISSIONS_SEED`: SSOT dos codenames, labels, categorias e grupos default de cada capability.
+- [`v2/backend/apps/core/views/me.py`](../../../backend/apps/core/views/me.py) — `MePoliciesView` (`GET /api/me/policies/`).
+- [`v2/backend/apps/core/signals.py`](../../../backend/apps/core/signals.py) — signal `m2m_changed` em `PermissaoFuncional.groups`: invalida cache + grava `AuditLog GROUP_CAPABILITY_CHANGED`.
+- [`v2/backend/scripts/rbac_lint.py`](../../../backend/scripts/rbac_lint.py) — lint AST (V001/V002/V003) que enforça a convenção em CI.
+
+Doc canônico detalhado (não duplicado aqui): convenção de nomes em [`RBAC_NAMING.md`](../../RBAC_NAMING.md), matriz declarativa ator × recurso em [`rbac_authorization_matrix.md`](../../rbac_authorization_matrix.md), e operação via Admin em [`GUIA_ADMIN_RBAC.md`](../../GUIA_ADMIN_RBAC.md).
+
+## Contratos e invariantes
+
+- **Idioma canônico**: `permission_classes = [IsAuthenticated, HasPerm("codename")]`. Composition por instância: `HasPerm("a") | HasPerm("b")` (OR), `& ` (AND), `~` (NOT). Para OR semântico recorrente (≥3 caps ou compartilhado entre views) usa-se uma Policy `Can*`.
+- **Grupos diretos são banidos**: `user.groups.filter(name=...)` em `apps/core/views*` ou `apps/core/services/` é violação **V001** do lint. Usos legítimos (composite, block, data-scope) exigem marcador `# noqa: RBAC-<tipo>-allowed` na linha. Classes `class Is<Word>(...)` fora da whitelist (`IsGerenteSuperintendencia`, `IsOwnerOrPrivileged`) são violação **V002**. Mutação de `PermissaoFuncional.groups` / `Group.permissions` em migration de `apps/core/` acima do cutoff D17 (número > 82) é violação **V003**. CI job `[required] backend rbac-lint`.
+- **Codename é capacidade, não identidade**: formato `verb_noun[_qualifier]` snake_case inglês. Proibido nome de setor/função/grupo. Exceções bundle conscientes: `manage_admin_registries`, `manage_purchases_and_materials`.
+- **Superuser sempre bypassa**: toda classe e helper retorna `True` para `is_superuser` antes de qualquer checagem.
+- **Fail-secure**: usuário anônimo/`None` → `False`; policy key ausente da matriz → `False`; capability sem grupos no seed → só superuser passa (feature em incubação).
+- **D17 — Admin-driven Group × Capability**: a atribuição grupo↔capability migra para o Django Admin superuser-only (`PermissaoFuncionalAdmin`). Codename/label/category/existência da capability são read-only (SSOT no seed); só `groups` é editável. Toda edição invalida cache (signal `m2m_changed`) e grava `AuditLog GROUP_CAPABILITY_CHANGED`.
+- **Policy key = contrato externo estável** (uma vez em `PUBLIC_POLICY_KEYS`): adicionar key é compatível; renomear/remover é breaking (deprecation de 2 releases); mudar capabilities elegíveis (`ACCESS_POLICIES[k]`) é compatível (frontend não depende). O endpoint nunca vaza capability codenames.
+- **SSOT da semântica de policy**: `user_has_policy(user, key)` é a fonte única; `_PolicyPermission.has_permission`, os testes e `resolve_public_policies` delegam para ele. Mudar avaliação = mudar num só lugar.
+- **Aprovação de solicitações (CP-02, PA-01)**: gate composite `CanAccessSolicitationApprovals` = Gerente da Superintendência (Setor `Superintendência` + Função `Gerente`) **OU** Assistente Administrativo do Controle (Setor `Controle` + Função `Assistente Administrativo`). Superuser nunca auto-aprova evento próprio (regra do importer, fora deste módulo). Detalhe em `approvals.spec.md`.
+
+## API / Interface
+
+**Classes DRF** (import via `from apps.core.rbac import ...`):
+
+- `HasPerm("codename")` — checa uma capability; aceita prefixo `core.` opcional. Suporta `| & ~`.
+- `HasSectorAccess` — scope dinâmico por `gerencia_id` (query/kwargs); sem `gerencia_id` exige `EquipeGerencia` ativa. Idiomático: `[IsAuthenticated, CanViewAllAvailability | HasSectorAccess]`.
+- `IsGerenteSuperintendencia` — composite funcperm `approve_solicitation_batch` + grupo `Gerente`.
+- `IsOwnerOrPrivileged` — object-level: superuser/privilegiado ou `obj.usuario == user`.
+- `IsAssistenteAdministrativoControle` — composite Setor `Controle` + Função `Assistente Administrativo`.
+- 17 classes `Can*` (`CanAccessAuditLogs`, `CanViewComprasDashboard`, `CanViewAllAvailability`, `CanAccessSolicitationApprovals`, ...) mapeadas em `ACCESS_POLICIES`.
+
+**Helpers** (não-DRF): `user_has_any_perm(user, *codenames)`, `user_has_all_perms(...)`, `user_has_policy(user, key)`, `user_is_assistente_administrativo_controle(user)`, `user_can_delegate_availability_block(user)`.
+
+**Endpoint**: `GET /api/me/policies/` (`IsAuthenticated`) → array JSON ordenado das `PUBLIC_POLICY_KEYS` que o usuário possui (subset de `ACCESS_POLICIES`). Anonymous → 401; superuser → todas as públicas; regular → subset (OR). Consumido pelo frontend para menu condicional/redirects.
+
+**Setores (13)** e **Funções (5)**: SSOT em `SETOR_GROUPS` / `FUNCAO_GROUPS` (`apps/core/constants.py`). Funções: Formador, Coordenador, Apoio de Coordenação, Gerente, Assistente Administrativo.
+
+## Fluxos principais
+
+1. **Checagem em request DRF**: DRF instancia a classe → `has_permission` rejeita não-autenticado, libera superuser, e consulta `get_user_functional_permissions(user)` (cache Redis, TTL) testando `codename in perms`. Composition `A | B` é resolvida pelas classes `OR/AND/NOT` do DRF (habilitadas em instâncias pelo monkey-patch).
+2. **Resolução de policy**: `user_has_policy(user, key)` → anônimo `False` → superuser `True` → composite key delega a helper dedicado (ex: `_user_has_solicitation_approvals`) → caso geral `user_has_any_perm(user, *ACCESS_POLICIES[key])`.
+3. **Mudança de atribuição (admin)**: superuser edita `PermissaoFuncional.groups` no Admin → signal `m2m_changed` consolida as 6 disparadas (pre/post × add/remove/clear) → invalida cache funcional dos usuários afetados (sem restart) → grava `AuditLog GROUP_CAPABILITY_CHANGED` (added/removed/groups_after).
+4. **Erros relevantes**: capability sem grupo no seed → 403 a todos exceto superuser; `gerencia_id` não-inteiro em `HasSectorAccess` → 403 com mensagem "gerencia_id deve ser um número inteiro"; Controle puro tentando aprovar (sem Função `Assistente Administrativo`) → 403.
+
+## Decisões relacionadas (ADRs)
+
+- Princípios de naming, vocabulário de verbos e enforcement: [`RBAC_NAMING.md`](../../RBAC_NAMING.md) (Epic 2; §8/D17 Admin-driven).
+- Matriz declarativa ator × recurso e motivo legítimo de acesso: [`rbac_authorization_matrix.md`](../../rbac_authorization_matrix.md).
+- Decisões D7–D9 (Grade Mensal / Diretoria / DAT transversal), D17 (Admin-driven), PR 3 (composite aprovações), PR 5/6 (lookup/audit hardening) — registradas como comentários rastreáveis em `policies.py` e `matrix.py`.
+
+## Testes que cobrem
+
+- [`v2/backend/apps/core/tests/test_rbac_matrix_contract.py`](../../../backend/apps/core/tests/test_rbac_matrix_contract.py) — paridade código × `ACCESS_MATRIX`; CI vermelho se um ator ganha/perde acesso.
+- [`v2/backend/apps/core/tests/test_rbac_matrix_living.py`](../../../backend/apps/core/tests/test_rbac_matrix_living.py) e [`test_rbac_matrix_endpoint_coverage.py`](../../../backend/apps/core/tests/test_rbac_matrix_endpoint_coverage.py) — Matriz Viva + cobertura de endpoints.
+- [`v2/backend/apps/core/tests/test_rbac_policies.py`](../../../backend/apps/core/tests/test_rbac_policies.py) e [`test_rbac_policies_contract.py`](../../../backend/apps/core/tests/test_rbac_policies_contract.py) — semântica de `user_has_policy` + contrato `ACCESS_POLICIES`/`PUBLIC_POLICY_KEYS`.
+- [`v2/backend/apps/core/tests/test_me_policies.py`](../../../backend/apps/core/tests/test_me_policies.py) — `GET /api/me/policies/` (incl. test de paridade que obriga registrar `Can*` nova como pública).
+- [`v2/backend/apps/core/tests/test_rbac_permissions.py`](../../../backend/apps/core/tests/test_rbac_permissions.py), [`test_rbac_helpers.py`](../../../backend/apps/core/tests/test_rbac_helpers.py) — classes DRF e helpers.
+- [`v2/backend/apps/core/tests/test_rbac_lint.py`](../../../backend/apps/core/tests/test_rbac_lint.py) — self-test do lint (aceita baseline, rejeita padrões banidos).
+- [`v2/backend/apps/core/tests/test_pr3_approvals_policy.py`](../../../backend/apps/core/tests/test_pr3_approvals_policy.py), [`test_pr6_audit_logs_policy.py`](../../../backend/apps/core/tests/test_pr6_audit_logs_policy.py) — gates compostos endurecidos.
+- [`v2/backend/apps/core/tests/test_rbac_labels_capability_oriented.py`](../../../backend/apps/core/tests/test_rbac_labels_capability_oriented.py), [`test_rbac_seed.py`](../../../backend/apps/core/tests/test_rbac_seed.py) — convenção de labels e seed idempotente.
+
+## Pontos de atenção / dívidas conhecidas
+
+- **Divergência doc × código (V003)**: `RBAC_NAMING.md §7` afirma "V003 (import de Group) foi descartado", mas `scripts/rbac_lint.py` **implementa** V003 com sentido diferente (proíbe mutação de `PermissaoFuncional.groups`/`Group.permissions` em migrations de `apps/core/` acima do cutoff D17=82). O texto do §7 está desatualizado; a fonte de verdade é o lint. Corrigir o §7.
+- **`GUIA_ADMIN_RBAC.md` lista "Gerência" como setor genérico**; o SSOT `SETOR_GROUPS` não contém "Gerência" (são 13 setores nomeados). Guia precisa alinhar.
+- **Cutoff D17 hardcoded** (`D17_LEGACY_MIGRATIONS_MAX = 82`): migrations futuras que precisem backfill legítimo de grupos exigem `# noqa: RBAC-migration-allowed` consciente.
+- **Composition OR em instâncias depende de monkey-patch** (`permissions.OR/AND/NOT.__call__ = lambda self: self`) aplicado em `permissions.py`; `policies.py` força o import por side-effect. Remover o patch quebra silenciosamente todo `permission_classes = [A | B]`.
+- **`HasSectorAccess` é o único ponto com TOCTOU residual** de scope: a checagem de `EquipeGerencia` ativa e a leitura de dados acontecem em requests separados; mudança de vínculo entre eles não é transacional (aceitável para o caso de uso atual).
+- **Schema OpenAPI de `/api/me/policies/`** declara `{policies: [...]}` via `inline_serializer`, mas o código retorna o array bruto. Divergência de documentação de schema (não afeta o contrato real consumido pelo frontend).

--- a/v2/docs/specs/backend/solicitacao-approval.spec.md
+++ b/v2/docs/specs/backend/solicitacao-approval.spec.md
@@ -1,0 +1,107 @@
+---
+title: Aprovação de Solicitações
+status: canonical
+last_verified: 2026-06-19
+sources_of_truth:
+  - v2/backend/apps/core/services/solicitacao_approval.py
+  - v2/backend/apps/core/models/solicitacao.py
+  - v2/backend/apps/core/views_solicitacao.py
+  - v2/backend/apps/core/rbac/policies.py
+  - v2/backend/apps/core/services/db_retry.py
+  - v2/backend/apps/core/services/solicitacao_create.py
+owner: backend
+supersedes: []
+related:
+  - v2/docs/specs/backend/politica-aprovacao.spec.md
+  - v2/docs/specs/backend/rbac.spec.md
+  - v2/docs/rbac_authorization_matrix.md
+  - v2/docs/API_REFERENCE.md
+---
+
+# Aprovação de Solicitações
+
+## Propósito
+
+Toda solicitação de evento (pré-agenda) nasce com status `pendente` e só vira agenda real (publicável no Google Calendar, RF05/RF06) depois de uma decisão humana de aprovação. Este módulo é a camada de serviço que executa essa transição de estado de forma transacional, auditável e segura contra corrida: aprovar (`pendente → aprovado`), reprovar (`pendente → reprovado`) e as variantes em lote. É o ponto onde a Política de Aprovação (PA-01..PA-07) deixa de ser regra escrita e vira código que muda o banco.
+
+A regra de *quem* pode decidir vive na camada de Policy RBAC; este módulo cuida do *como* a decisão é aplicada com integridade (lock de linha, idempotência por status, `AuditLog` por registro). A spec é o contrato conciso; a política autorizativa detalhada está em [politica-aprovacao.spec.md](../domain/politica-aprovacao.spec.md) e na [rbac_authorization_matrix.md](../../rbac_authorization_matrix.md).
+
+## Fonte de verdade no código
+
+- [`apps/core/services/solicitacao_approval.py`](../../../backend/apps/core/services/solicitacao_approval.py) — SSOT da transição de estado. Funções públicas: `approve_solicitacao`, `reject_solicitacao`, `batch_approve_solicitacoes`, `batch_reject_solicitacoes`. Dataclasses `ApprovalResult` e `BatchApprovalResult`. Helper de erros de status `_raise_invalid_status_error` e `_build_batch_status_errors`.
+- [`apps/core/models/solicitacao.py`](../../../backend/apps/core/models/solicitacao.py) — model `Solicitacao` com `Status` (`PENDENTE`/`APROVADO`/`REPROVADO`, valores `pendente`/`aprovado`/`reprovado`), `default="pendente"` (PA-01) e `CheckConstraint` `solicitacao_status_valid`.
+- [`apps/core/views_solicitacao.py`](../../../backend/apps/core/views_solicitacao.py) — `SolicitacaoViewSet` expõe as `@action` `approve`, `reject`, `batch_approve`, `batch_reject` e delega 100% ao service. Gate em `permission_classes=[CanAccessSolicitationApprovals]`.
+- [`apps/core/rbac/policies.py`](../../../backend/apps/core/rbac/policies.py) — Policy `CanAccessSolicitationApprovals` (key `access_solicitation_approvals`) + SSOT semântico `_user_has_solicitation_approvals`.
+- [`apps/core/services/db_retry.py`](../../../backend/apps/core/services/db_retry.py) — decorator `@retry_on_deadlock` aplicado às 4 funções.
+- [`apps/core/services/solicitacao_create.py`](../../../backend/apps/core/services/solicitacao_create.py) — origem do `status="pendente"` (PA-01: nunca auto-aprova na criação).
+
+## Contratos e invariantes
+
+- **PA-01 (status inicial)**: a criação sempre persiste `pendente`; este módulo NUNCA cria solicitação, só transiciona. Nenhum caminho aprova automaticamente.
+- **PA-02 (quem decide)**: o gate é `CanAccessSolicitationApprovals` — Gerente da Superintendência **OU** Assistente Administrativo do Controle **OU** superuser. É policy composta (Setor × Função), não OR de capabilities. SSOT em `_user_has_solicitation_approvals`. O service NÃO re-checa autorização — confia na Policy da view; chamadas diretas ao service assumem autorização já validada.
+- **Transição válida única**: só `pendente` é mutável. Se `status != "pendente"`, `_raise_invalid_status_error` levanta `ValidationAPIError` com code `already_approved`, `already_rejected` ou `invalid_status` (HTTP 400). Estado terminal: `aprovado` e `reprovado` são imutáveis por esta API.
+- **Idempotência / anti-corrida (issue #744)**: cada operação roda em `transaction.atomic()` e relê a linha com `select_for_update()` (lote usa `skip_locked=True`) antes de checar/gravar. Duas aprovações concorrentes no mesmo ID produzem exatamente um vencedor; o perdedor recebe erro de status.
+- **Auditoria obrigatória (PA-05)**: toda mudança grava um `AuditLog` (`Action.APPROVE`/`REJECT`) com `solicitacao_id`, `prev_status`, `new_status`, `justificativa`, `ip_address` e `user_agent` (truncado em 200). No lote, **um AuditLog por solicitação** com `batch=True` (nunca um log agregado).
+- **Limite de lote**: `ids` é obrigatório (`ids_required`) e no máximo **100** por requisição (`batch_limit_exceeded`); excedente levanta `ValidationAPIError`.
+- **Resiliência transitória**: `@retry_on_deadlock` reexecuta a função inteira em deadlock de banco (idempotente porque a re-leitura sob lock revalida o status).
+- **CP-04 / camadas**: regra de negócio vive no service (Single Responsibility, Epic #459); a view só orquestra e serializa.
+
+## API / Interface
+
+Endpoints do `SolicitacaoViewSet` (prefixo `/api/solicitacoes/`). Catálogo completo em [API_REFERENCE.md](../../API_REFERENCE.md).
+
+| Método | Rota | Ação | Corpo | Gate |
+|--------|------|------|-------|------|
+| PATCH | `/api/solicitacoes/{id}/approve/` | `approve` | `reason` ou `justificativa` (opcional) | `CanAccessSolicitationApprovals` |
+| PATCH | `/api/solicitacoes/{id}/reject/` | `reject` | `reason` ou `justificativa` (opcional) | `CanAccessSolicitationApprovals` |
+| POST | `/api/solicitacoes/batch-approve/` | `batch_approve` | `{ "ids": [int,...] }` | `CanAccessSolicitationApprovals` |
+| POST | `/api/solicitacoes/batch-reject/` | `batch_reject` | `{ "ids": [int,...] }` | `CanAccessSolicitationApprovals` |
+
+- Individual → `200 OK` com `{ "detail", "solicitacao": <SolicitacaoSerializer> }`.
+- Lote → `200 OK` com `{ "approved" | "rejected": int, "errors": [{ "id", "detail" }] }`. Erros por-ID em vez de falha global: IDs inexistentes (`"Solicitação não encontrada"`) ou já decididos (`"Status já é 'X'"`) entram em `errors` sem abortar os válidos.
+- Erros de status / validação → `400` via `ValidationAPIError`. Falta de permissão → `403`. Não autenticado → `401/403`.
+
+Interface de serviço (chamável internamente): `approve_solicitacao(solicitacao, user, request, justificativa="") -> ApprovalResult` e simétricos; lote recebe `ids: list[int]` e devolve `BatchApprovalResult(approved_count, rejected_count, errors)`.
+
+## Fluxos principais
+
+**Aprovação individual (caminho feliz)**
+1. View resolve `get_object()` e extrai `reason`/`justificativa`.
+2. Service abre transação, faz `select_for_update().get(pk=...)` (relê sob lock).
+3. Valida `status == "pendente"`; senão levanta erro de status (400).
+4. Grava `status = "aprovado"`, salva, cria `AuditLog` APPROVE e loga evento estruturado.
+5. Commit; retorna `ApprovalResult(success=True, ...)`; view responde 200.
+
+**Reprovação**: idêntico, com `status = "reprovado"`, `AuditLog` REJECT e mensagem "Solicitação reprovada.".
+
+**Lote (approve/reject)**
+1. Valida `ids` não vazio e `len(ids) <= 100`.
+2. Em uma transação, carrega `filter(id__in=ids, status="pendente").select_for_update(skip_locked=True).order_by("id")`.
+3. `_build_batch_status_errors` calcula em **uma query** os IDs faltantes/não-pendentes e os anexa a `errors`.
+4. Itera os pendentes travados, transiciona cada um, grava `AuditLog` com `batch=True`, incrementa contador.
+5. Commit; retorna contadores + `errors` parciais.
+
+**Erros relevantes**: já aprovado/reprovado (400 com code específico no individual; entra em `errors` no lote); deadlock → retry automático; concorrência → perdedor recebe erro de status (sem dupla escrita).
+
+## Decisões relacionadas (ADRs)
+
+- Política PA-02 adaptada (PR 3 #1308): composite Gerente Superintendência **+** Assistente Administrativo do Controle — ver `rbac_authorization_matrix.md` §6 (decisões D10–D17) e [politica-aprovacao.spec.md](../domain/politica-aprovacao.spec.md).
+- Camada Policy declarativa (capability/policy layer): contrato público `GET /api/me/policies/` expõe `access_solicitation_approvals` (Epic 4.4/4.5).
+- Extração para service layer: Epic #459 (`SolicitacaoViewSet` delega à camada de serviço).
+- Anti-corrida de dupla aprovação: issue #744 (`transaction.atomic` + `select_for_update`).
+
+## Testes que cobrem
+
+- [`tests/test_pr3_approvals_policy.py`](../../../backend/apps/core/tests/test_pr3_approvals_policy.py) — personas permitidas/proibidas (403) nos 4 endpoints; superuser permitido; anônimo bloqueado.
+- [`tests/test_solicitacao_approval_concurrency.py`](../../../backend/apps/core/tests/test_solicitacao_approval_concurrency.py) — único vencedor sob concorrência (individual e lote), issue #744.
+- [`tests/test_approval_policy_PA.py`](../../../backend/apps/core/tests/test_approval_policy_PA.py) — conformidade PA-01..PA-07.
+- [`tests/test_solicitacao_fluxo.py`](../../../backend/apps/core/tests/test_solicitacao_fluxo.py) — fluxo de transição de estado fim a fim.
+- [`tests/test_views_solicitacao_coverage.py`](../../../backend/apps/core/tests/test_views_solicitacao_coverage.py) — cobertura das actions da view.
+- Cobertura de matriz RBAC: `rbac/matrix.py` (`solicitacoes_batch_approve` representa os 4 endpoints) + `tests/test_rbac_matrix_endpoint_coverage.py`.
+
+## Pontos de atenção / dívidas conhecidas
+
+- **Divergência de doc**: [API_REFERENCE.md](../../API_REFERENCE.md) (linhas ~117–118) lista `approve`/`reject` como **POST** com gate `IsSuperintendencia`. O código atual usa **PATCH** e a policy composta `CanAccessSolicitationApprovals` (Super + Assistente Admin Controle + superuser). A spec reflete o código; o API_REFERENCE precisa ser sincronizado (método e gate).
+- **Justificativa não obrigatória na reprovação**: o docstring do endpoint diz "Requer justificativa", mas o service aceita `justificativa=""` (default). Não há validação que force texto ao reprovar — gap entre intenção e implementação.
+- **Service confia na view para autorização**: chamadas diretas ao service (Celery, management commands, futuros callers) NÃO re-checam `CanAccessSolicitationApprovals`. Qualquer novo caller fora da view deve validar a policy antes (ou expor a regra via `user_has_policy("access_solicitation_approvals")`).
+- **Sem efeito colateral de publicação na aprovação**: aprovar apenas muda `status`; a publicação no GCal (RF05/RF06) é um passo separado via actions `publish`/`resync-gcal` (gate `CanUseGcal`). PA-03 (integração externa só após aprovação) é garantido por convenção operacional, não por um trigger acoplado — não há enforcement de "não publicar antes de aprovar" neste módulo.

--- a/v2/docs/specs/domain/README.md
+++ b/v2/docs/specs/domain/README.md
@@ -11,7 +11,7 @@ related:
 
 Contratos imutáveis do negócio. Voltar ao [índice SDD](../INDEX_SDD.md).
 
-## Specs planejadas (Fase 3-4)
+## Specs (escritas em 2026-06-19) — origem de cada uma
 
 | Spec | Conteúdo | Fonte canônica atual |
 |---|---|---|
@@ -20,4 +20,4 @@ Contratos imutáveis do negócio. Voltar ao [índice SDD](../INDEX_SDD.md).
 | `politica-aprovacao.spec.md` | PA-01..PA-07 | `docs/business-rules/politica-aprovacao.md`, ADR-002 |
 | `requisitos-funcionais.spec.md` | RF-xx | `docs/business-rules/requisitos-funcionais.md` |
 
-> Status: esqueleto. Nenhuma spec escrita ainda (Fase 0).
+> Status: **specs escritas** (Fase 3-4, 2026-06-19) — links vivos no [índice SDD](../INDEX_SDD.md).

--- a/v2/docs/specs/domain/clausulas-petreas.spec.md
+++ b/v2/docs/specs/domain/clausulas-petreas.spec.md
@@ -1,0 +1,94 @@
+---
+title: Cláusulas Pétreas (CP-01..CP-08)
+status: canonical
+last_verified: 2026-06-19
+sources_of_truth:
+  - docs/business-rules/clausulas-petreas.md
+  - v2/backend/config/settings.py
+  - v2/backend/apps/dev_tools/apps.py
+  - .claude/settings.json
+  - .github/workflows/ci.yaml
+  - v2/scripts/ban_v1.sh
+  - docs/architecture/project-decisions/ADR-001-docker-only-deployment.md
+  - docs/architecture/project-decisions/ADR-002-approval-policy-manual.md
+  - docs/architecture/project-decisions/ADR-003-availability-rules-timezone.md
+  - docs/architecture/project-decisions/ADR-004-conventional-commits-branch-protection.md
+owner: domain
+supersedes:
+  - docs/business-rules/clausulas-petreas.md
+related:
+  - ../../INDEX_SDD.md
+  - ./politica-aprovacao.spec.md
+  - ./regras-disponibilidade.spec.md
+  - ../infra/deploy.spec.md
+  - ../../RBAC_NAMING.md
+---
+
+# Cláusulas Pétreas (CP-01..CP-08)
+
+## Propósito
+
+As Cláusulas Pétreas são os **8 contratos imutáveis** do Aprender Sistema v2: invariantes de plataforma (onde o sistema roda, como dados sensíveis são tratados) e de processo (como o código entra no repositório). Diferente de RF (funcionais) e RD/PA (domínio), uma CP **não pode ser flexibilizada por feature** — quando há conflito entre uma CP e qualquer outra regra, a CP vence.
+
+Esta spec é o **índice canônico** das CPs: lista cada cláusula com seu **enforcement real no código** (não a intenção). Onde a CP delega a outro domínio (CP-02 → PA, CP-03 → RD), ela apenas aponta para a spec canônica desse domínio. O doc-fonte legível é [`docs/business-rules/clausulas-petreas.md`](../../../../docs/business-rules/clausulas-petreas.md); esta spec é o contrato técnico que casa cada CP com o arquivo que a faz cumprir.
+
+## Fonte de verdade no código
+
+| CP | Enforcement real | Arquivo |
+|----|------------------|---------|
+| CP-01 | Guard de runtime + CI seta `REQUIRE_DOCKER=1` | [`v2/backend/config/settings.py`](../../../backend/config/settings.py) (linhas ~19-27), [`.github/workflows/ci.yaml`](../../../../.github/workflows/ci.yaml) |
+| CP-02 | Política de aprovação (PA-01..PA-07) | → [`politica-aprovacao.spec.md`](./politica-aprovacao.spec.md) |
+| CP-03 | Regras de disponibilidade (RD-01..RD-08) | → [`regras-disponibilidade.spec.md`](./regras-disponibilidade.spec.md) |
+| CP-04 | Workflow de sub-agents (convenção; **sem gate de CI**) | [`docs/business-rules/clausulas-petreas.md`](../../../../docs/business-rules/clausulas-petreas.md) §CP-04 |
+| CP-05 | v1 congelado (convenção/branch protection; **sem script dedicado**) | [`docs/business-rules/clausulas-petreas.md`](../../../../docs/business-rules/clausulas-petreas.md) §CP-05 |
+| CP-06 | Conventional commits (convenção; **sem commit-lint em CI**) | [ADR-004](../../../../docs/architecture/project-decisions/ADR-004-conventional-commits-branch-protection.md) |
+| CP-07 | Hook local `PreToolUse` + branch protection da `main` | [`.claude/settings.json`](../../../../.claude/settings.json) (bloco `PreToolUse`) |
+| CP-08 | Gate de `INSTALLED_APPS` por `INCLUDE_DEV_TOOLS` | [`v2/backend/config/settings.py`](../../../backend/config/settings.py) (linhas ~110-141) |
+
+## Contratos e invariantes
+
+- **CP-01 — REQUIRE_DOCKER**: v2 roda **apenas em Docker**. Quando `REQUIRE_DOCKER=1` e o processo **não** vê `/.dockerenv`, `settings.py` aborta com `sys.exit(1)`. Em dev a variável fica desligada (`"0"`); o job de integração da CI exporta `REQUIRE_DOCKER=1` e migra/roda dentro do container.
+- **CP-02 — Aprovação manual SUPER**: nenhum fluxo SUPER auto-aprova (nem evento passado, fix #1370); só superuser OU (Gerente + Superintendência) aprova; integrações (GCal) só disparam **após** aprovação. Contrato detalhado em PA-01..PA-07.
+- **CP-03 — Disponibilidade**: não-sobreposição, bloqueios T/P, buffer de deslocamento (D) e capacidade diária (M), timezone `America/Fortaleza` (storage UTC). Contrato detalhado em RD-01..RD-08.
+- **CP-04 — Workflow**: agentes autônomos seguem a ordem **Entender → Planejar → Implementar → Testar** (Infra/ETL/UI como fases subsequentes). É disciplina de processo, **não** verificada por CI.
+- **CP-05 — v1 congelado**: v1 só muda por branch `fix/v1-*` + PR para `main-v1`, com aprovação. Não há script que bloqueie edição de v1 — o backstop é a separação de branches + revisão.
+- **CP-06 — Conventional commits**: commits seguem `type(scope): message` (`feat|fix|chore|docs|test|refactor`); branches `type/nome`; PR exige aprovação + CI verde. Convenção formalizada em ADR-004 (não há job de commit-lint que reprove o título).
+- **CP-07 — Nunca push direto na `main`**: sempre via branch + PR (squash-merge após CI verde). Hook local `PreToolUse` em `.claude/settings.json` bloqueia `git push ... origin main`; o backstop **autoritativo** é o ruleset de branch protection da `main` no GitHub.
+- **CP-08 — dev_tools off em produção**: `apps.dev_tools` (seeds/backfills/fixtures/`FreezeTimeMiddleware`) **só** entra em `INSTALLED_APPS` se `INCLUDE_DEV_TOOLS != "false"`. **Default é `true`** — produção PRECISA setar `INCLUDE_DEV_TOOLS=false` explicitamente (`CP-08` no `stack.env`/Portainer).
+
+## API / Interface
+
+As CPs não expõem endpoints próprios; são invariantes atravessando o sistema. Pontos de controle:
+
+- **Variáveis de ambiente** (gate de runtime): `REQUIRE_DOCKER` (CP-01), `INCLUDE_DEV_TOOLS` (CP-08), `DEBUG_E2E` (gate duplo com `INCLUDE_DEV_TOOLS`).
+- **Hook do harness** (CP-07): `PreToolUse` → `Bash` em `.claude/settings.json`; `git push:*` também está na lista `ask` de permissões.
+- **CI gates relacionados**: job `[required] backend rbac-lint` (ci.yaml) reforça o idioma RBAC `permission_classes = [HasPerm("codename")]` via [`v2/backend/scripts/rbac_lint.py`](../../../backend/scripts/rbac_lint.py) — não é uma CP, mas é o guard que protege o modelo de capabilities citado no contexto de CP-02.
+
+## Fluxos principais
+
+1. **Boot do backend (CP-01 + CP-08)**: `settings.py` lê `REQUIRE_DOCKER` → se `1` e fora de container, aborta. Em seguida lê `INCLUDE_DEV_TOOLS` → se `≠ "false"`, anexa `apps.dev_tools` a `INSTALLED_APPS`; `FreezeTimeMiddleware` só é inserido com `DEBUG_E2E and INCLUDE_DEV_TOOLS` (gate duplo).
+2. **Tentativa de push na main (CP-07)**: o comando é interceptado pelo hook `PreToolUse`; se casar `push ... origin main`, falha com `CP-07 VIOLADO`. Mesmo que o hook não exista (clone novo), a branch protection da `main` recusa o push sem PR.
+3. **Aprovação de evento SUPER (CP-02)**: solicitação → aprovação manual por papel autorizado → só então a integração (GCal) executa. Erro relevante: SUPER tentando auto-aprovar é negado (PA-01).
+4. **Erro comum (CP-08)**: `stack.env` de produção sem `INCLUDE_DEV_TOOLS` → default `true` → `apps.dev_tools` carregado em prod (CP-08 violado silenciosamente). A mitigação é setar a variável explicitamente.
+
+## Decisões relacionadas (ADRs)
+
+- [ADR-001 — Docker-only deployment](../../../../docs/architecture/project-decisions/ADR-001-docker-only-deployment.md) (CP-01)
+- [ADR-002 — Approval policy manual](../../../../docs/architecture/project-decisions/ADR-002-approval-policy-manual.md) (CP-02)
+- [ADR-003 — Availability rules / timezone](../../../../docs/architecture/project-decisions/ADR-003-availability-rules-timezone.md) (CP-03)
+- [ADR-004 — Conventional commits & branch protection](../../../../docs/architecture/project-decisions/ADR-004-conventional-commits-branch-protection.md) (CP-06, CP-07)
+
+## Testes que cobrem
+
+- **CP-02 / CP-03**: cobertos pelas suítes de PA e RD (ver as specs `politica-aprovacao.spec.md` e `regras-disponibilidade.spec.md`); o skill `/approve-flow` e `/check-conflicts` exercitam PA-01..PA-07 e RD-01..RD-08.
+- **CP-01 / CP-08**: gates de configuração em `settings.py` — verificados em runtime/CI (job de integração com `REQUIRE_DOCKER=1`), não por teste unitário dedicado.
+- **CP-07**: enforcement por hook + branch protection — verificação operacional (comportamento do harness/GitHub), sem teste de código.
+- **CP-04 / CP-05 / CP-06**: convenções de processo — sem cobertura automatizada (ver Pontos de atenção).
+
+## Pontos de atenção / dívidas conhecidas
+
+- **CP-04, CP-05, CP-06 não têm enforcement automatizado**: são convenções. Não há commit-lint em CI (CP-06), nem script que proteja v1 (CP-05), nem gate de workflow (CP-04). O cumprimento depende de revisão humana + branch protection.
+- **`v2/scripts/ban_v1.sh` NÃO é o enforcement de CP-05**: apesar do nome, o script faz **limpeza de containers/redes/volumes Docker** do projeto legado (`project=aprendersistema`), não bane edições de código v1. Não citar como guard de CP-05.
+- **CP-07 — hook é gitignored**: `.claude/settings.json` vive em `.claude/` (não herdado por clone novo); o enforcement **confiável** é a branch protection da `main` no GitHub. O hook é defesa-em-profundidade local.
+- **CP-08 — default inseguro por design**: `INCLUDE_DEV_TOOLS` default `true` e **sem guard por `ENVIRONMENT`** → omitir a variável em produção carrega `apps.dev_tools`. Recomendação de hardening: tornar o default seguro ou adicionar guard `if ENVIRONMENT == "production": INCLUDE_DEV_TOOLS = False`.
+- **CP-01 — guard só dispara com `REQUIRE_DOCKER=1`**: rodar v2 fora de Docker com a variável ausente (`"0"`) não aborta. A garantia em prod vem do compose/imagem, não do guard isolado.

--- a/v2/docs/specs/domain/politica-aprovacao.spec.md
+++ b/v2/docs/specs/domain/politica-aprovacao.spec.md
@@ -1,0 +1,109 @@
+---
+title: Política de Aprovação (PA-01..PA-07)
+status: canonical
+last_verified: 2026-06-19
+sources_of_truth:
+  - v2/backend/apps/core/models/solicitacao.py
+  - v2/backend/apps/core/services/solicitacao_create.py
+  - v2/backend/apps/core/services/solicitacao_approval.py
+  - v2/backend/apps/core/rbac/policies.py
+  - v2/backend/apps/core/views_solicitacao.py
+  - v2/backend/apps/core/tests/test_approval_policy_PA.py
+  - v2/backend/apps/core/tests/test_solicitacao_fluxo.py
+  - v2/backend/apps/core/tests/test_pr3_approvals_policy.py
+  - v2/backend/apps/core/tests/test_auditlog_approve_reject.py
+owner: domain
+supersedes:
+  - docs/business-rules/politica-aprovacao.md
+  - docs/architecture/project-decisions/ADR-002-approval-policy-manual.md
+  - v2/docs/IMPLEMENTACAO_PA.md
+related:
+  - ../INDEX_SDD.md
+  - ../../rbac_authorization_matrix.md
+  - ../../RBAC_NAMING.md
+  - ./regras-disponibilidade.spec.md
+  - ./clausulas-petreas.spec.md
+---
+
+# Política de Aprovação (PA-01..PA-07)
+
+## Propósito
+
+A Política de Aprovação governa o fluxo de aprovação manual de `Solicitacao` (pré-agenda de eventos). É a materialização da Cláusula Pétrea **CP-02**: nenhuma solicitação de projeto que exige decisão humana entra na agenda sem aprovação explícita de um perfil autorizado, e nenhuma integração externa (Google Calendar / Meet) executa antes disso. O objetivo é manter a Superintendência como ponto de decisão com contexto humano que o sistema não captura (exceções, prioridades organizacionais, negociações).
+
+A política distingue dois fluxos de projeto: `SUPER` (requer aprovação manual, nasce `pendente`) e `NAO_SUPER` (auto-aprovado na criação, nasce `aprovado`). Essa distinção é decidida em camada de serviço no momento da criação — não no `save()` do model — para que PA-01 (sem auto-aprovação implícita) seja inviolável por gravações de campo subsequentes.
+
+## Fonte de verdade no código
+
+- **Estado inicial / sem auto-aprovação (PA-01, PA-04)**: [`v2/backend/apps/core/models/solicitacao.py`](../../../backend/apps/core/models/solicitacao.py) — campo `status` com `default="pendente"`, `CheckConstraint` `solicitacao_status_valid` (`pendente|aprovado|reprovado`). O model **não** sobrescreve `save()`: não há lógica de auto-aprovação ali (a regra histórica de auto-aprovar `NAO_SUPER` no `save()` foi removida).
+- **Resolução do estado inicial por fluxo**: [`v2/backend/apps/core/services/solicitacao_create.py`](../../../backend/apps/core/services/solicitacao_create.py) — `resolve_initial_status(projeto=...)` retorna `aprovado` sse `projeto.fluxo == "NAO_SUPER"`, senão `pendente`. Aplicado em `SolicitacaoViewSet.perform_create` ([`views_solicitacao.py`](../../../backend/apps/core/views_solicitacao.py)).
+- **Perfil exigido (PA-02)**: [`v2/backend/apps/core/rbac/policies.py`](../../../backend/apps/core/rbac/policies.py) — Policy composite `CanAccessSolicitationApprovals` (key `access_solicitation_approvals`) delegando para o helper SSOT `_user_has_solicitation_approvals`.
+- **Transições + auditoria + idempotência (PA-05)**: [`v2/backend/apps/core/services/solicitacao_approval.py`](../../../backend/apps/core/services/solicitacao_approval.py) — `approve_solicitacao`, `reject_solicitacao`, `batch_approve_solicitacoes`, `batch_reject_solicitacoes`.
+- **Endpoints (PA-02, PA-03)**: [`v2/backend/apps/core/views_solicitacao.py`](../../../backend/apps/core/views_solicitacao.py) — actions `approve`/`reject`/`batch_approve`/`batch_reject` (gate `CanAccessSolicitationApprovals`) e `publish`/`resync_gcal`/`cancel_gcal` (gate `CanUseGcal`, só pós-aprovação).
+- **Detalhe canônico das regras**: [`docs/business-rules/politica-aprovacao.md`](../../../../docs/business-rules/politica-aprovacao.md) e [ADR-002](../../../../docs/architecture/project-decisions/ADR-002-approval-policy-manual.md). Matriz de quem aprova: [`v2/docs/rbac_authorization_matrix.md`](../../rbac_authorization_matrix.md).
+
+## Contratos e invariantes
+
+- **PA-01 — Sem auto-aprovação implícita**: `Solicitacao.save()` / `full_clean()` nunca promovem `pendente → aprovado`. A única auto-aprovação válida é a explícita de projeto `NAO_SUPER` no `perform_create`, via `resolve_initial_status`.
+- **PA-02 — Perfil exigido**: aprovar/reprovar exige **superuser** OU composite **Gerente da Superintendência** (Setor `Superintendência` + Função `Gerente`) OU **Assistente Administrativo do Controle** (Setor `Controle` + Função `Assistente Administrativo`). DAT, Controle puro e Gerente pedagógico **não** aprovam. Idioma RBAC: `permission_classes = [CanAccessSolicitationApprovals]` (grupos diretos via `user.groups.filter(name=...)` são banidos por `scripts/rbac_lint.py`, salvo a whitelist `# noqa: RBAC-composite-allowed` no helper composite).
+- **PA-03 — Gatilhos pós-aprovação**: integrações externas (GCal/Meet) só rodam com `status == "aprovado"`. `publish` rejeita solicitação pendente e **não** enfileira a task Celery.
+- **PA-04 — Estado inicial**: toda solicitação nasce `pendente`, exceto fluxo `NAO_SUPER` (nasce `aprovado`). Garantido por `default="pendente"` + `resolve_initial_status`.
+- **PA-05 — Auditoria**: toda aprovação/reprovação grava `AuditLog` (`APPROVE`/`REJECT`) com `solicitacao_id`, `prev_status`, `new_status`, `justificativa`, `ip_address`, `user_agent`; em lote, `details["batch"] = True` por item.
+- **PA-06 — UI/UX**: botões de aprovar/reprovar ocultos para perfis sem a policy (frontend consome `access_solicitation_approvals` via `/api/me/policies/`; o legado `can_approve_super` em `/api/me/` **não** é fonte de decisão).
+- **PA-07 — Testes obrigatórios**: os 5 testes nomeados existem e passam (ver §Testes).
+- **Idempotência / concorrência**: transição só ocorre se `status == "pendente"` sob `select_for_update()` (single) e `select_for_update(skip_locked=True)` (lote) dentro de `transaction.atomic()`; reentrada em solicitação já `aprovado`/`reprovado` retorna `ValidationAPIError` (`already_approved` / `already_rejected` / `invalid_status`), não duplica AuditLog.
+- **Limites**: lote máximo de **100** ids por chamada (`batch_limit_exceeded`); `ids` vazio → `ids_required`.
+- **Aprovação NÃO revalida conflitos**: `approve` não chama `check_conflicts` (decisão deliberada — ver ADR-002 / §Pontos de atenção). A validação de disponibilidade ocorre na **criação** (`perform_create`).
+- **CP-02** é a cláusula pétrea que ancora toda esta política; ver [`clausulas-petreas.spec.md`](./clausulas-petreas.spec.md).
+
+## API / Interface
+
+Endpoints DRF do `SolicitacaoViewSet` (prefixo `/api/solicitacoes/`):
+
+| Ação | Método | Rota | Gate | Sucesso |
+|---|---|---|---|---|
+| Criar | POST | `/api/solicitacoes/` | `HasPerm("create_solicitation")` | 201 (`status` = `pendente`/`aprovado`) |
+| Aprovar | PATCH | `/api/solicitacoes/{id}/approve/` | `CanAccessSolicitationApprovals` | 200 |
+| Reprovar | PATCH | `/api/solicitacoes/{id}/reject/` | `CanAccessSolicitationApprovals` | 200 |
+| Aprovar em lote | POST | `/api/solicitacoes/batch_approve/` | `CanAccessSolicitationApprovals` | 200 |
+| Reprovar em lote | POST | `/api/solicitacoes/batch_reject/` | `CanAccessSolicitationApprovals` | 200 |
+| Publicar (GCal) | POST | `/api/solicitacoes/{id}/publish/` | `CanUseGcal` | 202 (só se `aprovado`; senão 400) |
+| Policies do usuário | GET | `/api/me/policies/` | `IsAuthenticated` | lista com `access_solicitation_approvals` quando elegível |
+
+Corpo de `approve`/`reject` aceita `{"justificativa": "..."}` (opcional). Lote aceita `{"ids": [...]}` e retorna `approved_count`/`rejected_count` + `errors[]` por id não processado.
+
+## Fluxos principais
+
+**Fluxo SUPER (aprovação manual):**
+1. Coordenador cria solicitação para projeto `fluxo == "SUPER"` → `perform_create` valida disponibilidade (`check_conflicts`) e grava `status="pendente"` (`resolve_initial_status`).
+2. Gerente da Superintendência (ou Assistente Administrativo do Controle) chama `approve`/`reject`.
+3. Service trava a linha (`select_for_update`), exige `status == "pendente"`, grava novo status e cria `AuditLog`.
+4. Aprovada → entra na Pré-Agenda; Controle/Super publica no GCal via `publish` (PA-03).
+
+**Fluxo NAO_SUPER (auto-aprovado):**
+1. Coordenador cria solicitação para projeto `fluxo == "NAO_SUPER"` → nasce `status="aprovado"` e vai direto à Pré-Agenda. Não passa pelos endpoints de aprovação.
+
+**Erros relevantes:**
+- Perfil não autorizado em `approve`/`reject` → **403** (mensagem cita "permissão"/"Superintendência").
+- `publish` em solicitação `pendente` → **400** e task Celery não enfileirada.
+- Reaprovar item já decidido → **400** (`already_approved`/`already_rejected`).
+- Lote > 100 ou `ids` vazio → **400** (`batch_limit_exceeded`/`ids_required`).
+
+## Decisões relacionadas (ADRs)
+
+- [ADR-002 — Approval Policy Manual](../../../../docs/architecture/project-decisions/ADR-002-approval-policy-manual.md) (CP-02).
+- Evolução do gate PA-02 para composite Setor × Função (PR 3 hardening RBAC, #1308) e exposição via `access_solicitation_approvals`: ver [`rbac_authorization_matrix.md`](../../rbac_authorization_matrix.md) e [`RBAC_NAMING.md`](../../RBAC_NAMING.md) §9 (Policy Resolution Rules).
+
+## Testes que cobrem
+
+- [`v2/backend/apps/core/tests/test_approval_policy_PA.py`](../../../backend/apps/core/tests/test_approval_policy_PA.py) — os 5 testes obrigatórios PA-07: `test_never_auto_approves_on_clean_or_save` (PA-01), `test_only_superintendencia_can_approve_or_reject` + `test_non_privileged_user_gets_403_on_approval_endpoint` (PA-02), `test_calendar_integration_not_called_before_approval` + `test_calendar_integration_is_called_after_approval` (PA-03), `test_approval_flow_records_audit_log` (PA-05).
+- [`v2/backend/apps/core/tests/test_solicitacao_fluxo.py`](../../../backend/apps/core/tests/test_solicitacao_fluxo.py) — PA-04: SUPER nasce `pendente`, NAO_SUPER nasce `aprovado`, `coordenador_acompanha` não altera fluxo, fallback de projeto ausente.
+- [`v2/backend/apps/core/tests/test_pr3_approvals_policy.py`](../../../backend/apps/core/tests/test_pr3_approvals_policy.py) — gate composite `access_solicitation_approvals` (PA-02).
+- [`v2/backend/apps/core/tests/test_auditlog_approve_reject.py`](../../../backend/apps/core/tests/test_auditlog_approve_reject.py) — auditoria de approve/reject (PA-05).
+
+## Pontos de atenção / dívidas conhecidas
+
+- **`approve` não revalida conflitos (deliberado)**: existe janela entre criação e aprovação manual em que a disponibilidade pode mudar; a Superintendência verifica manualmente em `/disponibilidade` antes de aprovar. Não é bug — é decisão de produto (ADR-002). Não reintroduzir `check_conflicts` em `approve` sem rediscutir a política.
+- **Doc legado desatualizado**: `v2/docs/IMPLEMENTACAO_PA.md` ainda cita `Solicitacao.save()` e o caminho obsoleto `apps/core/models.py` (linhas 412-436) e a "PA-02 Adaptada (inclui DAT)". A implementação atual decide estado inicial em `services/solicitacao_create.py` (não no `save()`) e o gate PA-02 é o composite que **exclui** DAT. Esta spec é o índice canônico; arquivar o doc legado em onda futura.
+- **`can_approve_super` (legado)**: permanece no payload de `/api/me/` apenas como contrato legado; consumidores novos devem usar `access_solicitation_approvals`. Remover após período de depreciação.
+- **Whitelist de lint**: o composite usa `groups.filter(name="Gerente"/"Superintendência")` com `# noqa: RBAC-composite-allowed` — qualquer novo caller que precise do composite deve reusar `_user_has_solicitation_approvals`/`user_has_policy`, não replicar o `groups.filter`.

--- a/v2/docs/specs/domain/regras-disponibilidade.spec.md
+++ b/v2/docs/specs/domain/regras-disponibilidade.spec.md
@@ -1,0 +1,117 @@
+---
+title: Regras de Disponibilidade (RD-01..RD-08)
+status: canonical
+last_verified: 2026-06-19
+sources_of_truth:
+  - v2/backend/apps/core/services/availability_service.py
+  - v2/backend/apps/core/views_availability.py
+  - v2/backend/apps/core/views_availability_monthly.py
+  - v2/backend/apps/core/types.py
+  - v2/backend/apps/core/services/config_service.py
+  - v2/backend/apps/core/utils/cache_utils.py
+  - v2/backend/apps/core/tests/test_availability_service.py
+  - v2/backend/config/settings.py
+  - v2/docs/GUIDE_AVAILABILITY.md
+  - docs/architecture/project-decisions/ADR-003-availability-rules-timezone.md
+owner: domain
+supersedes:
+  - v2/docs/GUIDE_AVAILABILITY.md
+  - docs/architecture/project-decisions/ADR-003-availability-rules-timezone.md
+related:
+  - v2/docs/specs/backend/rbac.spec.md
+  - v2/docs/specs/domain/politica-aprovacao.spec.md
+---
+
+# Regras de Disponibilidade (RD-01..RD-08)
+
+## Proposito
+
+As Regras de Disponibilidade (RD-01 a RD-08, **CP-03**) definem como o sistema detecta conflitos de agenda de um formador/coordenador ao se considerar um novo intervalo de evento. Substituem as antigas formulas Excel que falhavam em bordas de timezone (eventos proximos da meia-noite caiam no dia errado). O nucleo e um servico **puro e consultivo**: dado um usuario, um intervalo `(inicio, fim)` e um municipio opcional, devolve uma lista estruturada de conflitos. Nao grava, nao aprova, nao bloqueia nada por si so.
+
+O servico e a SSOT da logica de conflito. Os endpoints DRF (`/api/availability/check/`, `check-many/`) e a Grade Mensal apenas o consomem. A decisao final de disponibilidade e operacional/humana (Superintendencia via Grade Mensal); o check e ferramenta de apoio a criacao e aprovacao de solicitacoes.
+
+## Fonte de verdade no codigo
+
+- [`v2/backend/apps/core/services/availability_service.py`](../../../backend/apps/core/services/availability_service.py) — `check_conflicts(*, usuario, inicio, fim, municipio=None) -> CheckResult`; dataclasses `Conflict` e `CheckResult`; helpers `to_local`, `same_day_local`, `_fmt_interval_local`. Decorado com `@cache_availability_check(timeout=300)`.
+- [`v2/backend/apps/core/types.py`](../../../backend/apps/core/types.py) — `ConflictCode: TypeAlias = Literal["X", "T", "P", "D", "M", "E"]`.
+- [`v2/backend/apps/core/views_availability.py`](../../../backend/apps/core/views_availability.py) — `AvailabilityCheckView`, `AvailabilityCheckManyView`, `AvailabilityBlockViewSet`, helpers `is_privileged_user` / `can_check_availability_for_others`.
+- [`v2/backend/apps/core/views_availability_monthly.py`](../../../backend/apps/core/views_availability_monthly.py) — `MonthlyAvailabilityView` (grade mensal, codigos de celula).
+- [`v2/backend/apps/core/services/config_service.py`](../../../backend/apps/core/services/config_service.py) — `get_cfg("availability", {})` (overrides em runtime de buffer/limite).
+- [`v2/backend/config/settings.py`](../../../backend/config/settings.py) — `TIME_ZONE = TZ_PROJECT = "America/Fortaleza"`; `TRAVEL_BUFFER_MINUTES` (default 120); `AVAILABILITY_DAILY_LIMIT_HOURS` (default 8).
+
+Doc detalhado da API/permissoes da grade: [`v2/docs/GUIDE_AVAILABILITY.md`](../../GUIDE_AVAILABILITY.md). Decisao arquitetural: [`ADR-003`](../../../../docs/architecture/project-decisions/ADR-003-availability-rules-timezone.md).
+
+## Contratos e invariantes
+
+Codigos de conflito **emitidos pelo servico** (confirmado no codigo):
+
+| Codigo | Regra | Significado | Condicao |
+|--------|-------|-------------|----------|
+| `X` | RD-01 | Sobreposicao com evento aprovado | `inicio < ev.fim AND fim > ev.inicio` (overlap >= 1 min). Tambem usado em "intervalo invalido". |
+| `T` | RD-02 | Bloqueio total | `AvailabilityBlock` aprovado, `tipo="T"`, interseccao com o intervalo. |
+| `P` | RD-03 | Bloqueio parcial | `AvailabilityBlock` aprovado, `tipo != "T"` (ex.: `"P"`), interseccao com o subintervalo. |
+| `D` | RD-04 | Buffer de deslocamento insuficiente | Evento vizinho (anterior/posterior) em cidade diferente com gap `< buffer_min`. |
+| `M` | RD-05 | Capacidade diaria excedida | Soma de minutos no mesmo dia local `> AVAILABILITY_DAILY_LIMIT_HOURS * 60`. |
+
+Invariantes (NAO podem ser violados):
+
+- **CP-03** — RD-01..RD-08 sao clausula petrea. Timezone Fortaleza com storage UTC.
+- **RD-01 (adjacencia)**: `fim == inicio_vizinho` NAO conflita. Interseccao usa `<`/`>` estritos, nunca `<=`/`>=`.
+- **RD-04 (limite exato)**: gap exatamente igual ao buffer **passa**; so `mins < buffer_min` conflita. `municipio=None` (de qualquer lado) e tratado como **cidade diferente** → exige buffer (fix #588). Mesmo municipio → buffer 0.
+- **RD-05**: a duracao do **novo** intervalo entra na soma do dia; o recorte por dia usa range de datetime UTC derivado do dia local (`day_start`/`day_end`), nunca `.date()` cru (fix #249, bordas de meia-noite).
+- **RD-06**: comparacao sempre em `America/Fortaleza` via `to_local()`; entradas naive sao assumidas UTC (`make_aware(..., utc)`).
+- **RD-07**: o servico **reporta TODOS** os conflitos encontrados, na ordem Bloqueios (T/P) → Sobreposicao (X) → Buffer (D) → Capacidade (M). Nao ha short-circuit.
+- **RD-08**: cada `Conflict` carrega `code`, `title`, `detail` (com intervalo formatado `HH:MM dd/mm`) e `ref_id` opcional.
+- **Pureza**: `check_conflicts` so le; considera apenas `Solicitacao.status == APROVADO` e `AvailabilityBlock.status == APROVADO`. Validacao basica: `fim <= inicio` → `ok=False` com conflito `X` "Intervalo invalido".
+- **Cache**: resultado cacheado por 300s (`@cache_availability_check`); TTL curto porque dados mudam com frequencia.
+
+> Nota: `ConflictCode` inclui `E`, mas o servico **nao emite `E`** — `E`/`D1`/`2` sao codigos de celula da legenda da Grade Mensal (`GUIDE_AVAILABILITY.md`), nao saidas de `check_conflicts`.
+
+## API / Interface
+
+Funcao publica: `check_conflicts(*, usuario: Usuario, inicio: datetime, fim: datetime, municipio: Municipio | None = None) -> CheckResult`.
+
+Endpoints DRF (rota em `apps/core/urls.py`):
+
+- `GET /api/availability/check/` — params `usuario_id` (obrig.), `inicio`/`fim` ISO8601 (obrig.), `municipio_id` (opc.). Resposta `{ "ok": bool, "conflicts": [{code,title,detail,ref_id}] }`.
+- `POST /api/availability/check-many/` — body `{ "usuarios_ids": [...], "inicio", "fim", "municipio_id"? }`. Resposta `{ "results": [{usuario_id, ok, conflicts}] }`.
+- `GET /api/availability/monthly/` — grade mensal (legenda/celulas); ver `GUIDE_AVAILABILITY.md`.
+- `GET/POST /api/availability-blocks/` — CRUD de `AvailabilityBlock` (formador declara os proprios; RD-02/RD-03).
+
+RBAC dos endpoints de check: `permission_classes = [HasPerm("view_all_availability") | HasPerm("create_solicitation") | HasPerm("approve_solicitation_batch")]`. Filtro fino em runtime: consultar **outro** usuario exige `can_check_availability_for_others`; senao 403. Throttle scope `availability_check`. (Linguagem RBAC canonica `HasPerm`; grupos diretos banidos por `scripts/rbac_lint.py`.)
+
+## Fluxos principais
+
+Caminho feliz / deteccao (`check_conflicts`):
+
+1. Valida `fim > inicio` (senao retorna `X` "Intervalo invalido").
+2. Carrega `buffer_min` e `daily_limit_h` de `get_cfg("availability", {})` com fallback para settings (120 min / 8 h).
+3. Monta `events_qs` = `Solicitacao` APROVADO onde o usuario e dono **ou** participante (`participations__usuario`).
+4. RD-02/RD-03: itera blocos aprovados que intersectam → emite `T` ou `P`.
+5. RD-01: itera eventos aprovados que intersectam → emite `X`.
+6. RD-04: pega evento imediatamente anterior (`fim__lte=inicio`) e posterior (`inicio__gte=fim`); se cidade difere e gap `< buffer_min`, emite `D`.
+7. RD-05: soma minutos dos eventos que tocam o dia local + duracao do novo intervalo; se `> limite`, emite `M`.
+8. Retorna `CheckResult(ok=(len(conflicts)==0), conflicts=...)`.
+
+Caminhos de erro do endpoint `check/`: `usuario_id` ausente/invalido → 400; usuario inexistente → 404; consultar outro sem permissao → 403; `municipio_id` invalido → 400; `inicio`/`fim` ausentes ou nao-ISO → 400; `fim <= inicio` → 400; nao autenticado → 401/403. Datetimes naive sao convertidos para UTC antes do servico (RD-06).
+
+## Decisoes relacionadas (ADRs)
+
+- [ADR-003 — Regras de Disponibilidade e Timezone (RD-01..RD-08)](../../../../docs/architecture/project-decisions/ADR-003-availability-rules-timezone.md) — decisao de timezone-aware + os 8 codigos/regras.
+- Fixes historicos referenciados no codigo: #588 (`municipio=None` = cidade diferente), #249 (bordas de meia-noite via range UTC), #1222/PR #1183 (realinhamento RBAC do check), D9/PR #1308 hardening (`can_check_availability_for_others`).
+
+## Testes que cobrem
+
+[`v2/backend/apps/core/tests/test_availability_service.py`](../../../backend/apps/core/tests/test_availability_service.py):
+
+- `TestAvailabilityServiceRules` — `test_conflict_overlap_total`/`_partial` (X), `test_no_conflict_adjacent_end_equals_start` (RD-01 adjacencia), `test_block_total_T_prevents_any_event` (T), `test_block_partial_P_prevents_inside_allows_outside` (P), `test_travel_buffer_between_cities_required` / `test_same_city_allows_zero_buffer` (D), `test_daily_capacity_M_exceeded` (M), `test_timezone_aware_fortaleza_localtime` + `test_midnight_boundary_timezone_aware` (RD-06).
+- `TestAvailabilityCheckEndpoint` — 200/400/401-403/404, `usuario_id` obrigatorio, validacao de datas, batch `check-many/`, e `test_permission_only_self_or_privileged` (403 RBAC ao checar outro).
+- `TestAvailabilityServiceAdditional` — `test_multi_formador_any_conflict_blocks` (RD-01 multi-formador), `test_conflict_messages_include_codes_and_intervals` (RD-08: estrutura `{code,title,detail}` + intervalo).
+
+## Pontos de atencao / dividas conhecidas
+
+- **Codigo `E` orfao no `ConflictCode`**: presente no `Literal` mas nunca emitido pelo servico (so legenda da grade). Possivel fonte de confusao entre saida do check e celulas da Grade Mensal.
+- **TOCTOU**: `check_conflicts` e consultivo e cacheado por 300s; entre o check e a aprovacao/criacao real outro evento pode ser aprovado. A decisao final NAO e atomica com o check — por design, a aprovacao manual (Superintendencia) e o gate. Nao tratar o `ok=True` como garantia transacional.
+- **Sem checagem de buffer transitivo**: RD-04 so olha o evento imediatamente anterior e o imediatamente posterior; cadeias com 3+ eventos no mesmo dia nao reavaliam o buffer entre pares nao-adjacentes.
+- **Participacoes**: `events_qs` inclui solicitacoes onde o usuario e participante (`participations__usuario`) alem de dono; confirmar que novas relacoes de participacao mantenham esse filtro ao evoluir o modelo.
+- **GUIDE_AVAILABILITY.md** descreve gerencias/setores de forma resumida (lista parcial); a SSOT de setores/funcoes e `apps.core.constants` (13 setores / 5 funcoes, sendo 4 funcoes RBAC + Gerente). Nao tratar a tabela do guia como SSOT organizacional.

--- a/v2/docs/specs/domain/requisitos-funcionais.spec.md
+++ b/v2/docs/specs/domain/requisitos-funcionais.spec.md
@@ -1,0 +1,110 @@
+---
+title: Requisitos Funcionais (RF01..RF08)
+status: canonical
+last_verified: 2026-06-19
+sources_of_truth:
+  - v2/backend/apps/core/management/commands/import_export_contract.py
+  - v2/backend/apps/core/services/export_contract_importer.py
+  - v2/backend/apps/core/services/solicitacao_create.py
+  - v2/backend/apps/core/services/availability_service.py
+  - v2/backend/apps/core/services/solicitacao_approval.py
+  - v2/backend/apps/core/services/solicitacao_publish.py
+  - v2/backend/apps/core/services/gcal_client_factory.py
+  - v2/backend/apps/core/services/gcal_sync_service.py
+  - v2/backend/apps/core/services/monthly_grid_service.py
+  - v2/backend/apps/core/models/auditoria.py
+  - v2/backend/apps/core/views_solicitacao.py
+  - v2/backend/apps/core/views_availability.py
+  - v2/backend/apps/core/views_availability_monthly.py
+  - v2/backend/apps/core/urls.py
+owner: domain
+supersedes:
+  - docs/business-rules/requisitos-funcionais.md
+related:
+  - v2/docs/specs/INDEX_SDD.md
+  - v2/docs/specs/domain/README.md
+  - v2/docs/GUIDE_AVAILABILITY.md
+  - v2/docs/GUIDE_GCAL.md
+  - v2/docs/RBAC_NAMING.md
+  - docs/business-rules/regras-disponibilidade.md
+  - docs/business-rules/politica-aprovacao.md
+---
+
+# Requisitos Funcionais (RF01..RF08)
+
+## Propósito
+
+Os Requisitos Funcionais RF01..RF08 descrevem **o que** o Aprender Sistema v2 entrega ao negócio: importar dados, abrir e validar solicitações de evento, conferir conflitos de disponibilidade, aprovar manualmente, publicar no Google Calendar (com Meet quando online), auditar tudo e exibir o mapa mensal de disponibilidade. São o contrato de produto que substitui as planilhas (objetivo: eliminar as 82.389 fórmulas Excel).
+
+Esta spec é um **índice** (SSOT do conjunto RF) e não duplica os guias/specs detalhados: cada RF aponta para o serviço/arquivo que o implementa hoje e para a spec/guia canônico do tópico. As regras numéricas (RD-01..RD-08 de disponibilidade, PA-01..PA-07 de aprovação) vivem nas specs de domínio dedicadas — aqui ficam apenas os contratos de alto nível.
+
+## Fonte de verdade no código
+
+| RF | O que faz | Implementação atual |
+|---|---|---|
+| **RF01** Importação | Carga de dados a partir do export-contract (Sheets → Sistema), dry-run-first | [`management/commands/import_export_contract.py`](../../../backend/apps/core/management/commands/import_export_contract.py) + [`services/export_contract_importer.py`](../../../backend/apps/core/services/export_contract_importer.py); importers DRF por entidade em `views_imports.py` e `views_import_*.py` |
+| **RF02** Solicitação | Criação de pré-agenda, decide status inicial por `projeto.fluxo` | [`services/solicitacao_create.py`](../../../backend/apps/core/services/solicitacao_create.py) (`decide_initial_status`); `SolicitacaoViewSet` em [`views_solicitacao.py`](../../../backend/apps/core/views_solicitacao.py) |
+| **RF03** Conflitos | Checagem de disponibilidade (RD-01..RD-08) | [`services/availability_service.py`](../../../backend/apps/core/services/availability_service.py) (`check_conflicts`); views em [`views_availability.py`](../../../backend/apps/core/views_availability.py) |
+| **RF04** Aprovação | Aprovar/reprovar (PA-01..PA-07), individual e em lote | [`services/solicitacao_approval.py`](../../../backend/apps/core/services/solicitacao_approval.py); ações `approve`/`reject` no `SolicitacaoViewSet` |
+| **RF05** Google Calendar | Preview e publish do evento no GCal (fake vs google) | [`services/gcal_client_factory.py`](../../../backend/apps/core/services/gcal_client_factory.py), [`services/gcal_sync_service.py`](../../../backend/apps/core/services/gcal_sync_service.py), [`services/solicitacao_publish.py`](../../../backend/apps/core/services/solicitacao_publish.py) (`preview_gcal`, `publish_to_gcal`) |
+| **RF06** Google Meet | Link Meet gerado só quando `is_online=True`, no apply real | Campo `meet_link` em [`models/solicitacao.py`](../../../backend/apps/core/models/solicitacao.py); `conferenceData` montado no publish (`solicitacao_publish.py` / `gcal_sync_service.py`) |
+| **RF07** Auditoria | Trilha completa de ações sensíveis | [`models/auditoria.py`](../../../backend/apps/core/models/auditoria.py) (`AuditLog` + `AuditLog.Action`) |
+| **RF08** Mapa mensal | Grade mensal de disponibilidade por papel/setor | [`services/monthly_grid_service.py`](../../../backend/apps/core/services/monthly_grid_service.py) (`build_monthly_grid`); view em [`views_availability_monthly.py`](../../../backend/apps/core/views_availability_monthly.py) |
+
+> Correção histórica (RF01): o **ETL legado foi removido** (app `dat_ingest` deletado). O caminho de importação real é o **`import_export_contract`** + os endpoints DRF de import; comandos `etl_upsert_*` antigos não são mais a fonte de verdade.
+
+## Contratos e invariantes
+
+- **RF01 — dry-run-first / never-overwrite**: sem `--apply` o comando apenas classifica; `--apply` **exige** `--allow-entity` (allowlist) e roda em modo create-only; campos protegidos (`Solicitacao.status`, `Formacao.data_formacao`, `Acompanhamento`) nunca são sobrescritos. Idempotência por hash externo (`external_hash`). **Nenhum import real foi executado** — não importar dados de verdade até um `--apply` dry-run passar verde + autorização.
+- **RF02 / PA-04**: solicitação de projeto `fluxo == SUPER` nasce `pendente`; projeto `NAO_SUPER` é auto-aprovado na criação. Datas são timezone-aware em `America/Fortaleza` (armazenadas em UTC).
+- **RF03 / RD-01..RD-08**: precedência de checagens é Bloqueios (T/P) → Conflitos → Deslocamento (D) → Capacidade (M); `fim == inicio` **não** é conflito (adjacência permitida). Detalhe em [`regras-disponibilidade.spec.md`](./regras-disponibilidade.spec.md) / [GUIDE_AVAILABILITY](../../GUIDE_AVAILABILITY.md).
+- **RF04 / PA-01..PA-07 (CP-02)**: SUPER **nunca** auto-aprova; aprovar/reprovar exige autorização (`CanAccessSolicitationApprovals`); lote limitado a 100 ids, com `select_for_update(skip_locked=True)` para evitar dupla aprovação. Idioma RBAC: `permission_classes=[HasPerm("codename")]` (grupos diretos banidos por `scripts/rbac_lint.py`).
+- **RF05 / PA-03**: integração GCal só ocorre **após** aprovação manual; `preview` nunca persiste; idempotência por `external_event_id = asv2-{id}` + `gcal_payload_hash` (SHA256); retry/backoff para 429/5xx. Cliente selecionado por `GCAL_CLIENT=fake|google`.
+- **RF06**: `meet_link` é read-only no serializer; só é gerado/persistido em apply real com `is_online=True` (nunca em preview, dry-run ou 409). `is_online=False` (default) → sem `conferenceData`.
+- **RF07 / PA-05**: toda ação sensível grava `AuditLog` (usuario, action, model_name, details JSON com `solicitacao_id`, `prev_status`, `new_status`, `ip_address`, `user_agent`). Ações: `APPROVE`, `REJECT`, `PREVIEW_GCAL`, `PUBLISH_GCAL_REQUESTED`, `PUBLISH_GCAL`, `PUBLISH_GCAL_ERROR`, `RESYNC_GCAL_REQUESTED`, `CANCEL_GCAL_REQUESTED`, `CANCEL_GCAL`.
+- **RF08**: grade mensal usa precedência de código `X > D1 > 2 > E > T/P > D`; cacheada em Redis (~5 min); ranking denso por carga horária do mês.
+
+## API / Interface
+
+Rotas registradas em [`urls.py`](../../../backend/apps/core/urls.py) (prefixo `/api/`). Contrato detalhado em [`v2/docs/API_REFERENCE.md`](../../API_REFERENCE.md).
+
+- **RF02**: `SolicitacaoViewSet` (router `solicitacoes`); `POST /api/solicitacoes/validate/`.
+- **RF03**: `GET /api/availability/check/` (individual) · `POST /api/availability/check-many/` (lote).
+- **RF04**: `PATCH /api/solicitacoes/{id}/approve/` · `PATCH /api/solicitacoes/{id}/reject/` (+ ações de lote no viewset).
+- **RF05/RF06**: `POST /api/solicitacoes/{id}/preview-gcal/` · `POST /api/solicitacoes/{id}/publish/` (202 Accepted, Celery) · `POST /api/solicitacoes/{id}/resync-gcal/` · `POST /api/gcal/publish-batch/`. Permissão `CanUseGcal` (Controle + Superintendência).
+- **RF08**: `GET /api/availability/monthly/?year=&month=&role=§or=&q=`.
+- **RF01**: comando `python manage.py import_export_contract --path ... [--apply --allow-entity <entidade>] [--json]`; importers DRF sob `/api/.../import/`.
+
+## Fluxos principais
+
+1. **Importação (RF01)**: operador roda `import_export_contract` em dry-run → revisa classificação → (com autorização) `--apply --allow-entity X` → writes create-only idempotentes; campos protegidos preservados.
+2. **Solicitação → publicação (RF02→RF05/RF06)**: coordenador cria solicitação → sistema checa conflitos (RF03) → `NAO_SUPER` auto-aprova; `SUPER` fica `pendente` → Superintendência/DAT aprova (RF04, grava AuditLog) → Controle/Super faz `preview-gcal` (não persiste) → `publish` enfileira Celery → evento criado no GCal; se `is_online=True`, `meet_link` extraído de `hangoutLink` e persistido (RF06).
+3. **Mapa mensal (RF08)**: front pede `availability/monthly/` por ano/mês/papel/setor → `build_monthly_grid` agrega eventos, bloqueios e deslocamentos em códigos por dia/pessoa → resposta cacheada; clique abre detalhe do dia.
+- **Erros relevantes**: aprovar item não-`pendente` → `ValidationAPIError` (`already_approved`/`already_rejected`/`invalid_status`); lote > 100 → `batch_limit_exceeded`; `--apply` sem allowlist → bloqueado, nada escrito; publish com `apply_blocked=True` → respeitado (não escreve no GCal).
+
+## Decisões relacionadas (ADRs)
+
+- [ADR-001 Docker-only](../../../../docs/architecture/project-decisions/ADR-001-docker-only-deployment.md) (CP-01)
+- [ADR-002 Aprovação manual](../../../../docs/architecture/project-decisions/ADR-002-approval-policy-manual.md) (RF04/PA)
+- [ADR-003 Regras de disponibilidade + timezone](../../../../docs/architecture/project-decisions/ADR-003-availability-rules-timezone.md) (RF03/RD)
+- [ADR-005 SSOT PostgreSQL](../../../../docs/architecture/project-decisions/ADR-005-ssot-postgresql.md) (RF01)
+- [ADR-008 GCal requestId determinístico](../../../../docs/architecture/project-decisions/ADR-008-gcal-deterministic-requestid.md) (RF05/RF06)
+- [ADR-011 Polling sobre WebSocket](../../../../docs/architecture/project-decisions/ADR-011-polling-over-websocket.md)
+- [ADR-017 Documentação spec-driven](../../../../docs/architecture/project-decisions/ADR-017-spec-driven-documentation.md)
+
+## Testes que cobrem
+
+- **RF03**: [`tests/test_availability_service.py`](../../../backend/apps/core/tests/test_availability_service.py); [`tests/test_monthly_with_deslocamento.py`](../../../backend/apps/core/tests/test_monthly_with_deslocamento.py).
+- **RF04 / PA**: [`tests/test_approval_policy_PA.py`](../../../backend/apps/core/tests/test_approval_policy_PA.py) (5 testes obrigatórios); [`tests/test_solicitacao_approval_concurrency.py`](../../../backend/apps/core/tests/test_solicitacao_approval_concurrency.py).
+- **RF02**: [`tests/test_solicitacao_create_service.py`](../../../backend/apps/core/tests/test_solicitacao_create_service.py); [`tests/test_solicitacao_fluxo.py`](../../../backend/apps/core/tests/test_solicitacao_fluxo.py); [`tests/test_solicitacao_online_mode.py`](../../../backend/apps/core/tests/test_solicitacao_online_mode.py).
+- **RF05/RF06**: `tests/test_gcal_*.py` (ex.: [`test_gcal_endpoints.py`](../../../backend/apps/core/tests/test_gcal_endpoints.py), [`test_gcal_publish_apply_blocked.py`](../../../backend/apps/core/tests/test_gcal_publish_apply_blocked.py), [`test_gcal_meet_link_persist.py`](../../../backend/apps/core/tests/test_gcal_meet_link_persist.py), [`test_gcal_retry_backoff.py`](../../../backend/apps/core/tests/test_gcal_retry_backoff.py)).
+- **RF07**: coberto indiretamente por `test_approval_policy_PA.py::test_approval_flow_records_audit_log` e pelos testes de retry/audit GCal ([`test_gcal_retry_audit.py`](../../../backend/apps/core/tests/test_gcal_retry_audit.py)).
+- **RF01**: [`tests/test_export_contract_importer.py`](../../../backend/apps/core/tests/test_export_contract_importer.py); [`tests/test_export_contract_projeto_resolver.py`](../../../backend/apps/core/tests/test_export_contract_projeto_resolver.py).
+
+## Pontos de atenção / dívidas conhecidas
+
+- **RF01 não foi executado em produção**: o pipeline export-contract está em dry-run; `--apply` segue bloqueado sem allowlist. Re-import cego sobrescreveria data-fixes manuais (D2/C3-A/C4.4) — exige `--apply` dry-run verde + autorização.
+- **RF05/RF06 em prod**: GCal depende de `GCAL_CLIENT`, `GCAL_CALENDAR_ID`/`GCAL_AUTH_MODE` e `GCAL_ENCRYPTION_KEY` no Portainer; eventos vazios geralmente são config de ambiente, não código. Celery já teve broker quebrado em prod (#1089) — publish é assíncrono e depende do worker.
+- **TOCTOU de aprovação**: aprovação individual e em lote usam `select_for_update` para fechar a janela de corrida, mas a checagem de conflito (RF03) e a aprovação (RF04) são passos separados — alteração de disponibilidade entre eles não revalida automaticamente.
+- **PA-01 no importer de eventos**: corrigido para SUPER nunca auto-aprovar mesmo em evento passado (#1370); manter coberto ao evoluir RF01.
+- **Specs irmãs ainda planejadas**: `regras-disponibilidade.spec.md` e `politica-aprovacao.spec.md` referenciadas aqui podem estar como esqueleto; até serem escritas, a fonte canônica é `docs/business-rules/` + ADRs.

--- a/v2/docs/specs/frontend/README.md
+++ b/v2/docs/specs/frontend/README.md
@@ -11,7 +11,7 @@ related:
 
 Voltar ao [índice SDD](../INDEX_SDD.md).
 
-## Specs planejadas (Fase 3-4)
+## Specs (escritas em 2026-06-19) — origem de cada uma
 
 | Spec | Estado da doc hoje | Código |
 |---|---|---|
@@ -19,4 +19,4 @@ Voltar ao [índice SDD](../INDEX_SDD.md).
 | `pages.spec.md` | parcial (6/14 documentadas) | `src/pages/` (14 dirs reais; rever "45+ pages") |
 | `api-clients.spec.md` | contrato via `API_REFERENCE` + ADR-013 | `src/api/` (15 módulos) |
 
-> Status: esqueleto. Nenhuma spec escrita ainda (Fase 0).
+> Status: **specs escritas** (Fase 3-4, 2026-06-19) — links vivos no [índice SDD](../INDEX_SDD.md).

--- a/v2/docs/specs/frontend/api-clients.spec.md
+++ b/v2/docs/specs/frontend/api-clients.spec.md
@@ -1,0 +1,93 @@
+---
+title: Clientes de API (axios)
+status: canonical
+last_verified: 2026-06-19
+sources_of_truth:
+  - v2/frontend/src/api/config.ts
+  - v2/frontend/src/api/auth.ts
+  - v2/frontend/src/api/me.ts
+  - v2/frontend/src/api/lookup.ts
+  - v2/frontend/src/api/ops.ts
+  - v2/frontend/src/api/solicitacoes.ts
+  - v2/frontend/src/api/availability.ts
+  - v2/frontend/src/api/adminDAT.ts
+  - v2/frontend/src/api/datModule.ts
+  - v2/frontend/src/api/gcal.ts
+  - v2/frontend/src/constants/timing.ts
+  - v2/frontend/src/api/__tests__/config.test.ts
+  - docs/architecture/project-decisions/ADR-013-axios-pinning-fetch-migration.md
+owner: frontend
+supersedes:
+  - docs/architecture/project-decisions/ADR-013-axios-pinning-fetch-migration.md
+related:
+  - v2/docs/API_REFERENCE.md
+  - v2/docs/specs/backend/rbac.spec.md
+---
+
+# Clientes de API (axios)
+
+## Proposito
+
+A camada `src/api/` concentra todo o acesso HTTP do frontend ao backend DRF. Apesar do titulo historico mencionar "axios", **a migracao axios -> Fetch API nativa esta concluida**: nao ha mais dependencia `axios` no `package.json` e o unico residuo sao comentarios de testes legados (Epic #1039). Todos os ~20 clientes consomem um wrapper unico (`config.ts`) construido sobre `fetch()`, eliminando risco de supply chain e ~40KB de bundle (ver ADR-013).
+
+Cada arquivo em `src/api/` e um cliente tematico (auth, me, lookup, solicitacoes, availability, ops/Controle, adminDAT, datModule, gcal, dashboard, stats, teamMetrics, systemConfig, acoesNotificacao). Eles expoem funcoes tipadas que retornam `Promise<T>` e delegam o transporte, CSRF e tratamento de erro ao `config.ts`. Nenhum componente React deve chamar `fetch()` diretamente; a regra de ouro e uma funcao de cliente por endpoint.
+
+## Fonte de verdade no codigo
+
+- **Wrapper central**: [`v2/frontend/src/api/config.ts`](../../../frontend/src/api/config.ts) — `API_BASE`, `fetchAPI`, `fetchBlob`, `fetchWithErrorMapping`, `buildUrl` e helpers de CSRF (`getCsrfToken`, `ensureCsrfToken`, `clearCsrfCache`, `initCsrfToken`).
+- **Clientes tematicos** (todos importam `./config`): [`auth.ts`](../../../frontend/src/api/auth.ts), [`me.ts`](../../../frontend/src/api/me.ts), [`lookup.ts`](../../../frontend/src/api/lookup.ts), [`solicitacoes.ts`](../../../frontend/src/api/solicitacoes.ts), [`availability.ts`](../../../frontend/src/api/availability.ts), [`ops.ts`](../../../frontend/src/api/ops.ts), [`adminDAT.ts`](../../../frontend/src/api/adminDAT.ts), [`datModule.ts`](../../../frontend/src/api/datModule.ts), [`gcal.ts`](../../../frontend/src/api/gcal.ts), e ainda `dashboard.ts`, `stats.ts`, `teamMetrics.ts`, `systemConfig.ts`, `acoesNotificacao.ts`.
+- **Base URL**: `export const API_BASE = import.meta.env.VITE_API_URL || '/api'` — o default `/api` (same-origin) e o caminho canonico oficial (ver `API_REFERENCE.md`).
+- **TTL do cache CSRF**: [`v2/frontend/src/constants/timing.ts`](../../../frontend/src/constants/timing.ts) — `TIMING.CSRF_TOKEN_TTL_MS = 30 min`.
+
+## Contratos e invariantes
+
+- **Base path canonico `/api/`**: clientes passam paths relativos sem o prefixo (ex.: `'/me/events/'`); `fetchAPI`/`fetchBlob` prefixam `API_BASE`. URLs absolutas (`http...`) sao passadas inalteradas. **Proibido** usar o alias deprecated `/api/v1/` em codigo novo (CI bloqueia, #796/#797).
+- **Sessao via cookie**: toda chamada usa `credentials: 'include'`. Auth e por sessao Django (nao token Bearer).
+- **CSRF obrigatorio em mutacoes**: para `POST/PUT/PATCH/DELETE`, `fetchAPI` injeta header `X-CSRFToken` via `ensureCsrfToken()`. Se nao houver token, lanca `Error('CSRF token ausente...')` antes de enviar.
+- **Estrategia de obtencao do CSRF** (`ensureCsrfToken`): (1) le cookie `csrftoken`; (2) usa cache em memoria se valido (TTL 30 min, Issue #258); (3) busca fresco em `GET /api/csrf/` (Issue #135, suporta `CSRF_COOKIE_HTTPONLY=True` retornando o token no body).
+- **Retry idempotente de CSRF (1x)**: em `403` cujo body contem `"CSRF"`, limpa o cache e retenta uma unica vez com `forceRefresh` (flag `isRetry` impede loop). Em `401`, invalida o cache CSRF.
+- **Rotacao no login/logout**: `login()` e `logout()` chamam `clearCsrfCache()` porque o Django rotaciona o CSRF token apos login.
+- **Forma do erro**: em `!response.ok`, lanca `Error` enriquecido com `.status` e `.response = { status, data }`. A mensagem vem de `error.detail || error.message`. `401/403` sao logados em nivel debug (esperados em load inicial), demais erros em `error`.
+- **204 / corpo vazio**: `fetchAPI` retorna `undefined` (nunca chama `response.json()` em `204` ou `content-length: 0`) — contrato esperado por DELETEs.
+- **Construcao de query**: `buildUrl(path, params)` omite valores `null`/`undefined`/`''` e escolhe separador `?`/`&` automaticamente.
+
+## API / Interface
+
+Wrapper publico exportado por `config.ts`:
+
+| Funcao | Uso |
+|---|---|
+| `fetchAPI<T>(url, options?, isRetry?)` | Transporte JSON padrao (GET/POST/...). Retorna `T` ou `undefined` em 204. |
+| `fetchBlob(url, options?)` | Downloads binarios (CSV/Excel export). Injeta CSRF em mutacoes; sem parse JSON. |
+| `fetchWithErrorMapping<T>(url, options?, errorMap)` | Mapeia status HTTP -> mensagem amigavel por endpoint. |
+| `buildUrl(path, params?)` | Monta querystring filtrando valores vazios. |
+| `ensureCsrfToken(forceRefresh?)` / `getCsrfToken()` / `clearCsrfCache()` / `initCsrfToken()` | Ciclo de vida do token CSRF. |
+
+`API_BASE` e configuravel por `VITE_API_URL` (default `/api`). Os endpoints concretos consumidos por cada cliente estao em [`v2/docs/API_REFERENCE.md`](../../API_REFERENCE.md). `initCsrfToken()` roda automaticamente no import do modulo, exceto sob Vitest.
+
+## Fluxos principais
+
+1. **GET (leitura, ex. lookup/me)**: cliente monta path com `buildUrl` -> `fetchAPI` prefixa `API_BASE`, envia com `credentials: 'include'` (sem CSRF) -> `response.json()` tipado. Erro 401/403 -> `Error` com `.status`, logado em debug.
+2. **Mutacao (POST/PUT/PATCH/DELETE)**: `fetchAPI` chama `ensureCsrfToken()` -> injeta `X-CSRFToken` -> envia. Se backend responder `403 + "CSRF"`: limpa cache, busca token fresco e retenta 1x; se ainda falhar, propaga `Error`.
+3. **Login**: `auth.login()` -> `POST /auth/login/` -> sucesso -> `clearCsrfCache()` (Django rotacionou o token) de forma que a proxima mutacao busca token novo.
+4. **Bootstrap**: no carregamento do app, `initCsrfToken()` pre-aquece o token para evitar race no primeiro submit.
+5. **Download de arquivo**: `fetchBlob('/dat/compras/export/')` retorna `Blob`; o caller cria `URL.createObjectURL`. Falha lanca `Error('Export failed: HTTP <status>')`.
+
+## Decisoes relacionadas (ADRs)
+
+- [ADR-013 — Pin Axios + migracao para Fetch API](../../../../docs/architecture/project-decisions/ADR-013-axios-pinning-fetch-migration.md) (axios comprometido em 2026-03-31; CVE-2025-27152; issue #782). **Status: migracao concluida** — esta spec passa a ser o indice vivo do tema.
+- Base path `/api/` canonico e corte do `/api/v1/`: `API_REFERENCE.md` (#796/#797).
+
+## Testes que cobrem
+
+- [`v2/frontend/src/api/__tests__/config.test.ts`](../../../frontend/src/api/__tests__/config.test.ts) — `getCsrfToken`, `clearCsrfCache`, `buildUrl`, `fetchAPI` (com MSW). Nota: cookie de teste usa `; Secure` porque jsdom roda em HTTPS (memoria vitest+jsdom Secure cookies).
+- Testes por cliente: `availability.test.ts`, `lookup.test.ts`, `gcal.test.ts`, `adminDAT.test.ts`, `datModule.test.ts`, `systemConfig.test.ts`, `dashboard.test.ts`, `teamMetrics.test.ts`, `ops.normalizeImportResponse.test.ts` (todos em `v2/frontend/src/api/__tests__/`).
+- Mocks de rede via MSW (`src/test/mocks/`), sem servidor real.
+
+## Pontos de atencao / dividas conhecidas
+
+- **Sem instancia central legada**: nao existe `src/api.ts` nem `httpClient.ts`; o plano do ADR-013 foi simplificado para um unico `config.ts`. Citar `config.ts` como wrapper, nao `httpClient.ts`.
+- **Residuo historico de axios**: somente comentarios em `src/hooks/__tests__/useGoogleIntegration.test.js` e `useSessionMonitor.test.js`. Nenhum import real de axios — nao reintroduzir.
+- **Retry CSRF detecta por string**: o gatilho do retry e `errorBody.includes('CSRF')`; mudanca na mensagem do Django pode quebrar o retry silenciosamente.
+- **`fetchBlob` engole detalhe do erro**: lanca mensagem generica `HTTP <status>` sem parsear o body — pior UX que `fetchAPI` para exports que falham com 400 detalhado.
+- **CSRF stale residual**: o TTL de 30 min cobre a maioria dos casos, mas o cookie tem prioridade sobre o cache; se o cookie ficar stale (sem HttpOnly) o retry-1x e a unica rede de seguranca."

--- a/v2/docs/specs/frontend/hooks-rbac.spec.md
+++ b/v2/docs/specs/frontend/hooks-rbac.spec.md
@@ -1,0 +1,111 @@
+---
+title: Hooks de RBAC e Guards (Frontend)
+status: canonical
+last_verified: 2026-06-19
+sources_of_truth:
+  - v2/frontend/src/hooks/usePermissions.ts
+  - v2/frontend/src/hooks/useCanAccess.ts
+  - v2/frontend/src/hooks/useGoogleGuard.tsx
+  - v2/frontend/src/hooks/useGoogleIntegration.ts
+  - v2/frontend/src/api/me.ts
+  - v2/frontend/src/api/auth.ts
+  - v2/frontend/src/types/usuario.ts
+  - v2/frontend/src/App.tsx
+  - v2/frontend/src/components/AppRoutes.tsx
+  - v2/frontend/src/hooks/__tests__/usePermissions.test.js
+  - v2/frontend/src/hooks/__tests__/useCanAccess.test.ts
+  - v2/frontend/src/hooks/__tests__/rbac_matrix.test.ts
+  - v2/backend/apps/core/views/me.py
+  - v2/backend/apps/core/rbac/policies.py
+owner: frontend
+supersedes: []
+related:
+  - v2/docs/RBAC_NAMING.md
+  - v2/docs/rbac_authorization_matrix.md
+  - v2/docs/API_REFERENCE.md
+---
+
+# Hooks de RBAC e Guards (Frontend)
+
+## Proposito
+
+Esta camada decide **o que o usuario ve e pode acionar** na SPA React, sem nunca virar fonte de autoridade: a decisao final continua no backend (`permission_classes=[HasPerm("codename")]`). O frontend le o estado de identidade/autorizacao do usuario autenticado a partir de `GET /api/me/` (perfil + setores/funcoes) e `GET /api/me/policies/` (capabilities publicas), traduz isso em flags semanticas e usa essas flags para esconder/exibir menu, guardar rotas e desativar acoes. O objetivo e UX honesta (nao oferecer o que sera negado), nao seguranca: qualquer flag pode ser burlada no cliente e o backend revalida.
+
+Ha tambem um guard transversal de integracao Google (OAuth): antes de operacoes que tocam o Google Calendar, o frontend confere se a conta corporativa esta conectada e, se nao, conduz o usuario ao fluxo OAuth em vez de deixar a chamada falhar com `403 google_not_connected`.
+
+## Fonte de verdade no codigo
+
+- **Identidade e capabilities legacy**: [`v2/frontend/src/hooks/usePermissions.ts`](../../../frontend/src/hooks/usePermissions.ts) — funcao pura `computePermissions(user)` + hook memoizado `usePermissions(user)`. Computa flags de role (`isCoordenador`, `isFormador`, `isGerente`), setor (`inSuperintendencia`, `inDAT`, `inControle`, `inDiretoria`, `inGerencia`) e capability derivada (`canControle`, `canDAT`, `canDisponibilidade`, `canDashboard*`, `canSeeAllSectors`, etc.) a partir de `user.setores` / `user.funcoes` / `user.is_superuser`.
+- **Capability Policy Layer**: [`v2/frontend/src/hooks/useCanAccess.ts`](../../../frontend/src/hooks/useCanAccess.ts) — funcao pura `computeAccess(policies, legacy)` + hook `useCanAccess`. Traduz as `PUBLIC_POLICY_KEYS` recebidas em `policies` (mais flags legacy de fallback) nas **derived flags** que os componentes consomem: `canAccessApprovals`, `canAccessBlocks`, `canCreateSolicitation`, `canViewComprasDashboard`, e o predicado generico `can(key)`.
+- **Guard Google OAuth**: [`v2/frontend/src/hooks/useGoogleGuard.tsx`](../../../frontend/src/hooks/useGoogleGuard.tsx) — `requireGoogleConnection(action)`, `handleGoogleError(error)`, `isConnected`.
+- **Status da integracao Google**: [`v2/frontend/src/hooks/useGoogleIntegration.ts`](../../../frontend/src/hooks/useGoogleIntegration.ts) — `fetchStatus()` le `GET /api/integrations/google/status/`; expoe `status.connected` consumido pelo guard.
+- **Clientes HTTP**: [`v2/frontend/src/api/auth.ts`](../../../frontend/src/api/auth.ts) (`checkAuth()` le `/api/me/`) e [`v2/frontend/src/api/me.ts`](../../../frontend/src/api/me.ts) (`getMyPolicies()` le `/api/me/policies/`).
+- **Contrato de tipo + runtime guard**: [`v2/frontend/src/types/usuario.ts`](../../../frontend/src/types/usuario.ts) — interface `CurrentUser` e `assertCurrentUserPayload()` (lanca `Invalid /api/me payload shape` se o payload divergir).
+- **Wiring / composicao**: [`v2/frontend/src/App.tsx`](../../../frontend/src/App.tsx) carrega `user` e `policies` e injeta em [`v2/frontend/src/components/AppRoutes.tsx`](../../../frontend/src/components/AppRoutes.tsx), que aplica os guards por rota.
+- **Backend (contraparte autoritativa)**: [`v2/backend/apps/core/views/me.py`](../../../backend/apps/core/views/me.py) (`/api/me/policies/`) e [`v2/backend/apps/core/rbac/policies.py`](../../../backend/apps/core/rbac/policies.py) (`PUBLIC_POLICY_KEYS`, `resolve_public_policies`).
+
+## Contratos e invariantes
+
+- **O frontend NUNCA e autoridade.** Toda flag e cosmetica; o backend revalida via `HasPerm`/Policy. Esconder um botao nao substitui o gate de endpoint.
+- **SSOT de capability esta no backend.** O frontend reflete `PUBLIC_POLICY_KEYS` recebidas em `/api/me/policies/`; nunca infere policy a partir de nome de grupo/setor para decisao de acesso de capability. Flags de setor/funcao em `usePermissions` sao legacy/fallback e estao sendo migradas para policies (ver `useCanAccess`).
+- **Estabilidade do contrato de policy keys.** As keys de `PUBLIC_POLICY_KEYS` sao imutaveis apos release: renomear = breaking change; adicionar = compativel. Remover exige periodo de depreciacao de 2 releases (ver `v2/docs/RBAC_NAMING.md` §9). Os fixtures de `rbac_matrix.test.ts` e o snapshot do backend (`PUBLIC_POLICY_KEYS`) precisam permanecer simetricos.
+- **Anonymous nao chama `/me/policies/`.** `App.tsx` so busca policies **depois** de `getMe()` retornar com sucesso, evitando `403`/`401` espurio pre-login. Falha em policies degrada para `[]` (fail-closed: nenhuma capability publica).
+- **`policies = []` e ambiguo por design**: significa "ainda carregando" OU "anonymous". A distincao e feita pela flag `loading` em `App.tsx`, nao pelo array vazio.
+- **Superuser recebe todas as `PUBLIC_POLICY_KEYS`** via `/me/policies/`; `isAdmin` (de `user.is_superuser`) e escape hatch admin-only — usar so para widgets de debug/bypass, nunca para regra de negocio normal.
+- **Semantica das policies e OR.** Usuario obtem a policy se qualquer capability que a satisfaz estiver presente. O conjunto de capabilities que satisfaz uma policy pode mudar sem breaking.
+- **Formador owns own**: `canAccessBlocks` inclui Formador via flag legacy (`canBloqueios`) porque o escopo do proprio bloqueio (RD-02/RD-03) e garantido pelo queryset do backend, nao por policy publica.
+- **Guard Google (PA-06, controle explicito)**: nenhuma operacao GCal e disparada com conta desconectada. `requireGoogleConnection` retorna `false` e abre modal apenas quando `googleStatus` esta carregado E `connected === false`; com `googleStatus === null` (status ainda desconhecido) ele **permite prosseguir** e delega a deteccao ao backend via `handleGoogleError` (que trata `403` com `code === 'google_not_connected'`). O redirect OAuth sempre carrega `return_to` para voltar a pagina de origem.
+
+## API / Interface
+
+Endpoints backend consumidos (contrato detalhado em `v2/docs/API_REFERENCE.md` e `v2/docs/RBAC_NAMING.md`):
+
+- `GET /api/me/` — perfil do usuario autenticado (`CurrentUser`: `setores[]`, `funcoes[]`, `is_superuser`, `is_superintendencia`, `can_approve_super`, `permissions[]`, ...). `401` se anonimo.
+- `GET /api/me/policies/` — array ordenado de strings (subset de `PUBLIC_POLICY_KEYS`); `401` se anonimo; superuser recebe todas. Nunca expoe codenames brutos de capability.
+- `GET /api/integrations/google/status/` — `{ connected, googleEmail, tokenExpiry, expiresInDays, isExpired }`.
+- `GET /api/oauth/google/start/?return_to=<path>` — inicia o fluxo OAuth (redirect do browser, nao XHR).
+
+Interface publica dos hooks:
+
+- `usePermissions(user: CurrentUser | null): Permissions` — todas as flags `false` quando `user === null`.
+- `useCanAccess(policies: readonly string[], legacy?: LegacyAccessFlags): AccessState` — expoe `can(key)` + derived flags.
+- `useGoogleGuard({ googleStatus, returnTo }): { requireGoogleConnection, handleGoogleError, isConnected }`.
+- `useGoogleIntegration(): { status, loading, error, fetchStatus, disconnect }`.
+
+## Fluxos principais
+
+**Bootstrap de autorizacao (1x por mount, sem polling de RBAC):**
+1. `App.tsx` chama `getMe()` (= `/api/me/`); o payload passa por `assertCurrentUserPayload` (em `api/availability.ts`/`auth.ts`). Sucesso => `setUser`.
+2. So entao chama `getMyPolicies()` (= `/api/me/policies/`); sucesso => `setPolicies`. Erro nao-auth => log `warn` + degrada para `[]`.
+3. `usePermissions(user)` computa flags legacy; `AppRoutes` chama `useCanAccess(policies, { canBloqueios, canCoordenador, canDashboardCompras })` para derivar flags.
+4. Menu/rotas renderizam condicionalmente. Rota negada renderiza `<Forbidden />` (mensagem generica, OWASP — nao revela recurso/permissao necessaria).
+
+**Atualizacao de RBAC**: nao ha polling das capabilities. Mudancas de permissao so refletem apos reload/relogin (logout faz `window.location.reload()`). Os pollings existentes em `App.tsx` (`useGCalAlertsPolling`, `useUnreadNotificationsPolling`) sao de dados operacionais, gated pelas flags de `usePermissions`, e nao re-buscam policies.
+
+**Guard Google (caminho feliz + erro):**
+1. Pagina (ex: PreAgenda) obtem `googleStatus` via `useGoogleIntegration` e instancia `useGoogleGuard({ googleStatus, returnTo })`.
+2. Antes da acao: `if (!requireGoogleConnection('publicar eventos')) return;` — se desconectado, abre `Modal.confirm` e (no `onOk`) redireciona para `/api/oauth/google/start/?return_to=...`.
+3. No `catch` da chamada: `if (handleGoogleError(error)) return;` — trata `403 google_not_connected` reabrindo o modal; demais erros seguem o fluxo normal de mensagem.
+
+## Decisoes relacionadas (ADRs)
+
+- `v2/docs/RBAC_NAMING.md` §9 — Policy Resolution Rules, vocabulario canonico, `PUBLIC_POLICY_KEYS`, stability rules e contrato de `GET /api/me/policies/` (Epics 4.1–4.4).
+- `v2/docs/rbac_authorization_matrix.md` — matriz canonica modulo×papel/capability×grupo (decisoes D7–D9 referenciadas inline em `usePermissions.ts`; D10–D17 §6 Admin-driven Group×Cap).
+- Epic 3 / Issue #1228 — Capability Policy Layer no frontend (`useCanAccess`).
+- PR 3 / PR 10 hardening RBAC (2026-04-29/30) — `access_solicitation_approvals` como fonte exclusiva de `canAccessApprovals` (fallback `can_approve_super` removido do contrato do hook).
+
+## Testes que cobrem
+
+- [`v2/frontend/src/hooks/__tests__/usePermissions.test.js`](../../../frontend/src/hooks/__tests__/usePermissions.test.js) — `computePermissions` por ator (null, superuser, Coordenador/Apoio, DAT, Controle, Gerente, visibilidade de dashboards, `canDisponibilidade`).
+- [`v2/frontend/src/hooks/__tests__/useCanAccess.test.ts`](../../../frontend/src/hooks/__tests__/useCanAccess.test.ts) — `computeAccess` (match exato de policy, fallback legacy, derived flags).
+- [`v2/frontend/src/hooks/__tests__/rbac_matrix.test.ts`](../../../frontend/src/hooks/__tests__/rbac_matrix.test.ts) — **matriz viva** parametrizada por ator: garante simetria entre policies do backend e derived flags do frontend; falha em drift.
+- [`v2/frontend/src/components/__tests__/AppRoutes.access-by-profile.test.tsx`](../../../frontend/src/components/__tests__/AppRoutes.access-by-profile.test.tsx) — guards de rota por perfil.
+- Contraparte backend: `v2/backend/apps/core/tests/test_me_policies.py` e `test_rbac_policies_contract.py` provam o contrato de `/api/me/policies/`.
+
+## Pontos de atencao / dividas conhecidas
+
+- **`useGoogleGuard.tsx` sem teste unitario** — nao ha `useGoogleGuard.test.*` (apenas `useGoogleIntegration.test.js`). O contrato critico de "permitir prosseguir quando `googleStatus === null`" + tratamento de `403 google_not_connected` nao tem cobertura direta. GAP a fechar.
+- **TOCTOU benigno no guard Google**: o status pode estar stale entre `fetchStatus` e a acao; o `handleGoogleError` no `catch` e a rede de seguranca (backend e a autoridade). Por design, mas significa que a UX pode mostrar o modal so apos a tentativa.
+- **Sem invalidacao de RBAC em runtime**: mudanca de setor/funcao/grupo de um usuario logado so reflete apos reload/relogin (nao ha refetch de `/me/policies/`). Aceitavel para o tenant atual; revisitar se surgir admin que altere permissoes em tempo real.
+- **Camada legacy ainda em migracao**: varias derived flags de `useCanAccess` dependem de flags legacy de `usePermissions` (setor/funcao) porque ainda nao ha policy publica equivalente (`canCreateSolicitation`, parte de `canAccessBlocks`). Cada migracao = trocar 1 `OR` em `useCanAccess` + atualizar a matriz viva e o seed do backend em sincronia.
+- **`policies = []` ambiguo**: consumidores fora de `App.tsx` que recebam `policies` precisam tratar `loading` separadamente para nao confundir "carregando" com "sem acesso".

--- a/v2/docs/specs/frontend/pages.spec.md
+++ b/v2/docs/specs/frontend/pages.spec.md
@@ -1,0 +1,147 @@
+---
+title: Páginas (React)
+status: canonical
+last_verified: 2026-06-19
+sources_of_truth:
+  - v2/frontend/src/App.tsx
+  - v2/frontend/src/components/AppRoutes.tsx
+  - v2/frontend/src/components/AppSidebar.tsx
+  - v2/frontend/src/hooks/usePermissions.ts
+  - v2/frontend/src/hooks/useCanAccess.ts
+  - v2/frontend/src/pages
+  - v2/frontend/src/components/__tests__/AppRoutes.access-by-profile.test.tsx
+  - v2/frontend/src/components/__tests__/AppRoutes.dat-imports.test.tsx
+  - v2/frontend/src/pages/__tests__/DatImportsLegacyRemoval.test.tsx
+owner: frontend
+supersedes: []
+related:
+  - ../INDEX_SDD.md
+  - ./README.md
+  - ../../RBAC_NAMING.md
+  - ../../rbac_authorization_matrix.md
+  - ../../API_REFERENCE.md
+---
+
+# Páginas (React)
+
+## Propósito
+
+O frontend React (Vite 7 + Ant Design 5 + Tailwind) entrega a SPA do AS v2. Toda a árvore de páginas é registrada em [`AppRoutes.tsx`](../../../frontend/src/components/AppRoutes.tsx), montada dentro do shell de layout (sidebar + header) por [`App.tsx`](../../../frontend/src/App.tsx). Cada página é **lazy-loaded** (`React.lazy` + `Suspense`) para code-splitting; o gate de acesso é resolvido inline na rota a partir de flags derivadas das permissões do usuário.
+
+Esta spec é o **índice canônico do inventário de páginas**: domínio, rota e guard (capability) de cada página. O detalhe de cada capability (quem pode o quê e por quê) vive na [matriz de autorização RBAC](../../rbac_authorization_matrix.md); a convenção de nomes de permission em [`RBAC_NAMING.md`](../../RBAC_NAMING.md). O contrato dos endpoints consumidos pelas páginas está em [`API_REFERENCE.md`](../../API_REFERENCE.md).
+
+## Fonte de verdade no código
+
+- [`v2/frontend/src/App.tsx`](../../../frontend/src/App.tsx) — shell: carrega `getMe()` + `getMyPolicies()`, decide login vs app, monta sidebar/header/`<AppRoutes>`. `LoginPage` é a única página lazy fora de `AppRoutes`.
+- [`v2/frontend/src/components/AppRoutes.tsx`](../../../frontend/src/components/AppRoutes.tsx) — **registro único de rotas**. 39 páginas lazy + 50 `<Route>` (inclui 7 redirects de URLs legadas). Cada rota guardada usa o padrão `element={guard ? <Page /> : <Forbidden />}`.
+- [`v2/frontend/src/hooks/usePermissions.ts`](../../../frontend/src/hooks/usePermissions.ts) — deriva flags `canControle`/`canDAT`/`canDashboard*`/`canDisponibilidade`/… de `setores`+`funcoes`+`is_superuser` do payload de `/api/me/`.
+- [`v2/frontend/src/hooks/useCanAccess.ts`](../../../frontend/src/hooks/useCanAccess.ts) — camada de tradução semântica: converte `policies` públicas (de `GET /api/me/policies/`) em flags como `canAccessApprovals`, `canCreateSolicitation`, `canViewComprasDashboard`.
+- [`v2/frontend/src/components/AppSidebar.tsx`](../../../frontend/src/components/AppSidebar.tsx) — menu lateral; usa as mesmas flags para esconder itens (UX, não é o gate autoritativo).
+- Diretório [`v2/frontend/src/pages/`](../../../frontend/src/pages) — **14 diretórios de domínio** (AdminDAT, Aprovacoes, Auth, Controle, DAT, DATModule, Dashboards, Deslocamentos, Disponibilidade, Home, MapaBrasil, MeusEventos, PreAgenda, Solicitacoes) + `__tests__`.
+
+> **Correção de mito:** o número real é **40 páginas lazy-loaded** (39 em `AppRoutes` + `LoginPage` em `App.tsx`), não "45+". `Solicitacoes.tsx` e `Disponibilidade.tsx` na raiz de `pages/` ainda existem; `pages/Disponibilidade` (dir) é o que está roteado em `/solicitacoes/bloqueios`.
+
+## Contratos e invariantes
+
+- **Gate de rota é autoritativo, menu é só UX.** Esconder o item no `AppSidebar` não basta: a rota em `AppRoutes` **deve** renderizar `<Forbidden />` quando o guard é falso. Deep-link/bookmark/redirect 3rd-party não pode abrir página proibida (provado pelo teste de acesso por perfil).
+- **`<Forbidden />` não vaza recurso (OWASP).** Mensagem genérica fixa ("Recurso indisponível"); nunca revelar a policy/capability exigida nem a existência do recurso.
+- **Frontend não é a fronteira de segurança.** O guard de rota é defesa de UX; a autorização real é do backend (`permission_classes=[HasPerm("codename")]`). Toda página guardada tem endpoint correspondente protegido — o frontend nunca "abre" dado que o backend negaria.
+- **RBAC idiomático.** Decisões de acesso derivam de `policies`/flags computadas de `setores`+`funcoes`+`is_superuser`; nunca de checagem direta de nome de grupo (banido por `scripts/rbac_lint.py` no backend; o equivalente no FE é não hardcodar nomes de grupo nas páginas).
+- **`is_superuser` é escape hatch.** As flags `canControle`/`canDAT`/`canDashboard*` já embutem `is_superuser`; superuser passa em tudo. Páginas não devem ramificar por `is_superuser` para regra de negócio — só para widgets admin/debug.
+- **Aprovações = policy exclusiva.** `/solicitacoes/aprovacoes` depende **somente** da policy pública `access_solicitation_approvals` (composite Gerente∩Superintendência OU Assistente Administrativo∩Controle). O legacy `can_approve_super` foi removido do contrato do FE (PR 10 hardening RBAC).
+- **Redirects preservam deep-links.** URLs legadas (`/aprovacoes`, `/disponibilidade`, `/bloqueios`, `/deslocamentos`, `/meus-eventos`, `/dat/importacao`) redirecionam com `<Navigate replace>` para a rota canônica sob `/solicitacoes/*` ou `/dat/importacoes`.
+
+## API / Interface
+
+Inventário por domínio (rota → componente → guard). Detalhe da capability na [matriz RBAC](../../rbac_authorization_matrix.md).
+
+**Home**
+| Rota | Página | Guard |
+|---|---|---|
+| `/`, `/home` | `Home/HomePage` | autenticado |
+
+**Auth**
+| Rota | Página | Guard |
+|---|---|---|
+| (sem rota — render condicional em `App.tsx`) | `Auth/LoginPage` | anônimo |
+
+**Solicitações** (agrupadas sob `/solicitacoes/*`)
+| Rota | Página | Guard |
+|---|---|---|
+| `/solicitacoes/minhas` | `Solicitacoes/MySolicitacoesPage` | `access.canCreateSolicitation` |
+| `/solicitacoes/nova` | `Solicitacoes/NewSolicitacaoWizard` | `access.canCreateSolicitation` |
+| `/solicitacoes/:id/editar` | `Solicitacoes/EditSolicitacaoPage` | autenticado |
+| `/solicitacoes/meus-eventos` | `MeusEventos/MeusEventosPage` | autenticado |
+
+**Aprovações**
+| Rota | Página | Guard |
+|---|---|---|
+| `/solicitacoes/aprovacoes` | `Aprovacoes/ApprovalsPage` | policy `access_solicitation_approvals` |
+
+**Disponibilidade**
+| Rota | Página | Guard |
+|---|---|---|
+| `/solicitacoes/disponibilidade` | `Disponibilidade/MonthlyPage` | policy `view_all_availability` OU `canDisponibilidade` |
+| `/solicitacoes/bloqueios` | `Disponibilidade` (blocks) | `access.canAccessBlocks` (inclui Formador, escopo próprio) |
+| `/solicitacoes/deslocamentos` | `Deslocamentos/DeslocamentosPage` | `view_all_availability` OU `canControle`/`canCoordenador`/`canDAT` |
+
+**Controle**
+| Rota | Página | Guard |
+|---|---|---|
+| `/controle` | `Controle/ControlePage` | `canControle` |
+| `/controle/acoes` | `DATModule/AcoesPage` | `canControle` |
+| `/controle/compras`, `/compras-materiais` | `DATModule/ComprasPage` | `canControle` OU `canDAT` |
+| `/controle/coordenadores` | `DATModule/CoordenadoresPage` | `canControle` |
+| `/controle/formacoes` | `DATModule/FormacoesPage` | `canControle` |
+| `/controle/plano-formacoes` | `DATModule/PlanoFormacoesPage` | `canControle` |
+| `/controle/pre-agenda`, `/pre-agenda` | `PreAgenda/PreAgendaPage` | `canControle` |
+| `/acoes-notificacao`, `/acoes-notificacao/timeline`, `/notificacoes-internas` | `Controle/AcoesNotificacaoPage` / `AcoesTimelinePage` / `NotificacoesInternasPage` | `canAcoesInternas` |
+
+**DAT / AdminDAT**
+| Rota | Página | Guard |
+|---|---|---|
+| `/dat/admin` (+ `/usuarios`, `/municipios`, `/projetos`, `/grupos`, `/setores`, `/funcoes`, `/gerencias`, `/produtos`, `/configuracoes`, `/colecoes`, `/equipe-gerencia`) | `AdminDAT/*` | `canDAT` |
+| `/dat/cadastros` | `DATModule/CadastrosPage` | `canDAT` |
+| `/dat/importacoes` | `DAT/ImportacoesPage` | `canDAT` |
+| `/dat/registros` | `DATModule/DATRegistrosPage` | `canDAT` |
+| `/dat/compras-materiais` | `DATModule/ComprasPage` | `canControle` OU `canDAT` |
+| `/dat/coordenadores` | `DATModule/CoordenadoresPage` | `canControle` |
+
+**Dashboards**
+| Rota | Página | Guard |
+|---|---|---|
+| `/dashboards` | `Dashboards/DashboardsPage` | `canDashboardOverview` (Diretoria/superuser) |
+| `/dashboards/compras` | `Dashboards/ComprasDashboardPage` | `access.canViewComprasDashboard` (policy `view_compras_dashboard`) |
+| `/dashboards/equipe` | `Dashboards/EquipeDashboardPage` | `canDashboardEquipe` (Diretoria/DAT/superuser) |
+| `/dashboards/gcal` | `Dashboards/GCalDashboardPage` | `canDashboardGcal` (Diretoria/DAT/Controle/superuser) |
+| `/mapa-brasil` | `MapaBrasil/MapaBrasilPage` | `canMapaBrasil` (Diretoria/DAT/superuser) |
+
+## Fluxos principais
+
+1. **Boot / autenticação** — `App.tsx` chama `getMe()`; se anônimo (`isAuthError`), renderiza `LoginPage`. Autenticado: busca `getMyPolicies()` (sequencial, evita 403 espúrio pré-login), monta sidebar/header/rotas. Loading → `FullscreenLoader`.
+2. **Navegação para página guardada** — `AppRoutes` resolve `permissions` (`usePermissions`) + `access` (`useCanAccess`); se o guard é true, monta a página lazy (fallback `PageLoader` durante o chunk); se false, monta `<Forbidden />`.
+3. **URL legada** — `<Navigate replace>` redireciona para a rota canônica antes de qualquer render de página, preservando histórico/bookmark.
+4. **Erro de runtime na página** — `ErrorBoundary` (raiz, `App.tsx`) captura; falhas de auth em chamadas de API são tratadas por `isAuthError` e degradam para estado anônimo/`[]`.
+
+## Decisões relacionadas (ADRs)
+
+- [Matriz de autorização RBAC](../../rbac_authorization_matrix.md) — §3 dashboards, decisões D7/D8/D9 (acesso a dashboards e Grade Mensal), composite Setor×Função das aprovações.
+- [`RBAC_NAMING.md`](../../RBAC_NAMING.md) — convenção de codenames/policies públicas.
+- Issue #927 — decomposição de `App.tsx` (extração de hooks/`AppRoutes`/`AppSidebar`).
+- Epic 3 (#1227/#1228) — agrupamento sob `/solicitacoes/*` + camada `useCanAccess`. PR-C DAT Imports (#1227-relacionado, 2026-04-29) — unificação de imports em `/dat/importacoes`.
+
+## Testes que cobrem
+
+- [`v2/frontend/src/components/__tests__/AppRoutes.access-by-profile.test.tsx`](../../../frontend/src/components/__tests__/AppRoutes.access-by-profile.test.tsx) — matriz 10 atores canônicos × 12 rotas críticas; prova que deep-link proibido renderiza `<Forbidden />` com mensagem genérica.
+- [`v2/frontend/src/components/__tests__/AppRoutes.dat-imports.test.tsx`](../../../frontend/src/components/__tests__/AppRoutes.dat-imports.test.tsx) — gate e redirect das rotas DAT (`/dat/importacao` → `/dat/importacoes`).
+- [`v2/frontend/src/pages/__tests__/DatImportsLegacyRemoval.test.tsx`](../../../frontend/src/pages/__tests__/DatImportsLegacyRemoval.test.tsx) — remoção das rotas/imports legados de DAT.
+- Testes de página individuais: `NewSolicitacaoWizard.test.tsx`, `MeusEventosPage.test.tsx`, `ImportacoesPage.test.tsx`, `UsuariosPage.cpf.test.tsx`.
+
+## Pontos de atenção / dívidas conhecidas
+
+- **Guard duplicado FE/BE.** As flags de guard são reimplementação client-side da matriz RBAC do backend; divergência silenciosa é possível. A matriz viva no backend é o SSOT — qualquer página nova deve casar com a policy/permission do endpoint que consome.
+- **`Forbidden` inline vs `RequirePolicy`.** Há dois mecanismos de negação (o `Forbidden` inline em `AppRoutes` e o `<RequirePolicy>`); a unificação está pendente (comentário no próprio `AppRoutes`).
+- **`DATPage` (`pages/DAT/DATPage.tsx`) órfã.** Não está mais roteada (substituída por `ImportacoesPage`); remoção definitiva ficou para "PR-D" (ver comentário no `AppRoutes`).
+- **Páginas raiz legadas.** `pages/Solicitacoes.tsx` e `pages/Disponibilidade.tsx` (arquivos soltos na raiz de `pages/`) coexistem com os diretórios homônimos roteados — risco de confusão; conferir o import do `AppRoutes` antes de editar.
+- **Logout via `window.location.reload()`.** Tech-debt assumido (#927) — sem auth store centralizado, logout força reload em vez de limpeza de estado.
+- **README de specs frontend desatualizado.** [`./README.md`](./README.md) ainda diz "6/14 documentadas" e "45+ pages"; esta spec corrige a contagem para 14 dirs / 40 páginas lazy.

--- a/v2/docs/specs/infra/README.md
+++ b/v2/docs/specs/infra/README.md
@@ -11,7 +11,7 @@ related:
 
 Voltar ao [índice SDD](../INDEX_SDD.md).
 
-## Specs planejadas (Fase 3-4)
+## Specs (escritas em 2026-06-19) — origem de cada uma
 
 | Spec | Estado | Fonte canônica / código |
 |---|---|---|
@@ -19,5 +19,5 @@ Voltar ao [índice SDD](../INDEX_SDD.md).
 | `environments.spec.md` | planejado (migrar) | `v2/infra/ENVIRONMENTS.md`, `docker-compose*.yml` |
 | `ci.spec.md` | planejado (consolidar) | `.github/workflows/`, `docs/operations/ci-*.md` |
 
-> Status: esqueleto (Fase 0) + `deploy.spec.md` já preenchida a partir da verificação dev × prod de 2026-06-19.
+> Status: **specs escritas** (Fase 3-4, 2026-06-19); `deploy.spec.md` preenchida na verificação dev × prod de 2026-06-19. Links vivos no [índice SDD](../INDEX_SDD.md).
 > Lembrete (auditoria): o deploy é Portainer→prod (ADR-010), **sem staging remoto**; merge na main = deploy em produção.

--- a/v2/docs/specs/infra/ci.spec.md
+++ b/v2/docs/specs/infra/ci.spec.md
@@ -1,0 +1,114 @@
+---
+title: CI/CD (GitHub Actions)
+status: canonical
+last_verified: 2026-06-19
+sources_of_truth:
+  - .github/workflows/ci.yaml
+  - .github/workflows/deploy.yaml
+  - .github/workflows/_backend-test.yml
+  - .github/workflows/backend-xdist-canary.yml
+  - .github/workflows/staging-gate-audit.yml
+  - .github/workflows/frontend-ci.yml
+  - .github/actions/setup-python-deps/action.yml
+  - v2/backend/scripts/rbac_lint.py
+  - v2/scripts/xdist_canary_report.py
+  - docs/operations/ci-check-policy.md
+owner: infra
+supersedes:
+  - docs/operations/ci-check-policy.md
+  - docs/operations/ci-backend-xdist-canary.md
+  - docs/operations/ci-backend-xdist-stabilization-backlog.md
+  - docs/operations/ci-security-checks.md
+related:
+  - ./deploy.spec.md
+  - ../INDEX_SDD.md
+  - ../README.md
+---
+
+# CI/CD (GitHub Actions)
+
+## Propósito
+
+Pipeline de integração e entrega contínua do AS v2 sobre GitHub Actions. A CI valida cada PR para `main` (lint, RBAC lint, type-check, testes backend paralelos, paridade Docker, frontend) e bloqueia merge enquanto os gates `[required]` não passarem; o deploy publica imagens no Docker Hub e atualiza a stack via **Portainer CE API**. Como **não existe staging remoto** (merge na `main` = deploy direto em produção, ADR-010), os gates de PR são a única rede de proteção antes da produção.
+
+A nomenclatura dos checks é o contrato de governança: `[required]` bloqueia merge, `[info]` é informativo, `[ops]` é rotina manual/agendada fora do gate de PR. A SSOT desta convenção e da lista de checks obrigatórios é [`docs/operations/ci-check-policy.md`](../../../../docs/operations/ci-check-policy.md).
+
+## Fonte de verdade no código
+
+- **Gate principal de PR** — [`.github/workflows/ci.yaml`](../../../../.github/workflows/ci.yaml): backend impact detector, lint, rbac-lint, testes backend (split core + ingest/devtools), combine de cobertura, pyright, docker parity e o agregador `[required] tests`.
+- **Reusable de teste backend** — [`.github/workflows/_backend-test.yml`](../../../../.github/workflows/_backend-test.yml): SSOT do setup de teste (services postgres/redis, env vars, `migrate`, dirs, `pytest`, artifact). Consumido por `ci.yaml` e pelo canary (#1401).
+- **Canary xdist (não-bloqueante)** — [`.github/workflows/backend-xdist-canary.yml`](../../../../.github/workflows/backend-xdist-canary.yml) + report [`v2/scripts/xdist_canary_report.py`](../../../../v2/scripts/xdist_canary_report.py).
+- **Gate de staging (evidência)** — [`.github/workflows/staging-gate-audit.yml`](../../../../.github/workflows/staging-gate-audit.yml).
+- **Frontend** — [`.github/workflows/frontend-ci.yml`](../../../../.github/workflows/frontend-ci.yml): react doctor, build/lint, checklist (meta/a11y/security).
+- **Deploy** — [`.github/workflows/deploy.yaml`](../../../../.github/workflows/deploy.yaml) → ver [`deploy.spec.md`](./deploy.spec.md).
+- **RBAC lint (AST)** — [`v2/backend/scripts/rbac_lint.py`](../../../../v2/backend/scripts/rbac_lint.py).
+- **Setup de deps Python (composite)** — [`.github/actions/setup-python-deps/action.yml`](../../../../.github/actions/setup-python-deps/action.yml).
+
+## Contratos e invariantes
+
+- **Checks `[required]` (gate de merge em `main`)** — devem ficar obrigatórios no ruleset `Protect main`: `[required] tests`, `[required] lint`, `[required] backend rbac-lint`, `[required] build/lint do frontend`, `[required] checklist tests (meta, a11y, security)`, `[required] dependency review`, `[required] architecture dependency guardrails`, `[required] Python Dependencies`, `[required] Frontend Dependencies`, `[required] Container Scan`, `[required] Secret Detection`, `[required] staging gate evidence`. SSOT: [`ci-check-policy.md`](../../../../docs/operations/ci-check-policy.md).
+- **Least-privilege do `GITHUB_TOKEN`** — workflow-level default = `contents: read`; cada job que precisa de mais declara o seu (#1397). Em `deploy.yaml`, `contents: write` existe **apenas** no job `tag_and_release` (git tag + `gh release`); o job que builda/pusha imagem fica em `contents: read` (desacopla `contents:write` de alvo de supply-chain). No canary, `issues: write` vive só no job `canary-report` que comenta na issue #677.
+- **Cobertura backend ≥ 85%** — `coverage combine` dos dois jobs (core + ingest/devtools) com `coverage report --fail-under=85`. Falha abaixo do limiar bloqueia o gate.
+- **Paralelização xdist no gate (M3, #1402/#1403)** — gate usa `pytest -n auto --dist loadscope` (~15min→~5min). `loadscope` mantém testes da mesma classe/módulo no mesmo worker. Habilitado **só** após a suíte estabilizar (causa raiz: `transaction=True` truncava o seed RBAC; fix de re-seed pós-truncate). O canary cobre a matriz `workers×dist` mas **nunca** bloqueia (`fail_on_test_error=false`).
+- **Backend impact detector (fail-safe)** — eventos não-PR (push/dispatch) forçam `backend_changed=true` (modo full seguro); PR sem base/head SHA também. O agregador `[required] tests` exige que os jobs backend ou tenham passado (impacto) ou tenham `skipped` (sem impacto) — nunca silenciosamente verde por engano.
+- **Docker parity (#1401 carve-out)** — `docker-parity-backend` NÃO consome o reusable: usa topologia de container (`host.docker.internal`, `REQUIRE_DOCKER=1`, migrate in-container, build via buildx). Versões de postgres/redis aqui devem ser sincronizadas manualmente com o `services` do reusable (SSOT das versões: `postgres:15.13`, `redis:7.4`).
+- **Gate de staging (evidência)** — para PRs com impacto em runtime (`v2/backend/apps|config|requirements.txt`, `v2/frontend/src|public|Dockerfile.prod`, `v2/infra/...`), o corpo do PR precisa de 3 marcadores literais (sem acento, crase normalizada): checkbox `make staging-full ... (8/8 PASS)`, checkbox `Evidencia anexada no PR`, e o texto `ALL 8 CHECKS PASSED`. PRs em draft ou sem impacto em runtime são pulados.
+- **Guard rails de lint** — Black/isort/Flake8 + ban de `/api/v1/` fora da allowlist (#796); RBAC lint AST bane `user.groups.filter(name=...)` e classes `Is<Role>` fora da whitelist (idioma canônico: `permission_classes=[HasPerm("codename")]`).
+- **Deploy/security gate** — invariantes de imutabilidade de tag, fire-and-forget com confirmação (#1396) e gate Trivy (bloqueia HIGH/CRITICAL) são contrato do deploy: ver [`deploy.spec.md`](./deploy.spec.md).
+- **Não usar `paths` no gatilho `pull_request` de workflow que publica check `[required]`** (senão o check fica pendente para sempre e trava o ruleset). `frontend-ci.yml` removeu path filters de PR exatamente por isso.
+
+## API / Interface
+
+- **CI (`ci.yaml`)** — dispara em `push`/`pull_request` para `main`. Jobs: `backend-impact`, `lint`, `rbac-lint`, `backend-tests-core`, `backend-tests-ingest-devtools`, `backend-tests` (combine+threshold), `backend-typecheck`, `docker-parity-backend`, `tests` (agregador `[required]`).
+- **Reusable (`_backend-test.yml`)** — `workflow_call` com inputs: `pytest_paths`, `pytest_extra_args`, `coverage_file`, `validate_test_paths`, `fail_on_test_error`, `emit_canary_metadata`, `artifact_name`/`artifact_paths` (obrigatórios), entre outros. Roda em Python 3.12 com `COVERAGE_CORE=sysmon` (sys.monitoring do 3.12, #1399).
+- **Canary (`backend-xdist-canary.yml`)** — `schedule` (cron `20 10 * * *`), `workflow_dispatch` e `push` em paths do próprio canary. Matriz `workers=[2,auto] × dist=[loadscope,loadfile]`; publica snapshot na issue #677.
+- **Deploy (`deploy.yaml`)** — `push` em `main` → staging-auto; `workflow_dispatch` com `target_environment` (staging|production), `promotion_tag`, `rollback_tag`. Interface detalhada (modos, gate de promoção, polling): [`deploy.spec.md`](./deploy.spec.md).
+
+## Fluxos principais
+
+**PR → merge (caminho feliz):**
+1. `backend-impact` decide se a suíte backend roda (PR sem impacto em backend pula os jobs pesados; push/dispatch sempre full).
+2. `lint` + `rbac-lint` (rápidos, paralelos).
+3. `backend-tests-core` e `backend-tests-ingest-devtools` rodam via reusable com `-n auto --dist loadscope`, cada um emitindo um artifact de cobertura.
+4. `backend-tests` baixa os dois artifacts, faz `coverage combine`, exige ≥85% e sobe para o Codecov.
+5. `backend-typecheck` (pyright em `apps/core config`) e `docker-parity-backend` (smoke em imagem `Dockerfile.prod`) rodam em paralelo.
+6. `tests` agrega: verde só se todos passaram (ou todos `skipped` quando sem impacto).
+7. `frontend-ci` (react doctor + build/lint + checklist) e `staging-gate-audit` (evidência no corpo) completam o gate.
+8. Merge em `main` dispara `deploy.yaml`.
+
+**Deploy (resumo — detalhe em `deploy.spec.md`):** build+scan(Trivy)+push das imagens → `validate_existing_tag` (promotion/rollback) → `deploy` chama Portainer CE API atualizando só o `IMAGE_TAG` → post-deploy verification (polling de versão + fallback via Portainer API quando o health externo está inacessível por rede).
+
+**Erros relevantes:**
+- Cobertura < 85% → `backend-tests` falha → `tests` vermelho.
+- xdist instável → fica **isolado** no canary (não bloqueia); recorrências viram issues de estabilização antes de promover ao gate.
+- Corpo de PR sem os 3 marcadores → `staging gate evidence` falha (exceto draft / sem runtime impact).
+- Deploy timeout (HTTP 000 por firewall) → confirmação fail-fast via GET do `IMAGE_TAG` e fallback Portainer (não assume sucesso cego).
+
+## Decisões relacionadas (ADRs)
+
+- **ADR-010** — Deploy Portainer→prod, sem staging remoto (referenciado em [`deploy.spec.md`](./deploy.spec.md) e no índice de infra).
+- **#1397** — least-privilege do `GITHUB_TOKEN` (M2).
+- **#1401** — reusable `_backend-test.yml` (SSOT de setup de teste).
+- **#1402 / #1403** — estabilização xdist + promoção de `-n auto --dist loadscope` no gate (M3).
+- **#1399** — `COVERAGE_CORE=sysmon` (sys.monitoring do Python 3.12).
+- **#1396 / #1394** — fail-fast pós-timeout do Portainer + token via `curl --config` (fora do argv).
+
+## Testes que cobrem
+
+A CI é infra-as-code; sua "prova" são os próprios checks de gate e o canary, não testes unitários de aplicação:
+
+- **Auto-asserção do gate** — passo `Assert backend gates passed` em `ci.yaml::tests` e `Assert split backend test jobs passed` em `backend-tests` (validam que os resultados esperados ocorreram, inclusive `skipped`).
+- **Threshold de cobertura** — `coverage report --fail-under=85` em `ci.yaml`.
+- **RBAC lint** — [`v2/backend/scripts/rbac_lint.py`](../../../../v2/backend/scripts/rbac_lint.py) sobre `apps/`.
+- **Docker parity smoke** — `apps/core/tests/test_modular_imports.py` + `apps/core/tests/test_auth_backends.py` dentro do container.
+- **Validação de paths de teste** — guard `no /app hardcoded` no reusable (`validate_test_paths`).
+- **Suíte backend completa** — `apps/core/tests` + `apps/dev_tools/tests` (não há `apps/dat_ingest` — módulo removido).
+
+## Pontos de atenção / dívidas conhecidas
+
+- **Drift de versões postgres/redis** — `docker-parity-backend` é carve-out do reusable; bump no reusable não propaga sozinho (sincronizar manualmente). Apps = `core` + `dev_tools` apenas.
+- **Sem `makemigrations --check` na CI** — migrations não são validadas no gate e o deploy não aplica migrations automaticamente (manuais em prod). Rastreado em **#1456**.
+- **Canary só mostra top-5** — o report da issue #677 lista os 5 piores; a magnitude total de falhas pode ficar subdimensionada no comentário (vide M3: a issue citava 6 testes, eram 537).
+- **`pull_request` sem path filters em checks `[required]`** — necessário para o ruleset, mas faz `frontend-ci` rodar mesmo em PRs sem mudança de frontend (custo aceito por governança).
+- **react-doctor exige `--offline`** — o score depende de telemetria remota; sem `--offline` o gate é não-determinístico (memória `react-doctor-offline-determinism`).
+- **Deploy é Portainer→prod sem staging remoto** — o gate de evidência de staging depende de `make staging-full` **local** do autor; não há ambiente staging que a CI valide. Detalhe e gaps de deploy em [`deploy.spec.md`](./deploy.spec.md).

--- a/v2/docs/specs/infra/environments.spec.md
+++ b/v2/docs/specs/infra/environments.spec.md
@@ -1,0 +1,164 @@
+---
+title: Ambientes (dev / staging / prod-like)
+status: canonical
+last_verified: 2026-06-19
+sources_of_truth:
+  - v2/Makefile
+  - v2/infra/Makefile
+  - v2/infra/docker-compose.yml
+  - v2/infra/docker-compose.override.yml
+  - v2/infra/docker-compose.staging-gate.yml
+  - v2/infra/docker-compose.prod.yml
+  - v2/infra/.env.dev
+  - v2/infra/.env.staging
+  - v2/infra/.env.prodlike.example
+  - v2/infra/scripts/smoke_test_staging.sh
+owner: infra
+supersedes: []
+related:
+  - ./deploy.spec.md
+  - ../INDEX_SDD.md
+  - ../../OBSERVABILITY.md
+  - ../../DEPLOY_CHECKLIST.md
+---
+
+# Ambientes (dev / staging / prod-like)
+
+> **Verificado em 2026-06-19** contra os Makefiles, os `docker-compose*.yml` e os `.env.*` do repositório.
+> Esta spec descreve **quais** ambientes existem, **como cada um sobe** e **o que muda** entre eles.
+> Para o que **de fato roda em produção** (mecanismo de deploy, hardening, gaps de go-live), ver a
+> [deploy.spec](./deploy.spec.md) — esta spec não duplica esse conteúdo.
+
+## Propósito
+
+O sistema tem **quatro perfis de ambiente** montados sobre o mesmo conjunto de imagens Docker, diferenciados
+por arquivo de compose, `.env` e portas publicadas. O objetivo é permitir iterar em **dev** com hot-reload,
+validar fidelidade prod localmente (**staging-gate** e **prod-like**) e rodar **produção** com a stack
+endurecida — sem que os perfis colidam entre si (cada um usa `COMPOSE_PROJECT_NAME` e portas de host distintas).
+
+A separação de Makefiles é deliberada: **dev** é dirigido por [`v2/Makefile`](../../../Makefile) (que opera de
+dentro de `v2/`, prefixando `infra/...` nos compose); **staging / prod / prod-like / staging-gate** são
+dirigidos por [`v2/infra/Makefile`](../../../infra/Makefile). Vale a Cláusula Pétrea **CP-01**: v2 roda
+**apenas em Docker**.
+
+## Fonte de verdade no código
+
+| Perfil | Makefile (target) | Compose | `.env` | Imagem |
+|---|---|---|---|---|
+| **dev** | [`v2/Makefile`](../../../Makefile) `up` / `down` / `logs` | [`docker-compose.yml`](../../../infra/docker-compose.yml) + [`docker-compose.override.yml`](../../../infra/docker-compose.override.yml) | [`.env.dev`](../../../infra/.env.dev) | build local ([`Dockerfile.dev`](../../../infra/Dockerfile.dev)), `IMAGE_TAG=latest` |
+| **staging** | [`v2/infra/Makefile`](../../../infra/Makefile) `up-staging` / `health-staging` / `down-staging` | `docker-compose.yml` **sozinho** | [`.env.staging`](../../../infra/.env.staging) | pull por tag publicada (`--no-build`), `IMAGE_TAG` **obrigatório** |
+| **staging-gate** | `v2/infra/Makefile` `staging-full` (precheck→build→up→test→down) | `docker-compose.yml` + [`docker-compose.staging-gate.yml`](../../../infra/docker-compose.staging-gate.yml) | `.env.staging` | build local PROD ([`Dockerfile.prod`](../../../infra/Dockerfile.prod)), tag `staging-local` |
+| **prod-like** | `v2/infra/Makefile` `up-prod-like` / `health-prod-like` | [`docker-compose.prod.yml`](../../../infra/docker-compose.prod.yml) **standalone** | `.env.prodlike.local` (cópia de [`.env.prodlike.example`](../../../infra/.env.prodlike.example)) | pull por tag (`--no-build`) |
+| **prod** | `v2/infra/Makefile` `up-prod` (→ ver [deploy.spec](./deploy.spec.md)) | `docker-compose.prod.yml` **standalone** | `stack.env` no Portainer (`APP_ENV_FILE`) | tag imutável promovida |
+
+Definições das variáveis de composição estão no topo de [`v2/infra/Makefile`](../../../infra/Makefile)
+(`DEV_COMPOSE`, `STAGING_COMPOSE`, `PROD_COMPOSE`, `PRODLIKE_COMPOSE`, `STAGING_GATE_COMPOSE`).
+
+## Contratos e invariantes
+
+- **CP-01** — todo ambiente é Docker. Não há modo "roda na máquina sem container".
+- **Override é dev-only.** [`docker-compose.override.yml`](../../../infra/docker-compose.override.yml) monta o
+  código como volume (`../backend:/app`, `../frontend/src` ro) para hot-reload e **NÃO pode** ser aplicado em
+  staging/prod (declarado no cabeçalho do próprio arquivo). Staging usa `docker-compose.yml` sozinho; prod usa
+  `docker-compose.prod.yml` standalone (**não** mergeia a base).
+- **`IMAGE_TAG` é obrigatório fora de dev.** A base [`docker-compose.yml`](../../../infra/docker-compose.yml)
+  usa `${IMAGE_TAG:?IMAGE_TAG is required}` em todos os serviços de app. Só dev define `IMAGE_TAG=latest`;
+  staging/prod-like/prod **devem** passar tag explícita (`vYYYY.MM.DD-<sha>`).
+- **Isolamento por projeto + portas.** Cada perfil tem `COMPOSE_PROJECT_NAME` próprio
+  (`aprender_dev` / `aprender_staging` / `aprender_prod_like` / `aprender_prod`) e portas de host distintas
+  (dev 8002/5173/5434/6380; staging 18002/15173/15434/16380; prod-like 28000/18081). Subir dois perfis em
+  paralelo não colide.
+- **Topologia de produção (VM01 vs VM02).** Em prod, **Redis é container local na stack da VM01**
+  (`docker-compose.prod.yml`, serviço `redis` com `--requirepass` + AOF); **PostgreSQL é externo na VM02**
+  (`DB_HOST` aponta para o IP da VM02). Em dev/staging/prod-like o `db` é um container local da própria stack.
+- **`DEBUG` e `ENVIRONMENT`.** Apenas dev tem `DEBUG=1` / `ENVIRONMENT=development`. Staging =
+  `ENVIRONMENT=staging` (`DEBUG=0`); prod/prod-like = `ENVIRONMENT=production`. O `settings.py` deriva
+  comportamento disso (cookies `Secure`, `statement_timeout=30000ms`, JSON logging em staging/prod, Silk
+  profiler só em staging).
+- **`.env.*` versionados são templates.** `SECRET_KEY=CHANGE_ME_*` e senhas placeholder. Segredos reais de
+  produção vivem no `stack.env` do Portainer, **não** no repo.
+- **Observabilidade é DEV-only.** Prometheus+Grafana sobem só via `make up-obs` (compose de observabilidade é
+  **gitignored**, fora desta árvore). Em produção não há Prometheus/Grafana na stack: o endpoint `/metrics`
+  fica **gated** (`_metrics_gate` → staff ou IP interno, em `config/urls.py`) e Sentry só liga se `SENTRY_DSN`
+  estiver setado (atualmente OFF). Detalhe em [OBSERVABILITY.md](../../OBSERVABILITY.md).
+
+## API / Interface
+
+Comandos de operação (todos exigem Docker; CP-01):
+
+```bash
+# DEV (de dentro de v2/) — v2/Makefile
+make up          # docker-compose.yml + override, build local, sobe tudo
+make down
+make logs
+make health      # checa /api/readyz/, pg_isready, redis-cli ping
+
+# STAGING / PROD-LIKE / PROD (de dentro de v2/infra/) — v2/infra/Makefile
+make check-env-staging      # valida `docker compose config` sem subir
+make up-staging             # pull por tag + up --no-build  (IMAGE_TAG=... obrigatório)
+make health-staging         # /api/readyz/ com X-Forwarded-Proto: https
+make down-staging
+make up-prod-like           # docker-compose.prod.yml standalone, --no-build
+make health-prod-like
+make up-prod                 # idem prod (ver deploy.spec)
+
+# STAGING GATE (validação pré-merge prod-like local)
+make staging-full           # precheck → build PROD → up → smoke → teardown
+```
+
+Endpoints de health expostos por todos os perfis: `GET /api/readyz/` (db + redis) e `GET /healthz/` (app).
+
+## Fluxos principais
+
+**Subir dev (caminho feliz):** de `v2/`, `make up` → `DEV_COMPOSE` (`--env-file .env.dev -f infra/docker-compose.yml -f infra/docker-compose.override.yml`) faz build local e sobe `db`, `redis`, `web`, `frontend` (worker/beat sob demanda). Backend em `http://localhost:8002`, frontend em `:5173`. Hot-reload ativo pelos volumes do override.
+
+**Validar pré-merge (staging-gate):** de `v2/infra/`, `make staging-full` roda o pipeline
+[`smoke_test_staging.sh`](../../../infra/scripts/smoke_test_staging.sh): `staging-precheck` (valida o override
+`!reset`, exige Compose v2.24.6+) → `staging-build` (imagens PROD com `GIT_SHA`/`BUILD_DATE`) → `staging-up`
+(sobe + `migrate --noinput`, portas 18002/15173) → `staging-test` (smoke) → `staging-down -v` (teardown via
+`trap EXIT`, remove volumes).
+
+**Reproduzir prod localmente (prod-like):** `cp .env.prodlike.example .env.prodlike.local` (ajustar secrets) →
+`make up-prod-like`. Usa `docker-compose.prod.yml` standalone com `DB_HOST=host.docker.internal` para simular o
+PostgreSQL externo da VM02; Redis é local na stack. Backend em `:28000`, frontend em `:18081`.
+
+**Erros comuns:**
+- `IMAGE_TAG is required` ao subir staging/prod sem tag → exportar `IMAGE_TAG=vYYYY.MM.DD-<sha>`.
+- `staging-precheck falhou: !reset não suportado` → atualizar Docker Compose (v2.24.6+).
+- Colisão de porta → confirmar que não há outro perfil usando a mesma faixa (cada perfil tem portas próprias).
+
+## Decisões relacionadas (ADRs)
+
+- Separação de perfis e portas — issue **#753** (seção "Ambientes" do [`v2/infra/Makefile`](../../../infra/Makefile)).
+- Staging Gate (validação prod-like pré-merge) — Epic **#838**; override `!reset` transitório, solução
+  estrutural rastreada em **#857**.
+- Observabilidade movida para compose dedicado (dev-only) — issue **#234**.
+- Hardening de runtime / segmentação de rede em prod (SEC-006/013/014/015) — ver [deploy.spec](./deploy.spec.md).
+
+## Testes que cobrem
+
+- **Smoke do staging-gate:** [`v2/infra/scripts/smoke_test_staging.sh`](../../../infra/scripts/smoke_test_staging.sh)
+  (invocado por `make staging-test` / `staging-full`) — valida que a stack prod-like sobe e responde.
+- **Health gates por perfil:** targets `health-dev` / `health-staging` / `health-prod-like` em
+  [`v2/infra/Makefile`](../../../infra/Makefile) batem em `/api/readyz/`.
+- **Config validation:** `check-env-dev` / `check-env-staging` / `check-env-prod` / `check-env-prod-like`
+  rodam `docker compose config` para falhar cedo em compose inválido.
+- A validação combinada `make staging-full` (8/8 PASS) é o gate de merge documentado no body de PR
+  (ver [DEPLOY_CHECKLIST.md](../../DEPLOY_CHECKLIST.md) e [deploy.spec](./deploy.spec.md)).
+
+## Pontos de atenção / dívidas conhecidas
+
+- **Override `!reset` é transitório.** O `staging-gate` existe porque a base `docker-compose.yml` monta volumes
+  de dev no `frontend`; a solução estrutural (mover esses binds para o `override.yml` dev-only) está em **#857**.
+  Até lá, o gate depende de Docker Compose **v2.24.6+**.
+- **`v2/Makefile` desatualizado em alguns targets:** o target `test` ainda referencia `apps/dat_ingest/tests`,
+  app **removido** do projeto — usar os targets de teste de `apps/core`/`apps/dev_tools` (ver
+  [django-patterns]) e ignorar `dat_ingest` nesses alvos. Os targets `etl_*`/`etl_completo` do `v2/Makefile`
+  são do **ETL legado morto**; o import real hoje é `import_export_contract` + endpoints DRF.
+- **Não existe doc canônico `v2/docs/ENVIRONMENTS.md`** (esperado pelo contexto, mas ausente no repo) — esta
+  spec passa a ser a SSOT do tópico; quando o doc longo existir, deve ser linkado aqui (não duplicado).
+- **`make health-*` usa health externo via curl,** que em algumas redes (Kaspersky/Golden) retorna HTTP 000
+  para `:443` mesmo com containers `healthy` — não confundir falha de rede com falha de app (ver deploy.spec).
+- **Prod sem staging remoto:** não há ambiente de staging em VM; merge na `main` = deploy direto pra prod
+  (ver [deploy.spec](./deploy.spec.md)). O `staging-gate`/`prod-like` **locais** são a única barreira prod-like
+  antes do merge.


### PR DESCRIPTION
## Fases 1 + 3 + 4 do programa SDD — ADR + specs vivas

Fecha a maior parte do programa SDD (resta só a **Fase 6**, automação de CI, em PR separado).

### Fase 1 — Contratos no git
- **ADR-017** formaliza o modelo SDD (frontmatter obrigatório, 1 SSOT/tópico, histórico isolado, gerar-em-vez-de-copiar).
- Registra a **decisão `CLAUDE.md`/`AGENTS.md` = local-only** — os contratos *enforced* já vivem em git (`docs/business-rules/clausulas-petreas.md` + `specs/domain/`), então nada crítico depende de `.claude/` num clone limpo. CP-07/CP-08 já versionados em #1465.

### Fase 3 + 4 — 19 specs vivas
Autoradas por workflow multi-agente (1 agente por spec), **cada uma verificada contra o código** (`sources_of_truth` confirmados existir):

| Área | Specs |
|---|---|
| `domain/` | clausulas-petreas, regras-disponibilidade, politica-aprovacao, requisitos-funcionais |
| `backend/` | rbac, availability, solicitacao-approval, gcal, imports, backup-dr, dat, notificacoes, **deslocamento** (GAP), dev-tools |
| `frontend/` | pages, **hooks-rbac** (GAP), api-clients |
| `infra/` | environments, ci (deploy.spec já existia) |

Cada spec segue o template do plano (propósito, fonte de verdade no código, contratos/invariantes, API, fluxos, ADRs, testes, dívidas) + frontmatter `status`/`last_verified`/`sources_of_truth`. O `INDEX_SDD.md` virou o hub vivo com todos os links; READMEs de área atualizados.

### Drift que as specs corrigiram
- "45+ páginas" → **40 reais** (contadas em `AppRoutes.tsx`).
- Notificações documenta o sistema vivo **32-Passos** (`AcaoTemplate`/`CicloAcoes`/...), não o plano fantasma arquivado (`EtapaProjeto`/`Notification`, nunca implementado).
- **RD-04** (buffer de viagem, lido de *eventos*) ≠ model `Deslocamento` — distinção sutil documentada como dívida.

### Validação
- Link-checker (python): **0 quebras vivas**; todos os `sources_of_truth` **existem** no código.
- `git diff --check` limpo.
- Specs ficam em `v2/docs/specs/` (fora da nav MkDocs); o ADR-017 (sob `docs/`) usa URL absoluta para refs cross-tree → passa `mkdocs build --strict`.
- Docs-only → `[required] staging gate evidence` deve ficar `skipped`.

Parte da migração SDD (memória `sdd-doc-program-2026-06-19`; plano `v2/docs/plans/PLAN_sdd_migration_2026-06-19.md`).
