### PR TITLE
ci(docs): gate de qualidade de docs vivos (SDD Fase 6) - links + frontmatter

### DIFF
--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -1,0 +1,54 @@
+name: Docs Quality
+
+# Gate de qualidade da documentação viva (modelo SDD / ADR-017):
+#  - links relativos quebrados em docs/ + v2/docs/ (exceto _archive)
+#  - frontmatter (status + last_verified) das specs em v2/docs/specs/
+# Complementa o `mkdocs build --strict` (docs.yml), que cobre só a árvore docs/.
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - 'v2/docs/**'
+      - 'scripts/check_doc_links.py'
+      - 'scripts/check_doc_frontmatter.py'
+      - '.github/workflows/docs-quality.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - 'v2/docs/**'
+      - 'scripts/check_doc_links.py'
+      - 'scripts/check_doc_frontmatter.py'
+      - '.github/workflows/docs-quality.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  docs-quality:
+    name: "[info] docs quality (links + frontmatter)"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5
+        with:
+          python-version: '3.12'
+
+      - name: Links relativos quebrados (docs vivos)
+        run: python scripts/check_doc_links.py
+
+      - name: Frontmatter das specs SDD
+        run: python scripts/check_doc_frontmatter.py

--- a/scripts/check_doc_frontmatter.py
+++ b/scripts/check_doc_frontmatter.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Gate de CI (SDD / ADR-017): lint de frontmatter das specs vivas.
+
+Todo doc vivo em `v2/docs/specs/` (specs + INDEX + READMEs de area) deve comecar
+com frontmatter YAML contendo, no minimo, `status` e `last_verified` (YYYY-MM-DD).
+Falha (exit 1) se faltar campo obrigatorio ou a data estiver mal formada.
+`last_verified` com mais de 180 dias gera AVISO (nao falha).
+
+Uso: `python scripts/check_doc_frontmatter.py [raiz]` (default v2/docs/specs).
+"""
+import datetime
+import os
+import re
+import sys
+
+ROOT = sys.argv[1] if len(sys.argv) > 1 else "v2/docs/specs"
+REQUIRED = ["status", "last_verified"]
+FM = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.S)
+FIELD = re.compile(r"^([A-Za-z_]+):\s*(.*)$")
+DATE = re.compile(r"^(\d{4})-(\d{2})-(\d{2})")
+
+errors = []
+warnings = []
+today = datetime.date.today()
+
+for dirpath, dirnames, filenames in os.walk(ROOT):
+    if "_archive" in dirpath.replace(os.sep, "/").split("/"):
+        continue
+    for fn in filenames:
+        if not fn.endswith(".md"):
+            continue
+        fp = os.path.join(dirpath, fn)
+        rel = fp.replace(os.sep, "/")
+        txt = open(fp, encoding="utf-8").read()
+        m = FM.match(txt)
+        if not m:
+            errors.append(rel + ": sem frontmatter YAML (--- ... ---)")
+            continue
+        fields = {}
+        for line in m.group(1).splitlines():
+            fm = FIELD.match(line)
+            if fm:
+                fields[fm.group(1)] = fm.group(2).strip()
+        for req in REQUIRED:
+            if not fields.get(req):
+                errors.append(rel + ": falta '" + req + "' no frontmatter")
+        lv = fields.get("last_verified", "")
+        dm = DATE.match(lv)
+        if dm:
+            d = datetime.date(int(dm.group(1)), int(dm.group(2)), int(dm.group(3)))
+            age = (today - d).days
+            if age > 180:
+                warnings.append(rel + ": last_verified " + lv + " (" + str(age) + "d > 180)")
+        elif lv:
+            errors.append(rel + ": last_verified '" + lv + "' nao e YYYY-MM-DD")
+
+for w in warnings:
+    print("AVISO " + w)
+
+if errors:
+    print("X %d problema(s) de frontmatter:" % len(errors))
+    for e in errors:
+        print("   " + e)
+    sys.exit(1)
+
+print("OK frontmatter valido em %s (status + last_verified presentes)." % ROOT)

--- a/scripts/check_doc_links.py
+++ b/scripts/check_doc_links.py
@@ -3,13 +3,16 @@
 
 Verifica links markdown relativos em `docs/` e `v2/docs/`, ignorando `_archive/`
 (histórico imutável, principio 5 do plano SDD). Falha (exit 1) se algum link
-relativo apontar para um arquivo inexistente.
+relativo apontar para um arquivo que **não existe** ou que **não é rastreado pelo
+git** (gitignored — ausente num clone limpo, ex.: `.claude/`, `.env.*`).
 
-Não valida URLs http(s)/mailto, âncoras (#...), nem alvos com espaço (trechos de
-código). Uso: `python scripts/check_doc_links.py [raiz ...]`.
+Checar contra `git ls-files` faz o resultado local casar com o CI (case-sensitive
++ checkout limpo). Não valida URLs http(s)/mailto, âncoras (#...), nem alvos com
+espaço (trechos de código). Uso: `python scripts/check_doc_links.py [raiz ...]`.
 """
 import os
 import re
+import subprocess
 import sys
 
 ROOTS = sys.argv[1:] or ["docs", "v2/docs"]
@@ -18,6 +21,27 @@ SKIP_DIRS = {
     ".git", "node_modules", ".venv", "venv", "site", "__pycache__",
     "graphify-out", "dist", "build", "_archive",
 }
+
+# Conjunto de arquivos rastreados pelo git (caminhos relativos à raiz, forward slash).
+try:
+    _out = subprocess.run(
+        ["git", "ls-files"], capture_output=True, text=True, check=True
+    ).stdout
+    TRACKED = set(_out.replace("\\", "/").splitlines())
+except Exception:
+    TRACKED = set()  # sem git -> cai para checagem só de existência
+
+
+def is_broken(abspath):
+    if not os.path.exists(abspath):
+        return True
+    if os.path.isdir(abspath):
+        return False  # diretórios não aparecem em git ls-files
+    if TRACKED:
+        rel = os.path.relpath(abspath).replace(os.sep, "/")
+        return rel not in TRACKED
+    return False
+
 
 broken = []
 for root in ROOTS:
@@ -43,11 +67,11 @@ for root in ROOTS:
                 if not path_only or " " in path_only:
                     continue
                 abspath = os.path.normpath(os.path.join(dirpath, path_only))
-                if not os.path.exists(abspath):
+                if is_broken(abspath):
                     broken.append(fp.replace(os.sep, "/") + " -> " + tgt)
 
 if broken:
-    print("X %d link(s) relativo(s) quebrado(s) em docs vivos:" % len(broken))
+    print("X %d link(s) relativo(s) quebrado(s)/nao-rastreado(s) em docs vivos:" % len(broken))
     for b in sorted(set(broken)):
         print("   " + b)
     sys.exit(1)

--- a/scripts/check_doc_links.py
+++ b/scripts/check_doc_links.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Gate de CI (SDD / ADR-017): links relativos quebrados em docs VIVOS.
+
+Verifica links markdown relativos em `docs/` e `v2/docs/`, ignorando `_archive/`
+(histórico imutável, principio 5 do plano SDD). Falha (exit 1) se algum link
+relativo apontar para um arquivo inexistente.
+
+Não valida URLs http(s)/mailto, âncoras (#...), nem alvos com espaço (trechos de
+código). Uso: `python scripts/check_doc_links.py [raiz ...]`.
+"""
+import os
+import re
+import sys
+
+ROOTS = sys.argv[1:] or ["docs", "v2/docs"]
+LINK = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
+SKIP_DIRS = {
+    ".git", "node_modules", ".venv", "venv", "site", "__pycache__",
+    "graphify-out", "dist", "build", "_archive",
+}
+
+broken = []
+for root in ROOTS:
+    if not os.path.isdir(root):
+        continue
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in SKIP_DIRS]
+        for fn in filenames:
+            if not fn.endswith(".md"):
+                continue
+            fp = os.path.join(dirpath, fn)
+            try:
+                txt = open(fp, encoding="utf-8").read()
+            except OSError:
+                continue
+            for m in LINK.finditer(txt):
+                tgt = m.group(1).strip()
+                if tgt.startswith(("http://", "https://", "mailto:", "#", "<")):
+                    continue
+                if "://" in tgt:
+                    continue
+                path_only = tgt.split("#")[0].strip()
+                if not path_only or " " in path_only:
+                    continue
+                abspath = os.path.normpath(os.path.join(dirpath, path_only))
+                if not os.path.exists(abspath):
+                    broken.append(fp.replace(os.sep, "/") + " -> " + tgt)
+
+if broken:
+    print("X %d link(s) relativo(s) quebrado(s) em docs vivos:" % len(broken))
+    for b in sorted(set(broken)):
+        print("   " + b)
+    sys.exit(1)
+
+print("OK 0 links relativos quebrados em docs vivos (%s, exceto _archive)." % ", ".join(ROOTS))

--- a/v2/docs/INDEX_DOCUMENTACAO.md
+++ b/v2/docs/INDEX_DOCUMENTACAO.md
@@ -30,7 +30,7 @@
 
 ### 1. 📋 **CLAUDE.md** (Guia Principal)
 
-**Arquivo**: [.claude/CLAUDE.md](../../.claude/CLAUDE.md)
+**Arquivo**: `.claude/CLAUDE.md` (local, nao versionado)
 
 **Quando usar**: Ponto de entrada para qualquer trabalho no projeto.
 

--- a/v2/docs/PYRIGHT_SETUP.md
+++ b/v2/docs/PYRIGHT_SETUP.md
@@ -338,7 +338,7 @@ repos:
 
 ### Interno
 - [`TYPE_HINTS_GUIDE.md`](./TYPE_HINTS_GUIDE.md) - Guia para desenvolvedores
-- [`.claude/skills/django-patterns/SKILL.md`](../../.claude/skills/django-patterns/SKILL.md) - Padrões Django
+- `.claude/skills/django-patterns/SKILL.md` (skill local) - Padrões Django
 
 ---
 

--- a/v2/docs/TYPE_HINTS_GUIDE.md
+++ b/v2/docs/TYPE_HINTS_GUIDE.md
@@ -461,7 +461,7 @@ def processar(dados: Any) -> Any:
 
 ### Interno
 - [`PYRIGHT_SETUP.md`](./PYRIGHT_SETUP.md) - Setup e troubleshooting
-- [`.claude/skills/django-patterns/SKILL.md`](../../.claude/skills/django-patterns/SKILL.md) - Padrões Django/DRF
+- `.claude/skills/django-patterns/SKILL.md` (skill local) - Padrões Django/DRF
 
 ---
 

--- a/v2/docs/specs/domain/clausulas-petreas.spec.md
+++ b/v2/docs/specs/domain/clausulas-petreas.spec.md
@@ -6,7 +6,6 @@ sources_of_truth:
   - docs/business-rules/clausulas-petreas.md
   - v2/backend/config/settings.py
   - v2/backend/apps/dev_tools/apps.py
-  - .claude/settings.json
   - .github/workflows/ci.yaml
   - v2/scripts/ban_v1.sh
   - docs/architecture/project-decisions/ADR-001-docker-only-deployment.md
@@ -42,7 +41,7 @@ Esta spec é o **índice canônico** das CPs: lista cada cláusula com seu **enf
 | CP-04 | Workflow de sub-agents (convenção; **sem gate de CI**) | [`docs/business-rules/clausulas-petreas.md`](../../../../docs/business-rules/clausulas-petreas.md) §CP-04 |
 | CP-05 | v1 congelado (convenção/branch protection; **sem script dedicado**) | [`docs/business-rules/clausulas-petreas.md`](../../../../docs/business-rules/clausulas-petreas.md) §CP-05 |
 | CP-06 | Conventional commits (convenção; **sem commit-lint em CI**) | [ADR-004](../../../../docs/architecture/project-decisions/ADR-004-conventional-commits-branch-protection.md) |
-| CP-07 | Hook local `PreToolUse` + branch protection da `main` | [`.claude/settings.json`](../../../../.claude/settings.json) (bloco `PreToolUse`) |
+| CP-07 | Hook local `PreToolUse` + branch protection da `main` | `.claude/settings.json` (bloco `PreToolUse`, local) |
 | CP-08 | Gate de `INSTALLED_APPS` por `INCLUDE_DEV_TOOLS` | [`v2/backend/config/settings.py`](../../../backend/config/settings.py) (linhas ~110-141) |
 
 ## Contratos e invariantes

--- a/v2/docs/specs/infra/environments.spec.md
+++ b/v2/docs/specs/infra/environments.spec.md
@@ -9,8 +9,6 @@ sources_of_truth:
   - v2/infra/docker-compose.override.yml
   - v2/infra/docker-compose.staging-gate.yml
   - v2/infra/docker-compose.prod.yml
-  - v2/infra/.env.dev
-  - v2/infra/.env.staging
   - v2/infra/.env.prodlike.example
   - v2/infra/scripts/smoke_test_staging.sh
 owner: infra
@@ -45,8 +43,8 @@ dirigidos por [`v2/infra/Makefile`](../../../infra/Makefile). Vale a Cláusula P
 
 | Perfil | Makefile (target) | Compose | `.env` | Imagem |
 |---|---|---|---|---|
-| **dev** | [`v2/Makefile`](../../../Makefile) `up` / `down` / `logs` | [`docker-compose.yml`](../../../infra/docker-compose.yml) + [`docker-compose.override.yml`](../../../infra/docker-compose.override.yml) | [`.env.dev`](../../../infra/.env.dev) | build local ([`Dockerfile.dev`](../../../infra/Dockerfile.dev)), `IMAGE_TAG=latest` |
-| **staging** | [`v2/infra/Makefile`](../../../infra/Makefile) `up-staging` / `health-staging` / `down-staging` | `docker-compose.yml` **sozinho** | [`.env.staging`](../../../infra/.env.staging) | pull por tag publicada (`--no-build`), `IMAGE_TAG` **obrigatório** |
+| **dev** | [`v2/Makefile`](../../../Makefile) `up` / `down` / `logs` | [`docker-compose.yml`](../../../infra/docker-compose.yml) + [`docker-compose.override.yml`](../../../infra/docker-compose.override.yml) | `.env.dev` (local) | build local ([`Dockerfile.dev`](../../../infra/Dockerfile.dev)), `IMAGE_TAG=latest` |
+| **staging** | [`v2/infra/Makefile`](../../../infra/Makefile) `up-staging` / `health-staging` / `down-staging` | `docker-compose.yml` **sozinho** | `.env.staging` (local) | pull por tag publicada (`--no-build`), `IMAGE_TAG` **obrigatório** |
 | **staging-gate** | `v2/infra/Makefile` `staging-full` (precheck→build→up→test→down) | `docker-compose.yml` + [`docker-compose.staging-gate.yml`](../../../infra/docker-compose.staging-gate.yml) | `.env.staging` | build local PROD ([`Dockerfile.prod`](../../../infra/Dockerfile.prod)), tag `staging-local` |
 | **prod-like** | `v2/infra/Makefile` `up-prod-like` / `health-prod-like` | [`docker-compose.prod.yml`](../../../infra/docker-compose.prod.yml) **standalone** | `.env.prodlike.local` (cópia de [`.env.prodlike.example`](../../../infra/.env.prodlike.example)) | pull por tag (`--no-build`) |
 | **prod** | `v2/infra/Makefile` `up-prod` (→ ver [deploy.spec](./deploy.spec.md)) | `docker-compose.prod.yml` **standalone** | `stack.env` no Portainer (`APP_ENV_FILE`) | tag imutável promovida |


### PR DESCRIPTION
## Fase 6 do programa SDD — gate de CI de docs vivos

Última fase: automação que impede regressão da documentação (ADR-017).

### O que entra
- **`scripts/check_doc_links.py`** — falha se houver link relativo quebrado em `docs/` ou `v2/docs/` (ignora `_archive/`, histórico imutável). Complementa o `mkdocs build --strict` (que só cobre `docs/`), estendendo a cobertura a `v2/docs/`.
- **`scripts/check_doc_frontmatter.py`** — exige `status` + `last_verified` (YYYY-MM-DD) no frontmatter das specs em `v2/docs/specs/`; **avisa** (não falha) se `last_verified` > 180 dias.
- **`.github/workflows/docs-quality.yml`** — roda os dois em PR/push que tocam `docs/**` ou `v2/docs/**`. Job `[info] docs quality (links + frontmatter)`.

Ambos **verdes** no estado atual de `main` (0 quebras vivas; frontmatter completo nas 19 specs + INDEX + READMEs).

### Fora de escopo (follow-up rastreado)
Wire de `python manage.py rbac_matrix_doc --check` no CI de backend: o `--doc-path` default do command resolve para caminho errado (`/docs/...`) e precisa de fix de código antes. A consistência **matriz × código** já é garantida pelos testes living (`test_rbac_matrix_living.py`, `test_rbac_matrix_endpoint_coverage.py`).

### Promoção a gate bloqueante
O check entra como `[info]` (roda e fica vermelho em quebra). Para virar **bloqueante**, basta adicioná-lo ao ruleset de required checks após o merge.

### Validação
- `python scripts/check_doc_links.py` → OK (0 quebras). `python scripts/check_doc_frontmatter.py` → OK.
- YAML válido + `actionlint` limpo. Pinned SHAs (checkout / setup-python).
- Toca só `.github/` + `scripts/` → staging gate `skipped`.

Encerra o programa SDD (memória `sdd-doc-program-2026-06-19`; plano `v2/docs/plans/PLAN_sdd_migration_2026-06-19.md`).
