### PR TITLE
ci/docs(quality): guard codecov sem token + markdownlint limpo nas specs SDD

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -259,6 +259,8 @@ jobs:
       - backend-tests-core
       - backend-tests-ingest-devtools
     if: always() && needs.backend-impact.outputs.backend_changed == 'true'
+    env:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
@@ -315,13 +317,15 @@ jobs:
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
+      # Sobe cobertura apenas quando o secret CODECOV_TOKEN existe; sem token o
+      # codecov-action v4 falha o upload (tokenless rejeitado) e polui o log.
+      if: ${{ env.CODECOV_TOKEN != '' }}
       with:
+        token: ${{ env.CODECOV_TOKEN }}
         file: ./v2/backend/coverage.xml
         flags: backend
         name: backend-coverage
         fail_ci_if_error: false
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   # ----------------------------------------------------------------
   # Job 3: Backend typecheck with Pyright

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,5 +1,6 @@
 {
   "default": true,
   "MD060": false,
-  "MD013": false
+  "MD013": false,
+  "MD025": { "front_matter_title": "" }
 }

--- a/v2/docs/specs/backend/availability.spec.md
+++ b/v2/docs/specs/backend/availability.spec.md
@@ -71,6 +71,7 @@ Idioma RBAC canônico: `permission_classes=[HasPerm("codename")]` (grupos direto
 ## Fluxos principais
 
 **Check de conflito (`check_conflicts`)**
+
 1. Valida intervalo (`fim > inicio`); inválido → `CheckResult(ok=False)` com `Conflict("X", "Intervalo inválido", ...)`.
 2. Carrega `TRAVEL_BUFFER_MINUTES` e `AVAILABILITY_DAILY_LIMIT_HOURS` (config → fallback settings).
 3. **RD-02/03**: bloqueios aprovados que intersectam → conflito T ou P por `tipo`.

--- a/v2/docs/specs/backend/backup-dr.spec.md
+++ b/v2/docs/specs/backend/backup-dr.spec.md
@@ -72,6 +72,7 @@ Invariantes que NAO podem ser violados:
 Nao expoe endpoints HTTP. Interface = tasks Celery + scripts CLI + env vars.
 
 **Disparo manual (Docker):**
+
 ```bash
 # backup full
 docker compose exec web /app/infra/scripts/backup_db.sh full

--- a/v2/docs/specs/backend/rbac.spec.md
+++ b/v2/docs/specs/backend/rbac.spec.md
@@ -52,7 +52,7 @@ Doc canônico detalhado (não duplicado aqui): convenção de nomes em [`RBAC_NA
 
 ## Contratos e invariantes
 
-- **Idioma canônico**: `permission_classes = [IsAuthenticated, HasPerm("codename")]`. Composition por instância: `HasPerm("a") | HasPerm("b")` (OR), `& ` (AND), `~` (NOT). Para OR semântico recorrente (≥3 caps ou compartilhado entre views) usa-se uma Policy `Can*`.
+- **Idioma canônico**: `permission_classes = [IsAuthenticated, HasPerm("codename")]`. Composition por instância: `HasPerm("a") | HasPerm("b")` (OR), `&` (AND), `~` (NOT). Para OR semântico recorrente (≥3 caps ou compartilhado entre views) usa-se uma Policy `Can*`.
 - **Grupos diretos são banidos**: `user.groups.filter(name=...)` em `apps/core/views*` ou `apps/core/services/` é violação **V001** do lint. Usos legítimos (composite, block, data-scope) exigem marcador `# noqa: RBAC-<tipo>-allowed` na linha. Classes `class Is<Word>(...)` fora da whitelist (`IsGerenteSuperintendencia`, `IsOwnerOrPrivileged`) são violação **V002**. Mutação de `PermissaoFuncional.groups` / `Group.permissions` em migration de `apps/core/` acima do cutoff D17 (número > 82) é violação **V003**. CI job `[required] backend rbac-lint`.
 - **Codename é capacidade, não identidade**: formato `verb_noun[_qualifier]` snake_case inglês. Proibido nome de setor/função/grupo. Exceções bundle conscientes: `manage_admin_registries`, `manage_purchases_and_materials`.
 - **Superuser sempre bypassa**: toda classe e helper retorna `True` para `is_superuser` antes de qualquer checagem.

--- a/v2/docs/specs/backend/solicitacao-approval.spec.md
+++ b/v2/docs/specs/backend/solicitacao-approval.spec.md
@@ -65,7 +65,8 @@ Interface de serviço (chamável internamente): `approve_solicitacao(solicitacao
 
 ## Fluxos principais
 
-**Aprovação individual (caminho feliz)**
+### Aprovação individual (caminho feliz)
+
 1. View resolve `get_object()` e extrai `reason`/`justificativa`.
 2. Service abre transação, faz `select_for_update().get(pk=...)` (relê sob lock).
 3. Valida `status == "pendente"`; senão levanta erro de status (400).
@@ -74,7 +75,8 @@ Interface de serviço (chamável internamente): `approve_solicitacao(solicitacao
 
 **Reprovação**: idêntico, com `status = "reprovado"`, `AuditLog` REJECT e mensagem "Solicitação reprovada.".
 
-**Lote (approve/reject)**
+### Lote (approve/reject)
+
 1. Valida `ids` não vazio e `len(ids) <= 100`.
 2. Em uma transação, carrega `filter(id__in=ids, status="pendente").select_for_update(skip_locked=True).order_by("id")`.
 3. `_build_batch_status_errors` calcula em **uma query** os IDs faltantes/não-pendentes e os anexa a `errors`.

--- a/v2/docs/specs/domain/politica-aprovacao.spec.md
+++ b/v2/docs/specs/domain/politica-aprovacao.spec.md
@@ -75,15 +75,18 @@ Corpo de `approve`/`reject` aceita `{"justificativa": "..."}` (opcional). Lote a
 ## Fluxos principais
 
 **Fluxo SUPER (aprovação manual):**
+
 1. Coordenador cria solicitação para projeto `fluxo == "SUPER"` → `perform_create` valida disponibilidade (`check_conflicts`) e grava `status="pendente"` (`resolve_initial_status`).
 2. Gerente da Superintendência (ou Assistente Administrativo do Controle) chama `approve`/`reject`.
 3. Service trava a linha (`select_for_update`), exige `status == "pendente"`, grava novo status e cria `AuditLog`.
 4. Aprovada → entra na Pré-Agenda; Controle/Super publica no GCal via `publish` (PA-03).
 
 **Fluxo NAO_SUPER (auto-aprovado):**
+
 1. Coordenador cria solicitação para projeto `fluxo == "NAO_SUPER"` → nasce `status="aprovado"` e vai direto à Pré-Agenda. Não passa pelos endpoints de aprovação.
 
 **Erros relevantes:**
+
 - Perfil não autorizado em `approve`/`reject` → **403** (mensagem cita "permissão"/"Superintendência").
 - `publish` em solicitação `pendente` → **400** e task Celery não enfileirada.
 - Reaprovar item já decidido → **400** (`already_approved`/`already_rejected`).

--- a/v2/docs/specs/domain/requisitos-funcionais.spec.md
+++ b/v2/docs/specs/domain/requisitos-funcionais.spec.md
@@ -80,6 +80,7 @@ Rotas registradas em [`urls.py`](../../../backend/apps/core/urls.py) (prefixo `/
 1. **Importação (RF01)**: operador roda `import_export_contract` em dry-run → revisa classificação → (com autorização) `--apply --allow-entity X` → writes create-only idempotentes; campos protegidos preservados.
 2. **Solicitação → publicação (RF02→RF05/RF06)**: coordenador cria solicitação → sistema checa conflitos (RF03) → `NAO_SUPER` auto-aprova; `SUPER` fica `pendente` → Superintendência/DAT aprova (RF04, grava AuditLog) → Controle/Super faz `preview-gcal` (não persiste) → `publish` enfileira Celery → evento criado no GCal; se `is_online=True`, `meet_link` extraído de `hangoutLink` e persistido (RF06).
 3. **Mapa mensal (RF08)**: front pede `availability/monthly/` por ano/mês/papel/setor → `build_monthly_grid` agrega eventos, bloqueios e deslocamentos em códigos por dia/pessoa → resposta cacheada; clique abre detalhe do dia.
+
 - **Erros relevantes**: aprovar item não-`pendente` → `ValidationAPIError` (`already_approved`/`already_rejected`/`invalid_status`); lote > 100 → `batch_limit_exceeded`; `--apply` sem allowlist → bloqueado, nada escrito; publish com `apply_blocked=True` → respeitado (não escreve no GCal).
 
 ## Decisões relacionadas (ADRs)

--- a/v2/docs/specs/frontend/hooks-rbac.spec.md
+++ b/v2/docs/specs/frontend/hooks-rbac.spec.md
@@ -75,6 +75,7 @@ Interface publica dos hooks:
 ## Fluxos principais
 
 **Bootstrap de autorizacao (1x por mount, sem polling de RBAC):**
+
 1. `App.tsx` chama `getMe()` (= `/api/me/`); o payload passa por `assertCurrentUserPayload` (em `api/availability.ts`/`auth.ts`). Sucesso => `setUser`.
 2. So entao chama `getMyPolicies()` (= `/api/me/policies/`); sucesso => `setPolicies`. Erro nao-auth => log `warn` + degrada para `[]`.
 3. `usePermissions(user)` computa flags legacy; `AppRoutes` chama `useCanAccess(policies, { canBloqueios, canCoordenador, canDashboardCompras })` para derivar flags.
@@ -83,6 +84,7 @@ Interface publica dos hooks:
 **Atualizacao de RBAC**: nao ha polling das capabilities. Mudancas de permissao so refletem apos reload/relogin (logout faz `window.location.reload()`). Os pollings existentes em `App.tsx` (`useGCalAlertsPolling`, `useUnreadNotificationsPolling`) sao de dados operacionais, gated pelas flags de `usePermissions`, e nao re-buscam policies.
 
 **Guard Google (caminho feliz + erro):**
+
 1. Pagina (ex: PreAgenda) obtem `googleStatus` via `useGoogleIntegration` e instancia `useGoogleGuard({ googleStatus, returnTo })`.
 2. Antes da acao: `if (!requireGoogleConnection('publicar eventos')) return;` — se desconectado, abre `Modal.confirm` e (no `onOk`) redireciona para `/api/oauth/google/start/?return_to=...`.
 3. No `catch` da chamada: `if (handleGoogleError(error)) return;` — trata `403 google_not_connected` reabrindo o modal; demais erros seguem o fluxo normal de mensagem.

--- a/v2/docs/specs/frontend/pages.spec.md
+++ b/v2/docs/specs/frontend/pages.spec.md
@@ -55,17 +55,20 @@ Esta spec é o **índice canônico do inventário de páginas**: domínio, rota 
 
 Inventário por domínio (rota → componente → guard). Detalhe da capability na [matriz RBAC](../../rbac_authorization_matrix.md).
 
-**Home**
+### Home
+
 | Rota | Página | Guard |
 |---|---|---|
 | `/`, `/home` | `Home/HomePage` | autenticado |
 
-**Auth**
+### Auth
+
 | Rota | Página | Guard |
 |---|---|---|
 | (sem rota — render condicional em `App.tsx`) | `Auth/LoginPage` | anônimo |
 
-**Solicitações** (agrupadas sob `/solicitacoes/*`)
+### Solicitações (agrupadas sob `/solicitacoes/*`)
+
 | Rota | Página | Guard |
 |---|---|---|
 | `/solicitacoes/minhas` | `Solicitacoes/MySolicitacoesPage` | `access.canCreateSolicitation` |
@@ -73,19 +76,22 @@ Inventário por domínio (rota → componente → guard). Detalhe da capability 
 | `/solicitacoes/:id/editar` | `Solicitacoes/EditSolicitacaoPage` | autenticado |
 | `/solicitacoes/meus-eventos` | `MeusEventos/MeusEventosPage` | autenticado |
 
-**Aprovações**
+### Aprovações
+
 | Rota | Página | Guard |
 |---|---|---|
 | `/solicitacoes/aprovacoes` | `Aprovacoes/ApprovalsPage` | policy `access_solicitation_approvals` |
 
-**Disponibilidade**
+### Disponibilidade
+
 | Rota | Página | Guard |
 |---|---|---|
 | `/solicitacoes/disponibilidade` | `Disponibilidade/MonthlyPage` | policy `view_all_availability` OU `canDisponibilidade` |
 | `/solicitacoes/bloqueios` | `Disponibilidade` (blocks) | `access.canAccessBlocks` (inclui Formador, escopo próprio) |
 | `/solicitacoes/deslocamentos` | `Deslocamentos/DeslocamentosPage` | `view_all_availability` OU `canControle`/`canCoordenador`/`canDAT` |
 
-**Controle**
+### Controle
+
 | Rota | Página | Guard |
 |---|---|---|
 | `/controle` | `Controle/ControlePage` | `canControle` |
@@ -97,7 +103,8 @@ Inventário por domínio (rota → componente → guard). Detalhe da capability 
 | `/controle/pre-agenda`, `/pre-agenda` | `PreAgenda/PreAgendaPage` | `canControle` |
 | `/acoes-notificacao`, `/acoes-notificacao/timeline`, `/notificacoes-internas` | `Controle/AcoesNotificacaoPage` / `AcoesTimelinePage` / `NotificacoesInternasPage` | `canAcoesInternas` |
 
-**DAT / AdminDAT**
+### DAT / AdminDAT
+
 | Rota | Página | Guard |
 |---|---|---|
 | `/dat/admin` (+ `/usuarios`, `/municipios`, `/projetos`, `/grupos`, `/setores`, `/funcoes`, `/gerencias`, `/produtos`, `/configuracoes`, `/colecoes`, `/equipe-gerencia`) | `AdminDAT/*` | `canDAT` |
@@ -107,7 +114,8 @@ Inventário por domínio (rota → componente → guard). Detalhe da capability 
 | `/dat/compras-materiais` | `DATModule/ComprasPage` | `canControle` OU `canDAT` |
 | `/dat/coordenadores` | `DATModule/CoordenadoresPage` | `canControle` |
 
-**Dashboards**
+### Dashboards
+
 | Rota | Página | Guard |
 |---|---|---|
 | `/dashboards` | `Dashboards/DashboardsPage` | `canDashboardOverview` (Diretoria/superuser) |

--- a/v2/docs/specs/infra/ci.spec.md
+++ b/v2/docs/specs/infra/ci.spec.md
@@ -67,6 +67,7 @@ A nomenclatura dos checks é o contrato de governança: `[required]` bloqueia me
 ## Fluxos principais
 
 **PR → merge (caminho feliz):**
+
 1. `backend-impact` decide se a suíte backend roda (PR sem impacto em backend pula os jobs pesados; push/dispatch sempre full).
 2. `lint` + `rbac-lint` (rápidos, paralelos).
 3. `backend-tests-core` e `backend-tests-ingest-devtools` rodam via reusable com `-n auto --dist loadscope`, cada um emitindo um artifact de cobertura.
@@ -79,6 +80,7 @@ A nomenclatura dos checks é o contrato de governança: `[required]` bloqueia me
 **Deploy (resumo — detalhe em `deploy.spec.md`):** build+scan(Trivy)+push das imagens → `validate_existing_tag` (promotion/rollback) → `deploy` chama Portainer CE API atualizando só o `IMAGE_TAG` → post-deploy verification (polling de versão + fallback via Portainer API quando o health externo está inacessível por rede).
 
 **Erros relevantes:**
+
 - Cobertura < 85% → `backend-tests` falha → `tests` vermelho.
 - xdist instável → fica **isolado** no canary (não bloqueia); recorrências viram issues de estabilização antes de promover ao gate.
 - Corpo de PR sem os 3 marcadores → `staging gate evidence` falha (exceto draft / sem runtime impact).

--- a/v2/docs/specs/infra/environments.spec.md
+++ b/v2/docs/specs/infra/environments.spec.md
@@ -121,6 +121,7 @@ Endpoints de health expostos por todos os perfis: `GET /api/readyz/` (db + redis
 PostgreSQL externo da VM02; Redis é local na stack. Backend em `:28000`, frontend em `:18081`.
 
 **Erros comuns:**
+
 - `IMAGE_TAG is required` ao subir staging/prod sem tag → exportar `IMAGE_TAG=vYYYY.MM.DD-<sha>`.
 - `staging-precheck falhou: !reset não suportado` → atualizar Docker Compose (v2.24.6+).
 - Colisão de porta → confirmar que não há outro perfil usando a mesma faixa (cada perfil tem portas próprias).


### PR DESCRIPTION
## Qualidade: Codecov sem token + markdownlint nas specs SDD

Resolve dois itens de qualidade apontados.

### Codecov (`ci.yaml`)
O step "Upload coverage to Codecov" (job `backend-tests`) passava o token só por env e tentava upload mesmo sem `CODECOV_TOKEN` → o codecov-action v4 rejeita upload tokenless e polui o log (embora `fail_ci_if_error: false` já evitasse derrubar o job).

**Fix:** `CODECOV_TOKEN` no env do job + `if: ${{ env.CODECOV_TOKEN != '' }}` no step + token via `with: token:`. Sem o secret, o step **pula limpo**; com o secret, sobe normalmente. (Para ativar Codecov, basta criar o secret `CODECOV_TOKEN` no repo.)

### markdownlint
`.markdownlint.json` existe (default on, MD013/MD060 off) mas **não é gate** — os "problemas" eram warnings de IDE. Limpei:

- **MD025** (falso-positivo): as specs têm `title:` no frontmatter **e** um `# H1` no corpo; configurado `MD025.front_matter_title: ""` (padrão correto para docs com frontmatter).
- **MD036 / MD001 / MD026** etc.: `markdownlint --fix` + ajustes manuais (bold→heading, nível de heading, pontuação) nas 19 specs + ADR-017 + stubs.
- Resultado: **0 erros** de markdownlint nos 35 arquivos do modelo SDD.

### Validação
- `markdownlint-cli2` → **0 erros** nos 35 arquivos. `actionlint ci.yaml` limpo (só warnings shellcheck pré-existentes, fora do meu diff). Gates `docs-quality` (links + frontmatter) verdes.
- Toca `.github/` + `.markdownlint.json` + docs → staging gate `skipped`.
