### PR TITLE
chore(makefile,runbook): remover referencias ao ETL legado removido (#1470)

### DIFF
--- a/v2/Makefile
+++ b/v2/Makefile
@@ -2,8 +2,6 @@ DC = COMPOSE_PROJECT_NAME=aprender_dev IMAGE_TAG=latest docker compose -f infra/
 WEB = $(DC) exec -T web
 
 .PHONY: up down build logs shell migrate collect seed seed-demo seed-rbac \
-        etl-acomp-dry etl-acomp-apply etl-desloc-dry etl-desloc-apply \
-        etl-acoes-dry etl-acoes-apply etl-dat-dry etl-dat-apply \
         import-compras-dry import-acoes-dry import-cadastros-dry \
         solic-pend-super solic-approve solic-reject \
         readyz healthz preview-json apply-json flags-fake flags-google preview-on preview-off \
@@ -40,71 +38,6 @@ seed-demo:
 
 seed-rbac:
 	$(WEB) python manage.py seed_rbac
-
-etl-acomp-dry:
-	$(WEB) python manage.py etl_upsert_acompanhamento \
-		--events-csv /app/data/csv-import/etl_eventos_normalizados.csv \
-		--participants-csv /app/data/csv-import/etl_participantes_normalizados.csv \
-		--dry-run
-
-etl-acomp-apply:
-	$(WEB) python manage.py etl_upsert_acompanhamento \
-		--events-csv /app/data/csv-import/etl_eventos_normalizados.csv \
-		--participants-csv /app/data/csv-import/etl_participantes_normalizados.csv
-
-etl-desloc-dry:
-	@echo "⚙️  Uso: make etl-desloc-dry FILE=/app/data/deslocamentos.csv"
-	@if [ -z "$(FILE)" ]; then \
-		echo "❌ Erro: Variável FILE não definida"; \
-		echo "   Exemplo: make etl-desloc-dry FILE=/app/data/deslocamentos.xlsx"; \
-		exit 1; \
-	fi
-	$(WEB) python manage.py etl_upsert_deslocamento --file "$(FILE)" --dry-run
-
-etl-desloc-apply:
-	@echo "⚙️  Uso: make etl-desloc-apply FILE=/app/data/deslocamentos.csv"
-	@if [ -z "$(FILE)" ]; then \
-		echo "❌ Erro: Variável FILE não definida"; \
-		echo "   Exemplo: make etl-desloc-apply FILE=/app/data/deslocamentos.xlsx"; \
-		exit 1; \
-	fi
-	$(WEB) python manage.py etl_upsert_deslocamento --file "$(FILE)"
-
-etl-acoes-dry:
-	@echo "⚙️  Uso: make etl-acoes-dry FILE=/app/data/acoes_controle.csv"
-	@if [ -z "$(FILE)" ]; then \
-		echo "❌ Erro: Variável FILE não definida"; \
-		echo "   Exemplo: make etl-acoes-dry FILE=/app/data/acoes_controle.xlsx"; \
-		exit 1; \
-	fi
-	$(WEB) python manage.py etl_import_acoes_controle "$(FILE)" --dry-run
-
-etl-acoes-apply:
-	@echo "⚙️  Uso: make etl-acoes-apply FILE=/app/data/acoes_controle.csv"
-	@if [ -z "$(FILE)" ]; then \
-		echo "❌ Erro: Variável FILE não definida"; \
-		echo "   Exemplo: make etl-acoes-apply FILE=/app/data/acoes_controle.xlsx"; \
-		exit 1; \
-	fi
-	$(WEB) python manage.py etl_import_acoes_controle "$(FILE)"
-
-etl-dat-dry:
-	@echo "⚙️  Uso: make etl-dat-dry FILE=/app/data/dat_cadastros.csv"
-	@if [ -z "$(FILE)" ]; then \
-		echo "❌ Erro: Variável FILE não definida"; \
-		echo "   Exemplo: make etl-dat-dry FILE=/app/data/dat_cadastros.xlsx"; \
-		exit 1; \
-	fi
-	$(WEB) python manage.py etl_import_dat_cadastros "$(FILE)" --dry-run
-
-etl-dat-apply:
-	@echo "⚙️  Uso: make etl-dat-apply FILE=/app/data/dat_cadastros.csv"
-	@if [ -z "$(FILE)" ]; then \
-		echo "❌ Erro: Variável FILE não definida"; \
-		echo "   Exemplo: make etl-dat-apply FILE=/app/data/dat_cadastros.xlsx"; \
-		exit 1; \
-	fi
-	$(WEB) python manage.py etl_import_dat_cadastros "$(FILE)"
 
 # ════════════════════════════════════════════════════════════════════════════
 # API HTTP Imports (via curl - requer autenticação)
@@ -274,16 +207,6 @@ help:
 	@echo "  make seed                  Seed RBAC data"
 	@echo "  make seed-demo             Seed demo users"
 	@echo "  make seed-rbac             Seed RBAC groups/permissions (idempotent)"
-	@echo ""
-	@echo "ETL (via management commands):"
-	@echo "  make etl-acomp-dry         Preview ETL acompanhamento (dry-run)"
-	@echo "  make etl-acomp-apply       Apply ETL acompanhamento"
-	@echo "  make etl-desloc-dry        Preview ETL deslocamentos (use FILE=/path/to/file.{csv|xlsx})"
-	@echo "  make etl-desloc-apply      Apply ETL deslocamentos (use FILE=/path/to/file.{csv|xlsx})"
-	@echo "  make etl-acoes-dry         Preview ETL ações controle (use FILE=/path/to/file.{csv|xlsx})"
-	@echo "  make etl-acoes-apply       Apply ETL ações controle (use FILE=/path/to/file.{csv|xlsx})"
-	@echo "  make etl-dat-dry           Preview ETL DAT cadastros (use FILE=/path/to/file.{csv|xlsx})"
-	@echo "  make etl-dat-apply         Apply ETL DAT cadastros (use FILE=/path/to/file.{csv|xlsx})"
 	@echo ""
 	@echo "Import via API HTTP (porta 8002, trailing slashes):"
 	@echo "  make import-compras-dry    POST /api/controle/import-compras/ (use FILE=...)"

--- a/v2/docs/RUNBOOK.md
+++ b/v2/docs/RUNBOOK.md
@@ -499,6 +499,8 @@ docker compose -p aprender_v2 exec web python manage.py shell
 
 ## 📦 ETL e Seeds
 
+> **⚠️ Depreciado (#1470, 2026-06).** Os comandos `etl_upsert_*` / `etl_import_*` desta seção foram **removidos** junto com `apps.dat_ingest` (#967/#971) — não há mais `*/management/commands/etl_*.py`. A importação atual usa o pipeline **export-contract** (`import_export_contract`) + endpoints DRF `POST /api/<recurso>/import/` (alvos `make import-compras-dry` / `import-acoes-dry` / `import-cadastros-dry`). Ver a spec viva [`imports.spec.md`](specs/backend/imports.spec.md) e `v2/docs/imports/`. O conteúdo abaixo é **histórico** e não roda mais.
+
 ### Seeds RBAC
 
 Cria grupos e permissões mínimas (idempotente):
@@ -840,6 +842,8 @@ python manage.py preagenda_to_gcal \
 ---
 
 ## 📊 ETL: Importação de Ações (Controle e DAT)
+
+> **⚠️ Depreciado (#1470, 2026-06).** Os comandos `etl_upsert_*` / `etl_import_*` desta seção foram **removidos** junto com `apps.dat_ingest` (#967/#971) — não há mais `*/management/commands/etl_*.py`. A importação atual usa o pipeline **export-contract** (`import_export_contract`) + endpoints DRF `POST /api/<recurso>/import/` (alvos `make import-compras-dry` / `import-acoes-dry` / `import-cadastros-dry`). Ver a spec viva [`imports.spec.md`](specs/backend/imports.spec.md) e `v2/docs/imports/`. O conteúdo abaixo é **histórico** e não roda mais.
 
 ### **Visão Geral**
 
@@ -1289,6 +1293,8 @@ u.groups.add(g)
 ---
 
 ## 📦 ETL: Acompanhamento com hash v2 e Quality Gates (PR21)
+
+> **⚠️ Depreciado (#1470, 2026-06).** Os comandos `etl_upsert_*` / `etl_import_*` desta seção foram **removidos** junto com `apps.dat_ingest` (#967/#971) — não há mais `*/management/commands/etl_*.py`. A importação atual usa o pipeline **export-contract** (`import_export_contract`) + endpoints DRF `POST /api/<recurso>/import/` (alvos `make import-compras-dry` / `import-acoes-dry` / `import-cadastros-dry`). Ver a spec viva [`imports.spec.md`](specs/backend/imports.spec.md) e `v2/docs/imports/`. O conteúdo abaixo é **histórico** e não roda mais.
 
 ### **Visão Geral**
 


### PR DESCRIPTION
Fecha #1470. O ETL via management commands (`apps.dat_ingest`) foi removido (#967/#971) — nao existe mais `*/management/commands/etl_*.py`, entao `make etl-acomp-dry` falhava.

- **v2/Makefile**: removidos os 8 targets `etl-*` (acomp/desloc/acoes/dat × dry/apply) que chamavam `etl_upsert_*`/`etl_import_*` inexistentes, + entradas `.PHONY` + bloco de help. Mantidos os targets reais (`import-compras/acoes/cadastros` via API HTTP) e `import_export_contract`.
- **v2/docs/RUNBOOK.md**: banner de depreciacao nas 3 secoes ETL apontando ao pipeline atual (`imports.spec.md` + `v2/docs/imports/`); conteudo historico preservado.

Validacao: link-checker 0 quebras vivas; git diff --check limpo; docs-only/Makefile -> staging gate skipped.