### PR TITLE
ci(docs): promover docs-quality a [required] (sem path filter)

### DIFF
--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -6,24 +6,17 @@ name: Docs Quality
 # Complementa o `mkdocs build --strict` (docs.yml), que cobre só a árvore docs/.
 
 on:
+  # NOTE: SEM path filter de propósito. Este é um check [required] no ruleset da main,
+  # então PRECISA sempre reportar status — com path filter, um PR que não toca docs/**
+  # deixaria o check "Expected/pending" eterno e travaria o merge (trap clássico de
+  # required + path filter no GitHub). Os 2 scripts rodam em segundos e validam toda a
+  # árvore docs/ + v2/docs viva de qualquer forma (não são incrementais).
   pull_request:
     branches:
       - main
-    paths:
-      - 'docs/**'
-      - 'v2/docs/**'
-      - 'scripts/check_doc_links.py'
-      - 'scripts/check_doc_frontmatter.py'
-      - '.github/workflows/docs-quality.yml'
   push:
     branches:
       - main
-    paths:
-      - 'docs/**'
-      - 'v2/docs/**'
-      - 'scripts/check_doc_links.py'
-      - 'scripts/check_doc_frontmatter.py'
-      - '.github/workflows/docs-quality.yml'
   workflow_dispatch:
 
 permissions:
@@ -35,7 +28,7 @@ concurrency:
 
 jobs:
   docs-quality:
-    name: "[info] docs quality (links + frontmatter)"
+    name: "[required] docs quality (links + frontmatter)"
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/v2/docs/plans/PLAN_sdd_migration_2026-06-19.md
+++ b/v2/docs/plans/PLAN_sdd_migration_2026-06-19.md
@@ -1,7 +1,26 @@
 # Plano de Migração SDD (Spec-Driven Development) — 2026-06-19
 
-> Status: plano ativo (não-iniciado) · Base: [`../reports/AUDITORIA_DOCUMENTAL_2026-06-19.md`](../reports/AUDITORIA_DOCUMENTAL_2026-06-19.md)
-> Regra deste plano: **nenhum arquivo é movido nesta etapa**. Isto descreve a estrutura-alvo e as fases.
+> Status: **CONCLUÍDO (Fases 0-6 + cleanup), 2026-06-20** · Base: [`../reports/AUDITORIA_DOCUMENTAL_2026-06-19.md`](../reports/AUDITORIA_DOCUMENTAL_2026-06-19.md)
+> Backlog vivo: GitHub **#1477** (tracking). As seções 1-10 abaixo são o plano original (referência).
+
+## 0. Status de execução (atualizado 2026-06-20)
+
+Todas as fases concluídas. Mapeamento fase → PR:
+
+| Fase | PR(s) | Resultado |
+|---|---|---|
+| 0 — Fundação | #1464 | esqueleto `specs/` + `INDEX_SDD` + frontmatter + 8 links |
+| 1 — Contratos no git | #1472 | ADR-017 + decisão `CLAUDE.md`/`AGENTS.md` local-only; CP-07/08 em #1465 |
+| 2 — Reconciliar stale | #1465, #1471 | `dat_ingest`, deploy→Portainer, versões, Redis VM01, `etl.md` stub |
+| 3+4 — Specs + gaps | #1472 | **19 specs vivas** (domain/backend/frontend/infra) |
+| 5 — Histórico | #1467, #1468 | `analysis/` + planos + 18 stale → `_archive/` |
+| Onda 3 — Merges | #1469 | 17 merges → SSOTs + 7 stubs + archives |
+| 6 — Automação | #1473 | gate `docs-quality` (links vivos + frontmatter) |
+| Cleanup | #1475, #1476 | codecov guard + markdownlint; #1470 Makefile/RUNBOOK ETL |
+
+**Backlog restante** (baixa prio, rastreado em #1477): #1474 (`rbac_matrix_doc --check`); refs stale
+residuais em `.claude/`; promover `docs-quality` a `[required]`; ~40 links em `_archive/` (histórico
+imutável); remoção profunda das seções ETL do `RUNBOOK.md` (hoje com banner).
 
 ## 1. Objetivo
 


### PR DESCRIPTION
## O que

Promove o gate `docs-quality` (link-checker + frontmatter das specs SDD) de `[info]` para `[required]` no ruleset da `main`.

- Remove o **path filter** do `docs-quality.yml` (pull_request + push).
- Renomeia o job: `[info] docs quality (...)` -> `[required] docs quality (...)`.
- (Pós-merge) adiciono o check ao ruleset da main via `gh api`.

## Por que sem path filter

Required check **+** path filter é um trap clássico do GitHub: um PR que não toca `docs/**`/`v2/docs/**`/scripts **não dispara** o workflow, então o check fica `Expected/pending` eterno e **trava o merge**. Os 2 scripts rodam em ~segundos e validam toda a árvore `docs/` + `v2/docs` viva de forma **não-incremental**, então rodar em todo PR custa praticamente nada.

## Validação

- `python scripts/check_doc_links.py` -> **0 links quebrados** em docs vivos.
- `python scripts/check_doc_frontmatter.py` -> **frontmatter OK** nas specs.
- YAML válido (triggers: pull_request/push/workflow_dispatch, sem paths).

## Escopo / gate

Mudança **workflow-only** (`.github/workflows/docs-quality.yml`) — não casa o backend-impact regex (só `ci.yaml`/`_backend-test.yml`), então **não dispara backend tests nem staging gate**.

Fecha o item "docs-quality -> [required]" do tracking SDD #1477.