### PR TITLE
perf(tests): habilita pytest --no-migrations + migra seeds para factories (#1404)

### DIFF
--- a/.github/workflows/_backend-test.yml
+++ b/.github/workflows/_backend-test.yml
@@ -32,6 +32,10 @@ on:
         description: "Args extras do pytest (xdist, junit, dispatch passthrough)"
         type: string
         default: ""
+      run_migrations:
+        description: "Se true, roda `manage.py migrate` antes do pytest. O gate core usa false + `--no-migrations` (schema dos models, setup ~rapido, #1404); o job migrate-integrity usa true (exercita a cadeia RunPython em DB limpo)."
+        type: boolean
+        default: true
       coverage_file:
         description: "Se != '', exporta COVERAGE_FILE e adiciona --cov=apps --cov-report=term"
         type: string
@@ -155,6 +159,7 @@ jobs:
           echo "✅ No hardcoded '/app' paths found in tests"
 
       - name: Run migrations
+        if: ${{ inputs.run_migrations }}
         run: |
           cd v2/backend
           python manage.py migrate --noinput

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -216,10 +216,16 @@ jobs:
     with:
       runner_timeout: 35
       pytest_paths: apps/core/tests
+      # run_migrations=false + --no-migrations: pytest-django cria o schema dos
+      # models (sem replay das 24 RunPython), cortando o setup de DB. Os seeds RBAC
+      # vem das fixtures de sessao/funcao (ensure_base_groups + seed_functional_
+      # permissions), nao das migrations. A cadeia RunPython e exercitada a parte no
+      # job backend-migrate-integrity (deploy-safe). #1404.
+      run_migrations: false
       # Paralelizacao xdist no gate (~15min->~5min). loadscope mantem testes da
       # mesma classe/modulo no mesmo worker. Habilitado apos #1402 estabilizar a
       # suite (re-seed RBAC pos-truncate; canary 0/4 em 2 runs consecutivos). #1403.
-      pytest_extra_args: -n auto --dist loadscope
+      pytest_extra_args: -n auto --dist loadscope --no-migrations
       coverage_file: .coverage.core
       validate_test_paths: true
       summary_title: Backend Core Tests Runtime
@@ -240,7 +246,8 @@ jobs:
     with:
       runner_timeout: 30
       pytest_paths: apps/dev_tools/tests
-      pytest_extra_args: -n auto --dist loadscope  # paralelizacao xdist. #1403.
+      run_migrations: false  # --no-migrations: schema dos models, sem replay das RunPython. #1404.
+      pytest_extra_args: -n auto --dist loadscope --no-migrations  # xdist #1403 + --no-migrations #1404.
       coverage_file: .coverage.ingest_devtools
       summary_title: Backend Ingest/DevTools Tests Runtime
       artifact_name: backend-coverage-ingest-devtools

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -248,6 +248,34 @@ jobs:
       artifact_if_no_files: error
 
   # ----------------------------------------------------------------
+  # Job 2b2: Migrate-integrity — rede de seguranca da cadeia RunPython.
+  #
+  # Os gates core/ingest rodam com --no-migrations (schema dos models, setup
+  # rapido, #1404). Isso NAO exercita `manage.py migrate`, mas dev/prod aplicam
+  # a cadeia real de migrations no deploy. Este job preenche essa lacuna:
+  # run_migrations=true aplica as 24 RunPython em DB limpo (falha aqui = migration
+  # quebrada, pega ANTES do deploy) e roda os testes `-m migrations` contra o DB
+  # migrado. E gated pelo required `backend-tests` (needs + assert), sem mexer no
+  # ruleset de branch protection.
+  # ----------------------------------------------------------------
+  backend-migrate-integrity:
+    name: "[info] backend migrate-integrity"
+    needs:
+      - backend-impact
+    if: needs.backend-impact.outputs.backend_changed == 'true'
+    uses: ./.github/workflows/_backend-test.yml
+    with:
+      runner_timeout: 20
+      pytest_paths: apps/core/tests
+      # run_migrations=true (default): aplica a cadeia RunPython em DB limpo.
+      run_migrations: true
+      pytest_extra_args: -m migrations
+      summary_title: Backend Migrate-Integrity (cadeia RunPython)
+      artifact_name: backend-migrate-integrity
+      artifact_paths: v2/backend/.coverage.migrate_integrity
+      artifact_if_no_files: ignore
+
+  # ----------------------------------------------------------------
   # Job 2c: Backend coverage combine + required backend tests gate
   # ----------------------------------------------------------------
   backend-tests:
@@ -258,6 +286,7 @@ jobs:
       - backend-impact
       - backend-tests-core
       - backend-tests-ingest-devtools
+      - backend-migrate-integrity
     if: always() && needs.backend-impact.outputs.backend_changed == 'true'
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -276,6 +305,10 @@ jobs:
         fi
         if [ "${{ needs.backend-tests-ingest-devtools.result }}" != "success" ]; then
           echo "backend-tests-ingest-devtools failed with result=${{ needs.backend-tests-ingest-devtools.result }}" >&2
+          exit 1
+        fi
+        if [ "${{ needs.backend-migrate-integrity.result }}" != "success" ]; then
+          echo "backend-migrate-integrity failed with result=${{ needs.backend-migrate-integrity.result }}" >&2
           exit 1
         fi
         echo "Split backend test jobs passed."

--- a/v2/backend/apps/core/services/functional_permissions_seed.py
+++ b/v2/backend/apps/core/services/functional_permissions_seed.py
@@ -10,7 +10,31 @@ from dataclasses import dataclass
 from django.contrib.auth.models import Group
 from django.db import transaction
 
+from apps.core.constants import FUNCAO_GROUPS, SETOR_GROUPS
 from apps.core.models import PermissaoFuncional
+
+# União canônica de todos os grupos RBAC base (setor + função). SSOT em
+# apps.core.constants. Mesma lista usada pelo command dev_tools `seed_rbac`.
+BASE_GROUP_NAMES: tuple[str, ...] = tuple(SETOR_GROUPS + [f for f in FUNCAO_GROUPS if f not in SETOR_GROUPS])
+
+
+def ensure_base_groups() -> int:
+    """
+    Garante a existência de TODOS os grupos RBAC base (setor + função).
+
+    Idempotente. Necessário em ambientes sem as migrations de seed RunPython
+    (ex.: `pytest --no-migrations`), onde nenhuma migration cria os grupos.
+    `seed_functional_permissions(assign_default_groups=True)` só cria os grupos
+    que têm capability atribuída (7 dos 18); este helper cobre os demais
+    (setores sem capability, Formador, Assistente Administrativo). Retorna a
+    quantidade de grupos criados nesta chamada.
+    """
+    created = 0
+    for name in BASE_GROUP_NAMES:
+        _, was_created = Group.objects.get_or_create(name=name)
+        if was_created:
+            created += 1
+    return created
 
 
 @dataclass(frozen=True)

--- a/v2/backend/apps/core/tests/conftest.py
+++ b/v2/backend/apps/core/tests/conftest.py
@@ -14,7 +14,10 @@ from django.conf import settings
 
 import pytest
 
-from apps.core.services.functional_permissions_seed import seed_functional_permissions
+from apps.core.services.functional_permissions_seed import (
+    ensure_base_groups,
+    seed_functional_permissions,
+)
 
 
 def get_field_errors(response) -> dict[str, Any]:
@@ -66,10 +69,17 @@ def force_service_account_mode():
 @pytest.fixture(autouse=True, scope="session")
 def seed_functional_permissions_fixture(django_db_setup, django_db_blocker):
     """
-    Garante baseline de permissoes funcionais em todos os testes de apps.core.
+    Garante baseline de RBAC (todos os grupos base + permissoes funcionais +
+    vinculos) em todos os testes de apps.core.
 
     Idempotente: usa get_or_create/update_or_create internamente.
+
+    `ensure_base_groups()` cria os 18 grupos base (setor + funcao). Sob
+    `pytest --no-migrations` nenhuma migration RunPython cria os grupos, e
+    `seed_functional_permissions` so cria os 7 com capability — este passo
+    cobre os demais (Formador, setores sem capability, etc.). #1404.
     """
 
     with django_db_blocker.unblock():
+        ensure_base_groups()
         seed_functional_permissions(assign_default_groups=True)

--- a/v2/backend/apps/core/tests/factories.py
+++ b/v2/backend/apps/core/tests/factories.py
@@ -1,0 +1,123 @@
+"""
+factory_boy factories para os testes de apps.core (#1404).
+
+Centraliza a criação de entidades de teste, substituindo o boilerplate
+`Model.objects.create(...)` / `get_or_create(...)` espalhado pela suíte.
+
+Escopo: estas factories criam INSTÂNCIAS por-teste. Elas NÃO semeiam dados de
+referência (grupos RBAC, permissões funcionais) — isso é papel das fixtures de
+sessão em `conftest.py` (`ensure_base_groups` + `seed_functional_permissions`),
+que rodam mesmo sob `pytest --no-migrations`.
+
+Convenções:
+- Campos `unique` usam `factory.Sequence` (determinístico; nunca `hash()` —
+  ver memória `deterministic-unique-in-pytest`).
+- `TipoEventoFactory` e `GroupFactory` usam `django_get_or_create` para espelhar
+  o padrão `get_or_create(nome=...)` predominante (reaproveita a mesma linha).
+- `UsuarioFactory(groups=["Coordenador", ...])` anexa o usuário a grupos base
+  já existentes (criados pelo seed de sessão).
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownLambdaType=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportUntypedFunctionDecorator=false, reportMissingTypeStubs=false
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from django.contrib.auth.models import Group
+from django.utils import timezone
+
+import factory
+
+from apps.core.models import Municipio, Projeto, Solicitacao, TipoEvento, Usuario
+
+
+class GroupFactory(factory.django.DjangoModelFactory):
+    """Grupo RBAC. `django_get_or_create` evita duplicar grupos base do seed."""
+
+    class Meta:
+        model = Group
+        django_get_or_create = ("name",)
+
+    name = "Coordenador"
+
+
+class UsuarioFactory(factory.django.DjangoModelFactory):
+    """Usuário de teste com CPF/username/email únicos e determinísticos."""
+
+    class Meta:
+        model = Usuario
+        skip_postgeneration_save = True
+
+    username = factory.Sequence(lambda n: f"user_{n}")
+    email = factory.Sequence(lambda n: f"user_{n}@example.com")
+    first_name = "Test"
+    last_name = "User"
+    cpf = factory.Sequence(lambda n: str(n + 1).zfill(11))
+    is_active = True
+
+    class Params:
+        # UsuarioFactory(superuser=True) → staff + superuser
+        superuser = factory.Trait(is_staff=True, is_superuser=True)
+
+    @factory.post_generation
+    def groups(self, create: bool, extracted, **kwargs):  # noqa: ANN001
+        """UsuarioFactory(groups=["Coordenador", "DAT"]) anexa aos grupos."""
+        if not create or not extracted:
+            return
+        for name in extracted:
+            group, _ = Group.objects.get_or_create(name=name)
+            self.groups.add(group)
+
+
+class MunicipioFactory(factory.django.DjangoModelFactory):
+    """Município com nome único (constraint unique nome+uf)."""
+
+    class Meta:
+        model = Municipio
+
+    nome = factory.Sequence(lambda n: f"Municipio {n}")
+    uf = "CE"
+    ativo = True
+
+
+class ProjetoFactory(factory.django.DjangoModelFactory):
+    """Projeto NAO_SUPER por padrão; `ProjetoFactory(super=True)` → fluxo SUPER."""
+
+    class Meta:
+        model = Projeto
+
+    nome = factory.Sequence(lambda n: f"Projeto {n}")
+    fluxo = "NAO_SUPER"
+    ativo = True
+
+    class Params:
+        super = factory.Trait(fluxo="SUPER")
+
+
+class TipoEventoFactory(factory.django.DjangoModelFactory):
+    """Tipo de evento. `django_get_or_create` espelha o get_or_create(nome=...)."""
+
+    class Meta:
+        model = TipoEvento
+        django_get_or_create = ("nome",)
+
+    nome = "Formação"
+
+
+class SolicitacaoFactory(factory.django.DjangoModelFactory):
+    """
+    Solicitação pendente por padrão (PA-01: a auto-aprovação NAO_SUPER vive na
+    camada serializer/view, não no model — criar via ORM mantém `pendente`).
+    """
+
+    class Meta:
+        model = Solicitacao
+
+    usuario = factory.SubFactory(UsuarioFactory)
+    tipo_evento = factory.SubFactory(TipoEventoFactory)
+    municipio = factory.SubFactory(MunicipioFactory)
+    projeto = factory.SubFactory(ProjetoFactory)
+    inicio = factory.LazyFunction(lambda: timezone.now() + timedelta(days=1))
+    fim = factory.LazyAttribute(lambda o: o.inicio + timedelta(hours=2))
+    status = Solicitacao.Status.PENDENTE

--- a/v2/backend/apps/core/tests/factories.py
+++ b/v2/backend/apps/core/tests/factories.py
@@ -18,7 +18,7 @@ Convenções:
   já existentes (criados pelo seed de sessão).
 """
 
-# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownLambdaType=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportUntypedFunctionDecorator=false, reportMissingTypeStubs=false
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownLambdaType=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportUntypedFunctionDecorator=false, reportMissingTypeStubs=false, reportPrivateImportUsage=false, reportIncompatibleVariableOverride=false
 
 from __future__ import annotations
 

--- a/v2/backend/apps/core/tests/factories.py
+++ b/v2/backend/apps/core/tests/factories.py
@@ -32,7 +32,7 @@ import factory
 from apps.core.models import Municipio, Projeto, Solicitacao, TipoEvento, Usuario
 
 
-class GroupFactory(factory.django.DjangoModelFactory):
+class GroupFactory(factory.django.DjangoModelFactory[Group]):
     """Grupo RBAC. `django_get_or_create` evita duplicar grupos base do seed."""
 
     class Meta:
@@ -42,7 +42,7 @@ class GroupFactory(factory.django.DjangoModelFactory):
     name = "Coordenador"
 
 
-class UsuarioFactory(factory.django.DjangoModelFactory):
+class UsuarioFactory(factory.django.DjangoModelFactory[Usuario]):
     """Usuário de teste com CPF/username/email únicos e determinísticos."""
 
     class Meta:
@@ -82,7 +82,7 @@ class UsuarioFactory(factory.django.DjangoModelFactory):
             self.groups.add(group)
 
 
-class MunicipioFactory(factory.django.DjangoModelFactory):
+class MunicipioFactory(factory.django.DjangoModelFactory[Municipio]):
     """Município com nome único (constraint unique nome+uf)."""
 
     class Meta:
@@ -93,7 +93,7 @@ class MunicipioFactory(factory.django.DjangoModelFactory):
     ativo = True
 
 
-class ProjetoFactory(factory.django.DjangoModelFactory):
+class ProjetoFactory(factory.django.DjangoModelFactory[Projeto]):
     """Projeto NAO_SUPER por padrão; `ProjetoFactory(super=True)` → fluxo SUPER."""
 
     class Meta:
@@ -107,7 +107,7 @@ class ProjetoFactory(factory.django.DjangoModelFactory):
         super = factory.Trait(fluxo="SUPER")
 
 
-class TipoEventoFactory(factory.django.DjangoModelFactory):
+class TipoEventoFactory(factory.django.DjangoModelFactory[TipoEvento]):
     """Tipo de evento. `django_get_or_create` espelha o get_or_create(nome=...)."""
 
     class Meta:
@@ -117,7 +117,7 @@ class TipoEventoFactory(factory.django.DjangoModelFactory):
     nome = "Formação"
 
 
-class SolicitacaoFactory(factory.django.DjangoModelFactory):
+class SolicitacaoFactory(factory.django.DjangoModelFactory[Solicitacao]):
     """
     Solicitação pendente por padrão (PA-01: a auto-aprovação NAO_SUPER vive na
     camada serializer/view, não no model — criar via ORM mantém `pendente`).

--- a/v2/backend/apps/core/tests/factories.py
+++ b/v2/backend/apps/core/tests/factories.py
@@ -61,6 +61,18 @@ class UsuarioFactory(factory.django.DjangoModelFactory):
         superuser = factory.Trait(is_staff=True, is_superuser=True)
 
     @factory.post_generation
+    def password(self, create: bool, extracted, **kwargs):  # noqa: ANN001
+        """
+        Senha hasheada via set_password (default "testpass123"). Torna a factory
+        drop-in para create_user/create_superuser inclusive em testes que
+        autenticam por senha: UsuarioFactory(password="x") loga com "x".
+        """
+        if not create:
+            return
+        self.set_password(extracted if extracted else "testpass123")
+        self.save()
+
+    @factory.post_generation
     def groups(self, create: bool, extracted, **kwargs):  # noqa: ANN001
         """UsuarioFactory(groups=["Coordenador", "DAT"]) anexa aos grupos."""
         if not create or not extracted:

--- a/v2/backend/apps/core/tests/factories.py
+++ b/v2/backend/apps/core/tests/factories.py
@@ -51,8 +51,11 @@ class UsuarioFactory(factory.django.DjangoModelFactory[Usuario]):
 
     username = factory.Sequence(lambda n: f"user_{n}")
     email = factory.Sequence(lambda n: f"user_{n}@example.com")
-    first_name = "Test"
-    last_name = "User"
+    # first_name/last_name vazios por padrão = fiéis a create_user/create_superuser
+    # (que não preenchem nome). Importa p/ asserts em usuario_nome, que cai no
+    # username quando get_full_name() é vazio. Passe explicitamente se precisar.
+    first_name = ""
+    last_name = ""
     cpf = factory.Sequence(lambda n: str(n + 1).zfill(11))
     is_active = True
 

--- a/v2/backend/apps/core/tests/performance/test_api_latency.py
+++ b/v2/backend/apps/core/tests/performance/test_api_latency.py
@@ -14,12 +14,18 @@ import statistics
 import time
 from typing import TYPE_CHECKING
 
-from django.contrib.auth.models import Group
 from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import Gerencia, Municipio, Projeto, TipoEvento, Usuario
+from apps.core.models import Gerencia
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -92,7 +98,7 @@ def measure_latency(
 @pytest.fixture
 def authenticated_client(db) -> APIClient:
     """Create an authenticated API client."""
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username="perf_test_user",
         email="perf@test.com",
         password="test123",
@@ -106,11 +112,11 @@ def authenticated_client(db) -> APIClient:
 @pytest.fixture
 def setup_minimal_data(db) -> None:
     """Create minimal data for performance tests."""
-    Municipio.objects.get_or_create(nome="Fortaleza", defaults={"uf": "CE", "ativo": True})
+    MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
     Gerencia.objects.get_or_create(nome="SUPERINTENDENCIA", defaults={"nome_setor": "Super"})
-    Projeto.objects.get_or_create(nome="Teste Perf", defaults={"ativo": True, "fluxo": "SUPER"})
-    TipoEvento.objects.get_or_create(nome="Formação")
-    Group.objects.get_or_create(name="Formador")
+    ProjetoFactory(nome="Teste Perf", ativo=True, fluxo="SUPER")
+    TipoEventoFactory(nome="Formação")
+    GroupFactory(name="Formador")
 
 
 class TestHealthzLatency:

--- a/v2/backend/apps/core/tests/test_acoes_hardening.py
+++ b/v2/backend/apps/core/tests/test_acoes_hardening.py
@@ -25,19 +25,23 @@ from apps.core.models.acoes_notificacao import (
     TipoAncoraChoices,
 )
 from apps.core.services.prazo_engine_service import PrazoEngineService
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    UsuarioFactory,
+)
 
 
 @pytest.fixture()
 def group(db):  # type: ignore[no-untyped-def]
-    return Group.objects.create(name="Test Executors")
+    return GroupFactory(name="Test Executors")
 
 
 @pytest.fixture()
 def ciclo(db):  # type: ignore[no-untyped-def]
-    from apps.core.models import Municipio, Projeto
-
-    projeto = Projeto.objects.create(nome="Projeto Hardening Test")
-    municipio = Municipio.objects.create(nome="Municipio Test")
+    projeto = ProjetoFactory(nome="Projeto Hardening Test")
+    municipio = MunicipioFactory(nome="Municipio Test")
     return CicloAcoes.objects.create(
         projeto=projeto,
         municipio=municipio,
@@ -84,9 +88,7 @@ def template_c(template_b):  # type: ignore[no-untyped-def]
 
 @pytest.fixture()
 def usuario(db):  # type: ignore[no-untyped-def]
-    from apps.core.models import Usuario
-
-    return Usuario.objects.create_user(  # type: ignore[attr-defined]
+    return UsuarioFactory(
         username="hardening_test",
         password="test123",  # noqa: S106
         first_name="Test",
@@ -106,7 +108,7 @@ class TestExecutorGroupProtect:
         assert Group.objects.filter(pk=group.pk).exists()
 
     def test_delete_group_without_executor_succeeds(self, db) -> None:  # type: ignore[no-untyped-def]
-        g = Group.objects.create(name="Orphan Group")
+        g = GroupFactory(name="Orphan Group")
         g.delete()
         assert not Group.objects.filter(name="Orphan Group").exists()
 

--- a/v2/backend/apps/core/tests/test_acoes_notificacao_models.py
+++ b/v2/backend/apps/core/tests/test_acoes_notificacao_models.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 from datetime import date
 
-from django.contrib.auth.models import Group
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError
 
@@ -19,12 +18,16 @@ from apps.core.models import (
     AcaoTemplate,
     AcaoTemplateExecutor,
     CicloAcoes,
-    Municipio,
     NotificacaoInterna,
-    Projeto,
     RegistroAncora,
     RegistroConclusaoAcao,
     Usuario,
+)
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    UsuarioFactory,
 )
 
 
@@ -35,7 +38,7 @@ def usuario_factory(db):
     def _create(prefix: str = "user") -> Usuario:
         counter["n"] += 1
         n = counter["n"]
-        return Usuario.objects.create_user(
+        return UsuarioFactory(
             username=f"{prefix}{n}",
             email=f"{prefix}{n}@example.com",
             password="testpass123",
@@ -47,12 +50,12 @@ def usuario_factory(db):
 
 @pytest.fixture
 def projeto(db):
-    return Projeto.objects.create(nome="Projeto Teste Acoes")
+    return ProjetoFactory(nome="Projeto Teste Acoes")
 
 
 @pytest.fixture
 def municipio(db):
-    return Municipio.objects.create(nome="Municipio Teste Acoes", uf="CE")
+    return MunicipioFactory(nome="Municipio Teste Acoes", uf="CE")
 
 
 @pytest.fixture
@@ -111,7 +114,7 @@ def test_ciclo_acoes_unique_contexto(projeto, municipio, usuario_factory):
 
 @pytest.mark.django_db
 def test_acao_template_executor_unique_mapping(acao_template):
-    group, _ = Group.objects.get_or_create(name="Comercial")
+    group = GroupFactory(name="Comercial")
     AcaoTemplateExecutor.objects.create(acao_template=acao_template, group=group)
 
     with pytest.raises(IntegrityError):

--- a/v2/backend/apps/core/tests/test_admin_api.py
+++ b/v2/backend/apps/core/tests/test_admin_api.py
@@ -29,6 +29,12 @@ from apps.core.models import (
     Projeto,
     Usuario,
 )
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    UsuarioFactory,
+)
 
 
 @pytest.fixture
@@ -40,13 +46,13 @@ def api_client():
 @pytest.fixture
 def usuario_dat(db):
     """Usuário do grupo DAT"""
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username="dat_user",
         email="dat@example.com",
         password="senha123",
         cpf="12345678901",
     )
-    group_dat, _ = Group.objects.get_or_create(name="DAT")
+    group_dat = GroupFactory(name="DAT")
     user.groups.add(group_dat)
     return user
 
@@ -54,13 +60,13 @@ def usuario_dat(db):
 @pytest.fixture
 def usuario_controle(db):
     """Usuário do grupo Controle"""
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username="controle_user",
         email="controle@example.com",
         password="senha123",
         cpf="12345678902",
     )
-    group_controle, _ = Group.objects.get_or_create(name="Controle")
+    group_controle = GroupFactory(name="Controle")
     user.groups.add(group_controle)
     return user
 
@@ -68,13 +74,13 @@ def usuario_controle(db):
 @pytest.fixture
 def usuario_superintendencia(db):
     """Usuário do grupo Superintendência"""
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username="super_user",
         email="super@example.com",
         password="senha123",
         cpf="12345678903",
     )
-    group_super, _ = Group.objects.get_or_create(name="Superintendência")
+    group_super = GroupFactory(name="Superintendência")
     user.groups.add(group_super)
     return user
 
@@ -82,13 +88,13 @@ def usuario_superintendencia(db):
 @pytest.fixture
 def usuario_formador(db):
     """Usuário do grupo Formador (sem acesso admin)"""
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username="formador_user",
         email="formador@example.com",
         password="senha123",
         cpf="12345678904",
     )
-    group_formador, _ = Group.objects.get_or_create(name="Formador")
+    group_formador = GroupFactory(name="Formador")
     user.groups.add(group_formador)
     return user
 
@@ -96,13 +102,13 @@ def usuario_formador(db):
 @pytest.fixture
 def municipio_sample(db):
     """Município de exemplo"""
-    return Municipio.objects.create(nome="Fortaleza", uf="CE", ibge_code="2304400")
+    return MunicipioFactory(nome="Fortaleza", uf="CE", ibge_code="2304400")
 
 
 @pytest.fixture
 def projeto_sample(db):
     """Projeto de exemplo"""
-    return Projeto.objects.create(nome="Alfabetização", codigo="ALF-01")
+    return ProjetoFactory(nome="Alfabetização", codigo="ALF-01")
 
 
 @pytest.fixture
@@ -174,8 +180,8 @@ class TestMunicipioAPI:
 
     def test_filter_municipios_by_uf(self, api_client, usuario_dat, municipio_sample, db):
         """Filtrar municípios por UF"""
-        Municipio.objects.create(nome="Juazeiro do Norte", uf="CE")
-        Municipio.objects.create(nome="Recife", uf="PE")
+        MunicipioFactory(nome="Juazeiro do Norte", uf="CE")
+        MunicipioFactory(nome="Recife", uf="PE")
         api_client.force_authenticate(user=usuario_dat)
         response = api_client.get("/api/municipios/?uf=CE")
         assert response.status_code == status.HTTP_200_OK
@@ -197,7 +203,7 @@ class TestMunicipioAPI:
             fonte="sistemasaprender",
             ativo=True,
         )
-        Municipio.objects.create(nome="Fortaleza", uf="CE", ibge_code="2304400")
+        MunicipioFactory(nome="Fortaleza", uf="CE", ibge_code="2304400")
 
         api_client.force_authenticate(user=usuario_dat)
         response = api_client.get("/api/municipios/autocomplete/?q=Fort&uf=CE")
@@ -212,7 +218,7 @@ class TestMunicipioAPI:
 
     def test_autocomplete_municipios_fallbacks_to_existing_cadastro(self, api_client, usuario_dat):
         """Sem referência confiável, endpoint usa fallback de municípios já cadastrados."""
-        Municipio.objects.create(nome="Maranguape", uf="CE", ibge_code="2307705")
+        MunicipioFactory(nome="Maranguape", uf="CE", ibge_code="2307705")
 
         api_client.force_authenticate(user=usuario_dat)
         response = api_client.get("/api/municipios/autocomplete/?q=Maran&uf=CE")
@@ -292,7 +298,7 @@ class TestProjetoAPI:
 
     def test_filter_projetos_by_ativo(self, api_client, usuario_dat, projeto_sample):
         """Filtrar projetos por ativo"""
-        Projeto.objects.create(nome="Projeto Inativo", ativo=False)
+        ProjetoFactory(nome="Projeto Inativo", ativo=False)
         api_client.force_authenticate(user=usuario_dat)
         response = api_client.get("/api/projetos/?ativo=true")
         assert response.status_code == status.HTTP_200_OK
@@ -369,7 +375,7 @@ class TestCompraAPI:
 
     def test_filter_compras_by_projeto(self, api_client, usuario_dat, compra_sample, municipio_sample, db):
         """Filtrar compras por projeto"""
-        projeto2 = Projeto.objects.create(nome="Ciências")
+        projeto2 = ProjetoFactory(nome="Ciências")
         Compra.objects.create(
             codigo="COMP-004",
             projeto=projeto2,
@@ -444,7 +450,7 @@ class TestUsuarioAdminAPI:
 
     def test_dat_can_update_usuario_telefone_cargo_and_active(self, api_client, usuario_dat, db):
         """DAT pode atualizar telefone/cargo e status ativo de usuários comuns."""
-        target = Usuario.objects.create_user(
+        target = UsuarioFactory(
             username="usuario_perfil",
             email="perfil@example.com",
             password="SecurePass123!",
@@ -543,7 +549,7 @@ class TestUsuarioAdminAPI:
 
     def test_dat_cannot_patch_is_superuser(self, api_client, usuario_dat, db):
         """DAT não pode alterar is_superuser via endpoint de admin."""
-        target = Usuario.objects.create_user(
+        target = UsuarioFactory(
             username="target_common_user",
             email="target_common_user@example.com",
             password="SecurePass123!",
@@ -563,13 +569,8 @@ class TestUsuarioAdminAPI:
 
     def test_superuser_can_patch_is_superuser_for_other_user(self, api_client, db):
         """Superuser pode promover outro usuário para superuser via endpoint."""
-        super_admin = Usuario.objects.create_superuser(
-            username="api_super_admin",
-            email="api_super_admin@example.com",
-            password="SecurePass123!",
-            cpf="22312312312",
-        )
-        target = Usuario.objects.create_user(
+        super_admin = UsuarioFactory(superuser=True)
+        target = UsuarioFactory(
             username="api_target_common_user",
             email="api_target_common_user@example.com",
             password="SecurePass123!",
@@ -730,7 +731,7 @@ class TestRbacFunctionalAPI:
 
     def test_dat_can_patch_group_permissoes_funcionais(self, api_client, usuario_dat):
         """DAT pode vincular permissões funcionais a um grupo."""
-        group, _ = Group.objects.get_or_create(name="Equipe Operacional")
+        group = GroupFactory(name="Equipe Operacional")
         permissao_a = PermissaoFuncional.objects.create(
             codename="rbac.group_patch_a",
             label="Permissão Group Patch A",
@@ -759,7 +760,7 @@ class TestRbacFunctionalAPI:
 
     def test_rename_reserved_group_requires_confirmation(self, api_client, usuario_dat):
         """Renomeio de grupo reservado exige ?confirm_reserved=true."""
-        group, _ = Group.objects.get_or_create(name="Controle")
+        group = GroupFactory(name="Controle")
         api_client.force_authenticate(user=usuario_dat)
 
         response = api_client.patch(f"/api/grupos/{group.id}/", {"name": "Controle Novo"}, format="json")
@@ -769,7 +770,7 @@ class TestRbacFunctionalAPI:
 
     def test_delete_reserved_group_requires_confirmation(self, api_client, usuario_dat):
         """Exclusão de grupo reservado exige ?confirm_reserved=true."""
-        group, _ = Group.objects.get_or_create(name="Formador")
+        group = GroupFactory(name="Formador")
         api_client.force_authenticate(user=usuario_dat)
 
         response = api_client.delete(f"/api/grupos/{group.id}/")

--- a/v2/backend/apps/core/tests/test_admin_user_security.py
+++ b/v2/backend/apps/core/tests/test_admin_user_security.py
@@ -13,14 +13,14 @@ Valida hardening do serializer de admin de usuários:
 
 from __future__ import annotations
 
-from django.contrib.auth.models import Group
 from django.test import TestCase
 from rest_framework.test import APIRequestFactory
 
 import pytest
 
-from apps.core.models import PermissaoFuncional, Usuario
+from apps.core.models import PermissaoFuncional
 from apps.core.serializers import UsuarioAdminSerializer
+from apps.core.tests.factories import GroupFactory, UsuarioFactory
 
 
 class AdminUserSecurityTests(TestCase):
@@ -29,16 +29,16 @@ class AdminUserSecurityTests(TestCase):
     def setUp(self):
         """Setup: criar grupos e usuários de teste"""
         # Criar grupos padrão (usando get_or_create para idempotência)
-        self.group_dat, _ = Group.objects.get_or_create(name="DAT")
-        self.group_controle, _ = Group.objects.get_or_create(name="Controle")
-        self.group_super, _ = Group.objects.get_or_create(name="Superintendência")
-        self.group_coord, _ = Group.objects.get_or_create(name="Coordenador")
-        self.group_formador, _ = Group.objects.get_or_create(name="Formador")
-        self.group_gerencia, _ = Group.objects.get_or_create(name="Gerência")
-        self.group_invalid, _ = Group.objects.get_or_create(name="GrupoInválido")  # Não na whitelist
+        self.group_dat = GroupFactory(name="DAT")
+        self.group_controle = GroupFactory(name="Controle")
+        self.group_super = GroupFactory(name="Superintendência")
+        self.group_coord = GroupFactory(name="Coordenador")
+        self.group_formador = GroupFactory(name="Formador")
+        self.group_gerencia = GroupFactory(name="Gerência")
+        self.group_invalid = GroupFactory(name="GrupoInválido")  # Não na whitelist
 
         # Usuário DAT (quem administra usuários)
-        self.user_dat = Usuario.objects.create_user(
+        self.user_dat = UsuarioFactory(
             username="dat_user",
             email="dat@example.com",
             password="T3stP@ssw0rd!Qwerty#2025XyZ",
@@ -47,7 +47,7 @@ class AdminUserSecurityTests(TestCase):
         self.user_dat.groups.add(self.group_dat)
 
         # Usuário comum para testar atribuição
-        self.user_comum = Usuario.objects.create_user(
+        self.user_comum = UsuarioFactory(
             username="comum_user",
             email="comum@example.com",
             password="T3stP@ssw0rd!Qwerty#2025XyZ",
@@ -321,7 +321,7 @@ class AdminUserSecurityTests(TestCase):
         #832 - Grupo fora do fallback estatico passa a ser valido quando vinculado a permissao funcional.
         """
 
-        dynamic_group, _ = Group.objects.get_or_create(name="GrupoDinamicSerializer")
+        dynamic_group = GroupFactory(name="GrupoDinamicSerializer")
         permissao, _ = PermissaoFuncional.objects.get_or_create(
             codename="pode_usar_grupo_dinamico_serializer",
             defaults={
@@ -354,12 +354,7 @@ class AdminUserSecurityTests(TestCase):
         """
         RBAC funcional - superuser pode promover outro usuário a superuser.
         """
-        super_admin = Usuario.objects.create_superuser(
-            username="super_admin",
-            email="super_admin@example.com",
-            password="T3stP@ssw0rd!Qwerty#2025XyZ",
-            cpf="44444444444",
-        )
+        super_admin = UsuarioFactory(superuser=True, cpf="44444444444")
         data = {"is_superuser": True}
 
         request = self.factory.patch(f"/api/usuarios/{self.user_comum.id}/", data)
@@ -380,12 +375,7 @@ class AdminUserSecurityTests(TestCase):
         """
         RBAC funcional - superuser não pode remover o próprio privilégio.
         """
-        super_admin = Usuario.objects.create_superuser(
-            username="self_demote_admin",
-            email="self_demote_admin@example.com",
-            password="T3stP@ssw0rd!Qwerty#2025XyZ",
-            cpf="55555555555",
-        )
+        super_admin = UsuarioFactory(superuser=True, cpf="55555555555")
         data = {"is_superuser": False}
 
         request = self.factory.patch(f"/api/usuarios/{super_admin.id}/", data)
@@ -406,18 +396,8 @@ class AdminUserSecurityTests(TestCase):
         """
         RBAC funcional - último superuser ativo não pode ser removido.
         """
-        last_super = Usuario.objects.create_superuser(
-            username="last_super_admin",
-            email="last_super_admin@example.com",
-            password="T3stP@ssw0rd!Qwerty#2025XyZ",
-            cpf="66666666666",
-        )
-        actor_super = Usuario.objects.create_superuser(
-            username="inactive_super_actor",
-            email="inactive_super_actor@example.com",
-            password="T3stP@ssw0rd!Qwerty#2025XyZ",
-            cpf="77777777777",
-        )
+        last_super = UsuarioFactory(superuser=True, cpf="66666666666")
+        actor_super = UsuarioFactory(superuser=True, cpf="77777777777")
         actor_super.is_active = False
         actor_super.save(update_fields=["is_active"])
 
@@ -440,18 +420,8 @@ class AdminUserSecurityTests(TestCase):
         """
         RBAC funcional - último superuser ativo não pode ser desativado.
         """
-        last_super = Usuario.objects.create_superuser(
-            username="last_super_active",
-            email="last_super_active@example.com",
-            password="T3stP@ssw0rd!Qwerty#2025XyZ",
-            cpf="88888888888",
-        )
-        actor_super = Usuario.objects.create_superuser(
-            username="inactive_super_actor_two",
-            email="inactive_super_actor_two@example.com",
-            password="T3stP@ssw0rd!Qwerty#2025XyZ",
-            cpf="99999999999",
-        )
+        last_super = UsuarioFactory(superuser=True, cpf="88888888888")
+        actor_super = UsuarioFactory(superuser=True, cpf="99999999999")
         actor_super.is_active = False
         actor_super.save(update_fields=["is_active"])
 

--- a/v2/backend/apps/core/tests/test_api_acoes_notificacao.py
+++ b/v2/backend/apps/core/tests/test_api_acoes_notificacao.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 from datetime import date, datetime, timezone
 
-from django.contrib.auth.models import Group
 from rest_framework.test import APIClient
 
 import pytest
@@ -19,12 +18,11 @@ from apps.core.models import (
     AcaoTemplateExecutor,
     AuditLog,
     CicloAcoes,
-    Municipio,
     NotificacaoInterna,
-    Projeto,
     Usuario,
 )
 from apps.core.services.prazo_engine_service import PrazoEngineService
+from apps.core.tests.factories import GroupFactory, MunicipioFactory, ProjetoFactory, UsuarioFactory
 
 
 @pytest.fixture
@@ -45,7 +43,7 @@ def user_factory(db):
     ) -> Usuario:
         counter["n"] += 1
         idx = counter["n"]
-        user = Usuario.objects.create_user(
+        user = UsuarioFactory(
             username=f"{prefix}_{idx}",
             email=f"{prefix}_{idx}@example.com",
             password="testpass123",
@@ -54,7 +52,7 @@ def user_factory(db):
             is_staff=is_staff,
         )
         for group_name in groups or []:
-            group, _ = Group.objects.get_or_create(name=group_name)
+            group = GroupFactory(name=group_name)
             user.groups.add(group)
         return user
 
@@ -63,8 +61,8 @@ def user_factory(db):
 
 @pytest.fixture
 def base_entities(db):
-    projeto = Projeto.objects.create(nome="Projeto API Acoes")
-    municipio = Municipio.objects.create(nome="Municipio API Acoes", uf="CE")
+    projeto = ProjetoFactory(nome="Projeto API Acoes")
+    municipio = MunicipioFactory(nome="Municipio API Acoes", uf="CE")
     return {"projeto": projeto, "municipio": municipio}
 
 
@@ -86,7 +84,7 @@ def ciclo_com_acao(base_entities, user_factory):
         ref_evento_externo="EVENT_API",
         dias_prazo_uteis=1,
     )
-    comercial, _ = Group.objects.get_or_create(name="Comercial")
+    comercial = GroupFactory(name="Comercial")
     AcaoTemplateExecutor.objects.create(acao_template=template, group=comercial, ativo=True)
     action = AcaoInstancia.objects.create(
         ciclo=ciclo,
@@ -110,7 +108,7 @@ def test_ciclo_create_auto_instantiates_actions(api_client, user_factory, base_e
         ref_evento_externo="EVENT_CREATE",
         dias_prazo_uteis=2,
     )
-    comercial, _ = Group.objects.get_or_create(name="Comercial")
+    comercial = GroupFactory(name="Comercial")
     AcaoTemplateExecutor.objects.create(acao_template=template, group=comercial, ativo=True)
 
     # Não-superuser (qualquer grupo) é 403

--- a/v2/backend/apps/core/tests/test_api_availability_blocks.py
+++ b/v2/backend/apps/core/tests/test_api_availability_blocks.py
@@ -18,23 +18,22 @@ from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import AvailabilityBlock, Usuario
+from apps.core.models import AvailabilityBlock
 from apps.core.tests.conftest import get_field_errors
+from apps.core.tests.factories import GroupFactory, UsuarioFactory
 
 
 @pytest.fixture
 def user_test(db):
     """Issue #1222 (Epic 1): user adicionado ao Controle (que tem
     `view_all_availability`) para criar/CRUD bloqueios via /api/availability-blocks/."""
-    from django.contrib.auth.models import Group
-
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username="testuser",
         email="testuser@example.com",
         password="testpass123",
         cpf="12345678901",
     )
-    grupo_controle, _ = Group.objects.get_or_create(name="Controle")
+    grupo_controle = GroupFactory(name="Controle")
     user.groups.add(grupo_controle)
     return user
 
@@ -42,7 +41,7 @@ def user_test(db):
 @pytest.fixture
 def another_user(db):
     """Cria um segundo usuário de teste"""
-    return Usuario.objects.create_user(
+    return UsuarioFactory(
         username="anotheruser",
         email="another@example.com",
         password="testpass456",

--- a/v2/backend/apps/core/tests/test_api_create_solicitacao_pendente.py
+++ b/v2/backend/apps/core/tests/test_api_create_solicitacao_pendente.py
@@ -17,16 +17,21 @@ from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import Municipio, Solicitacao, TipoEvento, Usuario
+from apps.core.models import Solicitacao
 from apps.core.tests.conftest import get_field_errors
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 
 @pytest.fixture
 def user_test(db):
     """Cria um usuário de teste com grupo Coordenador (PA-06)"""
-    from django.contrib.auth.models import Group
-
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username="testuser",
         email="testuser@example.com",
         password="testpass123",
@@ -34,7 +39,7 @@ def user_test(db):
     )
 
     # PA-06: Adicionar grupo Coordenador para poder criar solicitações
-    coord_group, _ = Group.objects.get_or_create(name="Coordenador")
+    coord_group = GroupFactory(name="Coordenador")
     user.groups.add(coord_group)
 
     return user
@@ -43,13 +48,13 @@ def user_test(db):
 @pytest.fixture
 def tipo_evento_test(db):
     """Cria um tipo de evento de teste"""
-    return TipoEvento.objects.create(nome="Palestra", descricao="Palestra online")
+    return TipoEventoFactory(nome="Palestra", descricao="Palestra online")
 
 
 @pytest.fixture
 def municipio_test(db):
     """Cria um município de teste"""
-    return Municipio.objects.create(nome="Fortaleza", uf="CE")
+    return MunicipioFactory(nome="Fortaleza", uf="CE")
 
 
 @pytest.mark.django_db
@@ -264,10 +269,11 @@ class TestAPICreateSolicitacaoPendente:
         inicio_existente = now + timedelta(days=1, hours=9)
         fim_existente = inicio_existente + timedelta(hours=2)
 
-        Solicitacao.objects.create(
+        SolicitacaoFactory(
             usuario=user_test,
             tipo_evento=tipo_evento_test,
             municipio=municipio_test,
+            projeto=None,  # preserva o create original (projeto não era informado)
             inicio=inicio_existente,
             fim=fim_existente,
             status="aprovado",

--- a/v2/backend/apps/core/tests/test_api_me_permissions.py
+++ b/v2/backend/apps/core/tests/test_api_me_permissions.py
@@ -11,13 +11,13 @@ Cobertura:
 
 from __future__ import annotations
 
-from django.contrib.auth.models import Group
 from django.urls import reverse
 from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import GroupClassificacao, PermissaoFuncional, Usuario
+from apps.core.models import GroupClassificacao, PermissaoFuncional
+from apps.core.tests.factories import GroupFactory, UsuarioFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -26,9 +26,9 @@ def test_me_includes_groups_and_flag():
     """
     /api/me/ deve retornar groups (lista) e is_superintendencia (bool).
     """
-    user = Usuario.objects.create_user(username="u1", email="u1@x.com", password="x", cpf="11111111111")
-    group1, _ = Group.objects.get_or_create(name="Coordenador")
-    group2, _ = Group.objects.get_or_create(name="Formador")
+    user = UsuarioFactory(username="u1", email="u1@x.com", password="x", cpf="11111111111")
+    group1 = GroupFactory(name="Coordenador")
+    group2 = GroupFactory(name="Formador")
     user.groups.add(group1, group2)
 
     client = APIClient()
@@ -55,8 +55,8 @@ def test_is_superintendencia_true_only_for_group():
     """
     is_superintendencia = True apenas se usuário pertence ao grupo "Superintendência" (case-sensitive).
     """
-    user = Usuario.objects.create_user(username="u2", email="u2@x.com", password="x", cpf="22222222222")
-    super_group, _ = Group.objects.get_or_create(name="Superintendência")
+    user = UsuarioFactory(username="u2", email="u2@x.com", password="x", cpf="22222222222")
+    super_group = GroupFactory(name="Superintendência")
     user.groups.add(super_group)
 
     client = APIClient()
@@ -76,8 +76,8 @@ def test_is_superintendencia_false_for_similar_name():
     """
     Grupo com nome parecido (ex: "superintendencia" minúsculo) não ativa flag.
     """
-    user = Usuario.objects.create_user(username="u3", email="u3@x.com", password="x", cpf="33333333333")
-    fake_group, _ = Group.objects.get_or_create(name="superintendencia")  # minúsculo
+    user = UsuarioFactory(username="u3", email="u3@x.com", password="x", cpf="33333333333")
+    fake_group = GroupFactory(name="superintendencia")  # minúsculo
     user.groups.add(fake_group)
 
     client = APIClient()
@@ -97,7 +97,7 @@ def test_me_no_groups_returns_empty_list():
     """
     Usuário sem grupos retorna groups=[] e is_superintendencia=False.
     """
-    user = Usuario.objects.create_user(username="u4", email="u4@x.com", password="x", cpf="44444444444")
+    user = UsuarioFactory(username="u4", email="u4@x.com", password="x", cpf="44444444444")
 
     client = APIClient()
     client.force_authenticate(user=user)
@@ -117,7 +117,7 @@ def test_superuser_always_has_access():
     """
     Superusers sempre têm is_superintendencia=True, mesmo sem grupo.
     """
-    user = Usuario.objects.create_superuser(username="admin", email="admin@x.com", password="x", cpf="55555555555")
+    user = UsuarioFactory(superuser=True)
 
     client = APIClient()
     client.force_authenticate(user=user)
@@ -136,8 +136,8 @@ def test_me_returns_effective_functional_permissions():
     """
     /api/me/ deve retornar permissions (codenames) vindos do mapeamento funcional.
     """
-    user = Usuario.objects.create_user(username="u5", email="u5@x.com", password="x", cpf="66666666666")
-    dat_group, _ = Group.objects.get_or_create(name="DAT")
+    user = UsuarioFactory(username="u5", email="u5@x.com", password="x", cpf="66666666666")
+    dat_group = GroupFactory(name="DAT")
     user.groups.add(dat_group)
 
     perm = PermissaoFuncional.objects.create(
@@ -165,8 +165,8 @@ def test_me_classifies_dynamic_funcao_group():
     """
     Grupo classificado dinamicamente como função deve aparecer em funcoes.
     """
-    user = Usuario.objects.create_user(username="u6", email="u6@x.com", password="x", cpf="77777777777")
-    dynamic_group, _ = Group.objects.get_or_create(name="Analista de Campo")
+    user = UsuarioFactory(username="u6", email="u6@x.com", password="x", cpf="77777777777")
+    dynamic_group = GroupFactory(name="Analista de Campo")
     GroupClassificacao.objects.update_or_create(
         group=dynamic_group,
         defaults={"tipo": GroupClassificacao.Tipo.FUNCAO},

--- a/v2/backend/apps/core/tests/test_approval_policy_PA.py
+++ b/v2/backend/apps/core/tests/test_approval_policy_PA.py
@@ -17,14 +17,21 @@ from datetime import timedelta
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
-from django.contrib.auth.models import Group
 from django.test import override_settings
 from django.utils import timezone
 from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import AuditLog, Municipio, Projeto, Solicitacao, TipoEvento, Usuario
+from apps.core.models import AuditLog
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 pytestmark = pytest.mark.django_db
 
@@ -34,7 +41,7 @@ def usuario_comum(faker):
     """Usuário comum sem permissões especiais."""
     # Python uuid4() is truly random (faker.uuid4() is seeded and generates duplicates!)
     uid = uuid4().hex  # 32 chars hex, 128-bit entropy
-    return Usuario.objects.create_user(
+    return UsuarioFactory(
         username=f"comum_{uid}",
         email=f"comum_{uid}@example.com",
         password="testpass",
@@ -48,14 +55,14 @@ def usuario_superintendencia(faker):
     composite Setor `Superintendência` + Função `Gerente`. A regra antiga
     (Setor sozinho aprovava via PA-02) foi descontinuada."""
     uid = uuid4().hex  # 32 chars hex, 128-bit entropy
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username=f"super_{uid}",
         email=f"super_{uid}@example.com",
         password="testpass",
         cpf=str(uuid4().int % 10**11).zfill(11),  # 11-digit CPF from UUID int
     )
-    grupo_setor, _ = Group.objects.get_or_create(name="Superintendência")
-    grupo_funcao, _ = Group.objects.get_or_create(name="Gerente")
+    grupo_setor = GroupFactory(name="Superintendência")
+    grupo_funcao = GroupFactory(name="Gerente")
     user.groups.add(grupo_setor, grupo_funcao)
     return user
 
@@ -63,12 +70,12 @@ def usuario_superintendencia(faker):
 @pytest.fixture
 def solicitacao_pendente(usuario_comum):
     """Solicitação pendente para testes (projeto SUPER)."""
-    municipio, _ = Municipio.objects.get_or_create(nome="Fortaleza", defaults={"uf": "CE", "ativo": True})
-    projeto, _ = Projeto.objects.get_or_create(nome="Projeto Teste SUPER", defaults={"ativo": True, "fluxo": "SUPER"})
-    tipo_evento, _ = TipoEvento.objects.get_or_create(nome="Formação")
+    municipio = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+    projeto = ProjetoFactory(nome="Projeto Teste SUPER", ativo=True, fluxo="SUPER")
+    tipo_evento = TipoEventoFactory(nome="Formação")
 
     now = timezone.now()
-    return Solicitacao.objects.create(
+    return SolicitacaoFactory(
         usuario=usuario_comum,
         municipio=municipio,
         projeto=projeto,
@@ -256,25 +263,23 @@ def test_calendar_integration_is_called_after_approval(
 
     from django.utils import timezone
 
-    from apps.core.models import Municipio, Projeto, Solicitacao, TipoEvento, Usuario
-
     # Mock task.delay() para retornar objeto com id serializável (evita JSON error)
     mock_task_result = MagicMock()
     mock_task_result.id = "test-task-id-12345"
     mock_celery_task.return_value = mock_task_result
 
     # Criar Solicitacao já aprovada (evita caminho lento de aprovação)
-    mun, _ = Municipio.objects.get_or_create(nome="Fortaleza", defaults={"uf": "CE", "ativo": True})
-    proj, _ = Projeto.objects.get_or_create(nome="Projeto Teste SUPER", defaults={"ativo": True, "fluxo": "SUPER"})
-    tipo, _ = TipoEvento.objects.get_or_create(nome="Formação")
-    coord = Usuario.objects.create_user(
+    mun = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+    proj = ProjetoFactory(nome="Projeto Teste SUPER", ativo=True, fluxo="SUPER")
+    tipo = TipoEventoFactory(nome="Formação")
+    coord = UsuarioFactory(
         username=f"coord_pa03_{uuid4().hex[:8]}",
         email=f"coord_pa03_{uuid4().hex[:8]}@x.com",
         password="x",
         cpf=str(uuid4().int % 10**11).zfill(11),
     )
 
-    sol = Solicitacao.objects.create(
+    sol = SolicitacaoFactory(
         usuario=coord,
         municipio=mun,
         projeto=proj,

--- a/v2/backend/apps/core/tests/test_assign_groups.py
+++ b/v2/backend/apps/core/tests/test_assign_groups.py
@@ -12,12 +12,12 @@ Security tests added for Issue #561 (C-04):
 
 from __future__ import annotations
 
-from django.contrib.auth.models import Group
 from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import PermissaoFuncional, Usuario
+from apps.core.models import PermissaoFuncional
+from apps.core.tests.factories import GroupFactory, UsuarioFactory
 
 
 @pytest.fixture
@@ -29,13 +29,13 @@ def api_client():
 @pytest.fixture
 def usuario_dat(db):
     """Usuário com permissão DAT."""
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username="dat_user",
         email="dat@example.com",
         password="testpass123",
         cpf="11111111111",
     )
-    grupo_dat, _ = Group.objects.get_or_create(name="DAT")
+    grupo_dat = GroupFactory(name="DAT")
     user.groups.add(grupo_dat)
     return user
 
@@ -43,7 +43,7 @@ def usuario_dat(db):
 @pytest.fixture
 def usuario_formador(db):
     """Usuário formador sem grupos."""
-    return Usuario.objects.create_user(
+    return UsuarioFactory(
         username="formador1",
         email="formador1@example.com",
         password="testpass123",
@@ -54,7 +54,7 @@ def usuario_formador(db):
 @pytest.fixture
 def usuario_comum(db):
     """Usuário sem permissão DAT."""
-    return Usuario.objects.create_user(
+    return UsuarioFactory(
         username="comum",
         email="comum@example.com",
         password="testpass123",
@@ -69,8 +69,8 @@ class TestAssignGroups:
     def test_assign_groups_success(self, api_client, usuario_dat, usuario_formador):
         """Deve atribuir grupos com sucesso (200)."""
         # Criar grupos
-        grupo1, _ = Group.objects.get_or_create(name="Formador")
-        grupo2, _ = Group.objects.get_or_create(name="Coordenador")
+        grupo1 = GroupFactory(name="Formador")
+        grupo2 = GroupFactory(name="Coordenador")
 
         # Login como DAT
         api_client.force_authenticate(usuario_dat)
@@ -95,7 +95,7 @@ class TestAssignGroups:
 
     def test_assign_groups_nonexistent_group(self, api_client, usuario_dat, usuario_formador):
         """Deve retornar 400 quando grupo não existe."""
-        grupo1, _ = Group.objects.get_or_create(name="Formador")
+        grupo1 = GroupFactory(name="Formador")
 
         api_client.force_authenticate(usuario_dat)
 
@@ -114,7 +114,7 @@ class TestAssignGroups:
     def test_assign_groups_empty_list(self, api_client, usuario_dat, usuario_formador):
         """Deve remover todos os grupos quando lista vazia (200)."""
         # Adicionar grupo inicial
-        grupo1, _ = Group.objects.get_or_create(name="Formador")
+        grupo1 = GroupFactory(name="Formador")
         usuario_formador.groups.add(grupo1)
         assert usuario_formador.groups.count() == 1
 
@@ -135,7 +135,7 @@ class TestAssignGroups:
 
     def test_assign_groups_duplicates(self, api_client, usuario_dat, usuario_formador):
         """Deve ignorar IDs duplicados e atribuir apenas uma vez."""
-        grupo1, _ = Group.objects.get_or_create(name="Formador")
+        grupo1 = GroupFactory(name="Formador")
 
         api_client.force_authenticate(usuario_dat)
 
@@ -155,7 +155,7 @@ class TestAssignGroups:
 
     def test_assign_groups_permission_denied(self, api_client, usuario_comum, usuario_formador):
         """Deve retornar 403 quando usuário não tem permissão DAT."""
-        grupo1, _ = Group.objects.get_or_create(name="Formador")
+        grupo1 = GroupFactory(name="Formador")
 
         # Login como usuário comum (sem DAT)
         api_client.force_authenticate(usuario_comum)
@@ -199,9 +199,9 @@ class TestAssignGroups:
         (função canônica pós-realign).
         """
         # Configurar grupos iniciais
-        grupo1, _ = Group.objects.get_or_create(name="Formador")
-        grupo2, _ = Group.objects.get_or_create(name="Coordenador")
-        grupo3, _ = Group.objects.get_or_create(name="Gerente")
+        grupo1 = GroupFactory(name="Formador")
+        grupo2 = GroupFactory(name="Coordenador")
+        grupo3 = GroupFactory(name="Gerente")
 
         usuario_formador.groups.set([grupo1, grupo2])
         assert usuario_formador.groups.count() == 2
@@ -234,7 +234,7 @@ class TestAssignGroups:
         mesmo que tenham permissão DAT.
         """
         # Criar grupo válido da whitelist
-        grupo_formador, _ = Group.objects.get_or_create(name="Formador")
+        grupo_formador = GroupFactory(name="Formador")
 
         api_client.force_authenticate(usuario_dat)
 
@@ -255,7 +255,7 @@ class TestAssignGroups:
         Security: Apenas grupos em ALLOWED_USER_GROUPS podem ser atribuídos.
         """
         # Criar grupo que NÃO está na whitelist
-        grupo_invalido, _ = Group.objects.get_or_create(name="GrupoInvalido")
+        grupo_invalido = GroupFactory(name="GrupoInvalido")
 
         api_client.force_authenticate(usuario_dat)
 
@@ -276,8 +276,8 @@ class TestAssignGroups:
         Valida que grupos como 'Formador', 'Coordenador', 'DAT' funcionam.
         """
         # Criar grupos válidos da whitelist
-        grupo_formador, _ = Group.objects.get_or_create(name="Formador")
-        grupo_coordenador, _ = Group.objects.get_or_create(name="Coordenador")
+        grupo_formador = GroupFactory(name="Formador")
+        grupo_coordenador = GroupFactory(name="Coordenador")
 
         api_client.force_authenticate(usuario_dat)
 
@@ -303,8 +303,8 @@ class TestAssignGroups:
         toda a operação deve falhar.
         """
         # Criar um grupo válido e um inválido
-        grupo_formador, _ = Group.objects.get_or_create(name="Formador")
-        grupo_invalido, _ = Group.objects.get_or_create(name="GrupoHacker")
+        grupo_formador = GroupFactory(name="Formador")
+        grupo_invalido = GroupFactory(name="GrupoHacker")
 
         api_client.force_authenticate(usuario_dat)
 
@@ -328,7 +328,7 @@ class TestAssignGroups:
         #832 - Grupo fora do fallback estatico deve ser permitido se tiver permissao funcional vinculada.
         """
 
-        grupo_dinamico, _ = Group.objects.get_or_create(name="GrupoDinamicoRBAC")
+        grupo_dinamico = GroupFactory(name="GrupoDinamicoRBAC")
         permissao, _ = PermissaoFuncional.objects.get_or_create(
             codename="pode_operar_grupo_dinamico",
             defaults={

--- a/v2/backend/apps/core/tests/test_auditlog_approve_reject.py
+++ b/v2/backend/apps/core/tests/test_auditlog_approve_reject.py
@@ -11,13 +11,20 @@ from __future__ import annotations
 
 from datetime import timedelta
 
-from django.contrib.auth.models import Group
 from django.utils import timezone
 from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import AuditLog, Municipio, Projeto, Solicitacao, TipoEvento, Usuario
+from apps.core.models import AuditLog, Solicitacao
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 pytestmark = pytest.mark.django_db
 
@@ -29,14 +36,14 @@ def super_user():
     import uuid
 
     uid = uuid.uuid4().hex[:8]
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username=f"sup_audit_{uid}",
         email=f"sup_audit_{uid}@test.com",
         password="testpass",
         cpf=f"999{uid.ljust(8, '0')}",
     )
-    grupo_setor, _ = Group.objects.get_or_create(name="Superintendência")
-    grupo_funcao, _ = Group.objects.get_or_create(name="Gerente")
+    grupo_setor = GroupFactory(name="Superintendência")
+    grupo_funcao = GroupFactory(name="Gerente")
     user.groups.add(grupo_setor, grupo_funcao)
     return user
 
@@ -49,25 +56,26 @@ def solicitacao_pendente(super_user):
     IMPORTANTE: Usa fluxo='SUPER' para evitar auto-aprovação.
     Força status='pendente' via .update() para bypass de save() logic.
     """
-    municipio, _ = Municipio.objects.get_or_create(
+    municipio = MunicipioFactory(
         nome="Test City",
-        defaults={"uf": "TS", "ativo": True},
+        uf="TS",
+        ativo=True,
     )
 
     # Projeto com fluxo SUPER (não auto-aprova)
-    projeto = Projeto.objects.create(
+    projeto = ProjetoFactory(
         nome="Test Project SUPER",
         codigo="",
         ativo=True,
         fluxo="SUPER",
     )
 
-    tipo_evento, _ = TipoEvento.objects.get_or_create(
+    tipo_evento = TipoEventoFactory(
         nome="Test Event Type",
     )
 
     now = timezone.now()
-    sol = Solicitacao.objects.create(
+    sol = SolicitacaoFactory(
         usuario=super_user,
         municipio=municipio,
         projeto=projeto,

--- a/v2/backend/apps/core/tests/test_auth_backends.py
+++ b/v2/backend/apps/core/tests/test_auth_backends.py
@@ -21,7 +21,7 @@ from django.test import RequestFactory
 import pytest
 
 from apps.core.auth_backends import CPFOrUsernameBackend
-from apps.core.models import Usuario
+from apps.core.tests.factories import UsuarioFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -43,7 +43,7 @@ def usuario_com_cpf():
     """Usuário com CPF para testes de autenticação."""
     uid = uuid4().hex
     cpf = "12345678901"  # CPF fixo para testes
-    return Usuario.objects.create_user(
+    return UsuarioFactory(
         username=f"user_{uid}",
         email=f"user_{uid}@example.com",
         password="testpass123",
@@ -57,7 +57,7 @@ def usuario_cpf_com_zeros():
     """Usuário com CPF contendo leading zeros."""
     uid = uuid4().hex
     cpf = "00123456789"  # CPF com leading zeros
-    return Usuario.objects.create_user(
+    return UsuarioFactory(
         username=f"user_zeros_{uid}",
         email=f"user_zeros_{uid}@example.com",
         password="testpass123",
@@ -71,7 +71,7 @@ def usuario_inativo():
     """Usuário inativo para testes de bloqueio."""
     uid = uuid4().hex
     cpf = str(uuid4().int % 10**11).zfill(11)
-    return Usuario.objects.create_user(
+    return UsuarioFactory(
         username=f"inactive_{uid}",
         email=f"inactive_{uid}@example.com",
         password="testpass123",
@@ -310,7 +310,7 @@ def test_authenticate_alphanumeric_tries_username(backend, request_factory, usua
 
     # Criar usuário com username alfanumérico
     uid = uuid4().hex
-    user_alpha = Usuario.objects.create_user(
+    user_alpha = UsuarioFactory(
         username="user123",
         email=f"user123_{uid}@example.com",
         password="testpass123",

--- a/v2/backend/apps/core/tests/test_auth_ping.py
+++ b/v2/backend/apps/core/tests/test_auth_ping.py
@@ -13,22 +13,19 @@ Session keep-alive functionality:
 from __future__ import annotations
 
 from django.conf import settings
-from django.contrib.auth import get_user_model
 from rest_framework import status
 from rest_framework.test import APIClient
 
 import pytest
 
-Usuario = get_user_model()
+from apps.core.tests.factories import UsuarioFactory
 
 
 @pytest.fixture
 def authenticated_client(db):
     """Client with authenticated user."""
     client = APIClient()
-    user = Usuario.objects.create_user(
-        username="testuser", password="testpass123", email="test@example.com", cpf="12345678901"
-    )
+    user = UsuarioFactory(username="testuser", password="testpass123", email="test@example.com", cpf="12345678901")
     client.force_authenticate(user=user)
     return client, user
 

--- a/v2/backend/apps/core/tests/test_availability_batch.py
+++ b/v2/backend/apps/core/tests/test_availability_batch.py
@@ -18,14 +18,14 @@ from __future__ import annotations
 from datetime import timedelta
 from uuid import uuid4
 
-from django.contrib.auth.models import Group
 from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import AvailabilityBlock, Municipio, Usuario
+from apps.core.models import AvailabilityBlock
+from apps.core.tests.factories import GroupFactory, MunicipioFactory, UsuarioFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -33,14 +33,14 @@ pytestmark = pytest.mark.django_db
 @pytest.fixture
 def grupo_controle():
     """Grupo Controle (permissão para check-many)."""
-    grupo, _ = Group.objects.get_or_create(name="Controle")
+    grupo = GroupFactory(name="Controle")
     return grupo
 
 
 @pytest.fixture
 def grupo_superintendencia():
     """Grupo Superintendência (permissão para check-many)."""
-    grupo, _ = Group.objects.get_or_create(name="Superintendência")
+    grupo = GroupFactory(name="Superintendência")
     return grupo
 
 
@@ -48,7 +48,7 @@ def grupo_superintendencia():
 def user_controle(grupo_controle):
     """Usuário do grupo Controle com permissão para check-many."""
     uid = uuid4().hex[:8]
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username=f"controle_batch_{uid}",
         email=f"controle_batch_{uid}@test.com",
         password="testpass123",
@@ -62,7 +62,7 @@ def user_controle(grupo_controle):
 def user_formador():
     """Usuário formador comum (sem permissão para check-many de outros)."""
     uid = uuid4().hex[:8]
-    return Usuario.objects.create_user(
+    return UsuarioFactory(
         username=f"formador_batch_{uid}",
         email=f"formador_batch_{uid}@test.com",
         password="testpass123",
@@ -74,7 +74,7 @@ def user_formador():
 def formador_1():
     """Primeiro formador para testes batch."""
     uid = uuid4().hex[:8]
-    return Usuario.objects.create_user(
+    return UsuarioFactory(
         username=f"formador1_{uid}",
         email=f"formador1_{uid}@test.com",
         password="testpass123",
@@ -86,7 +86,7 @@ def formador_1():
 def formador_2():
     """Segundo formador para testes batch."""
     uid = uuid4().hex[:8]
-    return Usuario.objects.create_user(
+    return UsuarioFactory(
         username=f"formador2_{uid}",
         email=f"formador2_{uid}@test.com",
         password="testpass123",
@@ -98,7 +98,7 @@ def formador_2():
 def municipio():
     """Município para testes."""
     uid = uuid4().hex[:8]
-    return Municipio.objects.create(nome=f"Cidade Batch {uid}", uf="CE")
+    return MunicipioFactory(nome=f"Cidade Batch {uid}", uf="CE")
 
 
 class TestAvailabilityCheckManyEndpoint:

--- a/v2/backend/apps/core/tests/test_availability_block_autoapproval.py
+++ b/v2/backend/apps/core/tests/test_availability_block_autoapproval.py
@@ -19,7 +19,13 @@ from datetime import timedelta
 from django.test import TestCase
 from django.utils import timezone
 
-from apps.core.models import AvailabilityBlock, Municipio, Projeto, Solicitacao, TipoEvento, Usuario
+from apps.core.models import AvailabilityBlock, Solicitacao
+from apps.core.tests.factories import (
+    MunicipioFactory,
+    ProjetoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 
 class TestAvailabilityBlockAutoApproval(TestCase):
@@ -27,7 +33,7 @@ class TestAvailabilityBlockAutoApproval(TestCase):
 
     def setUp(self) -> None:
         """Create test fixtures."""
-        self.formador = Usuario.objects.create_user(
+        self.formador = UsuarioFactory(
             username="formador_block_test",
             email="formador_block@test.com",
             password="testpass123",
@@ -93,9 +99,9 @@ class TestAvailabilityBlockAutoApproval(TestCase):
         - Solicitacao SUPER: Requer aprovação gerencial (PA-01 a PA-07)
         - AvailabilityBlock: Informação factual do formador, não precisa aprovação
         """
-        projeto_super = Projeto.objects.create(nome="Test SUPER Project", fluxo="SUPER")
-        municipio = Municipio.objects.create(nome="Test City Block", uf="CE")
-        tipo_evento = TipoEvento.objects.create(nome="Formação Block Test")
+        projeto_super = ProjetoFactory(nome="Test SUPER Project", fluxo="SUPER")
+        municipio = MunicipioFactory(nome="Test City Block", uf="CE")
+        tipo_evento = TipoEventoFactory(nome="Formação Block Test")
 
         inicio = timezone.now() + timedelta(days=4)
         fim = inicio + timedelta(hours=4)

--- a/v2/backend/apps/core/tests/test_availability_block_idor.py
+++ b/v2/backend/apps/core/tests/test_availability_block_idor.py
@@ -14,13 +14,13 @@ from __future__ import annotations
 
 from datetime import timedelta
 
-from django.contrib.auth.models import Group
 from django.utils import timezone
 from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import AvailabilityBlock, EquipeGerencia, Gerencia, Usuario
+from apps.core.models import AvailabilityBlock, EquipeGerencia, Gerencia
+from apps.core.tests.factories import GroupFactory, UsuarioFactory
 
 
 @pytest.fixture
@@ -32,19 +32,19 @@ def api_client():
 @pytest.fixture
 def grupo_controle(db):
     """Grupo Controle."""
-    return Group.objects.get_or_create(name="Controle")[0]
+    return GroupFactory(name="Controle")
 
 
 @pytest.fixture
 def grupo_superintendencia(db):
     """Grupo Superintendência."""
-    return Group.objects.get_or_create(name="Superintendência")[0]
+    return GroupFactory(name="Superintendência")
 
 
 @pytest.fixture
 def usuario_comum(db):
     """Usuário comum sem privilégios especiais."""
-    return Usuario.objects.create_user(
+    return UsuarioFactory(
         username="comum",
         email="comum@example.com",
         password="testpass123",
@@ -55,7 +55,7 @@ def usuario_comum(db):
 @pytest.fixture
 def outro_usuario(db):
     """Outro usuário comum."""
-    return Usuario.objects.create_user(
+    return UsuarioFactory(
         username="outro",
         email="outro@example.com",
         password="testpass123",
@@ -80,7 +80,7 @@ def usuarios_mesma_gerencia(db, gerencia_vidas, usuario_comum, outro_usuario):
 @pytest.fixture
 def usuario_controle(db, grupo_controle):
     """Usuário com permissão Controle."""
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username="controle",
         email="controle@example.com",
         password="testpass123",
@@ -93,7 +93,7 @@ def usuario_controle(db, grupo_controle):
 @pytest.fixture
 def usuario_super(db, grupo_superintendencia):
     """Usuário com permissão Superintendência."""
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username="super",
         email="super@example.com",
         password="testpass123",
@@ -106,12 +106,7 @@ def usuario_super(db, grupo_superintendencia):
 @pytest.fixture
 def superuser(db):
     """Superuser."""
-    return Usuario.objects.create_superuser(
-        username="admin",
-        email="admin@example.com",
-        password="testpass123",
-        cpf="55555555555",
-    )
+    return UsuarioFactory(superuser=True)
 
 
 @pytest.fixture

--- a/v2/backend/apps/core/tests/test_availability_monthly_api.py
+++ b/v2/backend/apps/core/tests/test_availability_monthly_api.py
@@ -21,7 +21,14 @@ from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import AvailabilityBlock, Municipio, Participation, Projeto, Solicitacao, TipoEvento, Usuario
+from apps.core.models import AvailabilityBlock, Participation
+from apps.core.tests.factories import (
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 pytestmark = pytest.mark.django_db
 
@@ -42,14 +49,7 @@ def user_auth():
     `view_all_availability` OU `EquipeGerencia` ativa quando `gerencia_id`
     é omitido. Superuser bypassa, mantendo o foco do test.
     """
-    user = Usuario.objects.create_superuser(
-        username="api_user",
-        email="api@example.com",
-        password="test123",
-        cpf="99999999999",
-        first_name="API",
-        last_name="User",
-    )
+    user = UsuarioFactory(superuser=True)
     return user
 
 
@@ -74,7 +74,7 @@ def setup_data():
     tz = timezone.get_current_timezone()
 
     # Usuários
-    ana = Usuario.objects.create_user(
+    ana = UsuarioFactory(
         username="ana",
         email="ana@example.com",
         password="test123",
@@ -82,7 +82,7 @@ def setup_data():
         first_name="Ana",
         last_name="Silva",
     )
-    bruno = Usuario.objects.create_user(
+    bruno = UsuarioFactory(
         username="bruno",
         email="bruno@example.com",
         password="test123",
@@ -92,13 +92,13 @@ def setup_data():
     )
 
     # Dependências
-    municipio = Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
-    projeto = Projeto.objects.create(nome="Gestão Escolar", ativo=True)
-    tipo_evento = TipoEvento.objects.create(nome="Formação")
+    municipio = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+    projeto = ProjetoFactory(nome="Gestão Escolar", ativo=True)
+    tipo_evento = TipoEventoFactory(nome="Formação")
 
     # Eventos aprovados
     # 2025-10-03 (Ana, 4h)
-    sol1 = Solicitacao.objects.create(
+    sol1 = SolicitacaoFactory(
         usuario=ana,
         municipio=municipio,
         projeto=projeto,
@@ -110,7 +110,7 @@ def setup_data():
     Participation.objects.get_or_create(solicitacao=sol1, usuario=ana, role="FORMADOR")
 
     # 2025-10-08 08:00-10:00 (Ana, 2h)
-    sol2 = Solicitacao.objects.create(
+    sol2 = SolicitacaoFactory(
         usuario=ana,
         municipio=municipio,
         projeto=projeto,
@@ -122,7 +122,7 @@ def setup_data():
     Participation.objects.get_or_create(solicitacao=sol2, usuario=ana, role="FORMADOR")
 
     # 2025-10-08 14:00-16:00 (Ana, 2h)
-    sol3 = Solicitacao.objects.create(
+    sol3 = SolicitacaoFactory(
         usuario=ana,
         municipio=municipio,
         projeto=projeto,
@@ -134,7 +134,7 @@ def setup_data():
     Participation.objects.get_or_create(solicitacao=sol3, usuario=ana, role="FORMADOR")
 
     # 2025-10-01 (Bruno, 4h)
-    sol4 = Solicitacao.objects.create(
+    sol4 = SolicitacaoFactory(
         usuario=bruno,
         municipio=municipio,
         projeto=projeto,
@@ -146,7 +146,7 @@ def setup_data():
     Participation.objects.get_or_create(solicitacao=sol4, usuario=bruno, role="FORMADOR")
 
     # 2025-10-20 08:00-12:00 (Ana, 4h) - para gerar X
-    sol5 = Solicitacao.objects.create(
+    sol5 = SolicitacaoFactory(
         usuario=ana,
         municipio=municipio,
         projeto=projeto,

--- a/v2/backend/apps/core/tests/test_availability_monthly_rbac.py
+++ b/v2/backend/apps/core/tests/test_availability_monthly_rbac.py
@@ -23,7 +23,6 @@ view_all_availability é atribuído a Controle/Gerente/Coord/Apoio por design).
 
 from __future__ import annotations
 
-from django.contrib.auth.models import Group
 from django.core.cache import cache
 from django.core.management import call_command
 from rest_framework.test import APIClient
@@ -31,6 +30,7 @@ from rest_framework.test import APIClient
 import pytest
 
 from apps.core.models import EquipeGerencia, Gerencia, PermissaoFuncional, Usuario
+from apps.core.tests.factories import GroupFactory, UsuarioFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -50,14 +50,14 @@ def _make_user_with_groups_and_caps(username: str, group_names: list[str], capab
     ligada a pelo menos um desses grupos. Espelha o cenário de produção onde
     o seed 0077 atribuiu `view_all_availability` ao grupo Controle.
     """
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username=username,
         email=f"{username}@example.com",
         password="testpass123",
         cpf=_next_cpf(),
     )
     for gname in group_names:
-        group, _ = Group.objects.get_or_create(name=gname)
+        group = GroupFactory(name=gname)
         user.groups.add(group)
         for code in capability_codenames:
             perm = PermissaoFuncional.objects.filter(codename=code).first()
@@ -385,12 +385,7 @@ class TestSanity:
         assert res.status_code in (401, 403)
 
     def test_superuser_returns_200(self):
-        super_user = Usuario.objects.create_superuser(
-            username="super_test_monthly",
-            email="super_test_monthly@example.com",
-            password="testpass123",
-            cpf="99900099997",
-        )
+        super_user = UsuarioFactory(superuser=True)
         client = APIClient()
         client.force_authenticate(user=super_user)
         res = client.get(URL + QS)

--- a/v2/backend/apps/core/tests/test_availability_service.py
+++ b/v2/backend/apps/core/tests/test_availability_service.py
@@ -17,14 +17,21 @@ from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import AvailabilityBlock, Municipio, Solicitacao, TipoEvento, Usuario
+from apps.core.models import AvailabilityBlock
 from apps.core.services.availability_service import check_conflicts
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 
 @pytest.fixture
 def usuario_test(db):
     """Cria um usuário de teste"""
-    return Usuario.objects.create_user(
+    return UsuarioFactory(
         username="testuser",
         email="testuser@example.com",
         password="testpass123",
@@ -35,19 +42,19 @@ def usuario_test(db):
 @pytest.fixture
 def tipo_evento_test(db):
     """Cria um tipo de evento de teste"""
-    return TipoEvento.objects.create(nome="Formação Teste", descricao="Teste")
+    return TipoEventoFactory(nome="Formação Teste", descricao="Teste")
 
 
 @pytest.fixture
 def municipio_a(db):
     """Município A (Fortaleza)"""
-    return Municipio.objects.create(nome="Fortaleza", uf="CE")
+    return MunicipioFactory(nome="Fortaleza", uf="CE")
 
 
 @pytest.fixture
 def municipio_b(db):
     """Município B (Caucaia)"""
-    return Municipio.objects.create(nome="Caucaia", uf="CE")
+    return MunicipioFactory(nome="Caucaia", uf="CE")
 
 
 @pytest.mark.django_db
@@ -64,7 +71,7 @@ class TestAvailabilityServiceRules:
         now = timezone.now().replace(hour=10, minute=0, second=0, microsecond=0)
 
         # Criar evento aprovado existente
-        Solicitacao.objects.create(
+        SolicitacaoFactory(
             usuario=usuario_test,
             tipo_evento=tipo_evento_test,
             municipio=municipio_a,
@@ -92,7 +99,7 @@ class TestAvailabilityServiceRules:
         """
         now = timezone.now().replace(hour=10, minute=0, second=0, microsecond=0)
 
-        Solicitacao.objects.create(
+        SolicitacaoFactory(
             usuario=usuario_test,
             tipo_evento=tipo_evento_test,
             municipio=municipio_a,
@@ -119,7 +126,7 @@ class TestAvailabilityServiceRules:
         """
         now = timezone.now().replace(hour=10, minute=0, second=0, microsecond=0)
 
-        Solicitacao.objects.create(
+        SolicitacaoFactory(
             usuario=usuario_test,
             tipo_evento=tipo_evento_test,
             municipio=municipio_a,
@@ -213,7 +220,7 @@ class TestAvailabilityServiceRules:
         now = timezone.now().replace(hour=8, minute=0, second=0, microsecond=0)
 
         # Evento aprovado em Município A
-        Solicitacao.objects.create(
+        SolicitacaoFactory(
             usuario=usuario_test,
             tipo_evento=tipo_evento_test,
             municipio=municipio_a,
@@ -243,7 +250,7 @@ class TestAvailabilityServiceRules:
         """
         now = timezone.now().replace(hour=8, minute=0, second=0, microsecond=0)
 
-        Solicitacao.objects.create(
+        SolicitacaoFactory(
             usuario=usuario_test,
             tipo_evento=tipo_evento_test,
             municipio=municipio_a,
@@ -271,7 +278,7 @@ class TestAvailabilityServiceRules:
         now = timezone.now().replace(hour=8, minute=0, second=0, microsecond=0)
 
         # Criar evento de 7h já aprovado
-        Solicitacao.objects.create(
+        SolicitacaoFactory(
             usuario=usuario_test,
             tipo_evento=tipo_evento_test,
             municipio=municipio_a,
@@ -348,7 +355,7 @@ class TestAvailabilityServiceRules:
 
         # Criar evento aprovado às 23:30 Fortaleza
         # (persistido só pelo side effect — check_conflicts vai buscar no DB)
-        Solicitacao.objects.create(
+        SolicitacaoFactory(
             usuario=usuario_test,
             tipo_evento=tipo_evento_test,
             municipio=municipio_a,
@@ -398,10 +405,8 @@ class TestAvailabilityCheckEndpoint:
         Para chamar endpoint com sucesso (200), usuário deve ter permissão.
         Adiciona usuário ao grupo Controle para passar RBAC (403→200).
         """
-        from django.contrib.auth.models import Group
-
         # Dar permissão ao usuário (evitar 403)
-        grupo_controle, _ = Group.objects.get_or_create(name="Controle")
+        grupo_controle = GroupFactory(name="Controle")
         usuario_test.groups.add(grupo_controle)
 
         client = APIClient()
@@ -410,7 +415,7 @@ class TestAvailabilityCheckEndpoint:
         now = timezone.now().replace(hour=14, minute=0, second=0, microsecond=0)
 
         # Criar evento aprovado
-        Solicitacao.objects.create(
+        SolicitacaoFactory(
             usuario=usuario_test,
             tipo_evento=tipo_evento_test,
             municipio=municipio_a,
@@ -471,10 +476,8 @@ class TestAvailabilityCheckEndpoint:
         Para validar parâmetros (400), usuário deve ter permissão.
         Adiciona usuário ao grupo Controle para passar RBAC (403→400).
         """
-        from django.contrib.auth.models import Group
-
         # Dar permissão ao usuário (evitar 403 antes de validar parâmetros)
-        grupo_controle, _ = Group.objects.get_or_create(name="Controle")
+        grupo_controle = GroupFactory(name="Controle")
         usuario_test.groups.add(grupo_controle)
 
         client = APIClient()
@@ -500,10 +503,8 @@ class TestAvailabilityCheckEndpoint:
         Para validar parâmetros (400), usuário deve ter permissão.
         Adiciona usuário ao grupo Controle para passar RBAC (403→400).
         """
-        from django.contrib.auth.models import Group
-
         # Dar permissão ao usuário (evitar 403 antes de validar parâmetros)
-        grupo_controle, _ = Group.objects.get_or_create(name="Controle")
+        grupo_controle = GroupFactory(name="Controle")
         usuario_test.groups.add(grupo_controle)
 
         client = APIClient()
@@ -532,14 +533,12 @@ class TestAvailabilityCheckEndpoint:
         Coordenador/Apoio Coord têm `view_all_availability`. Superintendência
         deixou de ter (Diretoria assumiu dashboards executivos).
         """
-        from django.contrib.auth.models import Group
-
         # Tornar usuario_test privilegiado (grupo Controle tem view_all_availability)
-        grupo_controle, _ = Group.objects.get_or_create(name="Controle")
+        grupo_controle = GroupFactory(name="Controle")
         usuario_test.groups.add(grupo_controle)
 
         # Criar segundo usuário
-        usuario_2 = Usuario.objects.create_user(
+        usuario_2 = UsuarioFactory(
             username="user2",
             email="user2@example.com",
             password="pass",
@@ -552,7 +551,7 @@ class TestAvailabilityCheckEndpoint:
         now = timezone.now().replace(hour=14, minute=0, second=0, microsecond=0)
 
         # Criar conflito apenas para usuario_test
-        Solicitacao.objects.create(
+        SolicitacaoFactory(
             usuario=usuario_test,
             tipo_evento=tipo_evento_test,
             municipio=municipio_a,
@@ -589,7 +588,7 @@ class TestAvailabilityCheckEndpoint:
         Valida 403 RBAC quando usuário sem permissão tenta checar outro usuário.
         """
         # Criar segundo usuário (não privilegiado)
-        outro_usuario = Usuario.objects.create_user(
+        outro_usuario = UsuarioFactory(
             username="outro",
             email="outro@example.com",
             password="pass",
@@ -628,7 +627,7 @@ class TestAvailabilityServiceAdditional:
         Se qualquer formador tiver conflito, a solicitação não deve prosseguir.
         """
         # Criar segundo formador
-        formador_2 = Usuario.objects.create_user(
+        formador_2 = UsuarioFactory(
             username="formador2",
             email="formador2@example.com",
             password="pass",
@@ -638,7 +637,7 @@ class TestAvailabilityServiceAdditional:
         now = timezone.now().replace(hour=10, minute=0, second=0, microsecond=0)
 
         # Criar evento aprovado apenas para formador_2
-        Solicitacao.objects.create(
+        SolicitacaoFactory(
             usuario=formador_2,
             tipo_evento=tipo_evento_test,
             municipio=municipio_a,
@@ -675,7 +674,7 @@ class TestAvailabilityServiceAdditional:
         now = timezone.now().replace(hour=14, minute=0, second=0, microsecond=0)
 
         # Criar evento aprovado
-        Solicitacao.objects.create(
+        SolicitacaoFactory(
             usuario=usuario_test,
             tipo_evento=tipo_evento_test,
             municipio=municipio_a,

--- a/v2/backend/apps/core/tests/test_backfill_municipios_ibge_command.py
+++ b/v2/backend/apps/core/tests/test_backfill_municipios_ibge_command.py
@@ -12,13 +12,14 @@ from django.core.management import call_command
 
 import pytest
 
-from apps.core.models import Municipio, MunicipioReferencia
+from apps.core.models import MunicipioReferencia
+from apps.core.tests.factories import MunicipioFactory
 
 pytestmark = pytest.mark.django_db
 
 
 def test_backfill_municipios_ibge_dry_run_does_not_persist():
-    municipio = Municipio.objects.create(nome="Fortaleza", uf="CE", ibge_code=None)
+    municipio = MunicipioFactory(nome="Fortaleza", uf="CE", ibge_code=None)
     MunicipioReferencia.objects.create(
         nome="Fortaleza",
         uf="CE",
@@ -38,7 +39,7 @@ def test_backfill_municipios_ibge_dry_run_does_not_persist():
 
 
 def test_backfill_municipios_ibge_apply_persists_unique_match():
-    municipio = Municipio.objects.create(nome="Fortaleza", uf="CE", ibge_code=None)
+    municipio = MunicipioFactory(nome="Fortaleza", uf="CE", ibge_code=None)
     MunicipioReferencia.objects.create(
         nome="Fortaleza",
         uf="CE",
@@ -58,7 +59,7 @@ def test_backfill_municipios_ibge_apply_persists_unique_match():
 
 
 def test_backfill_municipios_ibge_apply_detects_ambiguous_normalized_names():
-    municipio = Municipio.objects.create(nome="Santo Antonio", uf="CE", ibge_code=None)
+    municipio = MunicipioFactory(nome="Santo Antonio", uf="CE", ibge_code=None)
     MunicipioReferencia.objects.create(
         nome="Santo Antônio",
         uf="CE",
@@ -85,8 +86,8 @@ def test_backfill_municipios_ibge_apply_detects_ambiguous_normalized_names():
 
 
 def test_backfill_municipios_ibge_apply_detects_conflict_with_existing_code():
-    Municipio.objects.create(nome="Aquiraz", uf="CE", ibge_code="2301000")
-    target = Municipio.objects.create(nome="Eusébio", uf="CE", ibge_code=None)
+    MunicipioFactory(nome="Aquiraz", uf="CE", ibge_code="2301000")
+    target = MunicipioFactory(nome="Eusébio", uf="CE", ibge_code=None)
     MunicipioReferencia.objects.create(
         nome="Eusébio",
         uf="CE",
@@ -106,7 +107,7 @@ def test_backfill_municipios_ibge_apply_detects_conflict_with_existing_code():
 
 
 def test_backfill_municipios_ibge_apply_matches_without_accents():
-    target = Municipio.objects.create(nome="Sao Paulo", uf="SP", ibge_code=None)
+    target = MunicipioFactory(nome="Sao Paulo", uf="SP", ibge_code=None)
     MunicipioReferencia.objects.create(
         nome="São Paulo",
         uf="SP",

--- a/v2/backend/apps/core/tests/test_cache_availability.py
+++ b/v2/backend/apps/core/tests/test_cache_availability.py
@@ -17,15 +17,22 @@ from datetime import datetime, timedelta
 from unittest.mock import patch
 from zoneinfo import ZoneInfo
 
-from django.contrib.auth.models import Group
 from django.core.cache import cache
 from django.utils import timezone
 from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import AvailabilityBlock, Municipio, Projeto, Solicitacao, TipoEvento, Usuario
+from apps.core.models import AvailabilityBlock
 from apps.core.services.availability_service import check_conflicts
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 
 @pytest.fixture
@@ -39,8 +46,8 @@ def clear_cache():
 @pytest.fixture
 def usuario_formador(db):
     """Cria um usuário formador para testes."""
-    grupo_formador = Group.objects.get_or_create(name="Formador")[0]
-    usuario = Usuario.objects.create_user(
+    grupo_formador = GroupFactory(name="Formador")
+    usuario = UsuarioFactory(
         username="formador_cache",
         email="formador_cache@test.com",
         first_name="Cache",
@@ -54,13 +61,13 @@ def usuario_formador(db):
 @pytest.fixture
 def municipio(db):
     """Cria um município para testes."""
-    return Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
+    return MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
 
 
 @pytest.fixture
 def projeto_super(db):
     """Cria um projeto SUPER para testes."""
-    return Projeto.objects.create(
+    return ProjetoFactory(
         nome="Projeto Cache Test",
         codigo="CACHE",
         fluxo="SUPER",
@@ -71,7 +78,7 @@ def projeto_super(db):
 @pytest.fixture
 def tipo_evento(db):
     """Cria um tipo de evento para testes."""
-    return TipoEvento.objects.create(nome="Formação Inicial")
+    return TipoEventoFactory(nome="Formação Inicial")
 
 
 # ================================================================
@@ -130,7 +137,7 @@ def test_cache_invalidated_on_solicitacao_create(clear_cache, usuario_formador, 
     assert result1.ok is True
 
     # Criar solicitação aprovada (conflita)
-    Solicitacao.objects.create(
+    SolicitacaoFactory(
         usuario=usuario_formador,
         inicio=inicio,
         fim=fim,
@@ -162,7 +169,7 @@ def test_cache_invalidated_on_solicitacao_update(clear_cache, usuario_formador, 
     fim = inicio + timedelta(hours=2)
 
     # Criar solicitação pendente
-    sol = Solicitacao.objects.create(
+    sol = SolicitacaoFactory(
         usuario=usuario_formador,
         inicio=inicio,
         fim=fim,
@@ -201,7 +208,7 @@ def test_cache_invalidated_on_solicitacao_delete(clear_cache, usuario_formador, 
     fim = inicio + timedelta(hours=2)
 
     # Criar solicitação aprovada (conflita)
-    sol = Solicitacao.objects.create(
+    sol = SolicitacaoFactory(
         usuario=usuario_formador,
         inicio=inicio,
         fim=fim,
@@ -274,7 +281,7 @@ def test_municipios_options_cached(clear_cache):
     """
     client = APIClient()
     # Criar usuário autenticado
-    usuario = Usuario.objects.create_user(
+    usuario = UsuarioFactory(
         username="test_municipios",
         email="test@test.com",
         password="test123",
@@ -282,8 +289,8 @@ def test_municipios_options_cached(clear_cache):
     client.force_authenticate(user=usuario)
 
     # Criar municípios
-    Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
-    Municipio.objects.create(nome="Sobral", uf="CE", ativo=True)
+    MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+    MunicipioFactory(nome="Sobral", uf="CE", ativo=True)
 
     # Primeira chamada: cache miss
     response1 = client.get("/api/options/municipios/")
@@ -307,7 +314,7 @@ def test_static_cache_invalidated_on_municipio_create(clear_cache):
     3. Verificar que cache foi invalidado e retorna 2 municípios
     """
     client = APIClient()
-    usuario = Usuario.objects.create_user(
+    usuario = UsuarioFactory(
         username="test_municipios2",
         email="test2@test.com",
         password="test123",
@@ -315,7 +322,7 @@ def test_static_cache_invalidated_on_municipio_create(clear_cache):
     client.force_authenticate(user=usuario)
 
     # Criar primeiro município
-    Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
+    MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
 
     # Cachear resultado
     response1 = client.get("/api/options/municipios/")
@@ -323,7 +330,7 @@ def test_static_cache_invalidated_on_municipio_create(clear_cache):
     assert len(response1.data) == 1
 
     # Criar novo município
-    Municipio.objects.create(nome="Sobral", uf="CE", ativo=True)
+    MunicipioFactory(nome="Sobral", uf="CE", ativo=True)
 
     # Cache invalidado, agora retorna 2 municípios
     response2 = client.get("/api/options/municipios/")
@@ -341,7 +348,7 @@ def test_projetos_options_cached(clear_cache):
     2. Segunda chamada: cache hit (retorna mesmos dados)
     """
     client = APIClient()
-    usuario = Usuario.objects.create_user(
+    usuario = UsuarioFactory(
         username="test_projetos",
         email="test3@test.com",
         password="test123",
@@ -349,8 +356,8 @@ def test_projetos_options_cached(clear_cache):
     client.force_authenticate(user=usuario)
 
     # Criar projetos
-    Projeto.objects.create(nome="Projeto 1", codigo="P1", fluxo="SUPER", ativo=True)
-    Projeto.objects.create(nome="Projeto 2", codigo="P2", fluxo="NAO_SUPER", ativo=True)
+    ProjetoFactory(nome="Projeto 1", codigo="P1", fluxo="SUPER", ativo=True)
+    ProjetoFactory(nome="Projeto 2", codigo="P2", fluxo="NAO_SUPER", ativo=True)
 
     # Primeira chamada: cache miss
     response1 = client.get("/api/options/projetos/")
@@ -375,7 +382,7 @@ def test_static_cache_invalidated_on_projeto_update(clear_cache):
     3. Verificar que cache foi invalidado
     """
     client = APIClient()
-    usuario = Usuario.objects.create_user(
+    usuario = UsuarioFactory(
         username="test_projetos2",
         email="test4@test.com",
         password="test123",
@@ -383,7 +390,7 @@ def test_static_cache_invalidated_on_projeto_update(clear_cache):
     client.force_authenticate(user=usuario)
 
     # Criar projeto ativo
-    projeto = Projeto.objects.create(nome="Projeto Cache", codigo="PCACHE", fluxo="SUPER", ativo=True)
+    projeto = ProjetoFactory(nome="Projeto Cache", codigo="PCACHE", fluxo="SUPER", ativo=True)
 
     # Cachear resultado
     response1 = client.get("/api/options/projetos/")
@@ -410,7 +417,7 @@ def test_tipos_evento_options_cached(clear_cache):
     2. Segunda chamada: cache hit
     """
     client = APIClient()
-    usuario = Usuario.objects.create_user(
+    usuario = UsuarioFactory(
         username="test_tipos",
         email="test5@test.com",
         password="test123",
@@ -418,8 +425,8 @@ def test_tipos_evento_options_cached(clear_cache):
     client.force_authenticate(user=usuario)
 
     # Criar tipos de evento
-    TipoEvento.objects.create(nome="Formação Inicial")
-    TipoEvento.objects.create(nome="Acompanhamento")
+    TipoEventoFactory(nome="Formação Inicial")
+    TipoEventoFactory(nome="Acompanhamento")
 
     # Primeira chamada: cache miss
     response1 = client.get("/api/options/tipos-evento/")
@@ -443,7 +450,7 @@ def test_static_cache_invalidated_on_tipo_evento_delete(clear_cache):
     3. Verificar que cache foi invalidado
     """
     client = APIClient()
-    usuario = Usuario.objects.create_user(
+    usuario = UsuarioFactory(
         username="test_tipos2",
         email="test6@test.com",
         password="test123",
@@ -451,8 +458,8 @@ def test_static_cache_invalidated_on_tipo_evento_delete(clear_cache):
     client.force_authenticate(user=usuario)
 
     # Criar tipos de evento
-    tipo1 = TipoEvento.objects.create(nome="Formação Inicial")
-    tipo2 = TipoEvento.objects.create(nome="Acompanhamento")
+    tipo1 = TipoEventoFactory(nome="Formação Inicial")
+    tipo2 = TipoEventoFactory(nome="Acompanhamento")
 
     # Cachear resultado
     response1 = client.get("/api/options/tipos-evento/")

--- a/v2/backend/apps/core/tests/test_celery_task_suite.py
+++ b/v2/backend/apps/core/tests/test_celery_task_suite.py
@@ -15,12 +15,19 @@ from datetime import timedelta
 from unittest.mock import patch
 from uuid import uuid4
 
-from django.contrib.auth.models import Group
 from django.utils import timezone
 
 import pytest
 
-from apps.core.models import AuditLog, Municipio, Projeto, Solicitacao, TipoEvento, Usuario
+from apps.core.models import AuditLog, Solicitacao
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 pytestmark = [pytest.mark.django_db]
 
@@ -29,19 +36,19 @@ pytestmark = [pytest.mark.django_db]
 def task_solicitacao(db):
     """Create a published solicitacao for task tests."""
     uid = uuid4().hex[:8]
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username=f"task_user_{uid}",
         email=f"task_{uid}@test.com",
         password="testpass",
         cpf=f"888{uid.ljust(8, '0')}",
     )
-    Group.objects.get_or_create(name="Controle")
-    municipio = Municipio.objects.create(nome=f"TaskCity_{uid}", uf="CE")
-    projeto = Projeto.objects.create(nome=f"TaskProj_{uid}", fluxo="SUPER")
-    tipo = TipoEvento.objects.create(nome=f"TaskType_{uid}")
+    GroupFactory(name="Controle")
+    municipio = MunicipioFactory(nome=f"TaskCity_{uid}", uf="CE")
+    projeto = ProjetoFactory(nome=f"TaskProj_{uid}", fluxo="SUPER")
+    tipo = TipoEventoFactory(nome=f"TaskType_{uid}")
 
     now = timezone.now()
-    sol = Solicitacao.objects.create(
+    sol = SolicitacaoFactory(
         usuario=user,
         municipio=municipio,
         projeto=projeto,

--- a/v2/backend/apps/core/tests/test_compras_domain_boundary.py
+++ b/v2/backend/apps/core/tests/test_compras_domain_boundary.py
@@ -8,12 +8,17 @@ from __future__ import annotations
 from datetime import date
 from decimal import Decimal
 
-from django.contrib.auth.models import Group
 from rest_framework.test import APIClient
 
 import pytest
 
 from apps.core.models import Compra, DATCompra, Municipio, Projeto, Usuario
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    UsuarioFactory,
+)
 
 pytestmark = pytest.mark.django_db
 
@@ -25,28 +30,28 @@ def api_client() -> APIClient:
 
 @pytest.fixture
 def controle_user() -> Usuario:
-    user = Usuario.objects.create_user(username="controle_boundary", password="test123", cpf="20000000001")
-    group, _ = Group.objects.get_or_create(name="Controle")
+    user = UsuarioFactory(username="controle_boundary", password="test123", cpf="20000000001")
+    group = GroupFactory(name="Controle")
     user.groups.add(group)
     return user
 
 
 @pytest.fixture
 def dat_user() -> Usuario:
-    user = Usuario.objects.create_user(username="dat_boundary", password="test123", cpf="20000000002")
-    group, _ = Group.objects.get_or_create(name="DAT")
+    user = UsuarioFactory(username="dat_boundary", password="test123", cpf="20000000002")
+    group = GroupFactory(name="DAT")
     user.groups.add(group)
     return user
 
 
 @pytest.fixture
 def municipio() -> Municipio:
-    return Municipio.objects.create(nome="Fortaleza", uf="CE")
+    return MunicipioFactory(nome="Fortaleza", uf="CE")
 
 
 @pytest.fixture
 def projeto() -> Projeto:
-    return Projeto.objects.create(nome="Projeto Fronteira")
+    return ProjetoFactory(nome="Projeto Fronteira")
 
 
 @pytest.fixture

--- a/v2/backend/apps/core/tests/test_compras_solicitacao_publish_chain.py
+++ b/v2/backend/apps/core/tests/test_compras_solicitacao_publish_chain.py
@@ -15,7 +15,6 @@ from datetime import timedelta
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
-from django.contrib.auth.models import Group
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import override_settings
 from django.utils import timezone
@@ -23,20 +22,27 @@ from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import AuditLog, Compra, Municipio, Projeto, Solicitacao, TipoEvento, Usuario
+from apps.core.models import AuditLog, Compra, Solicitacao, Usuario
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 pytestmark = pytest.mark.django_db
 
 
 def _create_user_in_group(*, prefix: str, group_name: str) -> Usuario:
     uid = uuid4().hex[:8]
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username=f"{prefix}_{uid}",
         email=f"{prefix}_{uid}@example.com",
         password="testpass",
         cpf=str(uuid4().int % 10**11).zfill(11),
     )
-    group, _ = Group.objects.get_or_create(name=group_name)
+    group = GroupFactory(name=group_name)
     user.groups.add(group)
     return user
 
@@ -77,12 +83,12 @@ def test_happy_path_import_compra_create_solicitacao_approve_and_publish():
     user_coordenador = _create_user_in_group(prefix="coord_chain", group_name="Coordenador")
     # PR 3 hardening RBAC (2026-04-29): aprovar exige composite Setor Sup + Função Gerente.
     user_super = _create_user_in_group(prefix="super_chain", group_name="Superintendência")
-    grupo_gerente, _ = Group.objects.get_or_create(name="Gerente")
+    grupo_gerente = GroupFactory(name="Gerente")
     user_super.groups.add(grupo_gerente)
 
-    municipio = Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
-    projeto = Projeto.objects.create(nome="Novo Lendo", codigo="NL", fluxo="SUPER", ativo=True)
-    tipo_evento = TipoEvento.objects.create(nome="Formacao")
+    municipio = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+    projeto = ProjetoFactory(nome="Novo Lendo", codigo="NL", fluxo="SUPER", ativo=True)
+    tipo_evento = TipoEventoFactory(nome="Formacao")
 
     # 1) Import compras via endpoint real (DAT-only após PR-A1 DAT-Imports).
     client.force_authenticate(user=user_dat)
@@ -154,10 +160,10 @@ def test_invalid_path_blocks_solicitacao_when_pair_municipio_projeto_has_no_comp
     user_controle = _create_user_in_group(prefix="dat_invalid", group_name="DAT")
     user_coordenador = _create_user_in_group(prefix="coord_invalid", group_name="Coordenador")
 
-    municipio = Municipio.objects.create(nome="Sobral", uf="CE", ativo=True)
-    projeto_com_compra = Projeto.objects.create(nome="Novo Lendo", codigo="NL2", fluxo="SUPER", ativo=True)
-    projeto_sem_compra = Projeto.objects.create(nome="ACerta", codigo="AC", fluxo="SUPER", ativo=True)
-    tipo_evento = TipoEvento.objects.create(nome="Acompanhamento")
+    municipio = MunicipioFactory(nome="Sobral", uf="CE", ativo=True)
+    projeto_com_compra = ProjetoFactory(nome="Novo Lendo", codigo="NL2", fluxo="SUPER", ativo=True)
+    projeto_sem_compra = ProjetoFactory(nome="ACerta", codigo="AC", fluxo="SUPER", ativo=True)
+    tipo_evento = TipoEventoFactory(nome="Acompanhamento")
 
     # Import cria compra somente para "Novo Lendo".
     client.force_authenticate(user=user_controle)

--- a/v2/backend/apps/core/tests/test_concurrency_regressions_asq016.py
+++ b/v2/backend/apps/core/tests/test_concurrency_regressions_asq016.py
@@ -22,7 +22,6 @@ from datetime import timezone as dt_timezone
 from unittest import mock
 from uuid import uuid4
 
-from django.contrib.auth.models import Group
 from django.db import close_old_connections
 from django.utils import timezone
 
@@ -31,19 +30,23 @@ import pytest
 from apps.core.models import (
     AvailabilityBlock,
     GoogleOAuthCredential,
-    Municipio,
-    Projeto,
     Solicitacao,
-    TipoEvento,
-    Usuario,
 )
 from apps.core.services.bloqueios_import import import_bloqueios_from_file
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 
 @pytest.fixture
 def usuario():
     uid = uuid4().hex[:8]
-    return Usuario.objects.create_user(
+    return UsuarioFactory(
         username=f"asq016_{uid}",
         password="x",
         cpf=str(uuid4().int % 10**11).zfill(11),
@@ -171,17 +174,17 @@ class _RecordingCalendarClient:
 
 @pytest.fixture
 def solicitacao_aprovada(usuario):
-    muni = Municipio.objects.create(nome=f"Mun_{uuid4().hex[:6]}", uf="CE", ativo=True)
-    proj = Projeto.objects.create(
+    muni = MunicipioFactory(nome=f"Mun_{uuid4().hex[:6]}", uf="CE", ativo=True)
+    proj = ProjetoFactory(
         nome=f"Proj_{uuid4().hex[:6]}",
         codigo=f"P{uuid4().hex[:5]}",
         fluxo="SUPER",
         ativo=True,
     )
-    tipo = TipoEvento.objects.get_or_create(nome="Evt_ASQ016")[0]
-    group, _ = Group.objects.get_or_create(name="Coordenador")
+    tipo = TipoEventoFactory(nome="Evt_ASQ016")
+    group = GroupFactory(name="Coordenador")
     usuario.groups.add(group)
-    return Solicitacao.objects.create(
+    return SolicitacaoFactory(
         usuario=usuario,
         municipio=muni,
         projeto=proj,

--- a/v2/backend/apps/core/tests/test_config_api.py
+++ b/v2/backend/apps/core/tests/test_config_api.py
@@ -18,16 +18,13 @@ from __future__ import annotations
 
 from typing import Any
 
-from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Group
 from django.urls import reverse
 from rest_framework.test import APIClient
 
 import pytest
 
 from apps.core.models import AuditLog, Config
-
-User = get_user_model()
+from apps.core.tests.factories import GroupFactory, UsuarioFactory
 
 
 @pytest.fixture
@@ -39,8 +36,8 @@ def client() -> APIClient:
 @pytest.fixture
 def dat_user(db: Any) -> Any:
     """Create a DAT user."""
-    user = User.objects.create_user(username="dat_user", email="dat@example.com", password="testpass123")
-    dat_group, _ = Group.objects.get_or_create(name="DAT")
+    user = UsuarioFactory(username="dat_user", email="dat@example.com", password="testpass123")
+    dat_group = GroupFactory(name="DAT")
     user.groups.add(dat_group)
     return user
 
@@ -48,8 +45,8 @@ def dat_user(db: Any) -> Any:
 @pytest.fixture
 def super_user(db: Any) -> Any:
     """Create a Superintendência user."""
-    user = User.objects.create_user(username="super_user", email="super@example.com", password="testpass123")
-    super_group, _ = Group.objects.get_or_create(name="Superintendência")
+    user = UsuarioFactory(username="super_user", email="super@example.com", password="testpass123")
+    super_group = GroupFactory(name="Superintendência")
     user.groups.add(super_group)
     return user
 
@@ -57,8 +54,8 @@ def super_user(db: Any) -> Any:
 @pytest.fixture
 def coordenador_user(db: Any) -> Any:
     """Create a Coordenador user (no DAT/Super access)."""
-    user = User.objects.create_user(username="coordenador", email="coord@example.com", password="testpass123")
-    coord_group, _ = Group.objects.get_or_create(name="Coordenador")
+    user = UsuarioFactory(username="coordenador", email="coord@example.com", password="testpass123")
+    coord_group = GroupFactory(name="Coordenador")
     user.groups.add(coord_group)
     return user
 

--- a/v2/backend/apps/core/tests/test_controle_dat_api.py
+++ b/v2/backend/apps/core/tests/test_controle_dat_api.py
@@ -19,16 +19,19 @@ from __future__ import annotations
 
 from datetime import date
 
-from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Group
 from rest_framework import status
 from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import AcaoControle, AcaoDAT, Municipio, Projeto, TipoAcaoDAT
+from apps.core.models import AcaoControle, AcaoDAT, TipoAcaoDAT
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    UsuarioFactory,
+)
 
-User = get_user_model()
 pytestmark = pytest.mark.django_db
 
 # ════════════════════════════════════════════════════════════════════════════
@@ -39,8 +42,8 @@ pytestmark = pytest.mark.django_db
 def test_controle_user_can_list():
     """Usuário do grupo Controle pode listar ações."""
     # Criar grupo e usuário
-    controle_group, _ = Group.objects.get_or_create(name="Controle")
-    user = User.objects.create_user(
+    controle_group = GroupFactory(name="Controle")
+    user = UsuarioFactory(
         username="controle1",
         email="controle@example.com",
         password="test123",
@@ -49,9 +52,9 @@ def test_controle_user_can_list():
     user.groups.add(controle_group)
 
     # Criar dados
-    municipio = Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
-    projeto = Projeto.objects.create(nome="ACerta", ativo=True)
-    coord = User.objects.create_user(
+    municipio = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+    projeto = ProjetoFactory(nome="ACerta", ativo=True)
+    coord = UsuarioFactory(
         username="coord1",
         email="coord@example.com",
         password="test123",
@@ -79,7 +82,7 @@ def test_controle_user_can_list():
 
 def test_regular_user_cannot_list_controle_acoes():
     """Usuário sem permissão recebe 403."""
-    user = User.objects.create_user(
+    user = UsuarioFactory(
         username="regular",
         email="regular@example.com",
         password="test123",
@@ -87,8 +90,8 @@ def test_regular_user_cannot_list_controle_acoes():
     )
 
     # Criar dados
-    municipio = Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
-    projeto = Projeto.objects.create(nome="ACerta", ativo=True)
+    municipio = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+    projeto = ProjetoFactory(nome="ACerta", ativo=True)
     AcaoControle.objects.create(
         municipio=municipio,
         projeto=projeto,
@@ -115,8 +118,8 @@ def test_unauthenticated_cannot_list_controle_acoes():
 
 def test_filter_by_date_range():
     """Filtro por data_inicio e data_fim funciona."""
-    controle_group, _ = Group.objects.get_or_create(name="Controle")
-    user = User.objects.create_user(
+    controle_group = GroupFactory(name="Controle")
+    user = UsuarioFactory(
         username="controle1",
         email="controle@example.com",
         password="test123",
@@ -124,8 +127,8 @@ def test_filter_by_date_range():
     )
     user.groups.add(controle_group)
 
-    municipio = Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
-    projeto = Projeto.objects.create(nome="ACerta", ativo=True)
+    municipio = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+    projeto = ProjetoFactory(nome="ACerta", ativo=True)
 
     # Criar ação dentro do intervalo
     AcaoControle.objects.create(
@@ -155,8 +158,8 @@ def test_filter_by_date_range():
 
 def test_controle_serializer_uses_string_related_field():
     """Serializer retorna nomes legíveis (não IDs) para FKs."""
-    controle_group, _ = Group.objects.get_or_create(name="Controle")
-    user = User.objects.create_user(
+    controle_group = GroupFactory(name="Controle")
+    user = UsuarioFactory(
         username="controle1",
         email="controle@example.com",
         password="test123",
@@ -164,8 +167,8 @@ def test_controle_serializer_uses_string_related_field():
     )
     user.groups.add(controle_group)
 
-    municipio = Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
-    projeto = Projeto.objects.create(nome="ACerta", ativo=True)
+    municipio = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+    projeto = ProjetoFactory(nome="ACerta", ativo=True)
     AcaoControle.objects.create(
         municipio=municipio,
         projeto=projeto,
@@ -192,8 +195,8 @@ def test_controle_serializer_uses_string_related_field():
 
 def test_dat_user_can_list():
     """Usuário do grupo DAT pode listar ações."""
-    dat_group, _ = Group.objects.get_or_create(name="DAT")
-    user = User.objects.create_user(
+    dat_group = GroupFactory(name="DAT")
+    user = UsuarioFactory(
         username="dat1",
         email="dat@example.com",
         password="test123",
@@ -201,8 +204,8 @@ def test_dat_user_can_list():
     )
     user.groups.add(dat_group)
 
-    municipio = Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
-    projeto = Projeto.objects.create(nome="ACerta", ativo=True)
+    municipio = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+    projeto = ProjetoFactory(nome="ACerta", ativo=True)
     AcaoDAT.objects.create(
         municipio=municipio,
         projeto=projeto,
@@ -222,15 +225,15 @@ def test_dat_user_can_list():
 
 def test_regular_user_cannot_list_dat_acoes():
     """Usuário sem permissão recebe 403."""
-    user = User.objects.create_user(
+    user = UsuarioFactory(
         username="regular",
         email="regular@example.com",
         password="test123",
         cpf="33333333333",
     )
 
-    municipio = Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
-    projeto = Projeto.objects.create(nome="ACerta", ativo=True)
+    municipio = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+    projeto = ProjetoFactory(nome="ACerta", ativo=True)
     AcaoDAT.objects.create(
         municipio=municipio,
         projeto=projeto,
@@ -246,8 +249,8 @@ def test_regular_user_cannot_list_dat_acoes():
 
 def test_filter_by_projeto():
     """Filtro por projeto funciona."""
-    dat_group, _ = Group.objects.get_or_create(name="DAT")
-    user = User.objects.create_user(
+    dat_group = GroupFactory(name="DAT")
+    user = UsuarioFactory(
         username="dat1",
         email="dat@example.com",
         password="test123",
@@ -255,9 +258,9 @@ def test_filter_by_projeto():
     )
     user.groups.add(dat_group)
 
-    municipio = Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
-    projeto1 = Projeto.objects.create(nome="ACerta", ativo=True)
-    projeto2 = Projeto.objects.create(nome="Outro Projeto", ativo=True)
+    municipio = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+    projeto1 = ProjetoFactory(nome="ACerta", ativo=True)
+    projeto2 = ProjetoFactory(nome="Outro Projeto", ativo=True)
 
     AcaoDAT.objects.create(
         municipio=municipio,
@@ -282,8 +285,8 @@ def test_filter_by_projeto():
 
 def test_filter_by_tipo_acao():
     """Filtro parcial por tipo_acao (icontains) funciona."""
-    dat_group, _ = Group.objects.get_or_create(name="DAT")
-    user = User.objects.create_user(
+    dat_group = GroupFactory(name="DAT")
+    user = UsuarioFactory(
         username="dat1",
         email="dat@example.com",
         password="test123",
@@ -291,8 +294,8 @@ def test_filter_by_tipo_acao():
     )
     user.groups.add(dat_group)
 
-    municipio = Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
-    projeto = Projeto.objects.create(nome="ACerta", ativo=True)
+    municipio = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+    projeto = ProjetoFactory(nome="ACerta", ativo=True)
 
     AcaoDAT.objects.create(
         municipio=municipio,
@@ -322,8 +325,8 @@ def test_filter_by_tipo_acao():
 
 def test_dat_user_can_create():
     """Usuário do grupo DAT pode criar ações."""
-    dat_group, _ = Group.objects.get_or_create(name="DAT")
-    user = User.objects.create_user(
+    dat_group = GroupFactory(name="DAT")
+    user = UsuarioFactory(
         username="dat1",
         email="dat@example.com",
         password="test123",
@@ -331,9 +334,9 @@ def test_dat_user_can_create():
     )
     user.groups.add(dat_group)
 
-    municipio = Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
-    projeto = Projeto.objects.create(nome="ACerta", ativo=True)
-    coord = User.objects.create_user(
+    municipio = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+    projeto = ProjetoFactory(nome="ACerta", ativo=True)
+    coord = UsuarioFactory(
         username="coord1",
         email="coord@example.com",
         password="test123",
@@ -363,15 +366,15 @@ def test_dat_user_can_create():
 
 def test_regular_user_cannot_create():
     """Usuário sem permissão recebe 403."""
-    user = User.objects.create_user(
+    user = UsuarioFactory(
         username="regular",
         email="regular@example.com",
         password="test123",
         cpf="33333333333",
     )
 
-    municipio = Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
-    projeto = Projeto.objects.create(nome="ACerta", ativo=True)
+    municipio = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+    projeto = ProjetoFactory(nome="ACerta", ativo=True)
 
     payload = {
         "municipio": municipio.id,
@@ -388,8 +391,8 @@ def test_regular_user_cannot_create():
 
 def test_create_returns_read_serializer():
     """POST retorna serializer de leitura (StringRelatedField)."""
-    dat_group, _ = Group.objects.get_or_create(name="DAT")
-    user = User.objects.create_user(
+    dat_group = GroupFactory(name="DAT")
+    user = UsuarioFactory(
         username="dat1",
         email="dat@example.com",
         password="test123",
@@ -397,8 +400,8 @@ def test_create_returns_read_serializer():
     )
     user.groups.add(dat_group)
 
-    municipio = Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
-    projeto = Projeto.objects.create(nome="ACerta", ativo=True)
+    municipio = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+    projeto = ProjetoFactory(nome="ACerta", ativo=True)
 
     payload = {
         "municipio": municipio.id,
@@ -419,8 +422,8 @@ def test_create_returns_read_serializer():
 
 def test_create_without_optional_fields():
     """Criação funciona sem campos opcionais (responsavel, observacao, data_registro)."""
-    dat_group, _ = Group.objects.get_or_create(name="DAT")
-    user = User.objects.create_user(
+    dat_group = GroupFactory(name="DAT")
+    user = UsuarioFactory(
         username="dat1",
         email="dat@example.com",
         password="test123",
@@ -428,8 +431,8 @@ def test_create_without_optional_fields():
     )
     user.groups.add(dat_group)
 
-    municipio = Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
-    projeto = Projeto.objects.create(nome="ACerta", ativo=True)
+    municipio = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+    projeto = ProjetoFactory(nome="ACerta", ativo=True)
 
     payload = {
         "municipio": municipio.id,
@@ -448,8 +451,8 @@ def test_create_without_optional_fields():
 
 def test_tipo_acao_invalido_rejeitado_pelo_serializer():
     """POST com tipo_acao fora dos choices retorna erro claro de validação."""
-    dat_group, _ = Group.objects.get_or_create(name="DAT")
-    user = User.objects.create_user(
+    dat_group = GroupFactory(name="DAT")
+    user = UsuarioFactory(
         username="dat1",
         email="dat@example.com",
         password="test123",
@@ -457,8 +460,8 @@ def test_tipo_acao_invalido_rejeitado_pelo_serializer():
     )
     user.groups.add(dat_group)
 
-    municipio = Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
-    projeto = Projeto.objects.create(nome="ACerta", ativo=True)
+    municipio = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+    projeto = ProjetoFactory(nome="ACerta", ativo=True)
 
     payload = {
         "municipio": municipio.id,
@@ -483,8 +486,8 @@ def test_tipo_acao_invalido_rejeitado_pelo_serializer():
 
 def test_create_missing_required_fields():
     """POST sem campos obrigatórios retorna 400."""
-    dat_group, _ = Group.objects.get_or_create(name="DAT")
-    user = User.objects.create_user(
+    dat_group = GroupFactory(name="DAT")
+    user = UsuarioFactory(
         username="dat1",
         email="dat@example.com",
         password="test123",
@@ -492,7 +495,7 @@ def test_create_missing_required_fields():
     )
     user.groups.add(dat_group)
 
-    municipio = Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
+    municipio = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
 
     payload = {
         "municipio": municipio.id,

--- a/v2/backend/apps/core/tests/test_csrf_httponly.py
+++ b/v2/backend/apps/core/tests/test_csrf_httponly.py
@@ -20,7 +20,7 @@ from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import Usuario
+from apps.core.tests.factories import UsuarioFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -57,7 +57,7 @@ def clear_throttle_cache():
 @pytest.fixture
 def usuario_teste():
     """Usuário válido para testes de autenticação."""
-    return Usuario.objects.create_user(
+    return UsuarioFactory(
         username="csrf_test_user",
         email="csrf@test.com",
         password="testpass123",

--- a/v2/backend/apps/core/tests/test_d9_availability_check.py
+++ b/v2/backend/apps/core/tests/test_d9_availability_check.py
@@ -4,15 +4,14 @@
 
 from __future__ import annotations
 
-from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Group
 from django.core.cache import cache
 from django.core.management import call_command
 from rest_framework.test import APIClient
 
 import pytest
 
-User = get_user_model()
+from apps.core.tests.factories import GroupFactory, UsuarioFactory
+
 pytestmark = pytest.mark.django_db
 
 
@@ -35,9 +34,9 @@ def _next_cpf():
 def _make_user_with_caps(username, group_names, cap_codenames):
     from apps.core.models import PermissaoFuncional
 
-    user = User.objects.create_user(username=username, email=f"{username}@t.com", password="x", cpf=_next_cpf())
+    user = UsuarioFactory(username=username, email=f"{username}@t.com", password="x", cpf=_next_cpf())
     for gn in group_names:
-        g, _ = Group.objects.get_or_create(name=gn)
+        g = GroupFactory(name=gn)
         user.groups.add(g)
         for code in cap_codenames:
             p = PermissaoFuncional.objects.filter(codename=code).first()
@@ -47,7 +46,7 @@ def _make_user_with_caps(username, group_names, cap_codenames):
 
 
 def _make_target():
-    return User.objects.create_user(
+    return UsuarioFactory(
         username=f"target_{_cpf_counter[0]}", email=f"t{_cpf_counter[0]}@t.com", password="x", cpf=_next_cpf()
     )
 

--- a/v2/backend/apps/core/tests/test_dat_imports_dat_only.py
+++ b/v2/backend/apps/core/tests/test_dat_imports_dat_only.py
@@ -31,12 +31,12 @@ from __future__ import annotations
 import io
 import itertools
 
-from django.contrib.auth.models import Group
 from rest_framework.test import APIClient
 
 import pytest
 
 from apps.core.models import Usuario
+from apps.core.tests.factories import GroupFactory, UsuarioFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -64,14 +64,14 @@ def _file(content: bytes = b"x", name: str = "f.csv") -> io.BytesIO:
 
 def _user_in_groups(*group_names: str, username: str = "u") -> Usuario:
     cpf = str(next(_CPF_COUNTER)).zfill(11)
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username=f"{username}_{cpf}",
         email=f"{username}_{cpf}@x.com",
         password="x",
         cpf=cpf,
     )
     for name in group_names:
-        group, _ = Group.objects.get_or_create(name=name)
+        group = GroupFactory(name=name)
         user.groups.add(group)
     return user
 
@@ -153,7 +153,8 @@ def test_anonymous_request_is_rejected(endpoint: str):
 def test_superuser_bypasses_dat_only_gate(endpoint: str):
     """Superuser tem bypass via HasPerm; passa em todos os endpoints PR-A1."""
     cpf = str(next(_CPF_COUNTER)).zfill(11)
-    user = Usuario.objects.create_superuser(
+    user = UsuarioFactory(
+        superuser=True,
         username=f"su_pr_a1_{cpf}",
         email=f"su_{cpf}@x.com",
         password="x",

--- a/v2/backend/apps/core/tests/test_dat_module.py
+++ b/v2/backend/apps/core/tests/test_dat_module.py
@@ -19,8 +19,6 @@ from __future__ import annotations
 from datetime import date, time, timedelta
 from decimal import Decimal
 
-from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Group
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 from django.urls import reverse
@@ -36,16 +34,16 @@ from apps.core.models import (
     DATCompra,
     DATCoordenador,
     DATFormacao,
-    Municipio,
-    Produto,
-    Projeto,
     ProjetoGeral,
-    Solicitacao,
-    TipoEvento,
 )
-
-User = get_user_model()
-
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 # ============================================================
 # Model Tests
@@ -79,9 +77,7 @@ class DATCoordenadorModelTests(TestCase):
         import uuid
 
         uid = uuid.uuid4().hex[:6]
-        cls.user = User.objects.create_user(
-            username=f"testuser_{uid}", password="test123", cpf=f"111{uid}11"  # 11 chars
-        )
+        cls.user = UsuarioFactory(username=f"testuser_{uid}", password="test123", cpf=f"111{uid}11")  # 11 chars
 
     def test_create_coordenador(self):
         """DATCoordenador should be created with correct fields."""
@@ -115,11 +111,9 @@ class DATAcaoModelTests(TestCase):
         import uuid
 
         uid = uuid.uuid4().hex[:5]
-        cls.user = User.objects.create_user(
-            username=f"testuser_acao_{uid}", password="test123", cpf=f"222{uid}222"  # 11 chars
-        )
-        cls.municipio = Municipio.objects.create(nome=f"Fortaleza_{uid}", uf="CE")
-        cls.projeto = Projeto.objects.create(nome=f"Projeto Teste_{uid}", codigo=f"PT{uid[:4]}", fluxo="NAO_SUPER")
+        cls.user = UsuarioFactory(username=f"testuser_acao_{uid}", password="test123", cpf=f"222{uid}222")  # 11 chars
+        cls.municipio = MunicipioFactory(nome=f"Fortaleza_{uid}", uf="CE")
+        cls.projeto = ProjetoFactory(nome=f"Projeto Teste_{uid}", codigo=f"PT{uid[:4]}", fluxo="NAO_SUPER")
         cls.coordenador = DATCoordenador.objects.create(nome="Coordenador Teste", area="DAT", created_by=cls.user)
 
     def test_create_acao(self):
@@ -190,13 +184,9 @@ class DATCompraModelTests(TestCase):
         import uuid
 
         uid = uuid.uuid4().hex[:5]
-        cls.user = User.objects.create_user(
-            username=f"testuser_compra_{uid}", password="test123", cpf=f"333{uid}333"  # 11 chars
-        )
-        cls.municipio = Municipio.objects.create(nome=f"Fortaleza_compra_{uid}", uf="CE")
-        cls.projeto = Projeto.objects.create(
-            nome=f"Projeto Teste_compra_{uid}", codigo=f"PC{uid[:4]}", fluxo="NAO_SUPER"
-        )
+        cls.user = UsuarioFactory(username=f"testuser_compra_{uid}", password="test123", cpf=f"333{uid}333")  # 11 chars
+        cls.municipio = MunicipioFactory(nome=f"Fortaleza_compra_{uid}", uf="CE")
+        cls.projeto = ProjetoFactory(nome=f"Projeto Teste_compra_{uid}", codigo=f"PC{uid[:4]}", fluxo="NAO_SUPER")
 
     def test_create_compra(self):
         """DATCompra should be created with correct fields."""
@@ -268,10 +258,10 @@ class DATCadastroModelTests(TestCase):
         import uuid
 
         uid = uuid.uuid4().hex[:5]
-        cls.user = User.objects.create_user(
+        cls.user = UsuarioFactory(
             username=f"testuser_cadastro_{uid}", password="test123", cpf=f"444{uid}444"  # 11 chars
         )
-        cls.municipio = Municipio.objects.create(nome=f"Fortaleza_cadastro_{uid}", uf="CE")
+        cls.municipio = MunicipioFactory(nome=f"Fortaleza_cadastro_{uid}", uf="CE")
         cls.projeto_geral = ProjetoGeral.objects.create(nome=f"PG Teste_cadastro_{uid}", usa_avaliar=True)
 
     def test_create_cadastro_formar(self):
@@ -343,13 +333,11 @@ class DATFormacaoModelTests(TestCase):
         import uuid
 
         uid = uuid.uuid4().hex[:5]
-        cls.user = User.objects.create_user(
+        cls.user = UsuarioFactory(
             username=f"testuser_formacao_{uid}", password="test123", cpf=f"555{uid}555"  # 11 chars
         )
-        cls.municipio = Municipio.objects.create(nome=f"Fortaleza_formacao_{uid}", uf="CE")
-        cls.projeto = Projeto.objects.create(
-            nome=f"Projeto Teste_formacao_{uid}", codigo=f"PF{uid[:4]}", fluxo="NAO_SUPER"
-        )
+        cls.municipio = MunicipioFactory(nome=f"Fortaleza_formacao_{uid}", uf="CE")
+        cls.projeto = ProjetoFactory(nome=f"Projeto Teste_formacao_{uid}", codigo=f"PF{uid[:4]}", fluxo="NAO_SUPER")
 
     def test_create_formacao(self):
         """DATFormacao should be created with correct fields."""
@@ -429,40 +417,38 @@ class DATModuleAPITestCase(APITestCase):
         import uuid
 
         # Create groups
-        cls.dat_group, _ = Group.objects.get_or_create(name="DAT")
-        cls.diretoria_group, _ = Group.objects.get_or_create(name="Diretoria")
-        cls.super_group, _ = Group.objects.get_or_create(name="Superintendência")
-        cls.gerente_group, _ = Group.objects.get_or_create(name="Gerente")
+        cls.dat_group = GroupFactory(name="DAT")
+        cls.diretoria_group = GroupFactory(name="Diretoria")
+        cls.super_group = GroupFactory(name="Superintendência")
+        cls.gerente_group = GroupFactory(name="Gerente")
 
         # Create users with unique CPFs (exactly 11 chars)
         uid = uuid.uuid4().hex[:5]
-        cls.dat_user = User.objects.create_user(
-            username=f"dat_user_{uid}", password="test123", cpf=f"666{uid}666"  # 11 chars
-        )
+        cls.dat_user = UsuarioFactory(username=f"dat_user_{uid}", password="test123", cpf=f"666{uid}666")  # 11 chars
         cls.dat_user.groups.add(cls.dat_group)
 
         uid2 = uuid.uuid4().hex[:5]
-        cls.super_user = User.objects.create_user(
+        cls.super_user = UsuarioFactory(
             username=f"super_user_{uid2}", password="test123", cpf=f"777{uid2}777"  # 11 chars
         )
         cls.super_user.groups.add(cls.super_group, cls.gerente_group)
 
         uid3 = uuid.uuid4().hex[:5]
-        cls.regular_user = User.objects.create_user(
+        cls.regular_user = UsuarioFactory(
             username=f"regular_user_{uid3}", password="test123", cpf=f"888{uid3}888"  # 11 chars
         )
 
         uid4 = uuid.uuid4().hex[:5]
-        cls.diretoria_user = User.objects.create_user(
+        cls.diretoria_user = UsuarioFactory(
             username=f"diretoria_user_{uid4}", password="test123", cpf=f"889{uid4}889"  # 11 chars
         )
         cls.diretoria_user.groups.add(cls.diretoria_group)
 
         # Create base data with unique names
         uid = uuid.uuid4().hex[:8]
-        cls.municipio = Municipio.objects.create(nome=f"Fortaleza_api_{uid}", uf="CE")
-        cls.municipio2 = Municipio.objects.create(nome=f"Caucaia_api_{uid}", uf="CE")
-        cls.projeto = Projeto.objects.create(nome=f"Projeto Teste_api_{uid}", codigo=f"PA{uid[:4]}", fluxo="NAO_SUPER")
+        cls.municipio = MunicipioFactory(nome=f"Fortaleza_api_{uid}", uf="CE")
+        cls.municipio2 = MunicipioFactory(nome=f"Caucaia_api_{uid}", uf="CE")
+        cls.projeto = ProjetoFactory(nome=f"Projeto Teste_api_{uid}", codigo=f"PA{uid[:4]}", fluxo="NAO_SUPER")
         cls.projeto_geral = ProjetoGeral.objects.create(nome=f"PG Teste_api_{uid}", usa_avaliar=True)
         cls.area, _ = DATArea.objects.get_or_create(nome="DAT", defaults={"cor": "blue", "ordem": 1})
         cls.coordenador = DATCoordenador.objects.create(
@@ -609,7 +595,7 @@ class DATAcaoAPITests(DATModuleAPITestCase):
 
         uid = uuid.uuid4().hex[:6]
         for prio in range(1, 7):
-            mun = Municipio.objects.create(nome=f"StatsCity_{uid}_{prio}", uf="CE")
+            mun = MunicipioFactory(nome=f"StatsCity_{uid}_{prio}", uf="CE")
             DATAcao.objects.create(
                 municipio=mun,
                 projeto=self.projeto,
@@ -705,7 +691,7 @@ class DATCompraAPITests(DATModuleAPITestCase):
         # 6 compras, same status_uso, varied municipio + ano_uso → would
         # fragment without the fix (GROUP BY status, ano_uso, municipio_nome).
         for i in range(6):
-            mun = Municipio.objects.create(nome=f"ComprasCity_{uid}_{i}", uf="CE")
+            mun = MunicipioFactory(nome=f"ComprasCity_{uid}_{i}", uf="CE")
             DATCompra.objects.create(
                 municipio=mun,
                 projeto=self.projeto,
@@ -755,7 +741,7 @@ class DATCompraAPITests(DATModuleAPITestCase):
         """Pendencias should list only core_compra pairs without pending/approved solicitacao."""
         self.client.force_authenticate(user=self.dat_user)
 
-        tipo_evento = TipoEvento.objects.create(nome="Seminário DAT")
+        tipo_evento = TipoEventoFactory(nome="Seminário DAT")
 
         Compra.objects.create(
             codigo="CORE-A",
@@ -778,7 +764,7 @@ class DATCompraAPITests(DATModuleAPITestCase):
 
         inicio = timezone.now() + timedelta(days=2)
         fim = inicio + timedelta(hours=2)
-        Solicitacao.objects.create(
+        SolicitacaoFactory(
             usuario=self.dat_user,
             municipio=self.municipio,
             projeto=self.projeto,
@@ -864,7 +850,7 @@ class DATCadastroAPITests(DATModuleAPITestCase):
         # por_plataforma == {"FORMAR": 6} (not 6 distinct buckets).
         # DATCadastro has unique_together(municipio, projeto_geral, plataforma).
         for i in range(6):
-            mun = Municipio.objects.create(nome=f"CadastroCity_{uid}_{i}", uf="CE")
+            mun = MunicipioFactory(nome=f"CadastroCity_{uid}_{i}", uf="CE")
             DATCadastro.objects.create(
                 municipio=mun,
                 projeto_geral=self.projeto_geral,

--- a/v2/backend/apps/core/tests/test_dat_registros.py
+++ b/v2/backend/apps/core/tests/test_dat_registros.py
@@ -11,17 +11,19 @@ from __future__ import annotations
 import json
 from decimal import Decimal
 
-from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Group
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from apps.core.models import DATRegistro, Municipio, Projeto, ProjetoGeral
-
-User = get_user_model()
+from apps.core.models import DATRegistro, ProjetoGeral
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    UsuarioFactory,
+)
 
 
 class ProjetoGeralModelTests(TestCase):
@@ -66,7 +68,7 @@ class DATRegistroModelTests(TestCase):
     @classmethod
     def setUpTestData(cls):
         """Set up test data."""
-        cls.municipio = Municipio.objects.create(nome="Test City", uf="CE")
+        cls.municipio = MunicipioFactory(nome="Test City", uf="CE")
         cls.projeto_geral_professor = ProjetoGeral.objects.create(
             nome="PG Professor",
             usa_avaliar=True,
@@ -79,13 +81,13 @@ class DATRegistroModelTests(TestCase):
             tipo_calculo_codigos="por_aluno",
             divisor_aluno=20,
         )
-        cls.projeto = Projeto.objects.create(
+        cls.projeto = ProjetoFactory(
             nome="Test Projeto",
             codigo="TEST",
             fluxo="NAO_SUPER",
             projeto_geral=cls.projeto_geral_professor,
         )
-        cls.user = User.objects.create_user(username="testuser", password="test123")
+        cls.user = UsuarioFactory(username="testuser", password="test123")
 
     def test_nr_codigos_calculated_por_professor(self):
         """nr_codigos should be calculated using professor * multiplicador."""
@@ -102,7 +104,7 @@ class DATRegistroModelTests(TestCase):
 
     def test_nr_codigos_calculated_por_aluno(self):
         """nr_codigos should be calculated using alunos / divisor."""
-        projeto_aluno = Projeto.objects.create(
+        projeto_aluno = ProjetoFactory(
             nome="Test Projeto Aluno",
             codigo="TESTALUNO",
             fluxo="NAO_SUPER",
@@ -132,7 +134,7 @@ class DATRegistroModelTests(TestCase):
 
     def test_avaliar_fields_set_to_nao_aplicavel_when_not_used(self):
         """Avaliar status fields should be 'nao_aplicavel' when usa_avaliar=False."""
-        projeto_aluno = Projeto.objects.create(
+        projeto_aluno = ProjetoFactory(
             nome="Test Projeto Aluno 2",
             codigo="TESTALUNO2",
             fluxo="NAO_SUPER",
@@ -255,14 +257,14 @@ class DATRegistroAPITests(APITestCase):
 
         suffix = str(uuid.uuid4())[:8]
 
-        cls.municipio = Municipio.objects.create(nome=f"API Test City {suffix}", uf="BA")
+        cls.municipio = MunicipioFactory(nome=f"API Test City {suffix}", uf="BA")
         cls.projeto_geral = ProjetoGeral.objects.create(
             nome=f"API PG {suffix}",
             usa_avaliar=True,
             tipo_calculo_codigos="por_professor",
             multiplicador_professor=Decimal("1.1"),
         )
-        cls.projeto = Projeto.objects.create(
+        cls.projeto = ProjetoFactory(
             nome=f"API Test Projeto {suffix}",
             codigo=f"APITEST{suffix}",
             fluxo="NAO_SUPER",
@@ -270,22 +272,22 @@ class DATRegistroAPITests(APITestCase):
         )
 
         # Create groups
-        cls.dat_group, _ = Group.objects.get_or_create(name="DAT")
-        cls.super_group, _ = Group.objects.get_or_create(name="Superintendência")
+        cls.dat_group = GroupFactory(name="DAT")
+        cls.super_group = GroupFactory(name="Superintendência")
 
         # Create users with unique CPFs (11 chars max)
-        cls.regular_user = User.objects.create_user(
+        cls.regular_user = UsuarioFactory(
             username=f"regular_{suffix}",
             password="test123",
             cpf=f"111{suffix[:8]}",  # 11 chars: 111 + 8 chars
         )
-        cls.dat_user = User.objects.create_user(
+        cls.dat_user = UsuarioFactory(
             username=f"datuser_{suffix}",
             password="test123",
             cpf=f"222{suffix[:8]}",
         )
         cls.dat_user.groups.add(cls.dat_group)
-        cls.super_user = User.objects.create_user(
+        cls.super_user = UsuarioFactory(
             username=f"superuser_{suffix}",
             password="test123",
             cpf=f"333{suffix[:8]}",
@@ -426,13 +428,13 @@ class ProjetoGeralAPITests(APITestCase):
 
         suffix = str(uuid.uuid4())[:8]
 
-        cls.dat_group, _ = Group.objects.get_or_create(name="DAT")
-        cls.regular_user = User.objects.create_user(
+        cls.dat_group = GroupFactory(name="DAT")
+        cls.regular_user = UsuarioFactory(
             username=f"regular2_{suffix}",
             password="test123",
             cpf=f"444{suffix[:8]}",  # 11 chars
         )
-        cls.dat_user = User.objects.create_user(
+        cls.dat_user = UsuarioFactory(
             username=f"datuser2_{suffix}",
             password="test123",
             cpf=f"555{suffix[:8]}",
@@ -504,7 +506,7 @@ class ProjetoGeralAPITests(APITestCase):
         suffix = str(uuid.uuid4())[:8]
 
         pg = ProjetoGeral.objects.create(nome=f"PG with Projects {suffix}", usa_avaliar=True)
-        Projeto.objects.create(
+        ProjetoFactory(
             nome=f"Linked Project {suffix}",
             codigo=f"LINKED{suffix}",
             fluxo="NAO_SUPER",
@@ -528,11 +530,11 @@ class DATRegistroFilterRegiaoTests(APITestCase):
         import uuid
 
         suffix = str(uuid.uuid4())[:8]
-        cls.dat_group, _ = Group.objects.get_or_create(name="DAT")
-        cls.user = User.objects.create_user(username=f"regiao_test_{suffix}", password="t123", cpf=f"444{suffix[:8]}")
+        cls.dat_group = GroupFactory(name="DAT")
+        cls.user = UsuarioFactory(username=f"regiao_test_{suffix}", password="t123", cpf=f"444{suffix[:8]}")
         cls.user.groups.add(cls.dat_group)
         cls.pg = ProjetoGeral.objects.create(nome=f"PG Regiao Test {suffix}", usa_avaliar=False)
-        cls.projeto = Projeto.objects.create(
+        cls.projeto = ProjetoFactory(
             nome=f"Projeto Regiao Test {suffix}",
             codigo=f"REG{suffix}",
             fluxo="NAO_SUPER",
@@ -540,11 +542,11 @@ class DATRegistroFilterRegiaoTests(APITestCase):
         )
 
         # One município per Brazilian region (UF picked from REGIAO_UFS).
-        cls.mun_nordeste = Municipio.objects.create(nome=f"MunNE_{suffix}", uf="CE")
-        cls.mun_sudeste = Municipio.objects.create(nome=f"MunSE_{suffix}", uf="SP")
-        cls.mun_sul = Municipio.objects.create(nome=f"MunS_{suffix}", uf="RS")
-        cls.mun_centro = Municipio.objects.create(nome=f"MunCO_{suffix}", uf="DF")
-        cls.mun_norte = Municipio.objects.create(nome=f"MunN_{suffix}", uf="PA")
+        cls.mun_nordeste = MunicipioFactory(nome=f"MunNE_{suffix}", uf="CE")
+        cls.mun_sudeste = MunicipioFactory(nome=f"MunSE_{suffix}", uf="SP")
+        cls.mun_sul = MunicipioFactory(nome=f"MunS_{suffix}", uf="RS")
+        cls.mun_centro = MunicipioFactory(nome=f"MunCO_{suffix}", uf="DF")
+        cls.mun_norte = MunicipioFactory(nome=f"MunN_{suffix}", uf="PA")
 
         for mun in (cls.mun_nordeste, cls.mun_sudeste, cls.mun_sul, cls.mun_centro, cls.mun_norte):
             DATRegistro.objects.create(

--- a/v2/backend/apps/core/tests/test_dat_tipo_acao_choices.py
+++ b/v2/backend/apps/core/tests/test_dat_tipo_acao_choices.py
@@ -35,6 +35,7 @@ def test_todos_tipos_validos_aceitos():
         assert serializer.is_valid(), serializer.errors
 
 
+@pytest.mark.migrations
 def test_data_migration_normaliza_existentes():
     """Data migration deve normalizar variantes históricas para o valor canônico."""
     municipio = Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)

--- a/v2/backend/apps/core/tests/test_data_integrity_929.py
+++ b/v2/backend/apps/core/tests/test_data_integrity_929.py
@@ -25,21 +25,23 @@ import pytest
 from apps.core.models import (
     AvailabilityBlock,
     Gerencia,
-    Municipio,
     Participation,
-    Projeto,
-    Solicitacao,
-    TipoEvento,
-    Usuario,
 )
 from apps.core.models.organizacao import EquipeGerencia
+from apps.core.tests.factories import (
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 # ── Fixtures ──────────────────────────────────────────────────────────
 
 
 @pytest.fixture
 def usuario(db):
-    return Usuario.objects.create_user(
+    return UsuarioFactory(
         username="integrity_user",
         email="integrity@test.com",
         password="testpass123",
@@ -49,7 +51,7 @@ def usuario(db):
 
 @pytest.fixture
 def usuario2(db):
-    return Usuario.objects.create_user(
+    return UsuarioFactory(
         username="integrity_user2",
         email="integrity2@test.com",
         password="testpass123",
@@ -59,17 +61,17 @@ def usuario2(db):
 
 @pytest.fixture
 def tipo_evento(db):
-    return TipoEvento.objects.create(nome="Teste Integridade")
+    return TipoEventoFactory(nome="Teste Integridade")
 
 
 @pytest.fixture
 def municipio(db):
-    return Municipio.objects.create(nome="Teste Mun", uf="CE")
+    return MunicipioFactory(nome="Teste Mun", uf="CE")
 
 
 @pytest.fixture
 def projeto(db):
-    return Projeto.objects.create(nome="Teste Projeto", fluxo="NAO_SUPER")
+    return ProjetoFactory(nome="Teste Projeto", fluxo="NAO_SUPER")
 
 
 @pytest.fixture
@@ -80,7 +82,7 @@ def gerencia(db):
 @pytest.fixture
 def solicitacao(usuario, tipo_evento, municipio, projeto):
     now = timezone.now()
-    return Solicitacao.objects.create(
+    return SolicitacaoFactory(
         usuario=usuario,
         tipo_evento=tipo_evento,
         municipio=municipio,
@@ -168,7 +170,8 @@ class TestQueryCountRegression:
 
     @pytest.fixture
     def superuser(self, db):
-        return Usuario.objects.create_superuser(
+        return UsuarioFactory(
+            superuser=True,
             username="superquery",
             email="superquery@test.com",
             password="testpass123",
@@ -187,7 +190,7 @@ class TestQueryCountRegression:
         now = timezone.now()
         solis = []
         for i in range(10):
-            sol = Solicitacao.objects.create(
+            sol = SolicitacaoFactory(
                 usuario=superuser,
                 tipo_evento=tipo_evento,
                 municipio=municipio,

--- a/v2/backend/apps/core/tests/test_deslocamento_api.py
+++ b/v2/backend/apps/core/tests/test_deslocamento_api.py
@@ -19,23 +19,23 @@ from __future__ import annotations
 
 from datetime import date, timedelta
 
-from django.contrib.auth.models import Group
 from rest_framework import status
 from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import AuditLog, Deslocamento, Usuario
+from apps.core.models import AuditLog, Deslocamento
 from apps.core.tests.conftest import get_field_errors
+from apps.core.tests.factories import GroupFactory, UsuarioFactory
 
 
 @pytest.fixture
 def grupos(db):
     """Create necessary groups."""
-    controle, _ = Group.objects.get_or_create(name="Controle")
-    dat, _ = Group.objects.get_or_create(name="DAT")
-    coordenador, _ = Group.objects.get_or_create(name="Coordenador")
-    formador, _ = Group.objects.get_or_create(name="Formador")
+    controle = GroupFactory(name="Controle")
+    dat = GroupFactory(name="DAT")
+    coordenador = GroupFactory(name="Coordenador")
+    formador = GroupFactory(name="Formador")
     return {
         "controle": controle,
         "dat": dat,
@@ -47,7 +47,7 @@ def grupos(db):
 @pytest.fixture
 def user_controle(db, grupos):
     """User with Controle permission."""
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username="controle1", email="controle1@example.com", password="testpass123", cpf="12345678901"
     )
     user.groups.add(grupos["controle"])
@@ -57,9 +57,7 @@ def user_controle(db, grupos):
 @pytest.fixture
 def user_dat(db, grupos):
     """User with DAT permission."""
-    user = Usuario.objects.create_user(
-        username="dat1", email="dat1@example.com", password="testpass123", cpf="98765432109"
-    )
+    user = UsuarioFactory(username="dat1", email="dat1@example.com", password="testpass123", cpf="98765432109")
     user.groups.add(grupos["dat"])
     return user
 
@@ -67,7 +65,7 @@ def user_dat(db, grupos):
 @pytest.fixture
 def user_formador(db, grupos):
     """User with Formador permission (no access to Deslocamentos)."""
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username="formador1",
         email="formador1@example.com",
         password="testpass123",

--- a/v2/backend/apps/core/tests/test_deslocamento_rbac.py
+++ b/v2/backend/apps/core/tests/test_deslocamento_rbac.py
@@ -21,13 +21,13 @@ from __future__ import annotations
 
 from datetime import date
 
-from django.contrib.auth.models import Group
 from django.core.cache import cache
 from rest_framework.test import APIClient
 
 import pytest
 
 from apps.core.models import Deslocamento, EquipeGerencia, Gerencia, Usuario
+from apps.core.tests.factories import GroupFactory, UsuarioFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -41,11 +41,9 @@ def _next_cpf() -> str:
 
 
 def _make_user(username: str, group_names: list[str]) -> Usuario:
-    user = Usuario.objects.create_user(
-        username=username, email=f"{username}@example.com", password="testpass123", cpf=_next_cpf()
-    )
+    user = UsuarioFactory(username=username, email=f"{username}@example.com", password="testpass123", cpf=_next_cpf())
     for gname in group_names:
-        group, _ = Group.objects.get_or_create(name=gname)
+        group = GroupFactory(name=gname)
         user.groups.add(group)
     return user
 
@@ -225,8 +223,12 @@ class TestSanity:
     def test_superuser_sees_all(self, gerencia_vidas):
         user = _user_in_gerencia("u", ["Formador"], gerencia_vidas)
         _create_deslocamento(user)
-        super_user = Usuario.objects.create_superuser(
-            username="super_d", email="super_d@example.com", password="testpass123", cpf="99900099996"
+        super_user = UsuarioFactory(
+            superuser=True,
+            username="super_d",
+            email="super_d@example.com",
+            password="testpass123",
+            cpf="99900099996",
         )
         client = APIClient()
         client.force_authenticate(user=super_user)

--- a/v2/backend/apps/core/tests/test_error_handling.py
+++ b/v2/backend/apps/core/tests/test_error_handling.py
@@ -10,13 +10,12 @@ from __future__ import annotations
 
 from unittest import mock
 
-from django.contrib.auth.models import Group
 from django.test import TestCase, override_settings
 from rest_framework import status
 from rest_framework.test import APITestCase
 
 from apps.core.exceptions import APIError, ConflictError, NotFoundError, ServiceUnavailableError, ValidationAPIError
-from apps.core.models import Usuario
+from apps.core.tests.factories import GroupFactory, UsuarioFactory
 
 
 class TestCustomExceptionClasses(TestCase):
@@ -89,7 +88,7 @@ class TestExceptionHandlerFormat(APITestCase):
 
     def setUp(self):
         """Create authenticated user."""
-        self.usuario = Usuario.objects.create_user(
+        self.usuario = UsuarioFactory(
             username="testuser",
             password="testpass123",
             email="test@example.com",
@@ -123,13 +122,13 @@ class TestGCalHealthErrorHandling(APITestCase):
 
     def setUp(self):
         """Create authenticated user with GCal access role."""
-        self.usuario = Usuario.objects.create_user(
+        self.usuario = UsuarioFactory(
             username="testuser",
             password="testpass123",
             email="test@example.com",
             cpf="12345678901",
         )
-        group, _ = Group.objects.get_or_create(name="Controle")
+        group = GroupFactory(name="Controle")
         self.usuario.groups.add(group)
         self.client.force_authenticate(user=self.usuario)
 

--- a/v2/backend/apps/core/tests/test_etl_acoes_controle.py
+++ b/v2/backend/apps/core/tests/test_etl_acoes_controle.py
@@ -20,14 +20,13 @@ from datetime import date
 from pathlib import Path
 
 from django.conf import settings
-from django.contrib.auth import get_user_model
 
 import pytest
 
-from apps.core.models import AcaoControle, Municipio, Projeto
+from apps.core.models import AcaoControle
 from apps.core.services.controle_acoes_import import import_acoes_controle
+from apps.core.tests.factories import MunicipioFactory, ProjetoFactory, UsuarioFactory
 
-User = get_user_model()
 pytestmark = pytest.mark.django_db
 
 
@@ -45,7 +44,7 @@ def _create_csv_file(rows, fieldnames):
 def test_import_creates_acao_controle():
     """Importação cria AcaoControle com todas as datas parseadas."""
     # Criar dependências diretamente
-    coord = User.objects.create_user(
+    coord = UsuarioFactory(
         username="coord1",
         email="coord@example.com",
         password="test123",
@@ -53,8 +52,8 @@ def test_import_creates_acao_controle():
         first_name="Maria",
         last_name="Silva",
     )
-    municipio = Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
-    projeto = Projeto.objects.create(nome="ACerta", ativo=True)
+    municipio = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+    projeto = ProjetoFactory(nome="ACerta", ativo=True)
 
     # Criar CSV temporário
     csv_file = _create_csv_file(
@@ -102,8 +101,8 @@ def test_import_creates_acao_controle():
 
 def test_idempotency_no_duplicates():
     """Rodar ETL 2x não duplica registros (external_hash)."""
-    municipio = Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
-    projeto = Projeto.objects.create(nome="ACerta", ativo=True)
+    municipio = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+    projeto = ProjetoFactory(nome="ACerta", ativo=True)
 
     csv_file = _create_csv_file(
         rows=[
@@ -131,8 +130,8 @@ def test_idempotency_no_duplicates():
 
 def test_dry_run_does_not_commit():
     """Dry-run não persiste dados no banco."""
-    municipio = Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
-    projeto = Projeto.objects.create(nome="ACerta", ativo=True)
+    municipio = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+    projeto = ProjetoFactory(nome="ACerta", ativo=True)
 
     csv_file = _create_csv_file(
         rows=[
@@ -156,7 +155,7 @@ def test_dry_run_does_not_commit():
 
 def test_skip_missing_municipio():
     """Registros com município inexistente são pulados."""
-    Projeto.objects.create(nome="ACerta", ativo=True)
+    ProjetoFactory(nome="ACerta", ativo=True)
 
     csv_file = _create_csv_file(
         rows=[
@@ -181,8 +180,8 @@ def test_skip_missing_municipio():
 
 def test_report_saved_to_out_etl():
     """Relatório é salvo em out_etl/import_acoes_controle_report.json."""
-    municipio = Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
-    projeto = Projeto.objects.create(nome="ACerta", ativo=True)
+    municipio = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+    projeto = ProjetoFactory(nome="ACerta", ativo=True)
 
     csv_file = _create_csv_file(
         rows=[
@@ -212,8 +211,8 @@ def test_report_saved_to_out_etl():
 
 def test_coordenador_optional():
     """Coordenador é opcional - registro criado mesmo se não encontrado."""
-    municipio = Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
-    projeto = Projeto.objects.create(nome="ACerta", ativo=True)
+    municipio = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+    projeto = ProjetoFactory(nome="ACerta", ativo=True)
 
     csv_file = _create_csv_file(
         rows=[
@@ -245,8 +244,8 @@ def test_municipio_with_accent_resolves():
 
     Fix: usar `resolve_municipio` que tem fallback NFKD.
     """
-    Municipio.objects.create(nome="Iguatú", uf="CE", ativo=True)
-    Projeto.objects.create(nome="ACerta", ativo=True)
+    MunicipioFactory(nome="Iguatú", uf="CE", ativo=True)
+    ProjetoFactory(nome="ACerta", ativo=True)
 
     csv_file = _create_csv_file(
         rows=[
@@ -276,8 +275,8 @@ def test_municipio_cidade_uf_format_resolves():
     única (vs a coluna separada Município/UF do COMPRAS). O resolver deve
     splitar e casar com Municipio(nome='Curvelo', uf='MG').
     """
-    Municipio.objects.create(nome="Curvelo", uf="MG", ativo=True)
-    Projeto.objects.create(nome="ACerta", ativo=True)
+    MunicipioFactory(nome="Curvelo", uf="MG", ativo=True)
+    ProjetoFactory(nome="ACerta", ativo=True)
 
     csv_file = _create_csv_file(
         rows=[
@@ -298,8 +297,8 @@ def test_municipio_cidade_uf_format_resolves():
 
 def test_update_existing_record():
     """Atualiza registro existente se dados mudarem."""
-    municipio = Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
-    projeto = Projeto.objects.create(nome="ACerta", ativo=True)
+    municipio = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+    projeto = ProjetoFactory(nome="ACerta", ativo=True)
 
     # Criar inicial
     csv_file = _create_csv_file(

--- a/v2/backend/apps/core/tests/test_etl_dat_cadastros.py
+++ b/v2/backend/apps/core/tests/test_etl_dat_cadastros.py
@@ -21,14 +21,13 @@ from datetime import date
 from pathlib import Path
 
 from django.conf import settings
-from django.contrib.auth import get_user_model
 
 import pytest
 
-from apps.core.models import AcaoDAT, Municipio, Projeto, TipoAcaoDAT
+from apps.core.models import AcaoDAT, TipoAcaoDAT
 from apps.core.services.dat_cadastros_import import import_dat_cadastros
+from apps.core.tests.factories import MunicipioFactory, ProjetoFactory, UsuarioFactory
 
-User = get_user_model()
 pytestmark = pytest.mark.django_db
 
 
@@ -45,7 +44,7 @@ def _create_csv_file(rows, fieldnames):
 
 def test_import_creates_acao_dat():
     """Importação cria AcaoDAT com todos os campos."""
-    responsavel = User.objects.create_user(
+    responsavel = UsuarioFactory(
         username="resp1",
         email="resp@example.com",
         password="test123",
@@ -53,8 +52,8 @@ def test_import_creates_acao_dat():
         first_name="João",
         last_name="Responsável",
     )
-    municipio = Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
-    projeto = Projeto.objects.create(nome="ACerta", ativo=True)
+    municipio = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+    projeto = ProjetoFactory(nome="ACerta", ativo=True)
 
     csv_file = _create_csv_file(
         rows=[
@@ -88,8 +87,8 @@ def test_import_creates_acao_dat():
 
 def test_etl_normaliza_variacao_de_grafia():
     """Variação de grafia é normalizada para valor canônico."""
-    Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
-    Projeto.objects.create(nome="ACerta", ativo=True)
+    MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+    ProjetoFactory(nome="ACerta", ativo=True)
 
     csv_file = _create_csv_file(
         rows=[
@@ -112,8 +111,8 @@ def test_etl_normaliza_variacao_de_grafia():
 
 def test_idempotency_no_duplicates():
     """Rodar ETL 2x não duplica registros (external_hash)."""
-    municipio = Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
-    projeto = Projeto.objects.create(nome="ACerta", ativo=True)
+    municipio = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+    projeto = ProjetoFactory(nome="ACerta", ativo=True)
 
     csv_file = _create_csv_file(
         rows=[
@@ -142,8 +141,8 @@ def test_idempotency_no_duplicates():
 
 def test_dry_run_does_not_commit():
     """Dry-run não persiste dados no banco."""
-    municipio = Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
-    projeto = Projeto.objects.create(nome="ACerta", ativo=True)
+    municipio = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+    projeto = ProjetoFactory(nome="ACerta", ativo=True)
 
     csv_file = _create_csv_file(
         rows=[
@@ -168,8 +167,8 @@ def test_dry_run_does_not_commit():
 
 def test_skip_missing_tipo_acao():
     """Registros sem tipo de ação são pulados (campo obrigatório)."""
-    municipio = Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
-    projeto = Projeto.objects.create(nome="ACerta", ativo=True)
+    municipio = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+    projeto = ProjetoFactory(nome="ACerta", ativo=True)
 
     csv_file = _create_csv_file(
         rows=[
@@ -193,8 +192,8 @@ def test_skip_missing_tipo_acao():
 
 def test_report_saved_to_out_etl():
     """Relatório é salvo em out_etl/import_dat_cadastros_report.json."""
-    municipio = Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
-    projeto = Projeto.objects.create(nome="ACerta", ativo=True)
+    municipio = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+    projeto = ProjetoFactory(nome="ACerta", ativo=True)
 
     csv_file = _create_csv_file(
         rows=[
@@ -224,8 +223,8 @@ def test_report_saved_to_out_etl():
 
 def test_responsavel_optional():
     """Responsável é opcional - registro criado mesmo se não encontrado."""
-    municipio = Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
-    projeto = Projeto.objects.create(nome="ACerta", ativo=True)
+    municipio = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+    projeto = ProjetoFactory(nome="ACerta", ativo=True)
 
     csv_file = _create_csv_file(
         rows=[
@@ -250,8 +249,8 @@ def test_responsavel_optional():
 
 def test_update_existing_record():
     """Atualiza registro existente se dados mudarem."""
-    municipio = Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
-    projeto = Projeto.objects.create(nome="ACerta", ativo=True)
+    municipio = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+    projeto = ProjetoFactory(nome="ACerta", ativo=True)
 
     # Criar inicial
     csv_file = _create_csv_file(
@@ -294,8 +293,8 @@ def test_update_existing_record():
 
 def test_external_hash_includes_tipo_acao():
     """external_hash inclui tipo_acao, diferenciando ações do mesmo projeto/município/data."""
-    municipio = Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
-    projeto = Projeto.objects.create(nome="ACerta", ativo=True)
+    municipio = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+    projeto = ProjetoFactory(nome="ACerta", ativo=True)
 
     # Criar 2 ações diferentes (mesmo município/projeto/data, tipo_acao diferente)
     csv_file = _create_csv_file(
@@ -327,8 +326,8 @@ def test_external_hash_includes_tipo_acao():
 
 def test_date_parsing_formats():
     """Testa parsing de múltiplos formatos de data."""
-    municipio = Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
-    projeto = Projeto.objects.create(nome="ACerta", ativo=True)
+    municipio = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+    projeto = ProjetoFactory(nome="ACerta", ativo=True)
 
     csv_file = _create_csv_file(
         rows=[

--- a/v2/backend/apps/core/tests/test_export_contract_importer.py
+++ b/v2/backend/apps/core/tests/test_export_contract_importer.py
@@ -26,17 +26,20 @@ from apps.core.models import (
     DATArea,
     DATCoordenador,
     Gerencia,
-    Municipio,
     PlanoFormacoes,
     Produto,
     Projeto,
     ProjetoGeral,
-    TipoEvento,
-    Usuario,
 )
 from apps.core.services.export_contract_importer import (
     ExportContractImporter,
     diff_and_classify,
+)
+from apps.core.tests.factories import (
+    MunicipioFactory,
+    ProjetoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
 )
 
 pytestmark = pytest.mark.django_db
@@ -118,7 +121,7 @@ def test_classify_dat_area(tmp_path):
 
 
 def test_classify_municipio(tmp_path):
-    Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
+    MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
     csv = "nome,uf,ativo\nFortaleza,CE,True\nNova Cidade,PE,True\n"
     path = _write_export(tmp_path, {"municipio": csv})
     r = ExportContractImporter(path=path).run()["por_entidade"]["municipio"]
@@ -141,7 +144,7 @@ def test_classify_projeto_geral(tmp_path):
 
 # ───────── uso do resolver de Projeto ─────────
 def test_uses_projeto_resolver():
-    Projeto.objects.create(nome="Vida & Matemática 6", fluxo="NAO_SUPER")
+    ProjetoFactory(nome="Vida & Matemática 6", fluxo="NAO_SUPER")
     imp = ExportContractImporter(path=".")
     pid = imp.resolve_projeto("VIDA E MATEMATICA 6")
     assert pid is not None
@@ -166,7 +169,7 @@ def test_report_has_no_pii(tmp_path):
 
 # ───────── entidades-mestre adicionais (PR feat/export-contract-master-importers) ─────────
 def test_classify_produto(tmp_path):
-    proj = Projeto.objects.create(nome="Proj Prod Teste", fluxo="NAO_SUPER")
+    proj = ProjetoFactory(nome="Proj Prod Teste", fluxo="NAO_SUPER")
     Produto.objects.create(codigo="PT-1", nome="Produto Existente", projeto=proj)
     Produto.objects.create(codigo="PT-2", nome="Produto Upd", projeto=proj)
     # PT-1 nome igual -> skip; PT-2 nome diverge -> update; PT-NOVO -> create; vazio -> reject
@@ -179,7 +182,7 @@ def test_classify_produto(tmp_path):
 
 
 def test_classify_usuario(tmp_path):
-    Usuario.objects.create_user(username="u_imp_exist", password="x", cpf="11122233344", email="u.exist@ex.com")
+    UsuarioFactory(username="u_imp_exist", password="x", cpf="11122233344", email="u.exist@ex.com")
     # existente por cpf -> skip; novo -> create; sem cpf/email -> reject
     csv = "nome_completo,cpf,email\nFulano,11122233344,u.exist@ex.com\nBeltrano,55566677788,novo@ex.com\nSem Id,,\n"
     r = ExportContractImporter(path=_write_export(tmp_path, {"usuario": csv})).run()["por_entidade"]["usuario"]
@@ -198,8 +201,8 @@ def test_usuario_no_pii_in_report(tmp_path):
 
 
 def test_classify_tipo_evento(tmp_path):
-    TipoEvento.objects.create(nome="Formacao TE", cor="#111111")
-    TipoEvento.objects.create(nome="Visita TE", cor="#222222")
+    TipoEventoFactory(nome="Formacao TE", cor="#111111")
+    TipoEventoFactory(nome="Visita TE", cor="#222222")
     # Formacao igual -> skip; Visita cor diverge -> update; Novo -> create
     csv = "nome,cor\nFormacao TE,#111111\nVisita TE,#999999\nEvento Novo TE,#333333\n"
     r = ExportContractImporter(path=_write_export(tmp_path, {"tipo_evento": csv})).run()["por_entidade"]["tipo_evento"]
@@ -219,7 +222,7 @@ def test_classify_gerencia_matches_by_setor(tmp_path):
 
 
 def test_classify_dat_coordenador(tmp_path):
-    creator = Usuario.objects.create_user(username="u_dc_creator", password="x", cpf="99900011122")
+    creator = UsuarioFactory(username="u_dc_creator", password="x", cpf="99900011122")
     area = DATArea.objects.create(nome="Area Coord Teste")
     DATCoordenador.objects.create(nome="Coord Existente", email="coord.exist@ex.com", area=area, created_by=creator)
     # existente por email -> skip; novo -> create; vazio -> reject
@@ -241,10 +244,10 @@ def test_dat_coordenador_no_pii(tmp_path):
 # ───────── entidades operacionais — espinhaço municipio+projeto (Slice 1, classify dry-run) ─────────
 def test_classify_dat_acao_skip_create_reject(tmp_path):
     # NK = (municipio_id, projeto_id). Existência decide skip vs create; FK não-resolvido → reject.
-    creator = Usuario.objects.create_user(username="u_da_creator", password="x", cpf="33344455566")
-    mun_a = Municipio.objects.create(nome="Cidade Acao Um", uf="CE", ativo=True)
-    Municipio.objects.create(nome="Cidade Acao Dois", uf="CE", ativo=True)
-    proj = Projeto.objects.create(nome="Proj Acao Teste", fluxo="NAO_SUPER")
+    creator = UsuarioFactory(username="u_da_creator", password="x", cpf="33344455566")
+    mun_a = MunicipioFactory(nome="Cidade Acao Um", uf="CE", ativo=True)
+    MunicipioFactory(nome="Cidade Acao Dois", uf="CE", ativo=True)
+    proj = ProjetoFactory(nome="Proj Acao Teste", fluxo="NAO_SUPER")
     DATAcao.objects.create(municipio=mun_a, projeto=proj, created_by=creator)
     # linha 1: (Um, Proj) existe → skip; linha 2: (Dois, Proj) resolve mas sem DATAcao → create;
     # linha 3: municipio inexistente → reject (FK não-resolvido).
@@ -262,10 +265,10 @@ def test_classify_dat_acao_skip_create_reject(tmp_path):
 
 
 def test_classify_plano_formacao_skip_create_reject(tmp_path):
-    creator = Usuario.objects.create_user(username="u_pf_creator", password="x", cpf="77788899900")
-    mun_a = Municipio.objects.create(nome="Cidade Plano Um", uf="CE", ativo=True)
-    Municipio.objects.create(nome="Cidade Plano Dois", uf="CE", ativo=True)
-    proj = Projeto.objects.create(nome="Proj Plano Teste", fluxo="NAO_SUPER")
+    creator = UsuarioFactory(username="u_pf_creator", password="x", cpf="77788899900")
+    mun_a = MunicipioFactory(nome="Cidade Plano Um", uf="CE", ativo=True)
+    MunicipioFactory(nome="Cidade Plano Dois", uf="CE", ativo=True)
+    proj = ProjetoFactory(nome="Proj Plano Teste", fluxo="NAO_SUPER")
     PlanoFormacoes.objects.create(municipio=mun_a, projeto=proj, created_by=creator)
     csv = (
         "municipio,uf,projeto,coordenador\n"
@@ -284,8 +287,8 @@ def test_classify_plano_formacao_skip_create_reject(tmp_path):
 
 def test_dat_acao_no_coordenador_pii(tmp_path):
     # coordenador é pessoa (DATCoordenador) → nunca deve vazar no relatório.
-    Municipio.objects.create(nome="Cidade PII", uf="CE", ativo=True)
-    Projeto.objects.create(nome="Proj PII Teste", fluxo="NAO_SUPER")
+    MunicipioFactory(nome="Cidade PII", uf="CE", ativo=True)
+    ProjetoFactory(nome="Proj PII Teste", fluxo="NAO_SUPER")
     csv = "municipio,uf,projeto,coordenador\nCidade PII,CE,Proj PII Teste,CoordSecretoXYZ\n"
     report = ExportContractImporter(path=_write_export(tmp_path, {"dat_acao": csv})).run()
     assert "CoordSecretoXYZ" not in json.dumps(report)

--- a/v2/backend/apps/core/tests/test_export_contract_projeto_resolver.py
+++ b/v2/backend/apps/core/tests/test_export_contract_projeto_resolver.py
@@ -14,8 +14,8 @@ from __future__ import annotations
 
 import pytest
 
-from apps.core.models import Projeto
 from apps.core.services.export_contract_projeto_resolver import resolve_projeto_export
+from apps.core.tests.factories import ProjetoFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -37,7 +37,7 @@ def catalogo():
         "ACerta Português",
         "Avançando Juntos Português",
     ]
-    return {n: Projeto.objects.create(nome=n, fluxo="NAO_SUPER") for n in nomes}
+    return {n: ProjetoFactory(nome=n, fluxo="NAO_SUPER") for n in nomes}
 
 
 def _assert_matches(raw, expected_nome):
@@ -104,8 +104,8 @@ def test_avancando_juntos_portugues_nao_vira_lingua_portuguesa(catalogo):
 def test_ambiguidade_falha_explicita(db):
     # Dois projetos que colapsam para a mesma chave canônica (& <-> E).
     # Raw com hífen NÃO casa nenhum norm exato → cai na chave canônica, que casa os 2 → ambíguo.
-    Projeto.objects.create(nome="Vida & Matemática 6", fluxo="NAO_SUPER")
-    Projeto.objects.create(nome="Vida E Matemática 6", fluxo="NAO_SUPER")
+    ProjetoFactory(nome="Vida & Matemática 6", fluxo="NAO_SUPER")
+    ProjetoFactory(nome="Vida E Matemática 6", fluxo="NAO_SUPER")
     res = resolve_projeto_export("VIDA - E - MATEMATICA 6")
     assert res.status == "ambiguous", f"esperado ambiguous, veio {res.status}"
     assert res.projeto is None

--- a/v2/backend/apps/core/tests/test_factories_smoke.py
+++ b/v2/backend/apps/core/tests/test_factories_smoke.py
@@ -1,0 +1,72 @@
+"""
+Smoke test das factories (#1404).
+
+Garante que cada factory instancia um objeto válido e persistido, e que os
+traits/params principais funcionam. Roda sob `pytest --no-migrations`.
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportAttributeAccessIssue=false, reportOptionalMemberAccess=false
+
+from __future__ import annotations
+
+import pytest
+
+from apps.core.models import Solicitacao
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+def test_usuario_factory_unique_cpf():
+    u1 = UsuarioFactory()
+    u2 = UsuarioFactory()
+    assert u1.pk and u2.pk
+    assert u1.cpf != u2.cpf
+    assert len(u1.cpf) == 11 and u1.cpf.isdigit()
+
+
+def test_usuario_factory_superuser_trait_and_groups():
+    admin = UsuarioFactory(superuser=True)
+    assert admin.is_superuser and admin.is_staff
+
+    user = UsuarioFactory(groups=["Coordenador", "DAT"])
+    assert set(user.groups.values_list("name", flat=True)) == {"Coordenador", "DAT"}
+
+
+def test_municipio_factory_unique():
+    m1 = MunicipioFactory()
+    m2 = MunicipioFactory()
+    assert m1.nome != m2.nome
+    assert m1.uf == "CE"
+
+
+def test_projeto_factory_fluxo_default_and_super_trait():
+    assert ProjetoFactory().fluxo == "NAO_SUPER"
+    assert ProjetoFactory(super=True).fluxo == "SUPER"
+
+
+def test_tipo_evento_factory_get_or_create():
+    t1 = TipoEventoFactory()
+    t2 = TipoEventoFactory()
+    # django_get_or_create no nome → mesma instância reutilizada
+    assert t1.pk == t2.pk
+    assert TipoEventoFactory(nome="Reunião").pk != t1.pk
+
+
+def test_group_factory_get_or_create():
+    assert GroupFactory(name="Controle").pk == GroupFactory(name="Controle").pk
+
+
+def test_solicitacao_factory_is_pendente_with_fks():
+    s = SolicitacaoFactory()
+    assert s.pk
+    assert s.status == Solicitacao.Status.PENDENTE
+    assert s.usuario_id and s.tipo_evento_id and s.municipio_id and s.projeto_id
+    assert s.fim > s.inicio

--- a/v2/backend/apps/core/tests/test_factories_smoke.py
+++ b/v2/backend/apps/core/tests/test_factories_smoke.py
@@ -40,6 +40,15 @@ def test_usuario_factory_superuser_trait_and_groups():
     assert set(user.groups.values_list("name", flat=True)) == {"Coordenador", "DAT"}
 
 
+def test_usuario_factory_password_is_hashed_and_authenticates():
+    # default
+    assert UsuarioFactory().check_password("testpass123")
+    # override (drop-in para create_user(password=...) em testes de login)
+    u = UsuarioFactory(password="s3cr3t")
+    assert u.check_password("s3cr3t")
+    assert u.password != "s3cr3t"  # hasheada, não raw
+
+
 def test_municipio_factory_unique():
     m1 = MunicipioFactory()
     m2 = MunicipioFactory()

--- a/v2/backend/apps/core/tests/test_features_endpoint.py
+++ b/v2/backend/apps/core/tests/test_features_endpoint.py
@@ -20,7 +20,7 @@ from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import Usuario
+from apps.core.tests.factories import UsuarioFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -41,7 +41,7 @@ def test_features_requires_authentication():
 
 def test_features_authenticated_user_allowed():
     """Usuário autenticado tem acesso a /api/features/."""
-    user = Usuario.objects.create_user(username="user1", email="user@x.com", password="x", cpf="11111111111")
+    user = UsuarioFactory(username="user1", email="user@x.com", password="x", cpf="11111111111")
 
     client = APIClient()
     client.force_authenticate(user=user)
@@ -59,7 +59,7 @@ def test_features_authenticated_user_allowed():
 
 def test_features_response_structure():
     """Resposta de /api/features/ tem estrutura esperada."""
-    user = Usuario.objects.create_user(username="user1", email="user@x.com", password="x", cpf="11111111111")
+    user = UsuarioFactory(username="user1", email="user@x.com", password="x", cpf="11111111111")
 
     client = APIClient()
     client.force_authenticate(user=user)
@@ -86,7 +86,7 @@ def test_features_default_values():
     Issue #130: Forçar GCAL_CLIENT='fake' para garantir que GCAL_MODE derivado
     seja 'fake' independente da configuração do ambiente Docker.
     """
-    user = Usuario.objects.create_user(username="user1", email="user@x.com", password="x", cpf="11111111111")
+    user = UsuarioFactory(username="user1", email="user@x.com", password="x", cpf="11111111111")
 
     client = APIClient()
     client.force_authenticate(user=user)
@@ -112,7 +112,7 @@ def test_features_default_values():
 
 def test_features_returns_fallback_when_no_config():
     """Se não houver Config, retorna fallback de settings."""
-    user = Usuario.objects.create_user(username="user1", email="user@x.com", password="x", cpf="11111111111")
+    user = UsuarioFactory(username="user1", email="user@x.com", password="x", cpf="11111111111")
 
     client = APIClient()
     client.force_authenticate(user=user)
@@ -141,7 +141,7 @@ def test_features_config_overrides_fallback():
         },
     )
 
-    user = Usuario.objects.create_user(username="user1", email="user@x.com", password="x", cpf="11111111111")
+    user = UsuarioFactory(username="user1", email="user@x.com", password="x", cpf="11111111111")
 
     client = APIClient()
     client.force_authenticate(user=user)
@@ -167,7 +167,7 @@ def test_features_config_overrides_fallback():
 
 def test_features_boolean_flags_are_booleans():
     """Flags booleanas retornam bool (não string)."""
-    user = Usuario.objects.create_user(username="user1", email="user@x.com", password="x", cpf="11111111111")
+    user = UsuarioFactory(username="user1", email="user@x.com", password="x", cpf="11111111111")
 
     client = APIClient()
     client.force_authenticate(user=user)
@@ -186,7 +186,7 @@ def test_features_boolean_flags_are_booleans():
 
 def test_features_gcal_mode_is_string():
     """GCAL_MODE retorna string."""
-    user = Usuario.objects.create_user(username="user1", email="user@x.com", password="x", cpf="11111111111")
+    user = UsuarioFactory(username="user1", email="user@x.com", password="x", cpf="11111111111")
 
     client = APIClient()
     client.force_authenticate(user=user)
@@ -208,7 +208,7 @@ def test_features_gcal_mode_is_string():
 
 def test_features_superuser_has_access():
     """Superuser tem acesso a /api/features/."""
-    user = Usuario.objects.create_superuser(username="admin", email="admin@x.com", password="x", cpf="99999999999")
+    user = UsuarioFactory(superuser=True)
 
     client = APIClient()
     client.force_authenticate(user=user)

--- a/v2/backend/apps/core/tests/test_fix_superintendencia_migration.py
+++ b/v2/backend/apps/core/tests/test_fix_superintendencia_migration.py
@@ -36,6 +36,7 @@ fix_superintendencia_fluxo = migration_module.fix_superintendencia_fluxo
 reverse_superintendencia_fluxo = migration_module.reverse_superintendencia_fluxo
 
 
+@pytest.mark.migrations
 @pytest.mark.django_db
 class TestFixSuperintendenciaFluxoMigration:
     """Tests for fix_superintendencia_fluxo data migration."""

--- a/v2/backend/apps/core/tests/test_fluxo_por_projeto.py
+++ b/v2/backend/apps/core/tests/test_fluxo_por_projeto.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 from datetime import date, timedelta
 
-from django.contrib.auth.models import Group
 from django.test import TestCase
 from django.utils import timezone
 from rest_framework import status
@@ -19,7 +18,15 @@ from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import Compra, Municipio, Projeto, Solicitacao, TipoEvento, Usuario
+from apps.core.models import Compra, Projeto, Solicitacao
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 
 class TestFluxoPorProjeto(TestCase):
@@ -32,13 +39,13 @@ class TestFluxoPorProjeto(TestCase):
         self.client = APIClient()
 
         # Criar grupos
-        self.grupo_coordenador, _ = Group.objects.get_or_create(name="Coordenador")
-        self.grupo_superintendencia, _ = Group.objects.get_or_create(name="Superintendência")
-        self.grupo_controle, _ = Group.objects.get_or_create(name="Controle")
-        self.grupo_dat, _ = Group.objects.get_or_create(name="DAT")
+        self.grupo_coordenador = GroupFactory(name="Coordenador")
+        self.grupo_superintendencia = GroupFactory(name="Superintendência")
+        self.grupo_controle = GroupFactory(name="Controle")
+        self.grupo_dat = GroupFactory(name="DAT")
 
         # Criar usuários
-        self.coordenador = Usuario.objects.create_user(
+        self.coordenador = UsuarioFactory(
             username="coordenador1",
             password="test123",
             email="coord@test.com",
@@ -46,7 +53,7 @@ class TestFluxoPorProjeto(TestCase):
         )
         self.coordenador.groups.add(self.grupo_coordenador)
 
-        self.superintendente = Usuario.objects.create_user(
+        self.superintendente = UsuarioFactory(
             username="super1",
             password="test123",
             email="super@test.com",
@@ -55,26 +62,26 @@ class TestFluxoPorProjeto(TestCase):
         self.superintendente.groups.add(self.grupo_superintendencia)
 
         # Criar dados de teste
-        self.municipio = Municipio.objects.create(
+        self.municipio = MunicipioFactory(
             nome="Fortaleza",
             uf="CE",
             ativo=True,
         )
 
-        self.tipo_evento = TipoEvento.objects.create(
+        self.tipo_evento = TipoEventoFactory(
             nome="Formação",
             descricao="Formação de professores",
         )
 
         # Criar projetos com diferentes fluxos
-        self.projeto_super = Projeto.objects.create(
+        self.projeto_super = ProjetoFactory(
             nome="ACerta",
             codigo="",  # Explicitly set empty string (default)
             fluxo="SUPER",
             ativo=True,
         )
 
-        self.projeto_outros = Projeto.objects.create(
+        self.projeto_outros = ProjetoFactory(
             nome="Workshop",
             codigo="",  # Explicitly set empty string (default)
             fluxo="NAO_SUPER",
@@ -212,7 +219,7 @@ class TestFluxoPorProjeto(TestCase):
         Testa que projetos sem fluxo definido usam o padrão (pendente).
         """
         # Criar projeto sem fluxo definido (simula migration antiga)
-        projeto_sem_fluxo = Projeto.objects.create(
+        projeto_sem_fluxo = ProjetoFactory(
             nome="Projeto Antigo",
             codigo="",  # Explicitly set empty string (default)
             ativo=True,
@@ -256,7 +263,7 @@ class TestFluxoPorProjeto(TestCase):
         Testa que o endpoint de pré-agenda filtra por fluxo do projeto.
         """
         # Criar solicitações aprovadas
-        sol_super = Solicitacao.objects.create(
+        sol_super = SolicitacaoFactory(
             usuario=self.coordenador,
             municipio=self.municipio,
             projeto=self.projeto_super,
@@ -267,7 +274,7 @@ class TestFluxoPorProjeto(TestCase):
             status="aprovado",
         )
 
-        sol_outros = Solicitacao.objects.create(
+        sol_outros = SolicitacaoFactory(
             usuario=self.coordenador,
             municipio=self.municipio,
             projeto=self.projeto_outros,
@@ -279,7 +286,7 @@ class TestFluxoPorProjeto(TestCase):
         )
 
         # Autenticar como Controle (pode ver pré-agenda)
-        usuario_controle = Usuario.objects.create_user(
+        usuario_controle = UsuarioFactory(
             username="controle1",
             password="test123",
             cpf="11111111111",
@@ -306,7 +313,7 @@ class TestFluxoPorProjeto(TestCase):
         Testa que o PreAgendaListSerializer retorna o fluxo correto.
         """
         # Criar solicitação
-        solicitacao = Solicitacao.objects.create(
+        solicitacao = SolicitacaoFactory(
             usuario=self.coordenador,
             municipio=self.municipio,
             projeto=self.projeto_super,
@@ -318,7 +325,7 @@ class TestFluxoPorProjeto(TestCase):
         )
 
         # Autenticar como Controle
-        usuario_controle = Usuario.objects.create_user(
+        usuario_controle = UsuarioFactory(
             username="controle2",
             password="test123",
             cpf="22222222222",
@@ -357,7 +364,7 @@ class TestFluxoPorProjeto(TestCase):
             pytest.skip(f"CSV não encontrado: {csv_path}")
 
         # Criar projeto para atualizar
-        projeto_teste = Projeto.objects.create(
+        projeto_teste = ProjetoFactory(
             nome="Lendo e Escrevendo",  # Nome no CSV como SUPER
             codigo="",  # Explicitly set empty string (default)
             fluxo="NAO_SUPER",  # Começar com NAO_SUPER

--- a/v2/backend/apps/core/tests/test_gcal_alerts.py
+++ b/v2/backend/apps/core/tests/test_gcal_alerts.py
@@ -16,14 +16,18 @@ import uuid
 from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 
-from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Group
 from django.test import TestCase
 from rest_framework.test import APIClient
 
-from apps.core.models import Municipio, Projeto, Solicitacao, TipoEvento
-
-User = get_user_model()
+from apps.core.models import Solicitacao
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 
 class TestGCalAlerts(TestCase):
@@ -47,12 +51,12 @@ class TestGCalAlerts(TestCase):
         self.tz_local = ZoneInfo("America/Fortaleza")
 
         # Criar grupos
-        self.group_controle = Group.objects.get_or_create(name="Controle")[0]
-        self.group_coordenador = Group.objects.get_or_create(name="Coordenador")[0]
+        self.group_controle = GroupFactory(name="Controle")
+        self.group_coordenador = GroupFactory(name="Coordenador")
 
         # Criar usuários com IDs únicos (xdist-safe)
         uid = uuid.uuid4().hex[:8]
-        self.user_controle = User.objects.create_user(
+        self.user_controle = UsuarioFactory(
             username=f"controle_alerts_{uid}",
             email=f"controle_{uid}@example.com",
             password="password123",
@@ -60,7 +64,7 @@ class TestGCalAlerts(TestCase):
         )
         self.user_controle.groups.add(self.group_controle)
 
-        self.user_coordenador = User.objects.create_user(
+        self.user_coordenador = UsuarioFactory(
             username=f"coordenador_alerts_{uid}",
             email=f"coordenador_{uid}@example.com",
             password="password123",
@@ -69,9 +73,9 @@ class TestGCalAlerts(TestCase):
         self.user_coordenador.groups.add(self.group_coordenador)
 
         # Criar fixtures com nomes únicos (xdist-safe)
-        self.municipio = Municipio.objects.create(nome=f"Fortaleza_{uid}")
-        self.projeto = Projeto.objects.create(nome=f"Projeto Teste_{uid}", fluxo="SUPER")
-        self.tipo_evento = TipoEvento.objects.create(nome=f"Formação_{uid}")
+        self.municipio = MunicipioFactory(nome=f"Fortaleza_{uid}")
+        self.projeto = ProjetoFactory(nome=f"Projeto Teste_{uid}", fluxo="SUPER")
+        self.tipo_evento = TipoEventoFactory(nome=f"Formação_{uid}")
 
     def test_alerts_requires_authentication(self):
         """
@@ -103,7 +107,7 @@ class TestGCalAlerts(TestCase):
         ref_date = datetime(2025, 2, 15, 10, 0, 0, tzinfo=self.tz_local)
 
         # Criar 4 eventos aprovados no mesmo dia
-        sol_error_1 = Solicitacao.objects.create(
+        sol_error_1 = SolicitacaoFactory(
             status="aprovado",
             inicio=ref_date,
             fim=ref_date + timedelta(hours=2),
@@ -115,7 +119,7 @@ class TestGCalAlerts(TestCase):
             gcal_status=Solicitacao.GCalStatus.ERROR,
         )
 
-        sol_error_2 = Solicitacao.objects.create(
+        sol_error_2 = SolicitacaoFactory(
             status="aprovado",
             inicio=ref_date.replace(hour=14),
             fim=ref_date.replace(hour=16),
@@ -127,7 +131,7 @@ class TestGCalAlerts(TestCase):
             gcal_status=Solicitacao.GCalStatus.ERROR,
         )
 
-        sol_pending = Solicitacao.objects.create(
+        sol_pending = SolicitacaoFactory(
             status="aprovado",
             inicio=ref_date.replace(hour=18),
             fim=ref_date.replace(hour=20),
@@ -139,7 +143,7 @@ class TestGCalAlerts(TestCase):
             gcal_status=Solicitacao.GCalStatus.PENDING,
         )
 
-        sol_published = Solicitacao.objects.create(
+        sol_published = SolicitacaoFactory(
             status="aprovado",
             inicio=ref_date.replace(hour=22),
             fim=ref_date.replace(hour=23, minute=30),
@@ -184,7 +188,7 @@ class TestGCalAlerts(TestCase):
         ref_date = datetime(2025, 2, 20, 0, 0, 0, tzinfo=self.tz_local)
 
         # Evento exatamente às 00:00 (início do dia)
-        sol_midnight = Solicitacao.objects.create(
+        sol_midnight = SolicitacaoFactory(
             status="aprovado",
             inicio=ref_date,
             fim=ref_date + timedelta(hours=1),
@@ -197,7 +201,7 @@ class TestGCalAlerts(TestCase):
         )
 
         # Evento exatamente às 23:59:59 (fim do dia)
-        sol_eod = Solicitacao.objects.create(
+        sol_eod = SolicitacaoFactory(
             status="aprovado",
             inicio=ref_date.replace(hour=23, minute=59, second=59),
             fim=ref_date.replace(hour=23, minute=59, second=59) + timedelta(hours=1),
@@ -210,7 +214,7 @@ class TestGCalAlerts(TestCase):
         )
 
         # Evento um dia antes (excluir)
-        sol_before = Solicitacao.objects.create(
+        sol_before = SolicitacaoFactory(
             status="aprovado",
             inicio=ref_date - timedelta(days=1, hours=1),
             fim=ref_date - timedelta(days=1),
@@ -223,7 +227,7 @@ class TestGCalAlerts(TestCase):
         )
 
         # Evento um dia depois (excluir)
-        sol_after = Solicitacao.objects.create(
+        sol_after = SolicitacaoFactory(
             status="aprovado",
             inicio=ref_date + timedelta(days=1, hours=1),
             fim=ref_date + timedelta(days=1, hours=2),
@@ -261,7 +265,7 @@ class TestGCalAlerts(TestCase):
         # Criar 3 eventos em datas diferentes
         now = datetime.now(self.tz_local)
 
-        sol_1 = Solicitacao.objects.create(
+        sol_1 = SolicitacaoFactory(
             status="aprovado",
             inicio=now,
             fim=now + timedelta(hours=2),
@@ -273,7 +277,7 @@ class TestGCalAlerts(TestCase):
             gcal_status=Solicitacao.GCalStatus.ERROR,
         )
 
-        sol_2 = Solicitacao.objects.create(
+        sol_2 = SolicitacaoFactory(
             status="aprovado",
             inicio=now + timedelta(days=5),
             fim=now + timedelta(days=5, hours=2),
@@ -285,7 +289,7 @@ class TestGCalAlerts(TestCase):
             gcal_status=Solicitacao.GCalStatus.PUBLISHED,
         )
 
-        sol_3 = Solicitacao.objects.create(
+        sol_3 = SolicitacaoFactory(
             status="aprovado",
             inicio=now + timedelta(days=10),
             fim=now + timedelta(days=10, hours=2),

--- a/v2/backend/apps/core/tests/test_gcal_batch_operations.py
+++ b/v2/backend/apps/core/tests/test_gcal_batch_operations.py
@@ -27,7 +27,6 @@ from __future__ import annotations
 from datetime import timedelta
 from unittest.mock import patch
 
-from django.contrib.auth.models import Group
 from django.test import override_settings
 from django.utils import timezone
 from rest_framework import status as http_status
@@ -35,8 +34,16 @@ from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import GoogleOAuthCredential, Municipio, Projeto, Solicitacao, TipoEvento, Usuario
+from apps.core.models import GoogleOAuthCredential, Solicitacao
 from apps.core.services.google_oauth import _encrypt_token
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 # ============================================================================
 # FIXTURES
@@ -52,8 +59,8 @@ def api_client():
 @pytest.fixture
 def usuario_controle(db):
     """Cria usuário do grupo Controle"""
-    controle_group, _ = Group.objects.get_or_create(name="Controle")
-    user = Usuario.objects.create_user(
+    controle_group = GroupFactory(name="Controle")
+    user = UsuarioFactory(
         username="controle_batch_test",
         email="controle@aprendereditora.com.br",
         password="testpass123",
@@ -66,8 +73,8 @@ def usuario_controle(db):
 @pytest.fixture
 def usuario_coordenador(db):
     """Cria usuário do grupo Coordenador (sem permissão para batch)"""
-    coord_group, _ = Group.objects.get_or_create(name="Coordenador")
-    user = Usuario.objects.create_user(
+    coord_group = GroupFactory(name="Coordenador")
+    user = UsuarioFactory(
         username="coord_batch_test",
         email="coord@example.com",
         password="testpass123",
@@ -80,15 +87,15 @@ def usuario_coordenador(db):
 @pytest.fixture
 def setup_solicitacoes(usuario_controle):
     """Cria 3 solicitações aprovadas para testes de batch"""
-    municipio = Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
-    projeto = Projeto.objects.create(nome="Projeto Batch Test", codigo="PBT", fluxo="SUPER", ativo=True)
-    tipo_evento = TipoEvento.objects.create(nome="Formação Batch Test")
+    municipio = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+    projeto = ProjetoFactory(nome="Projeto Batch Test", codigo="PBT", fluxo="SUPER", ativo=True)
+    tipo_evento = TipoEventoFactory(nome="Formação Batch Test")
 
     now = timezone.now()
     solicitacoes = []
 
     for i in range(3):
-        sol = Solicitacao.objects.create(
+        sol = SolicitacaoFactory(
             usuario=usuario_controle,
             municipio=municipio,
             projeto=projeto,

--- a/v2/backend/apps/core/tests/test_gcal_cancel_resync.py
+++ b/v2/backend/apps/core/tests/test_gcal_cancel_resync.py
@@ -15,15 +15,22 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from django.contrib.auth.models import Group
 from django.utils import timezone
 from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import AuditLog, Municipio, Projeto, Solicitacao, TipoEvento, Usuario
+from apps.core.models import AuditLog, Solicitacao
 from apps.core.services.gcal_sync_service import SyncOutcome, cancel_solicitacao, resync_solicitacao
 from apps.core.tasks import task_cancel_solicitacao_from_gcal
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 # ============================================================================
 # FIXTURES
@@ -39,21 +46,21 @@ def api_client():
 @pytest.fixture
 def grupo_super(db):
     """Grupo Superintendência."""
-    grupo, _ = Group.objects.get_or_create(name="Superintendência")
+    grupo = GroupFactory(name="Superintendência")
     return grupo
 
 
 @pytest.fixture
 def grupo_controle(db):
     """Grupo Controle."""
-    grupo, _ = Group.objects.get_or_create(name="Controle")
+    grupo = GroupFactory(name="Controle")
     return grupo
 
 
 @pytest.fixture
 def usuario_super(db, grupo_super):
     """Usuário com perfil Superintendência."""
-    usuario = Usuario.objects.create_user(
+    usuario = UsuarioFactory(
         username="superintendente", email="super@example.com", password="testpass123", cpf="11111111111"
     )
     usuario.groups.add(grupo_super)
@@ -63,7 +70,7 @@ def usuario_super(db, grupo_super):
 @pytest.fixture
 def usuario_controle(db, grupo_controle):
     """Usuário com perfil Controle."""
-    usuario = Usuario.objects.create_user(
+    usuario = UsuarioFactory(
         username="controle", email="controle@example.com", password="testpass123", cpf="22222222222"
     )
     usuario.groups.add(grupo_controle)
@@ -73,33 +80,31 @@ def usuario_controle(db, grupo_controle):
 @pytest.fixture
 def usuario_coordenador(db):
     """Usuário coordenador (sem permissões especiais)."""
-    return Usuario.objects.create_user(
-        username="coordenador", email="coord@example.com", password="testpass123", cpf="33333333333"
-    )
+    return UsuarioFactory(username="coordenador", email="coord@example.com", password="testpass123", cpf="33333333333")
 
 
 @pytest.fixture
 def municipio(db):
     """Município de teste."""
-    return Municipio.objects.create(nome="Fortaleza", uf="CE", ibge_code="2304400")
+    return MunicipioFactory(nome="Fortaleza", uf="CE", ibge_code="2304400")
 
 
 @pytest.fixture
 def tipo_evento(db):
     """Tipo de evento de teste."""
-    return TipoEvento.objects.create(nome="Formação", cor="#0000FF")
+    return TipoEventoFactory(nome="Formação", cor="#0000FF")
 
 
 @pytest.fixture
 def projeto(db):
     """Projeto de teste."""
-    return Projeto.objects.create(nome="Projeto Teste", fluxo="SUPER")
+    return ProjetoFactory(nome="Projeto Teste", fluxo="SUPER")
 
 
 @pytest.fixture
 def solicitacao_aprovada(db, usuario_coordenador, municipio, tipo_evento, projeto):
     """Solicitação aprovada (pronta para publicação)."""
-    return Solicitacao.objects.create(
+    return SolicitacaoFactory(
         usuario=usuario_coordenador,
         municipio=municipio,
         tipo_evento=tipo_evento,

--- a/v2/backend/apps/core/tests/test_gcal_circuit_breaker.py
+++ b/v2/backend/apps/core/tests/test_gcal_circuit_breaker.py
@@ -14,8 +14,6 @@ from __future__ import annotations
 
 from unittest import mock
 
-from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Group
 from django.test import override_settings
 from rest_framework import status
 from rest_framework.test import APIClient
@@ -31,8 +29,7 @@ from apps.core.services.gcal.circuit_breaker import (
     reset_circuit,
 )
 from apps.core.services.gcal.utils import _retry_with_circuit_breaker
-
-User = get_user_model()
+from apps.core.tests.factories import GroupFactory, UsuarioFactory
 
 
 @pytest.fixture(autouse=True)
@@ -160,14 +157,14 @@ class TestCircuitBreakerEndpoint:
 
     @pytest.fixture
     def staff_user(self, db):
-        user = User.objects.create_user(username="operator", email="operator@test.com", password="x")
-        group, _ = Group.objects.get_or_create(name="Controle")
+        user = UsuarioFactory(username="operator", email="operator@test.com", password="x")
+        group = GroupFactory(name="Controle")
         user.groups.add(group)
         return user
 
     @pytest.fixture
     def regular_user(self, db):
-        return User.objects.create_user(username="regular", email="regular@test.com", password="x")
+        return UsuarioFactory(username="regular", email="regular@test.com", password="x")
 
     def test_returns_closed_state_on_fresh_breaker(self, client, staff_user):
         client.force_authenticate(user=staff_user)

--- a/v2/backend/apps/core/tests/test_gcal_dashboard.py
+++ b/v2/backend/apps/core/tests/test_gcal_dashboard.py
@@ -18,14 +18,21 @@ from __future__ import annotations
 from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
-from django.contrib.auth.models import Group
 from django.test import override_settings
 from django.utils import timezone
 from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import Municipio, Projeto, Solicitacao, TipoEvento, Usuario
+from apps.core.models import Solicitacao, TipoEvento
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 
 @pytest.fixture
@@ -37,13 +44,13 @@ def api_client():
 @pytest.fixture
 def usuario_controle(db):
     """Usuário do grupo Controle."""
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username="controle_user",
         password="testpass123",
         first_name="Controle",
         last_name="User",
     )
-    group, _ = Group.objects.get_or_create(name="Controle")
+    group = GroupFactory(name="Controle")
     user.groups.add(group)
     return user
 
@@ -51,13 +58,13 @@ def usuario_controle(db):
 @pytest.fixture
 def usuario_coordenador(db):
     """Usuário do grupo Coordenador (sem permissão)."""
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username="coord_user",
         password="testpass123",
         first_name="Coord",
         last_name="User",
     )
-    group, _ = Group.objects.get_or_create(name="Coordenador")
+    group = GroupFactory(name="Coordenador")
     user.groups.add(group)
     return user
 
@@ -65,16 +72,16 @@ def usuario_coordenador(db):
 @pytest.fixture
 def setup_solicitacoes(db, usuario_controle):
     """Cria solicitações aprovadas com diferentes gcal_status para testes."""
-    municipio_fortaleza = Municipio.objects.create(nome="Fortaleza", uf="CE")
-    municipio_caucaia = Municipio.objects.create(nome="Caucaia", uf="CE")
-    tipo_evento = TipoEvento.objects.create(nome="Formação")
-    projeto_super = Projeto.objects.create(nome="Gestão Escolar", fluxo="SUPER")
-    projeto_outros = Projeto.objects.create(nome="Alfabetização", fluxo="NAO_SUPER")
+    municipio_fortaleza = MunicipioFactory(nome="Fortaleza", uf="CE")
+    municipio_caucaia = MunicipioFactory(nome="Caucaia", uf="CE")
+    tipo_evento = TipoEventoFactory(nome="Formação")
+    projeto_super = ProjetoFactory(nome="Gestão Escolar", fluxo="SUPER")
+    projeto_outros = ProjetoFactory(nome="Alfabetização", fluxo="NAO_SUPER")
 
     now = timezone.now()
 
     # Solicitação 1: NONE (Fortaleza, Gestão Escolar, hoje)
-    sol1 = Solicitacao.objects.create(
+    sol1 = SolicitacaoFactory(
         usuario=usuario_controle,
         municipio=municipio_fortaleza,
         tipo_evento=tipo_evento,
@@ -86,7 +93,7 @@ def setup_solicitacoes(db, usuario_controle):
     )
 
     # Solicitação 2: PENDING (Fortaleza, Gestão Escolar, hoje + 1 dia)
-    sol2 = Solicitacao.objects.create(
+    sol2 = SolicitacaoFactory(
         usuario=usuario_controle,
         municipio=municipio_fortaleza,
         tipo_evento=tipo_evento,
@@ -98,7 +105,7 @@ def setup_solicitacoes(db, usuario_controle):
     )
 
     # Solicitação 3: PUBLISHED (Caucaia, Alfabetização, hoje + 2 dias)
-    sol3 = Solicitacao.objects.create(
+    sol3 = SolicitacaoFactory(
         usuario=usuario_controle,
         municipio=municipio_caucaia,
         tipo_evento=tipo_evento,
@@ -111,7 +118,7 @@ def setup_solicitacoes(db, usuario_controle):
     )
 
     # Solicitação 4: ERROR (Fortaleza, Gestão Escolar, hoje + 3 dias)
-    sol4 = Solicitacao.objects.create(
+    sol4 = SolicitacaoFactory(
         usuario=usuario_controle,
         municipio=municipio_fortaleza,
         tipo_evento=tipo_evento,
@@ -335,7 +342,7 @@ class TestGCalBulkReapply:
     def test_reapply_validates_approved_status(self, api_client, usuario_controle, setup_solicitacoes):
         """Apenas solicitações aprovadas podem ser republicadas."""
         # Criar solicitação pendente
-        sol_pendente = Solicitacao.objects.create(
+        sol_pendente = SolicitacaoFactory(
             usuario=usuario_controle,
             municipio=setup_solicitacoes["municipio_fortaleza"],
             tipo_evento=TipoEvento.objects.first(),

--- a/v2/backend/apps/core/tests/test_gcal_dashboard_metrics.py
+++ b/v2/backend/apps/core/tests/test_gcal_dashboard_metrics.py
@@ -14,26 +14,33 @@ from __future__ import annotations
 
 from datetime import date, timedelta
 
-from django.contrib.auth.models import Group
 from django.utils import timezone
 from rest_framework import status as http_status
 from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import Municipio, Projeto, Solicitacao, TipoEvento, Usuario
+from apps.core.models import Solicitacao
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 
 @pytest.fixture
 def usuario_controle():
     """Usuário do grupo Controle"""
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username="controle_sprint5",
         email="controle_sprint5@test.com",
         password="testpass",
         cpf="11111111111",
     )
-    grupo, _ = Group.objects.get_or_create(name="Controle")
+    grupo = GroupFactory(name="Controle")
     user.groups.add(grupo)
     return user
 
@@ -41,19 +48,19 @@ def usuario_controle():
 @pytest.fixture
 def municipio():
     """Município de teste"""
-    return Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
+    return MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
 
 
 @pytest.fixture
 def projeto():
     """Projeto de teste"""
-    return Projeto.objects.create(nome="Projeto Sprint5", codigo="SP5", fluxo="SUPER", ativo=True)
+    return ProjetoFactory(nome="Projeto Sprint5", codigo="SP5", fluxo="SUPER", ativo=True)
 
 
 @pytest.fixture
 def tipo_evento():
     """Tipo de evento de teste"""
-    return TipoEvento.objects.create(nome="Formação Sprint5")
+    return TipoEventoFactory(nome="Formação Sprint5")
 
 
 def create_solicitacao(usuario, municipio, projeto, tipo_evento, gcal_status, data_offset_days, gcal_last_error=""):
@@ -62,7 +69,7 @@ def create_solicitacao(usuario, municipio, projeto, tipo_evento, gcal_status, da
     inicio = now + timedelta(days=data_offset_days)
     fim = inicio + timedelta(hours=3)
 
-    sol = Solicitacao.objects.create(
+    sol = SolicitacaoFactory(
         usuario=usuario,
         municipio=municipio,
         projeto=projeto,
@@ -203,13 +210,13 @@ class TestDashboardMetrics:
         Caso 5: Endpoint exige permissão Controle ou Superintendência
         """
         # Usuário sem grupo Controle/Super
-        user = Usuario.objects.create_user(
+        user = UsuarioFactory(
             username="coordenador_sprint5",
             email="coordenador@test.com",
             password="testpass",
             cpf="22222222222",
         )
-        grupo_coord, _ = Group.objects.get_or_create(name="Coordenador")
+        grupo_coord = GroupFactory(name="Coordenador")
         user.groups.add(grupo_coord)
 
         client = APIClient()
@@ -370,13 +377,13 @@ class TestDashboardEvents:
         Caso 7: Endpoint exige permissão Controle ou Superintendência
         """
         # Usuário sem grupo Controle/Super
-        user = Usuario.objects.create_user(
+        user = UsuarioFactory(
             username="formador_sprint5",
             email="formador@test.com",
             password="testpass",
             cpf="33333333333",
         )
-        grupo_formador, _ = Group.objects.get_or_create(name="Formador")
+        grupo_formador = GroupFactory(name="Formador")
         user.groups.add(grupo_formador)
 
         client = APIClient()

--- a/v2/backend/apps/core/tests/test_gcal_endpoints.py
+++ b/v2/backend/apps/core/tests/test_gcal_endpoints.py
@@ -12,14 +12,13 @@ Testes com override_settings para fake vs google client.
 
 from __future__ import annotations
 
-from django.contrib.auth.models import Group
 from django.test import override_settings
 from rest_framework import status
 from rest_framework.test import APITestCase
 
 import pytest
 
-from apps.core.models import Usuario
+from apps.core.tests.factories import GroupFactory, UsuarioFactory
 
 
 class TestGCalCalendarsEndpoint(APITestCase):
@@ -29,13 +28,13 @@ class TestGCalCalendarsEndpoint(APITestCase):
 
     def setUp(self):
         """Setup: criar usuário com permissão de acesso ao GCal"""
-        self.usuario = Usuario.objects.create_user(
+        self.usuario = UsuarioFactory(
             username="testuser",
             password="testpass123",
             email="test@example.com",
             cpf="12345678901",
         )
-        group, _ = Group.objects.get_or_create(name="Controle")
+        group = GroupFactory(name="Controle")
         self.usuario.groups.add(group)
         self.client.force_authenticate(user=self.usuario)
 
@@ -79,7 +78,7 @@ class TestGCalCalendarsEndpoint(APITestCase):
 
     def test_list_calendars_denies_authenticated_user_without_role(self):
         """Usuário autenticado sem Controle/Superintendência recebe 403."""
-        no_role_user = Usuario.objects.create_user(
+        no_role_user = UsuarioFactory(
             username="norole",
             password="testpass123",
             email="norole@example.com",
@@ -97,13 +96,13 @@ class TestGCalHealthEndpoint(APITestCase):
 
     def setUp(self):
         """Setup: criar usuário com permissão de acesso ao GCal"""
-        self.usuario = Usuario.objects.create_user(
+        self.usuario = UsuarioFactory(
             username="testuser",
             password="testpass123",
             email="test@example.com",
             cpf="12345678901",
         )
-        group, _ = Group.objects.get_or_create(name="Controle")
+        group = GroupFactory(name="Controle")
         self.usuario.groups.add(group)
         self.client.force_authenticate(user=self.usuario)
 
@@ -143,7 +142,7 @@ class TestGCalHealthEndpoint(APITestCase):
 
     def test_health_check_denies_authenticated_user_without_role(self):
         """Usuário autenticado sem Controle/Superintendência recebe 403."""
-        no_role_user = Usuario.objects.create_user(
+        no_role_user = UsuarioFactory(
             username="norole2",
             password="testpass123",
             email="norole2@example.com",
@@ -172,13 +171,13 @@ class TestGCalEndpointsIntegration(APITestCase):
 
     def setUp(self):
         """Setup: criar usuário com permissão de acesso ao GCal"""
-        self.usuario = Usuario.objects.create_user(
+        self.usuario = UsuarioFactory(
             username="testuser",
             password="testpass123",
             email="test@example.com",
             cpf="12345678901",
         )
-        group, _ = Group.objects.get_or_create(name="Controle")
+        group = GroupFactory(name="Controle")
         self.usuario.groups.add(group)
         self.client.force_authenticate(user=self.usuario)
 

--- a/v2/backend/apps/core/tests/test_gcal_event_detail.py
+++ b/v2/backend/apps/core/tests/test_gcal_event_detail.py
@@ -16,26 +16,33 @@ from __future__ import annotations
 
 from datetime import timedelta
 
-from django.contrib.auth.models import Group
 from django.utils import timezone
 from rest_framework import status as http_status
 from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import AuditLog, Municipio, Projeto, Solicitacao, TipoEvento, Usuario
+from apps.core.models import AuditLog, Solicitacao
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 
 @pytest.fixture
 def usuario_controle():
     """Usuário do grupo Controle"""
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username="controle_test_detail",
         email="controle_detail@test.com",
         password="testpass",
         cpf="22222222222",
     )
-    grupo, _ = Group.objects.get_or_create(name="Controle")
+    grupo = GroupFactory(name="Controle")
     user.groups.add(grupo)
     return user
 
@@ -43,13 +50,13 @@ def usuario_controle():
 @pytest.fixture
 def usuario_formador():
     """Usuário sem permissão (grupo Formador)"""
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username="formador_test_detail",
         email="formador_detail@test.com",
         password="testpass",
         cpf="33333333333",
     )
-    grupo, _ = Group.objects.get_or_create(name="Formador")
+    grupo = GroupFactory(name="Formador")
     user.groups.add(grupo)
     return user
 
@@ -57,19 +64,19 @@ def usuario_formador():
 @pytest.fixture
 def municipio():
     """Município de teste"""
-    return Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
+    return MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
 
 
 @pytest.fixture
 def projeto():
     """Projeto de teste"""
-    return Projeto.objects.create(nome="Projeto Detail Test", codigo="PDT", fluxo="SUPER", ativo=True)
+    return ProjetoFactory(nome="Projeto Detail Test", codigo="PDT", fluxo="SUPER", ativo=True)
 
 
 @pytest.fixture
 def tipo_evento():
     """Tipo de evento de teste"""
-    return TipoEvento.objects.create(nome="Formação Detail Test")
+    return TipoEventoFactory(nome="Formação Detail Test")
 
 
 @pytest.fixture
@@ -79,7 +86,7 @@ def solicitacao_aprovada(usuario_controle, municipio, projeto, tipo_evento):
     inicio = now + timedelta(days=5)
     fim = inicio + timedelta(hours=4)
 
-    return Solicitacao.objects.create(
+    return SolicitacaoFactory(
         usuario=usuario_controle,
         municipio=municipio,
         projeto=projeto,

--- a/v2/backend/apps/core/tests/test_gcal_export.py
+++ b/v2/backend/apps/core/tests/test_gcal_export.py
@@ -20,16 +20,20 @@ import io
 import json
 from datetime import date, datetime, timedelta
 
-from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Group
 from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
 from rest_framework.test import APIClient
 
-from apps.core.models import Municipio, Projeto, Solicitacao, TipoEvento, Usuario
-
-User = get_user_model()
+from apps.core.models import Solicitacao
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 
 class TestGCalExport(TestCase):
@@ -44,37 +48,35 @@ class TestGCalExport(TestCase):
         self.now = timezone.make_aware(datetime(2025, 1, 15, 12, 0, 0))
 
         # Criar grupos
-        self.grupo_controle, _ = Group.objects.get_or_create(name="Controle")
-        self.grupo_super, _ = Group.objects.get_or_create(name="Superintendência")
-        self.grupo_coordenador, _ = Group.objects.get_or_create(name="Coordenador")
+        self.grupo_controle = GroupFactory(name="Controle")
+        self.grupo_super = GroupFactory(name="Superintendência")
+        self.grupo_coordenador = GroupFactory(name="Coordenador")
 
         # Criar usuários (Usuario é o User customizado com cpf obrigatório)
-        self.user_controle = User.objects.create_user(
+        self.user_controle = UsuarioFactory(
             username="controle_user",
             password="testpass123",
             cpf="11111111111",  # CPF único para evitar constraint violation
         )
         self.user_controle.groups.add(self.grupo_controle)
 
-        self.user_super = User.objects.create_user(
-            username="super_user", password="testpass123", cpf="22222222222"  # CPF único
-        )
+        self.user_super = UsuarioFactory(username="super_user", password="testpass123", cpf="22222222222")  # CPF único
         self.user_super.groups.add(self.grupo_super)
 
-        self.user_coordenador = User.objects.create_user(
+        self.user_coordenador = UsuarioFactory(
             username="coordenador_user", password="testpass123", cpf="33333333333"  # CPF único
         )
         self.user_coordenador.groups.add(self.grupo_coordenador)
 
         # Criar dados de teste
-        self.municipio = Municipio.objects.create(nome="Fortaleza", uf="CE")
+        self.municipio = MunicipioFactory(nome="Fortaleza", uf="CE")
 
-        self.projeto = Projeto.objects.create(nome="ACERTA", fluxo="SUPER")
+        self.projeto = ProjetoFactory(nome="ACERTA", fluxo="SUPER")
 
-        self.tipo_evento = TipoEvento.objects.create(nome="Fundamental I Online")
+        self.tipo_evento = TipoEventoFactory(nome="Fundamental I Online")
 
         # Criar solicitações aprovadas com gcal_status diferentes
-        self.sol_published = Solicitacao.objects.create(
+        self.sol_published = SolicitacaoFactory(
             status="aprovado",
             inicio=self.now + timedelta(days=1),
             fim=self.now + timedelta(days=1, hours=2),
@@ -88,7 +90,7 @@ class TestGCalExport(TestCase):
             meet_link="https://meet.google.com/abc-def-ghi",
         )
 
-        self.sol_error = Solicitacao.objects.create(
+        self.sol_error = SolicitacaoFactory(
             status="aprovado",
             inicio=self.now + timedelta(days=2),
             fim=self.now + timedelta(days=2, hours=2),
@@ -101,7 +103,7 @@ class TestGCalExport(TestCase):
             gcal_last_error="500 Internal Server Error",
         )
 
-        self.sol_none = Solicitacao.objects.create(
+        self.sol_none = SolicitacaoFactory(
             status="aprovado",
             inicio=self.now + timedelta(days=3),
             fim=self.now + timedelta(days=3, hours=2),
@@ -315,7 +317,7 @@ class TestGCalExport(TestCase):
         ref_date = datetime(2025, 2, 10, 0, 0, 0, tzinfo=tz_local)
 
         # Evento exatamente às 00:00 (início do dia)
-        sol_midnight = Solicitacao.objects.create(
+        sol_midnight = SolicitacaoFactory(
             status="aprovado",
             inicio=ref_date,  # 2025-02-10 00:00 BRT
             fim=ref_date + timedelta(hours=1),
@@ -328,7 +330,7 @@ class TestGCalExport(TestCase):
         )
 
         # Evento exatamente às 23:59:59 (fim do dia)
-        sol_eod = Solicitacao.objects.create(
+        sol_eod = SolicitacaoFactory(
             status="aprovado",
             inicio=ref_date.replace(hour=23, minute=59, second=59),  # 2025-02-10 23:59:59 BRT
             fim=ref_date.replace(hour=23, minute=59, second=59) + timedelta(hours=1),
@@ -341,7 +343,7 @@ class TestGCalExport(TestCase):
         )
 
         # Evento um dia antes (deve ser excluído quando start=2025-02-10)
-        sol_before = Solicitacao.objects.create(
+        sol_before = SolicitacaoFactory(
             status="aprovado",
             inicio=ref_date - timedelta(days=1),  # 2025-02-09
             fim=ref_date - timedelta(days=1) + timedelta(hours=2),
@@ -354,7 +356,7 @@ class TestGCalExport(TestCase):
         )
 
         # Evento um dia depois (deve ser excluído quando end=2025-02-10)
-        sol_after = Solicitacao.objects.create(
+        sol_after = SolicitacaoFactory(
             status="aprovado",
             inicio=ref_date + timedelta(days=1),  # 2025-02-11
             fim=ref_date + timedelta(days=1) + timedelta(hours=2),

--- a/v2/backend/apps/core/tests/test_gcal_hash_drift.py
+++ b/v2/backend/apps/core/tests/test_gcal_hash_drift.py
@@ -17,20 +17,26 @@ from django.utils import timezone
 
 import pytest
 
-from apps.core.models import Municipio, Projeto, Solicitacao, TipoEvento, Usuario
 from apps.core.services.gcal.payload import build_event_payload, compute_payload_hash
+from apps.core.tests.factories import (
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 
 @pytest.fixture
 def online_solicitacao(db):
     """Cria uma solicitação online aprovada para testes de hash."""
-    user = Usuario.objects.create_user(username="hash_test_user", password="test123")
-    municipio = Municipio.objects.create(nome="HashCity", uf="CE")
-    projeto = Projeto.objects.create(nome="HASH TEST", fluxo="NAO_SUPER")
-    tipo = TipoEvento.objects.create(nome="Formação Hash")
+    user = UsuarioFactory(username="hash_test_user", password="test123")
+    municipio = MunicipioFactory(nome="HashCity", uf="CE")
+    projeto = ProjetoFactory(nome="HASH TEST", fluxo="NAO_SUPER")
+    tipo = TipoEventoFactory(nome="Formação Hash")
 
     now = timezone.now()
-    sol = Solicitacao.objects.create(
+    sol = SolicitacaoFactory(
         usuario=user,
         municipio=municipio,
         projeto=projeto,
@@ -46,13 +52,13 @@ def online_solicitacao(db):
 @pytest.fixture
 def presencial_solicitacao(db):
     """Cria uma solicitação presencial aprovada para testes de hash."""
-    user = Usuario.objects.create_user(username="hash_test_pres", password="test123")
-    municipio = Municipio.objects.create(nome="PresCity", uf="SP")
-    projeto = Projeto.objects.create(nome="PRES TEST", fluxo="NAO_SUPER")
-    tipo = TipoEvento.objects.create(nome="Formação Pres")
+    user = UsuarioFactory(username="hash_test_pres", password="test123")
+    municipio = MunicipioFactory(nome="PresCity", uf="SP")
+    projeto = ProjetoFactory(nome="PRES TEST", fluxo="NAO_SUPER")
+    tipo = TipoEventoFactory(nome="Formação Pres")
 
     now = timezone.now()
-    sol = Solicitacao.objects.create(
+    sol = SolicitacaoFactory(
         usuario=user,
         municipio=municipio,
         projeto=projeto,

--- a/v2/backend/apps/core/tests/test_gcal_insights.py
+++ b/v2/backend/apps/core/tests/test_gcal_insights.py
@@ -16,14 +16,18 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 
-from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Group
 from django.test import TestCase
 from rest_framework.test import APIClient
 
-from apps.core.models import Municipio, Projeto, Solicitacao, TipoEvento
-
-User = get_user_model()
+from apps.core.models import Solicitacao
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 
 class TestGCalInsights(TestCase):
@@ -51,11 +55,11 @@ class TestGCalInsights(TestCase):
         self.tz_local = ZoneInfo("America/Fortaleza")
 
         # Criar grupos
-        self.group_controle = Group.objects.get_or_create(name="Controle")[0]
-        self.group_coordenador = Group.objects.get_or_create(name="Coordenador")[0]
+        self.group_controle = GroupFactory(name="Controle")
+        self.group_coordenador = GroupFactory(name="Coordenador")
 
         # Criar usuários (com CPFs únicos para evitar unique constraint violation)
-        self.user_controle = User.objects.create_user(
+        self.user_controle = UsuarioFactory(
             username="controle_insights",
             email="controle_insights@example.com",
             password="password123",
@@ -63,7 +67,7 @@ class TestGCalInsights(TestCase):
         )
         self.user_controle.groups.add(self.group_controle)
 
-        self.user_coordenador = User.objects.create_user(
+        self.user_coordenador = UsuarioFactory(
             username="coordenador_insights",
             email="coordenador_insights@example.com",
             password="password123",
@@ -72,11 +76,11 @@ class TestGCalInsights(TestCase):
         self.user_coordenador.groups.add(self.group_coordenador)
 
         # Criar fixtures (municipios, projetos, tipo_evento)
-        self.municipio_fortaleza = Municipio.objects.create(nome="Fortaleza - CE")
-        self.municipio_caucaia = Municipio.objects.create(nome="Caucaia - CE")
-        self.projeto_super = Projeto.objects.create(nome="Projeto SUPER", fluxo="SUPER")
-        self.projeto_outros = Projeto.objects.create(nome="Projeto OUTROS", fluxo="NAO_SUPER")
-        self.tipo_evento = TipoEvento.objects.create(nome="Formação")
+        self.municipio_fortaleza = MunicipioFactory(nome="Fortaleza - CE")
+        self.municipio_caucaia = MunicipioFactory(nome="Caucaia - CE")
+        self.projeto_super = ProjetoFactory(nome="Projeto SUPER", fluxo="SUPER")
+        self.projeto_outros = ProjetoFactory(nome="Projeto OUTROS", fluxo="NAO_SUPER")
+        self.tipo_evento = TipoEventoFactory(nome="Formação")
 
     def test_success_rate_requires_authentication(self):
         """
@@ -110,7 +114,7 @@ class TestGCalInsights(TestCase):
 
         # Criar 4 PUBLISHED
         for i in range(4):
-            Solicitacao.objects.create(
+            SolicitacaoFactory(
                 status="aprovado",
                 inicio=ref_date.replace(hour=10 + i),
                 fim=ref_date.replace(hour=11 + i),
@@ -124,7 +128,7 @@ class TestGCalInsights(TestCase):
 
         # Criar 2 ERROR
         for i in range(2):
-            Solicitacao.objects.create(
+            SolicitacaoFactory(
                 status="aprovado",
                 inicio=ref_date.replace(hour=14 + i),
                 fim=ref_date.replace(hour=15 + i),
@@ -137,7 +141,7 @@ class TestGCalInsights(TestCase):
             )
 
         # Criar 1 PENDING
-        Solicitacao.objects.create(
+        SolicitacaoFactory(
             status="aprovado",
             inicio=ref_date.replace(hour=16),
             fim=ref_date.replace(hour=17),
@@ -150,7 +154,7 @@ class TestGCalInsights(TestCase):
         )
 
         # Criar 1 NONE
-        Solicitacao.objects.create(
+        SolicitacaoFactory(
             status="aprovado",
             inicio=ref_date.replace(hour=18),
             fim=ref_date.replace(hour=19),
@@ -194,7 +198,7 @@ class TestGCalInsights(TestCase):
 
         # Fortaleza: 3 PUBLISHED, 1 ERROR
         for i in range(3):
-            Solicitacao.objects.create(
+            SolicitacaoFactory(
                 status="aprovado",
                 inicio=ref_date.replace(hour=10 + i),
                 fim=ref_date.replace(hour=11 + i),
@@ -206,7 +210,7 @@ class TestGCalInsights(TestCase):
                 gcal_status=Solicitacao.GCalStatus.PUBLISHED,
             )
 
-        Solicitacao.objects.create(
+        SolicitacaoFactory(
             status="aprovado",
             inicio=ref_date.replace(hour=14),
             fim=ref_date.replace(hour=15),
@@ -219,7 +223,7 @@ class TestGCalInsights(TestCase):
         )
 
         # Caucaia: 1 PUBLISHED, 2 ERROR
-        Solicitacao.objects.create(
+        SolicitacaoFactory(
             status="aprovado",
             inicio=ref_date.replace(hour=10),
             fim=ref_date.replace(hour=11),
@@ -232,7 +236,7 @@ class TestGCalInsights(TestCase):
         )
 
         for i in range(2):
-            Solicitacao.objects.create(
+            SolicitacaoFactory(
                 status="aprovado",
                 inicio=ref_date.replace(hour=12 + i),
                 fim=ref_date.replace(hour=13 + i),
@@ -286,7 +290,7 @@ class TestGCalInsights(TestCase):
 
         # SUPER: 2 PUBLISHED
         for i in range(2):
-            Solicitacao.objects.create(
+            SolicitacaoFactory(
                 status="aprovado",
                 inicio=ref_date.replace(hour=10 + i),
                 fim=ref_date.replace(hour=11 + i),
@@ -299,7 +303,7 @@ class TestGCalInsights(TestCase):
             )
 
         # OUTROS: 1 ERROR
-        Solicitacao.objects.create(
+        SolicitacaoFactory(
             status="aprovado",
             inicio=ref_date.replace(hour=14),
             fim=ref_date.replace(hour=15),
@@ -365,8 +369,8 @@ class TestGCalInsights(TestCase):
 
         # Criar 25 municípios com 1 evento ERROR cada
         for i in range(25):
-            municipio = Municipio.objects.create(nome=f"Municipio {i}")
-            Solicitacao.objects.create(
+            municipio = MunicipioFactory(nome=f"Municipio {i}")
+            SolicitacaoFactory(
                 status="aprovado",
                 inicio=ref_date,
                 fim=ref_date + timedelta(hours=1),
@@ -411,7 +415,7 @@ class TestGCalInsights(TestCase):
         ref_date = datetime(2025, 2, 20, 10, 0, 0, tzinfo=self.tz_local)
 
         # Evento dentro do período (incluir)
-        Solicitacao.objects.create(
+        SolicitacaoFactory(
             status="aprovado",
             inicio=ref_date,
             fim=ref_date + timedelta(hours=2),
@@ -424,7 +428,7 @@ class TestGCalInsights(TestCase):
         )
 
         # Evento um dia antes (excluir)
-        Solicitacao.objects.create(
+        SolicitacaoFactory(
             status="aprovado",
             inicio=ref_date - timedelta(days=1),
             fim=ref_date - timedelta(days=1, hours=-1),
@@ -437,7 +441,7 @@ class TestGCalInsights(TestCase):
         )
 
         # Evento um dia depois (excluir)
-        Solicitacao.objects.create(
+        SolicitacaoFactory(
             status="aprovado",
             inicio=ref_date + timedelta(days=1),
             fim=ref_date + timedelta(days=1, hours=1),

--- a/v2/backend/apps/core/tests/test_gcal_meet_link_by_mode.py
+++ b/v2/backend/apps/core/tests/test_gcal_meet_link_by_mode.py
@@ -17,25 +17,31 @@ from datetime import timedelta
 from unittest.mock import MagicMock, patch
 from urllib.parse import urlparse
 
-from django.contrib.auth.models import Group
 from django.utils import timezone
 from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import Municipio, Projeto, Solicitacao, TipoEvento, Usuario
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 
 @pytest.fixture
 def usuario_controle():
     """Usuário do grupo Controle"""
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username="controle_mode",
         email="controle_mode@test.com",
         password="testpass",
         cpf="44444444444",
     )
-    grupo, _ = Group.objects.get_or_create(name="Controle")
+    grupo = GroupFactory(name="Controle")
     user.groups.add(grupo)
     return user
 
@@ -43,9 +49,9 @@ def usuario_controle():
 @pytest.fixture
 def fixtures_basicas():
     """Fixtures básicas para criar solicitações"""
-    municipio = Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
-    projeto = Projeto.objects.create(nome="Projeto Mode", ativo=True)
-    tipo_evento = TipoEvento.objects.create(nome="Formação")
+    municipio = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+    projeto = ProjetoFactory(nome="Projeto Mode", ativo=True)
+    tipo_evento = TipoEventoFactory(nome="Formação")
 
     return {
         "municipio": municipio,
@@ -71,7 +77,7 @@ class TestGCalMeetLinkByMode:
         - DB permanece com meet_link=None
         """
         now = timezone.now()
-        sol = Solicitacao.objects.create(
+        sol = SolicitacaoFactory(
             usuario=usuario_controle,
             municipio=fixtures_basicas["municipio"],
             projeto=fixtures_basicas["projeto"],
@@ -125,7 +131,7 @@ class TestGCalMeetLinkByMode:
         - DB permanece com meet_link=None
         """
         now = timezone.now()
-        sol = Solicitacao.objects.create(
+        sol = SolicitacaoFactory(
             usuario=usuario_controle,
             municipio=fixtures_basicas["municipio"],
             projeto=fixtures_basicas["projeto"],
@@ -184,7 +190,7 @@ class TestGCalMeetLinkByMode:
         settings.GCAL_CALENDAR_ID = "test@calendar.google.com"
 
         now = timezone.now()
-        sol = Solicitacao.objects.create(
+        sol = SolicitacaoFactory(
             usuario=usuario_controle,
             municipio=fixtures_basicas["municipio"],
             projeto=fixtures_basicas["projeto"],
@@ -239,7 +245,7 @@ class TestGCalMeetLinkByMode:
         settings.GCAL_CLIENT = "fake"
 
         now = timezone.now()
-        sol = Solicitacao.objects.create(
+        sol = SolicitacaoFactory(
             usuario=usuario_controle,
             municipio=fixtures_basicas["municipio"],
             projeto=fixtures_basicas["projeto"],
@@ -288,7 +294,7 @@ class TestGCalMeetLinkByMode:
         settings.GCAL_CLIENT = "fake"
 
         now = timezone.now()
-        sol = Solicitacao.objects.create(
+        sol = SolicitacaoFactory(
             usuario=usuario_controle,
             municipio=fixtures_basicas["municipio"],
             projeto=fixtures_basicas["projeto"],
@@ -332,7 +338,7 @@ class TestGCalMeetLinkByMode:
         - preview.payload não contém conferenceData
         """
         now = timezone.now()
-        sol = Solicitacao.objects.create(
+        sol = SolicitacaoFactory(
             usuario=usuario_controle,
             municipio=fixtures_basicas["municipio"],
             projeto=fixtures_basicas["projeto"],
@@ -370,7 +376,7 @@ class TestGCalMeetLinkByMode:
         - preview.payload contém conferenceData
         """
         now = timezone.now()
-        sol = Solicitacao.objects.create(
+        sol = SolicitacaoFactory(
             usuario=usuario_controle,
             municipio=fixtures_basicas["municipio"],
             projeto=fixtures_basicas["projeto"],

--- a/v2/backend/apps/core/tests/test_gcal_meet_link_persist.py
+++ b/v2/backend/apps/core/tests/test_gcal_meet_link_persist.py
@@ -14,25 +14,31 @@ from __future__ import annotations
 from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
-from django.contrib.auth.models import Group
 from django.utils import timezone
 from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import Municipio, Projeto, Solicitacao, TipoEvento, Usuario
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 
 @pytest.fixture
 def usuario_controle():
     """Usuário do grupo Controle"""
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username="controle_meet",
         email="controle_meet@test.com",
         password="testpass",
         cpf="22222222222",
     )
-    grupo, _ = Group.objects.get_or_create(name="Controle")
+    grupo = GroupFactory(name="Controle")
     user.groups.add(grupo)
     return user
 
@@ -40,12 +46,12 @@ def usuario_controle():
 @pytest.fixture
 def solicitacao_aprovada(usuario_controle):
     """Solicitação aprovada sem meet_link"""
-    municipio = Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
-    projeto = Projeto.objects.create(nome="Projeto Meet", ativo=True)
-    tipo_evento = TipoEvento.objects.create(nome="Formação")
+    municipio = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+    projeto = ProjetoFactory(nome="Projeto Meet", ativo=True)
+    tipo_evento = TipoEventoFactory(nome="Formação")
 
     now = timezone.now()
-    sol = Solicitacao.objects.create(
+    sol = SolicitacaoFactory(
         usuario=usuario_controle,
         municipio=municipio,
         projeto=projeto,

--- a/v2/backend/apps/core/tests/test_gcal_oauth_mode.py
+++ b/v2/backend/apps/core/tests/test_gcal_oauth_mode.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 from datetime import timedelta
 from unittest.mock import patch
 
-from django.contrib.auth.models import Group
 from django.test import override_settings
 from django.utils import timezone
 from rest_framework import status as http_status
@@ -31,8 +30,16 @@ from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import GoogleOAuthCredential, Municipio, Projeto, Solicitacao, TipoEvento, Usuario
+from apps.core.models import GoogleOAuthCredential, Solicitacao
 from apps.core.services.google_oauth import _encrypt_token
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 # ============================================================================
 # FIXTURES
@@ -45,8 +52,8 @@ def usuario_controle(db):
     import uuid
 
     uid = uuid.uuid4().hex[:8]
-    controle_group, _ = Group.objects.get_or_create(name="Controle")
-    user = Usuario.objects.create_user(
+    controle_group = GroupFactory(name="Controle")
+    user = UsuarioFactory(
         username=f"controle_oauth_{uid}",
         email=f"controle_{uid}@aprendereditora.com.br",
         password="testpass123",
@@ -62,12 +69,12 @@ def solicitacao_aprovada(usuario_controle):
     import uuid
 
     uid = uuid.uuid4().hex[:8]
-    municipio = Municipio.objects.create(nome=f"Fortaleza_oauth_{uid}", uf="CE", ativo=True)
-    projeto = Projeto.objects.create(nome=f"Projeto OAuth {uid}", codigo=f"PO{uid[:3]}", fluxo="SUPER", ativo=True)
-    tipo_evento = TipoEvento.objects.create(nome=f"Formação OAuth {uid}")
+    municipio = MunicipioFactory(nome=f"Fortaleza_oauth_{uid}", uf="CE", ativo=True)
+    projeto = ProjetoFactory(nome=f"Projeto OAuth {uid}", codigo=f"PO{uid[:3]}", fluxo="SUPER", ativo=True)
+    tipo_evento = TipoEventoFactory(nome=f"Formação OAuth {uid}")
 
     now = timezone.now()
-    return Solicitacao.objects.create(
+    return SolicitacaoFactory(
         usuario=usuario_controle,
         municipio=municipio,
         projeto=projeto,

--- a/v2/backend/apps/core/tests/test_gcal_publish_apply_blocked.py
+++ b/v2/backend/apps/core/tests/test_gcal_publish_apply_blocked.py
@@ -14,14 +14,20 @@ from __future__ import annotations
 from datetime import timedelta
 from unittest.mock import Mock, patch
 
-from django.contrib.auth.models import Group
 from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import Municipio, Projeto, Solicitacao, TipoEvento, Usuario
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 
 def mock_task_result():
@@ -34,13 +40,13 @@ def mock_task_result():
 @pytest.fixture
 def usuario_controle():
     """Usuário do grupo Controle"""
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username="controle_test",
         email="controle@test.com",
         password="testpass",
         cpf="33333333333",
     )
-    grupo, _ = Group.objects.get_or_create(name="Controle")
+    grupo = GroupFactory(name="Controle")
     user.groups.add(grupo)
     return user
 
@@ -48,12 +54,12 @@ def usuario_controle():
 @pytest.fixture
 def solicitacao_aprovada(usuario_controle):
     """Solicitação aprovada para testes de publicação"""
-    municipio = Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
-    projeto = Projeto.objects.create(nome="Projeto Teste", ativo=True)
-    tipo_evento = TipoEvento.objects.create(nome="Formação")
+    municipio = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+    projeto = ProjetoFactory(nome="Projeto Teste", ativo=True)
+    tipo_evento = TipoEventoFactory(nome="Formação")
 
     now = timezone.now()
-    return Solicitacao.objects.create(
+    return SolicitacaoFactory(
         usuario=usuario_controle,
         municipio=municipio,
         projeto=projeto,

--- a/v2/backend/apps/core/tests/test_gcal_publish_batch.py
+++ b/v2/backend/apps/core/tests/test_gcal_publish_batch.py
@@ -15,13 +15,19 @@ from __future__ import annotations
 import os
 from unittest.mock import MagicMock, patch
 
-from django.contrib.auth.models import Group
 from django.test import override_settings
 from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import Municipio, Projeto, Solicitacao, TipoEvento, Usuario
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 
 @pytest.fixture
@@ -33,13 +39,13 @@ def api_client():
 @pytest.fixture
 def grupo_controle(db):
     """Cria grupo Controle."""
-    return Group.objects.get_or_create(name="Controle")[0]
+    return GroupFactory(name="Controle")
 
 
 @pytest.fixture
 def usuario_controle(db, grupo_controle):
     """Cria usuário com grupo Controle."""
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username="controle_user", email="controle@test.com", password="testpass123", cpf="12345678901"  # CPF único
     )
     user.groups.add(grupo_controle)
@@ -49,7 +55,7 @@ def usuario_controle(db, grupo_controle):
 @pytest.fixture
 def usuario_comum(db):
     """Cria usuário sem permissões especiais."""
-    return Usuario.objects.create_user(
+    return UsuarioFactory(
         username="comum_user", email="comum@test.com", password="testpass123", cpf="98765432109"  # CPF único diferente
     )
 
@@ -57,25 +63,25 @@ def usuario_comum(db):
 @pytest.fixture
 def projeto(db):
     """Cria projeto de teste."""
-    return Projeto.objects.create(nome="Projeto Teste", codigo="PROJ001", fluxo="SUPER")
+    return ProjetoFactory(nome="Projeto Teste", codigo="PROJ001", fluxo="SUPER")
 
 
 @pytest.fixture
 def municipio(db):
     """Cria município de teste."""
-    return Municipio.objects.create(nome="Fortaleza", uf="CE", ibge_code="2304400")
+    return MunicipioFactory(nome="Fortaleza", uf="CE", ibge_code="2304400")
 
 
 @pytest.fixture
 def tipo_evento(db):
     """Cria tipo de evento de teste."""
-    return TipoEvento.objects.create(nome="Formação")
+    return TipoEventoFactory(nome="Formação")
 
 
 @pytest.fixture
 def solicitacao_aprovada(db, usuario_controle, projeto, municipio, tipo_evento):
     """Cria solicitação aprovada."""
-    return Solicitacao.objects.create(
+    return SolicitacaoFactory(
         usuario=usuario_controle,
         projeto=projeto,
         municipio=municipio,
@@ -90,7 +96,7 @@ def solicitacao_aprovada(db, usuario_controle, projeto, municipio, tipo_evento):
 @pytest.fixture
 def solicitacao_pendente(db, usuario_controle, projeto, municipio, tipo_evento):
     """Cria solicitação pendente."""
-    return Solicitacao.objects.create(
+    return SolicitacaoFactory(
         usuario=usuario_controle,
         projeto=projeto,
         municipio=municipio,
@@ -114,7 +120,7 @@ class TestGCalPublishBatchEndpoint:
         Espera: 202 com queued=2, errors=[]
         """
         # Criar segunda solicitação aprovada
-        sol2 = Solicitacao.objects.create(
+        sol2 = SolicitacaoFactory(
             usuario=usuario_controle,
             projeto=solicitacao_aprovada.projeto,
             municipio=solicitacao_aprovada.municipio,

--- a/v2/backend/apps/core/tests/test_gcal_publish_resync.py
+++ b/v2/backend/apps/core/tests/test_gcal_publish_resync.py
@@ -17,14 +17,21 @@ from __future__ import annotations
 from datetime import timedelta
 from unittest.mock import ANY, Mock, patch
 
-from django.contrib.auth.models import Group
 from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import Municipio, Projeto, Solicitacao, TipoEvento, Usuario
+from apps.core.models import Solicitacao
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 
 def mock_task_result(task_id="fake-task-id"):
@@ -37,13 +44,13 @@ def mock_task_result(task_id="fake-task-id"):
 @pytest.fixture
 def usuario_controle():
     """Usuário do grupo Controle"""
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username="controle_sprint3",
         email="controle_sprint3@test.com",
         password="testpass",
         cpf="99999999999",
     )
-    grupo, _ = Group.objects.get_or_create(name="Controle")
+    grupo = GroupFactory(name="Controle")
     user.groups.add(grupo)
     return user
 
@@ -51,12 +58,12 @@ def usuario_controle():
 @pytest.fixture
 def solicitacao_aprovada(usuario_controle):
     """Solicitação aprovada para testes de publicação"""
-    municipio = Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
-    projeto = Projeto.objects.create(nome="Projeto Sprint3", codigo="SP3", fluxo="SUPER", ativo=True)
-    tipo_evento = TipoEvento.objects.create(nome="Formação Sprint3")
+    municipio = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+    projeto = ProjetoFactory(nome="Projeto Sprint3", codigo="SP3", fluxo="SUPER", ativo=True)
+    tipo_evento = TipoEventoFactory(nome="Formação Sprint3")
 
     now = timezone.now()
-    return Solicitacao.objects.create(
+    return SolicitacaoFactory(
         usuario=usuario_controle,
         municipio=municipio,
         projeto=projeto,
@@ -72,12 +79,12 @@ def solicitacao_aprovada(usuario_controle):
 @pytest.fixture
 def solicitacao_published(usuario_controle):
     """Solicitação já publicada para testes de resync"""
-    municipio = Municipio.objects.create(nome="Sobral", uf="CE", ativo=True)
-    projeto = Projeto.objects.create(nome="Projeto B", codigo="PRB", fluxo="NAO_SUPER", ativo=True)
-    tipo_evento = TipoEvento.objects.create(nome="Workshop Sprint3")
+    municipio = MunicipioFactory(nome="Sobral", uf="CE", ativo=True)
+    projeto = ProjetoFactory(nome="Projeto B", codigo="PRB", fluxo="NAO_SUPER", ativo=True)
+    tipo_evento = TipoEventoFactory(nome="Workshop Sprint3")
 
     now = timezone.now()
-    return Solicitacao.objects.create(
+    return SolicitacaoFactory(
         usuario=usuario_controle,
         municipio=municipio,
         projeto=projeto,
@@ -218,12 +225,12 @@ class TestPublishEndpoint:
         """
         Validação: Apenas solicitações aprovadas podem ser publicadas
         """
-        municipio = Municipio.objects.create(nome="Juazeiro", uf="CE", ativo=True)
-        projeto = Projeto.objects.create(nome="Projeto Pendente", fluxo="SUPER", ativo=True)
-        tipo_evento = TipoEvento.objects.create(nome="Teste")
+        municipio = MunicipioFactory(nome="Juazeiro", uf="CE", ativo=True)
+        projeto = ProjetoFactory(nome="Projeto Pendente", fluxo="SUPER", ativo=True)
+        tipo_evento = TipoEventoFactory(nome="Teste")
 
         now = timezone.now()
-        sol_pendente = Solicitacao.objects.create(
+        sol_pendente = SolicitacaoFactory(
             usuario=usuario_controle,
             municipio=municipio,
             projeto=projeto,
@@ -287,12 +294,12 @@ class TestResyncEndpoint:
         """
         Validação: Apenas solicitações aprovadas podem ser resync
         """
-        municipio = Municipio.objects.create(nome="Crato", uf="CE", ativo=True)
-        projeto = Projeto.objects.create(nome="Projeto Reprovado", fluxo="SUPER", ativo=True)
-        tipo_evento = TipoEvento.objects.create(nome="Teste Resync")
+        municipio = MunicipioFactory(nome="Crato", uf="CE", ativo=True)
+        projeto = ProjetoFactory(nome="Projeto Reprovado", fluxo="SUPER", ativo=True)
+        tipo_evento = TipoEventoFactory(nome="Teste Resync")
 
         now = timezone.now()
-        sol_reprovada = Solicitacao.objects.create(
+        sol_reprovada = SolicitacaoFactory(
             usuario=usuario_controle,
             municipio=municipio,
             projeto=projeto,

--- a/v2/backend/apps/core/tests/test_gcal_retry_audit.py
+++ b/v2/backend/apps/core/tests/test_gcal_retry_audit.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 from datetime import timedelta
 from unittest.mock import MagicMock, Mock, patch
 
-from django.contrib.auth.models import Group
 from django.utils import timezone
 from rest_framework import status as http_status
 from rest_framework.test import APIClient
@@ -25,19 +24,27 @@ from rest_framework.test import APIClient
 import pytest
 from googleapiclient.errors import HttpError
 
-from apps.core.models import AuditLog, Municipio, Projeto, Solicitacao, TipoEvento, Usuario
+from apps.core.models import AuditLog, Solicitacao
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 
 @pytest.fixture
 def usuario_controle():
     """Usuário do grupo Controle"""
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username="controle_sprint4",
         email="controle_sprint4@test.com",
         password="testpass",
         cpf="88888888888",
     )
-    grupo, _ = Group.objects.get_or_create(name="Controle")
+    grupo = GroupFactory(name="Controle")
     user.groups.add(grupo)
     return user
 
@@ -45,12 +52,12 @@ def usuario_controle():
 @pytest.fixture
 def solicitacao_aprovada(usuario_controle):
     """Solicitação aprovada para testes"""
-    municipio = Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
-    projeto = Projeto.objects.create(nome="Projeto Sprint4", codigo="SP4", fluxo="SUPER", ativo=True)
-    tipo_evento = TipoEvento.objects.create(nome="Formação Sprint4")
+    municipio = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+    projeto = ProjetoFactory(nome="Projeto Sprint4", codigo="SP4", fluxo="SUPER", ativo=True)
+    tipo_evento = TipoEventoFactory(nome="Formação Sprint4")
 
     now = timezone.now()
-    return Solicitacao.objects.create(
+    return SolicitacaoFactory(
         usuario=usuario_controle,
         municipio=municipio,
         projeto=projeto,

--- a/v2/backend/apps/core/tests/test_gcal_sync_dryrun.py
+++ b/v2/backend/apps/core/tests/test_gcal_sync_dryrun.py
@@ -14,15 +14,21 @@ from django.utils import timezone
 
 import pytest
 
-from apps.core.models import Municipio, Solicitacao, TipoEvento, Usuario
+from apps.core.models import Solicitacao
 from apps.core.services.gcal_fake_client import FakeCalendarClient
 from apps.core.services.gcal_sync_service import upsert_one
+from apps.core.tests.factories import (
+    MunicipioFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 
 @pytest.fixture
 def usuario_test(db):
     """Cria um usuário de teste"""
-    return Usuario.objects.create_user(
+    return UsuarioFactory(
         username="testuser",
         email="testuser@example.com",
         password="testpass123",
@@ -33,13 +39,13 @@ def usuario_test(db):
 @pytest.fixture
 def tipo_evento_test(db):
     """Cria um tipo de evento de teste"""
-    return TipoEvento.objects.create(nome="Formação Teste", descricao="Teste")
+    return TipoEventoFactory(nome="Formação Teste", descricao="Teste")
 
 
 @pytest.fixture
 def municipio_test(db):
     """Município de teste"""
-    return Municipio.objects.create(nome="Fortaleza", uf="CE")
+    return MunicipioFactory(nome="Fortaleza", uf="CE")
 
 
 @pytest.fixture
@@ -63,7 +69,7 @@ class TestGCalSyncIdempotency:
         now = timezone.now().replace(hour=10, minute=0, second=0, microsecond=0)
 
         # Criar solicitação aprovada
-        sol = Solicitacao.objects.create(
+        sol = SolicitacaoFactory(
             usuario=usuario_test,
             tipo_evento=tipo_evento_test,
             municipio=municipio_test,
@@ -121,7 +127,7 @@ class TestGCalSyncIdempotency:
         now = timezone.now().replace(hour=14, minute=0, second=0, microsecond=0)
 
         # Criar solicitação aprovada SEM external_event_id
-        sol = Solicitacao.objects.create(
+        sol = SolicitacaoFactory(
             usuario=usuario_test,
             tipo_evento=tipo_evento_test,
             municipio=municipio_test,
@@ -173,7 +179,7 @@ class TestGCalSyncIdempotency:
         now = timezone.now().replace(hour=9, minute=0, second=0, microsecond=0)
 
         # Criar e sincronizar evento inicial
-        sol = Solicitacao.objects.create(
+        sol = SolicitacaoFactory(
             usuario=usuario_test,
             tipo_evento=tipo_evento_test,
             municipio=municipio_test,
@@ -228,7 +234,7 @@ class TestGCalSyncIdempotency:
         now = timezone.now().replace(hour=11, minute=0, second=0, microsecond=0)
 
         # Criar solicitação aprovada e sincronizar
-        sol = Solicitacao.objects.create(
+        sol = SolicitacaoFactory(
             usuario=usuario_test,
             tipo_evento=tipo_evento_test,
             municipio=municipio_test,
@@ -285,7 +291,7 @@ class TestGCalSyncIdempotency:
         now = timezone.now().replace(hour=15, minute=0, second=0, microsecond=0)
 
         # Criar e sincronizar solicitação aprovada
-        sol = Solicitacao.objects.create(
+        sol = SolicitacaoFactory(
             usuario=usuario_test,
             tipo_evento=tipo_evento_test,
             municipio=municipio_test,
@@ -338,7 +344,7 @@ class TestGCalSyncDryRun:
         now = timezone.now().replace(hour=8, minute=0, second=0, microsecond=0)
 
         # Criar solicitação aprovada sem external_event_id
-        sol = Solicitacao.objects.create(
+        sol = SolicitacaoFactory(
             usuario=usuario_test,
             tipo_evento=tipo_evento_test,
             municipio=municipio_test,
@@ -378,7 +384,7 @@ class TestGCalSyncDryRun:
         now = timezone.now().replace(hour=10, minute=0, second=0, microsecond=0)
 
         # Criar solicitação aprovada
-        sol = Solicitacao.objects.create(
+        sol = SolicitacaoFactory(
             usuario=usuario_test,
             tipo_evento=tipo_evento_test,
             municipio=municipio_test,
@@ -422,7 +428,7 @@ class TestGCalSyncFilters:
         base = timezone.now().replace(hour=10, minute=0, second=0, microsecond=0)
 
         # Criar 3 solicitações em diferentes datas
-        sol_passado = Solicitacao.objects.create(
+        sol_passado = SolicitacaoFactory(
             usuario=usuario_test,
             tipo_evento=tipo_evento_test,
             municipio=municipio_test,
@@ -431,7 +437,7 @@ class TestGCalSyncFilters:
             status="aprovado",
         )
 
-        sol_presente = Solicitacao.objects.create(
+        sol_presente = SolicitacaoFactory(
             usuario=usuario_test,
             tipo_evento=tipo_evento_test,
             municipio=municipio_test,
@@ -440,7 +446,7 @@ class TestGCalSyncFilters:
             status="aprovado",
         )
 
-        sol_futuro = Solicitacao.objects.create(
+        sol_futuro = SolicitacaoFactory(
             usuario=usuario_test,
             tipo_evento=tipo_evento_test,
             municipio=municipio_test,
@@ -486,7 +492,7 @@ class TestGCalSyncFilters:
         now = timezone.now().replace(hour=14, minute=0, second=0, microsecond=0)
 
         # Criar 3 solicitações
-        sol1 = Solicitacao.objects.create(
+        sol1 = SolicitacaoFactory(
             usuario=usuario_test,
             tipo_evento=tipo_evento_test,
             municipio=municipio_test,
@@ -495,7 +501,7 @@ class TestGCalSyncFilters:
             status="aprovado",
         )
 
-        sol2 = Solicitacao.objects.create(
+        sol2 = SolicitacaoFactory(
             usuario=usuario_test,
             tipo_evento=tipo_evento_test,
             municipio=municipio_test,
@@ -504,7 +510,7 @@ class TestGCalSyncFilters:
             status="aprovado",
         )
 
-        sol3 = Solicitacao.objects.create(
+        sol3 = SolicitacaoFactory(
             usuario=usuario_test,
             tipo_evento=tipo_evento_test,
             municipio=municipio_test,
@@ -552,7 +558,7 @@ class TestGCalSyncEdgeCases:
         """
         now = timezone.now().replace(hour=13, minute=0, second=0, microsecond=0)
 
-        sol = Solicitacao.objects.create(
+        sol = SolicitacaoFactory(
             usuario=usuario_test,
             tipo_evento=tipo_evento_test,
             municipio=municipio_test,
@@ -582,7 +588,7 @@ class TestGCalSyncEdgeCases:
         """
         now = timezone.now().replace(hour=9, minute=30, second=0, microsecond=0)
 
-        sol = Solicitacao.objects.create(
+        sol = SolicitacaoFactory(
             usuario=usuario_test,
             tipo_evento=tipo_evento_test,
             municipio=municipio_test,

--- a/v2/backend/apps/core/tests/test_gcal_template_fase3.py
+++ b/v2/backend/apps/core/tests/test_gcal_template_fase3.py
@@ -22,7 +22,6 @@ from datetime import datetime, timedelta
 from datetime import timezone as dt_timezone
 from zoneinfo import ZoneInfo
 
-from django.contrib.auth.models import Group
 from django.test import TestCase, override_settings
 from django.utils import timezone
 from rest_framework import status as http_status
@@ -30,8 +29,15 @@ from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import Municipio, Projeto, Solicitacao, TipoEvento, Usuario
 from apps.core.services.gcal_sync_service import build_event_payload, build_preview_for_solicitacao
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 
 class GCalTemplateFase3Tests(TestCase):
@@ -40,11 +46,11 @@ class GCalTemplateFase3Tests(TestCase):
     def setUp(self):
         """Setup: criar dados de teste completos"""
         # Criar grupos (get_or_create para evitar IntegrityError)
-        self.group_coord, _ = Group.objects.get_or_create(name="Coordenador")
-        self.group_controle, _ = Group.objects.get_or_create(name="Controle")
+        self.group_coord = GroupFactory(name="Coordenador")
+        self.group_controle = GroupFactory(name="Controle")
 
         # Criar usuários (com CPF único para evitar IntegrityError)
-        self.coord = Usuario.objects.create_user(
+        self.coord = UsuarioFactory(
             username="coord_fase3",
             email="coord_fase3@example.com",
             password="senha123",
@@ -54,7 +60,7 @@ class GCalTemplateFase3Tests(TestCase):
         )
         self.coord.groups.add(self.group_coord)
 
-        self.formador = Usuario.objects.create_user(
+        self.formador = UsuarioFactory(
             username="formador_fase3",
             email="formador_fase3@example.com",
             password="senha123",
@@ -63,7 +69,7 @@ class GCalTemplateFase3Tests(TestCase):
             last_name="Santos",
         )
 
-        self.controle = Usuario.objects.create_user(
+        self.controle = UsuarioFactory(
             username="controle_fase3",
             email="controle_fase3@example.com",
             password="senha123",
@@ -72,13 +78,13 @@ class GCalTemplateFase3Tests(TestCase):
         self.controle.groups.add(self.group_controle)
 
         # Criar entidades de negócio
-        self.municipio = Municipio.objects.create(nome="Salvador", uf="BA")
-        self.projeto = Projeto.objects.create(
+        self.municipio = MunicipioFactory(nome="Salvador", uf="BA")
+        self.projeto = ProjetoFactory(
             nome="Projeto ACerta",
             codigo="ACERTA",
             fluxo="NAO_SUPER",
         )
-        self.tipo_evento = TipoEvento.objects.create(nome="Formação Presencial")
+        self.tipo_evento = TipoEventoFactory(nome="Formação Presencial")
 
         # Datas (America/Fortaleza)
         fortaleza_tz = ZoneInfo("America/Fortaleza")
@@ -93,7 +99,7 @@ class GCalTemplateFase3Tests(TestCase):
 
         Expected: "Salvador - BA Fundamental I Online [ACERTA]"
         """
-        solicitacao = Solicitacao.objects.create(
+        solicitacao = SolicitacaoFactory(
             usuario=self.coord,
             municipio=self.municipio,
             projeto=self.projeto,
@@ -117,7 +123,7 @@ class GCalTemplateFase3Tests(TestCase):
 
         Expected: "Salvador - BA Presencial [ACERTA]"
         """
-        solicitacao = Solicitacao.objects.create(
+        solicitacao = SolicitacaoFactory(
             usuario=self.coord,
             municipio=self.municipio,
             projeto=self.projeto,
@@ -141,13 +147,13 @@ class GCalTemplateFase3Tests(TestCase):
 
         Expected: "Salvador - BA Online [Projeto sem Código]"
         """
-        projeto_sem_codigo = Projeto.objects.create(
+        projeto_sem_codigo = ProjetoFactory(
             nome="Projeto sem Código",
             codigo="",  # Vazio
             fluxo="NAO_SUPER",
         )
 
-        solicitacao = Solicitacao.objects.create(
+        solicitacao = SolicitacaoFactory(
             usuario=self.coord,
             municipio=self.municipio,
             projeto=projeto_sem_codigo,
@@ -170,7 +176,7 @@ class GCalTemplateFase3Tests(TestCase):
 
         Expected: "... Presencial ..."
         """
-        solicitacao = Solicitacao.objects.create(
+        solicitacao = SolicitacaoFactory(
             usuario=self.coord,
             municipio=self.municipio,
             projeto=self.projeto,
@@ -201,7 +207,7 @@ class GCalTemplateFase3Tests(TestCase):
         - Equipe: "👥 Equipe: ..."
         - Observações: "📝 Observações: ..."
         """
-        solicitacao = Solicitacao.objects.create(
+        solicitacao = SolicitacaoFactory(
             usuario=self.coord,
             municipio=self.municipio,
             projeto=self.projeto,
@@ -238,7 +244,7 @@ class GCalTemplateFase3Tests(TestCase):
 
         Expected: Seções obrigatórias presentes, opcionais ausentes
         """
-        solicitacao = Solicitacao.objects.create(
+        solicitacao = SolicitacaoFactory(
             usuario=self.coord,
             municipio=self.municipio,
             projeto=self.projeto,
@@ -278,7 +284,7 @@ class GCalTemplateFase3Tests(TestCase):
         inicio_utc = timezone.make_aware(datetime(2025, 12, 15, 12, 0, 0), timezone=dt_timezone.utc)
         fim_utc = timezone.make_aware(datetime(2025, 12, 15, 15, 0, 0), timezone=dt_timezone.utc)
 
-        solicitacao = Solicitacao.objects.create(
+        solicitacao = SolicitacaoFactory(
             usuario=self.coord,
             municipio=self.municipio,
             projeto=self.projeto,
@@ -306,18 +312,18 @@ class GCalTemplateFase3Tests(TestCase):
         - Template formatado corretamente
         """
         # Criar município com nome longo (respeitando max_length=100)
-        municipio_longo = Municipio.objects.create(
+        municipio_longo = MunicipioFactory(
             nome="A" * 95,  # Nome com 95 caracteres (< 100)
             uf="BA",
         )
 
-        projeto_longo = Projeto.objects.create(
+        projeto_longo = ProjetoFactory(
             nome="B" * 200,  # Nome com 200 caracteres
             codigo="C" * 50,  # Código com 50 caracteres
             fluxo="NAO_SUPER",
         )
 
-        solicitacao = Solicitacao.objects.create(
+        solicitacao = SolicitacaoFactory(
             usuario=self.coord,
             municipio=municipio_longo,
             projeto=projeto_longo,
@@ -354,7 +360,7 @@ class GCalTemplateFase3Tests(TestCase):
         # Criar observações com texto muito longo
         observacoes_longas = "X" * 6000  # 6000 caracteres
 
-        solicitacao = Solicitacao.objects.create(
+        solicitacao = SolicitacaoFactory(
             usuario=self.coord,
             municipio=self.municipio,
             projeto=self.projeto,
@@ -380,7 +386,7 @@ class GCalTemplateFase3Tests(TestCase):
 
         Expected: JSON com payload contendo título e descrição formatados
         """
-        solicitacao = Solicitacao.objects.create(
+        solicitacao = SolicitacaoFactory(
             usuario=self.coord,
             municipio=self.municipio,
             projeto=self.projeto,
@@ -428,7 +434,7 @@ class GCalTemplateFase3Tests(TestCase):
         - gcal_payload_hash setado (SHA1)
         - Título e descrição formatados conforme Fase 3
         """
-        solicitacao = Solicitacao.objects.create(
+        solicitacao = SolicitacaoFactory(
             usuario=self.coord,
             municipio=self.municipio,
             projeto=self.projeto,
@@ -471,7 +477,7 @@ class GCalTemplateFase3Tests(TestCase):
 
         Expected: dict com event_id, payload, payload_hash, meet_link (se online)
         """
-        solicitacao = Solicitacao.objects.create(
+        solicitacao = SolicitacaoFactory(
             usuario=self.coord,
             municipio=self.municipio,
             projeto=self.projeto,
@@ -506,7 +512,7 @@ class GCalTemplateFase3Tests(TestCase):
 
         Expected: "Formador(es): João Santos, Pedro Oliveira"
         """
-        formador2 = Usuario.objects.create_user(
+        formador2 = UsuarioFactory(
             username="formador2_fase3",
             email="formador2_fase3@example.com",
             password="senha123",
@@ -515,7 +521,7 @@ class GCalTemplateFase3Tests(TestCase):
             last_name="Oliveira",
         )
 
-        solicitacao = Solicitacao.objects.create(
+        solicitacao = SolicitacaoFactory(
             usuario=self.coord,
             municipio=self.municipio,
             projeto=self.projeto,

--- a/v2/backend/apps/core/tests/test_google_oauth.py
+++ b/v2/backend/apps/core/tests/test_google_oauth.py
@@ -35,7 +35,6 @@ from datetime import timedelta
 from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
-from django.contrib.auth.models import Group
 from django.utils import timezone
 from rest_framework import status as http_status
 from rest_framework.test import APIClient, APIRequestFactory
@@ -43,7 +42,7 @@ from rest_framework.test import APIClient, APIRequestFactory
 import pytest
 from cryptography.fernet import Fernet
 
-from apps.core.models import AuditLog, GoogleOAuthCredential, Usuario
+from apps.core.models import AuditLog, GoogleOAuthCredential
 from apps.core.services.google_oauth import (
     _decrypt_token,
     _encrypt_token,
@@ -51,6 +50,7 @@ from apps.core.services.google_oauth import (
     refresh_access_token_safe,
     rotate_encryption_key,
 )
+from apps.core.tests.factories import UsuarioFactory
 
 # ============================================================================
 # FIXTURES
@@ -101,29 +101,25 @@ def patch_decrypt_for_memoryview(monkeypatch):
 @pytest.fixture
 def usuario_controle(db):
     """Cria usuário do grupo Controle"""
-    controle_group, _ = Group.objects.get_or_create(name="Controle")
-    user = Usuario.objects.create_user(
+    return UsuarioFactory(
         username="controle_test",
         email="controle@aprendereditora.com.br",
         password="testpass123",
         cpf="11111111111",
+        groups=["Controle"],
     )
-    user.groups.add(controle_group)
-    return user
 
 
 @pytest.fixture
 def usuario_formador(db):
     """Cria usuário do grupo Formador (sem permissão OAuth)"""
-    formador_group, _ = Group.objects.get_or_create(name="Formador")
-    user = Usuario.objects.create_user(
+    return UsuarioFactory(
         username="formador_test",
         email="formador@aprendereditora.com.br",
         password="testpass123",
         cpf="22222222222",
+        groups=["Formador"],
     )
-    user.groups.add(formador_group)
-    return user
 
 
 @pytest.fixture
@@ -457,14 +453,13 @@ class TestGoogleOAuthEndpoints:
         cache.clear()
 
         # Criar usuário único para este teste (evitar throttle compartilhado)
-        controle_group, _ = Group.objects.get_or_create(name="Controle")
-        unique_user = Usuario.objects.create_user(
+        unique_user = UsuarioFactory(
             username="throttle_test_user",
             email="throttle@aprendereditora.com.br",
             password="testpass123",
             cpf="99999999999",
+            groups=["Controle"],
         )
-        unique_user.groups.add(controle_group)
 
         client = APIClient()
         client.force_authenticate(user=unique_user)

--- a/v2/backend/apps/core/tests/test_group_sync_members.py
+++ b/v2/backend/apps/core/tests/test_group_sync_members.py
@@ -13,6 +13,7 @@ from rest_framework.test import APIClient
 import pytest
 
 from apps.core.models import AuditLog, Usuario
+from apps.core.tests.factories import GroupFactory, UsuarioFactory
 
 
 @pytest.fixture
@@ -22,33 +23,30 @@ def api_client() -> APIClient:
 
 @pytest.fixture
 def usuario_dat(db) -> Usuario:
-    user = Usuario.objects.create_user(
+    return UsuarioFactory(
         username="dat_sync",
         email="dat_sync@example.com",
         password="senha123",
         cpf="81234567890",
+        groups=["DAT"],
     )
-    dat_group, _ = Group.objects.get_or_create(name="DAT")
-    user.groups.add(dat_group)
-    return user
 
 
 @pytest.fixture
 def usuario_sem_dat(db) -> Usuario:
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username="comum_sync",
         email="comum_sync@example.com",
         password="senha123",
         cpf="81234567891",
     )
-    Group.objects.get_or_create(name="Formador")
+    GroupFactory(name="Formador")
     return user
 
 
 @pytest.fixture
 def grupo_alvo(db) -> Group:
-    group, _ = Group.objects.get_or_create(name="Grupo Operacional X")
-    return group
+    return GroupFactory(name="Grupo Operacional X")
 
 
 @pytest.fixture
@@ -56,7 +54,7 @@ def usuarios_alvo(db) -> list[Usuario]:
     users = []
     for idx in range(3):
         users.append(
-            Usuario.objects.create_user(
+            UsuarioFactory(
                 username=f"user_sync_{idx}",
                 email=f"user_sync_{idx}@example.com",
                 password="senha123",

--- a/v2/backend/apps/core/tests/test_home_stats_rbac.py
+++ b/v2/backend/apps/core/tests/test_home_stats_rbac.py
@@ -26,7 +26,6 @@ rbac_lint via `# noqa: RBAC-data-scope-allowed`.
 
 from __future__ import annotations
 
-from django.contrib.auth.models import Group
 from django.core.cache import cache
 from django.utils import timezone
 from rest_framework.test import APIClient
@@ -42,6 +41,13 @@ from apps.core.models import (
     Solicitacao,
     TipoEvento,
     Usuario,
+)
+from apps.core.tests.factories import (
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
 )
 
 pytestmark = pytest.mark.django_db
@@ -63,20 +69,14 @@ def _next_username(prefix: str) -> str:
 
 def _make_user(prefix: str, group_names: list[str], is_superuser: bool = False) -> Usuario:
     username = _next_username(prefix)
-    user = Usuario.objects.create_user(
+    return UsuarioFactory(
         username=username,
         email=f"{username}@example.com",
         password="testpass123",
         cpf=_next_cpf(),
+        superuser=is_superuser,
+        groups=group_names,
     )
-    if is_superuser:
-        user.is_superuser = True
-        user.is_staff = True
-        user.save(update_fields=["is_superuser", "is_staff"])
-    for gname in group_names:
-        group, _ = Group.objects.get_or_create(name=gname)
-        user.groups.add(group)
-    return user
 
 
 def _make_gerencia(nome: str, setor: str) -> Gerencia:
@@ -104,7 +104,7 @@ def _link_to_gerencia(
 
 
 def _make_projeto(nome: str, gerencia: Gerencia, fluxo: str = "NAO_SUPER") -> Projeto:
-    return Projeto.objects.create(nome=nome, codigo=nome[:20], fluxo=fluxo, ativo=True, gerencia=gerencia)
+    return ProjetoFactory(nome=nome, codigo=nome[:20], fluxo=fluxo, ativo=True, gerencia=gerencia)
 
 
 def _make_solicitacao(
@@ -117,7 +117,7 @@ def _make_solicitacao(
     days_ahead: int = 7,
 ) -> Solicitacao:
     inicio = timezone.now() + timezone.timedelta(days=days_ahead)
-    return Solicitacao.objects.create(
+    return SolicitacaoFactory(
         usuario=usuario,
         municipio=municipio,
         projeto=projeto,
@@ -139,8 +139,8 @@ def _clear_rbac_cache(db):
 @pytest.fixture
 def world():
     """Mundo compartilhado: 2 gerências, projetos, eventos aprovados em cada."""
-    municipio = Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
-    tipo_evento = TipoEvento.objects.create(nome="Formação")
+    municipio = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+    tipo_evento = TipoEventoFactory(nome="Formação")
 
     g1 = _make_gerencia("GERENCIA 2", "Vidas")
     g2 = _make_gerencia("GERENCIA 3", "Fluir")

--- a/v2/backend/apps/core/tests/test_import_bloqueios.py
+++ b/v2/backend/apps/core/tests/test_import_bloqueios.py
@@ -16,8 +16,6 @@ import io
 import tempfile
 from pathlib import Path
 
-from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Group
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -25,49 +23,44 @@ import pytest
 
 from apps.core.models import AvailabilityBlock
 from apps.core.services.bloqueios_import import import_bloqueios_from_file
+from apps.core.tests.factories import UsuarioFactory
 
 # URL direta (evita problemas de cache de rotas no container)
 IMPORT_BLOQUEIOS_URL = "/api/disponibilidade/import-bloqueios/"
-
-User = get_user_model()
 
 
 @pytest.fixture
 def dat_import_user(db):
     """Usuario do grupo DAT (PR-A1 DAT-Imports: detentor de import_spreadsheet)."""
-    user = User.objects.create_user(
+    return UsuarioFactory(
         username="dat_import_user",
         email="dat_imports@test.com",
         password="testpass123",
         cpf="11111111111",
         first_name="DAT",
         last_name="Imports",
+        groups=["DAT"],
     )
-    group, _ = Group.objects.get_or_create(name="DAT")
-    user.groups.add(group)
-    return user
 
 
 @pytest.fixture
 def formador_user(db):
     """Usuario do grupo Formador (sem permissao de import)."""
-    user = User.objects.create_user(
+    return UsuarioFactory(
         username="formador_user",
         email="formador@test.com",
         password="testpass123",
         cpf="22222222222",
         first_name="Formador",
         last_name="User",
+        groups=["Formador"],
     )
-    group, _ = Group.objects.get_or_create(name="Formador")
-    user.groups.add(group)
-    return user
 
 
 @pytest.fixture
 def target_user(db):
     """Usuario que sera bloqueado."""
-    return User.objects.create_user(
+    return UsuarioFactory(
         username="target_user",
         email="target@test.com",
         password="testpass123",

--- a/v2/backend/apps/core/tests/test_import_colecoes.py
+++ b/v2/backend/apps/core/tests/test_import_colecoes.py
@@ -14,24 +14,25 @@ Cobertura:
 import tempfile
 from pathlib import Path
 
-from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Group
 from rest_framework import status
 from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import Colecao, Projeto
+from apps.core.models import Colecao
 from apps.core.services.colecoes_import import import_colecoes_from_file
+from apps.core.tests.factories import (
+    GroupFactory,
+    ProjetoFactory,
+    UsuarioFactory,
+)
 
 IMPORT_COLECOES_URL = "/api/colecoes/import/"
-
-User = get_user_model()
 
 
 @pytest.fixture
 def dat_user(db):
-    user = User.objects.create_user(
+    user = UsuarioFactory(
         username="dat_user",
         email="dat@test.com",
         password="testpass123",
@@ -39,14 +40,14 @@ def dat_user(db):
         first_name="DAT",
         last_name="User",
     )
-    group, _ = Group.objects.get_or_create(name="DAT")
+    group = GroupFactory(name="DAT")
     user.groups.add(group)
     return user
 
 
 @pytest.fixture
 def formador_user(db):
-    user = User.objects.create_user(
+    user = UsuarioFactory(
         username="formador_user",
         email="formador@test.com",
         password="testpass123",
@@ -54,21 +55,14 @@ def formador_user(db):
         first_name="Formador",
         last_name="User",
     )
-    group, _ = Group.objects.get_or_create(name="Formador")
+    group = GroupFactory(name="Formador")
     user.groups.add(group)
     return user
 
 
 @pytest.fixture
 def superuser(db):
-    return User.objects.create_superuser(
-        username="admin",
-        email="admin@test.com",
-        password="testpass123",
-        cpf="99999999999",
-        first_name="Admin",
-        last_name="User",
-    )
+    return UsuarioFactory(superuser=True)
 
 
 @pytest.fixture
@@ -78,7 +72,7 @@ def api_client():
 
 @pytest.fixture
 def projeto_teste(db):
-    return Projeto.objects.create(
+    return ProjetoFactory(
         nome="Projeto Teste",
         codigo="PROJ-TEST",
         fluxo="NAO_SUPER",

--- a/v2/backend/apps/core/tests/test_import_compras.py
+++ b/v2/backend/apps/core/tests/test_import_compras.py
@@ -16,13 +16,13 @@ import tempfile
 from datetime import date
 from pathlib import Path
 
-from django.contrib.auth.models import Group
 from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import Compra, Municipio, Projeto, Usuario
+from apps.core.models import Compra, Municipio, Projeto
 from apps.core.services.controle_imports import import_compras_from_file
+from apps.core.tests.factories import GroupFactory, UsuarioFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -31,13 +31,13 @@ pytestmark = pytest.mark.django_db
 def user_dat():
     """Cria usuário no grupo DAT (PR-A1 DAT-Imports: detentor de
     `import_spreadsheet` via seed_functional_permissions)."""
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username="dat_imports",
         email="dat_imports@test.com",
         password="testpass",
         cpf="11111111111",
     )
-    group, _ = Group.objects.get_or_create(name="DAT")
+    group = GroupFactory(name="DAT")
     user.groups.add(group)
     return user
 
@@ -304,13 +304,13 @@ def test_import_compras_forbidden_for_formador():
     PR-A1 DAT-Imports (2026-04-29): endpoint é DAT-only via
     `HasPerm("import_spreadsheet")`. Formador → 403.
     """
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username="formador",
         email="formador@test.com",
         password="testpass",
         cpf="22222222222",
     )
-    group, _ = Group.objects.get_or_create(name="Formador")
+    group = GroupFactory(name="Formador")
     user.groups.add(group)
 
     client = APIClient()
@@ -326,13 +326,13 @@ def test_import_compras_forbidden_for_controle_after_pr_a1():
     em massa. Compras continuam visíveis em /controle, mas o upload é
     feito em /dat/importacoes (D-1 do plano DAT-Imports).
     """
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username="controle2",
         email="controle2@test.com",
         password="testpass",
         cpf="33333333333",
     )
-    group, _ = Group.objects.get_or_create(name="Controle")
+    group = GroupFactory(name="Controle")
     user.groups.add(group)
 
     client = APIClient()

--- a/v2/backend/apps/core/tests/test_import_deslocamentos.py
+++ b/v2/backend/apps/core/tests/test_import_deslocamentos.py
@@ -16,8 +16,6 @@ import io
 import tempfile
 from pathlib import Path
 
-from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Group
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -25,17 +23,16 @@ import pytest
 
 from apps.core.models import Deslocamento
 from apps.core.services.deslocamentos_import import import_deslocamentos_from_file
+from apps.core.tests.factories import GroupFactory, UsuarioFactory
 
 # URL direta (evita problemas de cache de rotas no container)
 IMPORT_DESLOCAMENTOS_URL = "/api/deslocamentos/import/"
-
-User = get_user_model()
 
 
 @pytest.fixture
 def dat_import_user(db):
     """Usuario do grupo DAT (PR-A1 DAT-Imports: detentor de import_spreadsheet)."""
-    user = User.objects.create_user(
+    user = UsuarioFactory(
         username="dat_import_user",
         email="dat_imports@test.com",
         password="testpass123",
@@ -43,7 +40,7 @@ def dat_import_user(db):
         first_name="DAT",
         last_name="Imports",
     )
-    group, _ = Group.objects.get_or_create(name="DAT")
+    group = GroupFactory(name="DAT")
     user.groups.add(group)
     return user
 
@@ -51,7 +48,7 @@ def dat_import_user(db):
 @pytest.fixture
 def formador_user(db):
     """Usuario do grupo Formador (sem permissao de import)."""
-    user = User.objects.create_user(
+    user = UsuarioFactory(
         username="formador_user",
         email="formador@test.com",
         password="testpass123",
@@ -59,7 +56,7 @@ def formador_user(db):
         first_name="Formador",
         last_name="User",
     )
-    group, _ = Group.objects.get_or_create(name="Formador")
+    group = GroupFactory(name="Formador")
     user.groups.add(group)
     return user
 
@@ -67,7 +64,7 @@ def formador_user(db):
 @pytest.fixture
 def target_user(db):
     """Usuario que tera deslocamentos registrados."""
-    return User.objects.create_user(
+    return UsuarioFactory(
         username="target_user",
         email="target@test.com",
         password="testpass123",

--- a/v2/backend/apps/core/tests/test_import_endpoints.py
+++ b/v2/backend/apps/core/tests/test_import_endpoints.py
@@ -17,12 +17,11 @@ from __future__ import annotations
 import io
 from unittest.mock import patch
 
-from django.contrib.auth.models import Group
 from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import Usuario
+from apps.core.tests.factories import GroupFactory, UsuarioFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -36,13 +35,13 @@ def _file(bytes_: bytes, name="sample.csv"):
 
 def _user_in_group(group_name: str):
     """Helper para criar usuário em grupo específico."""
-    u = Usuario.objects.create_user(
+    u = UsuarioFactory(
         username=f"u{group_name}",
         email=f"{group_name}@x.com",
         password="x",
         cpf="1" * 11,
     )
-    g, _ = Group.objects.get_or_create(name=group_name)
+    g = GroupFactory(name=group_name)
     u.groups.add(g)
     return u
 
@@ -117,7 +116,7 @@ def test_import_cadastros_requires_dat():
 
 def test_import_unauthorized_returns_403():
     """Usuário sem permissão recebe 403 Forbidden."""
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username="plain",
         email="plain@test.com",
         password="x",

--- a/v2/backend/apps/core/tests/test_import_equipe_gerencia.py
+++ b/v2/backend/apps/core/tests/test_import_equipe_gerencia.py
@@ -14,8 +14,6 @@ Cobertura:
 import tempfile
 from pathlib import Path
 
-from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Group
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -23,45 +21,41 @@ import pytest
 
 from apps.core.models import EquipeGerencia, Gerencia
 from apps.core.services.equipe_gerencia_import import import_equipe_gerencia_from_file
+from apps.core.tests.factories import UsuarioFactory
 
 IMPORT_EQUIPE_URL = "/api/equipe-gerencia/import/"
-
-User = get_user_model()
 
 
 @pytest.fixture
 def dat_user(db):
-    user = User.objects.create_user(
+    return UsuarioFactory(
         username="dat_user",
         email="dat@test.com",
         password="testpass123",
         cpf="11111111111",
         first_name="DAT",
         last_name="User",
+        groups=["DAT"],
     )
-    group, _ = Group.objects.get_or_create(name="DAT")
-    user.groups.add(group)
-    return user
 
 
 @pytest.fixture
 def formador_user(db):
-    user = User.objects.create_user(
+    return UsuarioFactory(
         username="formador_user",
         email="formador@test.com",
         password="testpass123",
         cpf="22222222222",
         first_name="Formador",
         last_name="User",
+        groups=["Formador"],
     )
-    group, _ = Group.objects.get_or_create(name="Formador")
-    user.groups.add(group)
-    return user
 
 
 @pytest.fixture
 def superuser(db):
-    return User.objects.create_superuser(
+    return UsuarioFactory(
+        superuser=True,
         username="admin",
         email="admin@test.com",
         password="testpass123",
@@ -78,7 +72,7 @@ def api_client():
 
 @pytest.fixture
 def usuario_formador(db):
-    return User.objects.create_user(
+    return UsuarioFactory(
         username="formador1",
         email="formador1@test.com",
         password="testpass123",
@@ -90,7 +84,7 @@ def usuario_formador(db):
 
 @pytest.fixture
 def usuario_coordenador(db):
-    return User.objects.create_user(
+    return UsuarioFactory(
         username="coord1",
         email="coord1@test.com",
         password="testpass123",

--- a/v2/backend/apps/core/tests/test_import_eventos.py
+++ b/v2/backend/apps/core/tests/test_import_eventos.py
@@ -18,58 +18,56 @@ import tempfile
 from datetime import date, timedelta
 from pathlib import Path
 
-from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Group
 from rest_framework import status
 from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import Municipio, Participation, Projeto, Solicitacao, TipoEvento
+from apps.core.models import Participation, Solicitacao
 from apps.core.services.eventos_import import import_eventos_from_file
+from apps.core.tests.factories import (
+    MunicipioFactory,
+    ProjetoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 # URL direta (evita problemas de cache de rotas no container)
 IMPORT_EVENTOS_URL = "/api/solicitacoes/import/"
-
-User = get_user_model()
 
 
 @pytest.fixture
 def dat_import_user(db):
     """Usuario do grupo DAT (PR-A1 DAT-Imports: detentor de import_spreadsheet)."""
-    user = User.objects.create_user(
+    return UsuarioFactory(
         username="dat_import_user",
         email="dat_imports@test.com",
         password="testpass123",
         cpf="11111111111",
         first_name="DAT",
         last_name="Imports",
+        groups=["DAT"],
     )
-    group, _ = Group.objects.get_or_create(name="DAT")
-    user.groups.add(group)
-    return user
 
 
 @pytest.fixture
 def formador_user(db):
     """Usuario do grupo Formador (sem permissao de import)."""
-    user = User.objects.create_user(
+    return UsuarioFactory(
         username="formador_user",
         email="formador@test.com",
         password="testpass123",
         cpf="22222222222",
         first_name="Formador",
         last_name="User",
+        groups=["Formador"],
     )
-    group, _ = Group.objects.get_or_create(name="Formador")
-    user.groups.add(group)
-    return user
 
 
 @pytest.fixture
 def coordenador_user(db):
     """Usuario que sera coordenador dos eventos."""
-    return User.objects.create_user(
+    return UsuarioFactory(
         username="coord_user",
         email="coord@test.com",
         password="testpass123",
@@ -82,7 +80,7 @@ def coordenador_user(db):
 @pytest.fixture
 def formador1_user(db):
     """Usuario que sera formador 1."""
-    return User.objects.create_user(
+    return UsuarioFactory(
         username="formador1",
         email="formador1@test.com",
         password="testpass123",
@@ -95,7 +93,7 @@ def formador1_user(db):
 @pytest.fixture
 def municipio(db):
     """Municipio para os eventos."""
-    return Municipio.objects.create(
+    return MunicipioFactory(
         nome="Fortaleza",
         uf="CE",
     )
@@ -104,7 +102,7 @@ def municipio(db):
 @pytest.fixture
 def projeto_super(db):
     """Projeto com fluxo SUPER (requer aprovacao)."""
-    return Projeto.objects.create(
+    return ProjetoFactory(
         nome="Projeto Super",
         fluxo="SUPER",
     )
@@ -113,7 +111,7 @@ def projeto_super(db):
 @pytest.fixture
 def projeto_nao_super(db):
     """Projeto com fluxo NAO_SUPER (auto-aprovado)."""
-    return Projeto.objects.create(
+    return ProjetoFactory(
         nome="Projeto Nao Super",
         fluxo="NAO_SUPER",
     )
@@ -122,7 +120,7 @@ def projeto_nao_super(db):
 @pytest.fixture
 def tipo_evento(db):
     """Tipo de evento para os eventos."""
-    return TipoEvento.objects.create(
+    return TipoEventoFactory(
         nome="Formacao",
     )
 

--- a/v2/backend/apps/core/tests/test_import_job_endpoints.py
+++ b/v2/backend/apps/core/tests/test_import_job_endpoints.py
@@ -27,8 +27,6 @@ import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Group
 from django.core.files.uploadedfile import SimpleUploadedFile
 from rest_framework import status
 from rest_framework.test import APIClient
@@ -36,47 +34,42 @@ from rest_framework.test import APIClient
 import pytest
 
 from apps.core.models import ImportJob
+from apps.core.tests.factories import UsuarioFactory
 
 UPLOAD_URL = "/api/imports/bloqueios/"
 LIST_URL = "/api/imports/"
 
 
-User = get_user_model()
-
-
 @pytest.fixture
 def controle_user(db):
-    user = User.objects.create_user(
+    return UsuarioFactory(
         username="ctrl_imp",
         email="ctrl_imp@test.com",
         password="testpass123",
         cpf="11111111111",
         first_name="Ctrl",
         last_name="Imp",
+        groups=["Controle"],
     )
-    group, _ = Group.objects.get_or_create(name="Controle")
-    user.groups.add(group)
-    return user
 
 
 @pytest.fixture
 def formador_user(db):
-    user = User.objects.create_user(
+    return UsuarioFactory(
         username="frm_imp",
         email="frm_imp@test.com",
         password="testpass123",
         cpf="22222222222",
         first_name="Frm",
         last_name="Imp",
+        groups=["Formador"],
     )
-    group, _ = Group.objects.get_or_create(name="Formador")
-    user.groups.add(group)
-    return user
 
 
 @pytest.fixture
 def super_user(db):
-    return User.objects.create_superuser(
+    return UsuarioFactory(
+        superuser=True,
         username="super_imp",
         email="super_imp@test.com",
         password="testpass123",

--- a/v2/backend/apps/core/tests/test_import_job_integration.py
+++ b/v2/backend/apps/core/tests/test_import_job_integration.py
@@ -16,16 +16,13 @@ from __future__ import annotations
 import tempfile
 from pathlib import Path
 
-from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Group
 from rest_framework import status
 from rest_framework.test import APIClient
 
 import pytest
 
 from apps.core.models import AvailabilityBlock, ImportJob
-
-User = get_user_model()
+from apps.core.tests.factories import UsuarioFactory
 
 UPLOAD_URL = "/api/imports/bloqueios/"
 
@@ -34,22 +31,20 @@ UPLOAD_URL = "/api/imports/bloqueios/"
 def controle_user(db):
     # O seed RBAC (incl. pos-truncate de transaction=True) e garantido globalmente
     # pela fixture autouse `ensure_rbac_seed` (conftest raiz, #1402).
-    user = User.objects.create_user(
+    return UsuarioFactory(
         username="ctrl_intg",
         email="ctrl_intg@test.com",
         password="testpass123",
         cpf="11111111111",
         first_name="Ctrl",
         last_name="Intg",
+        groups=["Controle"],
     )
-    group, _ = Group.objects.get_or_create(name="Controle")
-    user.groups.add(group)
-    return user
 
 
 @pytest.fixture
 def target_user(db):
-    return User.objects.create_user(
+    return UsuarioFactory(
         username="target_intg",
         email="target_intg@test.com",
         password="testpass123",

--- a/v2/backend/apps/core/tests/test_import_produtos.py
+++ b/v2/backend/apps/core/tests/test_import_produtos.py
@@ -16,26 +16,23 @@ import io
 import tempfile
 from pathlib import Path
 
-from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Group
 from rest_framework import status
 from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import Produto, Projeto
+from apps.core.models import Produto
 from apps.core.services.produtos_import import import_produtos_from_file
+from apps.core.tests.factories import GroupFactory, ProjetoFactory, UsuarioFactory
 
 # URL direta (evita problemas de cache de rotas no container)
 IMPORT_PRODUTOS_URL = "/api/produtos/import/"
-
-User = get_user_model()
 
 
 @pytest.fixture
 def dat_import_user(db):
     """Usuario do grupo DAT (PR-A1 DAT-Imports: detentor de import_spreadsheet)."""
-    user = User.objects.create_user(
+    user = UsuarioFactory(
         username="dat_import_user",
         email="dat_imports@test.com",
         password="testpass123",
@@ -43,7 +40,7 @@ def dat_import_user(db):
         first_name="DAT",
         last_name="Imports",
     )
-    group, _ = Group.objects.get_or_create(name="DAT")
+    group = GroupFactory(name="DAT")
     user.groups.add(group)
     return user
 
@@ -51,7 +48,7 @@ def dat_import_user(db):
 @pytest.fixture
 def formador_user(db):
     """Usuario do grupo Formador (sem permissao de import)."""
-    user = User.objects.create_user(
+    user = UsuarioFactory(
         username="formador_user",
         email="formador@test.com",
         password="testpass123",
@@ -59,7 +56,7 @@ def formador_user(db):
         first_name="Formador",
         last_name="User",
     )
-    group, _ = Group.objects.get_or_create(name="Formador")
+    group = GroupFactory(name="Formador")
     user.groups.add(group)
     return user
 
@@ -67,14 +64,7 @@ def formador_user(db):
 @pytest.fixture
 def superuser(db):
     """Superusuario (sempre tem permissao)."""
-    return User.objects.create_superuser(
-        username="admin",
-        email="admin@test.com",
-        password="testpass123",
-        cpf="99999999999",
-        first_name="Admin",
-        last_name="User",
-    )
+    return UsuarioFactory(superuser=True)
 
 
 @pytest.fixture
@@ -86,7 +76,7 @@ def api_client():
 @pytest.fixture
 def projeto_teste(db):
     """Projeto de teste para vincular produtos."""
-    return Projeto.objects.create(
+    return ProjetoFactory(
         nome="Projeto Teste",
         codigo="PROJ-TEST",
         fluxo="NAO_SUPER",
@@ -97,7 +87,7 @@ def projeto_teste(db):
 @pytest.fixture
 def projeto_acerta(db):
     """Projeto ACerta para testes."""
-    return Projeto.objects.create(
+    return ProjetoFactory(
         nome="ACERTA MATEMATICA",
         codigo="ACERTA",
         fluxo="NAO_SUPER",

--- a/v2/backend/apps/core/tests/test_import_usuarios.py
+++ b/v2/backend/apps/core/tests/test_import_usuarios.py
@@ -17,13 +17,13 @@ import tempfile
 from pathlib import Path
 
 from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Group
 from rest_framework import status
 from rest_framework.test import APIClient
 
 import pytest
 
 from apps.core.services.usuarios_import import import_usuarios_from_file
+from apps.core.tests.factories import GroupFactory, UsuarioFactory
 
 # URL direta (evita problemas de cache de rotas no container)
 IMPORT_USUARIOS_URL = "/api/usuarios/import/"
@@ -34,7 +34,7 @@ User = get_user_model()
 @pytest.fixture
 def dat_user(db):
     """Usuario do grupo DAT (com permissao de import)."""
-    user = User.objects.create_user(
+    user = UsuarioFactory(
         username="dat_user",
         email="dat@test.com",
         password="testpass123",
@@ -42,7 +42,7 @@ def dat_user(db):
         first_name="DAT",
         last_name="User",
     )
-    group, _ = Group.objects.get_or_create(name="DAT")
+    group = GroupFactory(name="DAT")
     user.groups.add(group)
     return user
 
@@ -50,7 +50,7 @@ def dat_user(db):
 @pytest.fixture
 def formador_user(db):
     """Usuario do grupo Formador (sem permissao de import)."""
-    user = User.objects.create_user(
+    user = UsuarioFactory(
         username="formador_user",
         email="formador@test.com",
         password="testpass123",
@@ -58,7 +58,7 @@ def formador_user(db):
         first_name="Formador",
         last_name="User",
     )
-    group, _ = Group.objects.get_or_create(name="Formador")
+    group = GroupFactory(name="Formador")
     user.groups.add(group)
     return user
 
@@ -66,14 +66,7 @@ def formador_user(db):
 @pytest.fixture
 def superuser(db):
     """Superusuario (sempre tem permissao)."""
-    return User.objects.create_superuser(
-        username="admin",
-        email="admin@test.com",
-        password="testpass123",
-        cpf="99999999999",
-        first_name="Admin",
-        last_name="User",
-    )
+    return UsuarioFactory(superuser=True)
 
 
 @pytest.fixture
@@ -100,8 +93,8 @@ def sample_csv(db):
 def sample_csv_with_groups(db):
     """CSV com grupos especificados."""
     # Criar grupos primeiro
-    Group.objects.get_or_create(name="Formador")
-    Group.objects.get_or_create(name="Coordenador")
+    GroupFactory(name="Formador")
+    GroupFactory(name="Coordenador")
 
     content = """cpf,nome,email,grupos
 55555555555,Ana Costa Lima,ana.costa@test.com,Formador
@@ -160,7 +153,7 @@ def sample_csv_flexible_headers(db):
 def sample_csv_update_existing(db):
     """CSV para testar atualizacao de usuario existente."""
     # Criar usuario existente
-    User.objects.create_user(
+    UsuarioFactory(
         username="existing_user",
         email="old@test.com",
         password="testpass123",

--- a/v2/backend/apps/core/tests/test_login_throttle_behavior.py
+++ b/v2/backend/apps/core/tests/test_login_throttle_behavior.py
@@ -38,7 +38,7 @@ from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import Usuario
+from apps.core.tests.factories import UsuarioFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -48,7 +48,7 @@ def usuario_valido():
     """Usuário válido para testes de throttling."""
     uid = uuid4().hex
     cpf = str(uuid4().int % 10**11).zfill(11)
-    return Usuario.objects.create_user(
+    return UsuarioFactory(
         username=f"throttle_user_{uid}",
         email=f"throttle_{uid}@example.com",
         password="validpass123",

--- a/v2/backend/apps/core/tests/test_lookup_validate.py
+++ b/v2/backend/apps/core/tests/test_lookup_validate.py
@@ -15,12 +15,18 @@ from __future__ import annotations
 
 from datetime import date
 
-from django.contrib.auth.models import Group
 from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import Compra, Municipio, Projeto, TipoEvento, Usuario
+from apps.core.models import Compra
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 
 @pytest.fixture
@@ -31,7 +37,7 @@ def api_client():
 @pytest.fixture
 def authenticated_user(db):
     """Criar usuário autenticado para testes"""
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username="testuser",
         email="test@example.com",
         password="testpass123",
@@ -39,7 +45,7 @@ def authenticated_user(db):
         first_name="Test",
         last_name="User",
     )
-    coord_group, _ = Group.objects.get_or_create(name="Coordenador")
+    coord_group = GroupFactory(name="Coordenador")
     user.groups.add(coord_group)
     return user
 
@@ -48,19 +54,19 @@ def authenticated_user(db):
 def sample_data(db):
     """Criar dados de exemplo para testes"""
     # Municípios
-    m1 = Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
-    m2 = Municipio.objects.create(nome="Sobral", uf="CE", ativo=True)
+    m1 = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+    m2 = MunicipioFactory(nome="Sobral", uf="CE", ativo=True)
 
     # Projetos
-    p1 = Projeto.objects.create(nome="ACerta", codigo="ACERTA", ativo=True, fluxo="SUPER")
-    p2 = Projeto.objects.create(nome="Brincando e Aprendendo", codigo="BRINCANDO", ativo=True, fluxo="NAO_SUPER")
+    p1 = ProjetoFactory(nome="ACerta", codigo="ACERTA", ativo=True, fluxo="SUPER")
+    p2 = ProjetoFactory(nome="Brincando e Aprendendo", codigo="BRINCANDO", ativo=True, fluxo="NAO_SUPER")
 
     # Tipos de Evento
-    t1 = TipoEvento.objects.create(nome="Formação")
-    t2 = TipoEvento.objects.create(nome="Acompanhamento")
+    t1 = TipoEventoFactory(nome="Formação")
+    t2 = TipoEventoFactory(nome="Acompanhamento")
 
     # Usuários
-    u1 = Usuario.objects.create_user(
+    u1 = UsuarioFactory(
         username="formador1",
         email="formador1@example.com",
         password="pass123",
@@ -68,7 +74,7 @@ def sample_data(db):
         first_name="João",
         last_name="Silva",
     )
-    formador_group, _ = Group.objects.get_or_create(name="Formador")
+    formador_group = GroupFactory(name="Formador")
     u1.groups.add(formador_group)
 
     return {

--- a/v2/backend/apps/core/tests/test_mark_test_projects_migration.py
+++ b/v2/backend/apps/core/tests/test_mark_test_projects_migration.py
@@ -35,6 +35,7 @@ mark_test_projects = migration_module.mark_test_projects
 unmark_test_projects = migration_module.unmark_test_projects
 
 
+@pytest.mark.migrations
 @pytest.mark.django_db
 class TestMarkTestProjectsMigration:
     """Tests for mark_test_projects data migration."""

--- a/v2/backend/apps/core/tests/test_me_events.py
+++ b/v2/backend/apps/core/tests/test_me_events.py
@@ -15,14 +15,18 @@ Cobertura:
 
 from __future__ import annotations
 
-from django.contrib.auth import get_user_model
 from django.urls import reverse
 from django.utils import timezone
 from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import Municipio, Participation, Projeto, Solicitacao, TipoEvento
+from apps.core.models import Municipio, Participation, Projeto, Solicitacao
+from apps.core.tests.factories import (
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 pytestmark = pytest.mark.django_db
 
@@ -30,13 +34,12 @@ pytestmark = pytest.mark.django_db
 @pytest.fixture
 def make_user():
     """Cria Usuario com cpf único."""
-    User = get_user_model()
     counter = {"i": 0}
 
     def _factory(username: str = "", **extra):
         counter["i"] += 1
         idx = counter["i"]
-        return User.objects.create_user(
+        return UsuarioFactory(
             username=username or f"user_{idx}",
             email=f"user_{idx}@example.com",
             password="testpass123",
@@ -61,9 +64,7 @@ def make_solicitacao(make_user):
                 nome="Fortaleza", uf="CE", defaults={"ativo": True}
             )
         if "tipo_evento" not in kwargs:
-            kwargs["tipo_evento"], _ = TipoEvento.objects.get_or_create(
-                nome="Formação E2E", defaults={"descricao": "Formação para tests"}
-            )
+            kwargs["tipo_evento"] = TipoEventoFactory(nome="Formação E2E", descricao="Formação para tests")
         if "projeto" not in kwargs:
             kwargs["projeto"], _ = Projeto.objects.get_or_create(nome="Projeto Teste", defaults={"ativo": True})
         if "inicio" not in kwargs:
@@ -72,7 +73,7 @@ def make_solicitacao(make_user):
             kwargs["fim"] = kwargs["inicio"] + timezone.timedelta(hours=2)
         if "status" not in kwargs:
             kwargs["status"] = "aprovado"
-        return Solicitacao.objects.create(**kwargs)
+        return SolicitacaoFactory(**kwargs)
 
     return _factory
 

--- a/v2/backend/apps/core/tests/test_me_policies.py
+++ b/v2/backend/apps/core/tests/test_me_policies.py
@@ -18,8 +18,6 @@ Padrão: TDD-first — testes escritos antes da implementação.
 
 from __future__ import annotations
 
-from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Group
 from django.core.management import call_command
 from django.urls import reverse
 from rest_framework.test import APIClient
@@ -28,6 +26,7 @@ import pytest
 
 from apps.core.models import PermissaoFuncional
 from apps.core.rbac.policies import ACCESS_POLICIES, PUBLIC_POLICY_KEYS, _PolicyPermission
+from apps.core.tests.factories import GroupFactory, UsuarioFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -50,15 +49,14 @@ def _next_cpf() -> str:
 
 def _make_user(username: str, *codenames: str):
     """Cria User autenticado e atribui capabilities via grupo dedicado."""
-    User = get_user_model()
-    user = User.objects.create_user(
+    user = UsuarioFactory(
         username=username,
         email=f"{username}@example.com",
         password="testpass123",
         cpf=_next_cpf(),
     )
     if codenames:
-        group, _ = Group.objects.get_or_create(name=f"test-group-{username}")
+        group = GroupFactory(name=f"test-group-{username}")
         user.groups.add(group)
         for code in codenames:
             perm = PermissaoFuncional.objects.filter(codename=code).first()
@@ -110,13 +108,7 @@ class TestBasicCases:
         assert body == []
 
     def test_superuser_returns_all_public_policy_keys_sorted(self, seeded_db):
-        User = get_user_model()
-        super_user = User.objects.create_superuser(
-            username="super_test",
-            email="super_test@example.com",
-            password="testpass123",
-            cpf="99900000999",
-        )
+        super_user = UsuarioFactory(superuser=True)
         client = APIClient()
         client.force_authenticate(user=super_user)
         res = client.get(reverse(ENDPOINT_URL_NAME))
@@ -171,13 +163,7 @@ class TestContract:
         assert isinstance(body, list), f"Response deve ser JSON list (flat), não object. Got: {type(body).__name__}"
 
     def test_response_is_alphabetically_sorted(self, seeded_db):
-        User = get_user_model()
-        super_user = User.objects.create_superuser(
-            username="sorted_test",
-            email="sorted_test@example.com",
-            password="testpass123",
-            cpf="99900001000",
-        )
+        super_user = UsuarioFactory(superuser=True)
         client = APIClient()
         client.force_authenticate(user=super_user)
         res = client.get(reverse(ENDPOINT_URL_NAME))
@@ -189,13 +175,7 @@ class TestContract:
         Anti-leakage guard: nenhum elemento da response pode ser uma key fora
         de PUBLIC_POLICY_KEYS. Garante que policy interna futura não vaze.
         """
-        User = get_user_model()
-        super_user = User.objects.create_superuser(
-            username="leak_test",
-            email="leak_test@example.com",
-            password="testpass123",
-            cpf="99900001001",
-        )
+        super_user = UsuarioFactory(superuser=True)
         client = APIClient()
         client.force_authenticate(user=super_user)
         res = client.get(reverse(ENDPOINT_URL_NAME))
@@ -215,13 +195,7 @@ class TestContract:
         view_compras_dashboard, view_overview_dashboard, view_map_metrics,
         view_all_availability) — essas são intencionais.
         """
-        User = get_user_model()
-        super_user = User.objects.create_superuser(
-            username="codename_leak_test",
-            email="codename_leak_test@example.com",
-            password="testpass123",
-            cpf="99900001002",
-        )
+        super_user = UsuarioFactory(superuser=True)
         client = APIClient()
         client.force_authenticate(user=super_user)
         res = client.get(reverse(ENDPOINT_URL_NAME))

--- a/v2/backend/apps/core/tests/test_metrics_api.py
+++ b/v2/backend/apps/core/tests/test_metrics_api.py
@@ -16,23 +16,30 @@ from __future__ import annotations
 
 from datetime import timedelta
 
-from django.contrib.auth.models import Group
 from django.utils import timezone
 from rest_framework import status as http_status
 from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import AuditLog, Municipio, Participation, Projeto, Solicitacao, TipoEvento, Usuario
+from apps.core.models import AuditLog, Participation, Solicitacao
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 
 @pytest.fixture
 def grupos(db):
     """Create necessary groups (Controle, Gerência, Formador, Coordenador)"""
-    controle, _ = Group.objects.get_or_create(name="Controle")
-    gerencia, _ = Group.objects.get_or_create(name="Gerência")
-    formador, _ = Group.objects.get_or_create(name="Formador")
-    coordenador, _ = Group.objects.get_or_create(name="Coordenador")
+    controle = GroupFactory(name="Controle")
+    gerencia = GroupFactory(name="Gerência")
+    formador = GroupFactory(name="Formador")
+    coordenador = GroupFactory(name="Coordenador")
     return {
         "controle": controle,
         "gerencia": gerencia,
@@ -44,7 +51,7 @@ def grupos(db):
 @pytest.fixture
 def controle_user(db, grupos):
     """User in Controle group"""
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username="controle1",
         email="controle1@test.com",
         password="testpass123",
@@ -59,7 +66,7 @@ def controle_user(db, grupos):
 @pytest.fixture
 def gerencia_user(db, grupos):
     """User in Gerência group"""
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username="gerencia1",
         email="gerencia1@test.com",
         password="testpass123",
@@ -74,7 +81,7 @@ def gerencia_user(db, grupos):
 @pytest.fixture
 def formador_user(db, grupos):
     """User in Formador group (unauthorized for metrics)"""
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username="formador1",
         email="formador1@test.com",
         password="testpass123",
@@ -89,7 +96,7 @@ def formador_user(db, grupos):
 @pytest.fixture
 def coordenador_user(db, grupos):
     """User in Coordenador group (unauthorized for metrics)"""
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username="coord1",
         email="coord1@test.com",
         password="testpass123",
@@ -102,25 +109,25 @@ def coordenador_user(db, grupos):
 @pytest.fixture
 def tipo_evento(db):
     """Sample event type"""
-    return TipoEvento.objects.create(nome="Formação", descricao="Formação presencial")
+    return TipoEventoFactory(nome="Formação", descricao="Formação presencial")
 
 
 @pytest.fixture
 def projeto(db):
     """Sample project"""
-    return Projeto.objects.create(nome="Projeto Teste", codigo="TESTE", fluxo="SUPER")
+    return ProjetoFactory(nome="Projeto Teste", codigo="TESTE", fluxo="SUPER")
 
 
 @pytest.fixture
 def municipio_a(db):
     """Municipality A"""
-    return Municipio.objects.create(nome="Fortaleza", uf="CE", ibge_code="2304400")
+    return MunicipioFactory(nome="Fortaleza", uf="CE", ibge_code="2304400")
 
 
 @pytest.fixture
 def municipio_b(db):
     """Municipality B"""
-    return Municipio.objects.create(nome="Caucaia", uf="CE", ibge_code="2303501")
+    return MunicipioFactory(nome="Caucaia", uf="CE", ibge_code="2303501")
 
 
 @pytest.mark.django_db
@@ -155,7 +162,7 @@ class TestProductivityMetrics:
 
         # 6 approved
         for i in range(6):
-            sol = Solicitacao.objects.create(
+            sol = SolicitacaoFactory(
                 usuario=controle_user,
                 tipo_evento=tipo_evento,
                 projeto=projeto,
@@ -182,7 +189,7 @@ class TestProductivityMetrics:
 
         # 3 rejected
         for i in range(3):
-            sol = Solicitacao.objects.create(
+            sol = SolicitacaoFactory(
                 usuario=controle_user,
                 tipo_evento=tipo_evento,
                 projeto=projeto,
@@ -196,7 +203,7 @@ class TestProductivityMetrics:
             solicitacoes.append(sol)
 
         # 1 pending
-        sol = Solicitacao.objects.create(
+        sol = SolicitacaoFactory(
             usuario=controle_user,
             tipo_evento=tipo_evento,
             projeto=projeto,
@@ -265,7 +272,7 @@ class TestProductivityMetrics:
         now = timezone.now()
 
         # Create event 2 days ago (should be included in days=7)
-        Solicitacao.objects.create(
+        SolicitacaoFactory(
             usuario=controle_user,
             tipo_evento=tipo_evento,
             projeto=projeto,
@@ -277,7 +284,7 @@ class TestProductivityMetrics:
         )
 
         # Create event 10 days ago (should NOT be included in days=7)
-        Solicitacao.objects.create(
+        SolicitacaoFactory(
             usuario=controle_user,
             tipo_evento=tipo_evento,
             projeto=projeto,
@@ -324,7 +331,7 @@ class TestFormadoresMetrics:
         client = APIClient()
 
         # Create Controle user for authentication
-        controle_user = Usuario.objects.create_user(
+        controle_user = UsuarioFactory(
             username="controle_test",
             email="controle@test.com",
             password="testpass123",
@@ -340,7 +347,7 @@ class TestFormadoresMetrics:
         # Create 15 formadores
         formadores = []
         for i in range(15):
-            formador = Usuario.objects.create_user(
+            formador = UsuarioFactory(
                 username=f"formador{i}",
                 email=f"formador{i}@test.com",
                 password="testpass123",
@@ -359,7 +366,7 @@ class TestFormadoresMetrics:
 
             for i in range(count):
                 # Create solicitacao (approved, in date range)
-                sol = Solicitacao.objects.create(
+                sol = SolicitacaoFactory(
                     usuario=controle_user,
                     tipo_evento=tipo_evento,
                     projeto=projeto,
@@ -420,7 +427,7 @@ class TestFormadoresMetrics:
         """Test that formadores ranking is limited to top 10"""
         client = APIClient()
 
-        controle_user = Usuario.objects.create_user(
+        controle_user = UsuarioFactory(
             username="controle_top10",
             email="controle_top10@test.com",
             password="testpass123",
@@ -435,7 +442,7 @@ class TestFormadoresMetrics:
 
         # Create 15 formadores with 1 event each
         for i in range(15):
-            formador = Usuario.objects.create_user(
+            formador = UsuarioFactory(
                 username=f"formador_top10_{i}",
                 email=f"formador_top10_{i}@test.com",
                 password="testpass123",
@@ -446,7 +453,7 @@ class TestFormadoresMetrics:
             formador.groups.add(grupos["formador"])
 
             # Create 1 event
-            sol = Solicitacao.objects.create(
+            sol = SolicitacaoFactory(
                 usuario=controle_user,
                 tipo_evento=tipo_evento,
                 projeto=projeto,
@@ -477,7 +484,7 @@ class TestFormadoresMetrics:
         """Test that guest participations (no usuario) are excluded"""
         client = APIClient()
 
-        controle_user = Usuario.objects.create_user(
+        controle_user = UsuarioFactory(
             username="controle_guest",
             email="controle_guest@test.com",
             password="testpass123",
@@ -491,7 +498,7 @@ class TestFormadoresMetrics:
         base_time = now - timedelta(days=5)
 
         # Create event with guest participation (should be excluded)
-        sol = Solicitacao.objects.create(
+        sol = SolicitacaoFactory(
             usuario=controle_user,
             tipo_evento=tipo_evento,
             projeto=projeto,
@@ -551,7 +558,7 @@ class TestQualityMetrics:
 
         # 7 approved (no conflicts)
         for i in range(7):
-            sol = Solicitacao.objects.create(
+            sol = SolicitacaoFactory(
                 usuario=controle_user,
                 tipo_evento=tipo_evento,
                 projeto=projeto,
@@ -574,7 +581,7 @@ class TestQualityMetrics:
             solicitacoes.append(sol)
 
         # 1 approved with conflict in observacoes
-        sol_conflict = Solicitacao.objects.create(
+        sol_conflict = SolicitacaoFactory(
             usuario=controle_user,
             tipo_evento=tipo_evento,
             projeto=projeto,
@@ -590,7 +597,7 @@ class TestQualityMetrics:
 
         # 2 rejected
         for i in range(2):
-            sol = Solicitacao.objects.create(
+            sol = SolicitacaoFactory(
                 usuario=controle_user,
                 tipo_evento=tipo_evento,
                 projeto=projeto,

--- a/v2/backend/apps/core/tests/test_metrics_map.py
+++ b/v2/backend/apps/core/tests/test_metrics_map.py
@@ -18,14 +18,21 @@ from __future__ import annotations
 
 from datetime import timedelta
 
-from django.contrib.auth.models import Group
 from django.urls import reverse
 from django.utils import timezone
 from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import Compra, Municipio, Participation, Produto, Projeto, Solicitacao, TipoEvento, Usuario
+from apps.core.models import Compra, Participation, Produto
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 pytestmark = pytest.mark.django_db
 
@@ -38,19 +45,19 @@ pytestmark = pytest.mark.django_db
 def grupos():
     """Criar grupos necessários para os testes."""
     return {
-        "diretoria": Group.objects.get_or_create(name="Diretoria")[0],
-        "controle": Group.objects.get_or_create(name="Controle")[0],
-        "dat": Group.objects.get_or_create(name="DAT")[0],
-        "superintendencia": Group.objects.get_or_create(name="Superintendência")[0],
-        "coordenador": Group.objects.get_or_create(name="Coordenador")[0],
-        "formador": Group.objects.get_or_create(name="Formador")[0],
+        "diretoria": GroupFactory(name="Diretoria"),
+        "controle": GroupFactory(name="Controle"),
+        "dat": GroupFactory(name="DAT"),
+        "superintendencia": GroupFactory(name="Superintendência"),
+        "coordenador": GroupFactory(name="Coordenador"),
+        "formador": GroupFactory(name="Formador"),
     }
 
 
 @pytest.fixture
 def user_diretoria(grupos):
     """Issue #1222 (Epic 1): Diretoria tem `view_map_metrics` no seed realinhado."""
-    user = Usuario.objects.create_user(username="diretoria1", email="dir@x.com", password="x", cpf="99999999991")
+    user = UsuarioFactory(username="diretoria1", email="dir@x.com", password="x", cpf="99999999991")
     user.groups.add(grupos["diretoria"])
     return user
 
@@ -58,7 +65,7 @@ def user_diretoria(grupos):
 @pytest.fixture
 def user_controle(grupos):
     """Usuário do grupo Controle (sem view_map_metrics no seed realinhado)."""
-    user = Usuario.objects.create_user(username="controle1", email="controle@x.com", password="x", cpf="11111111111")
+    user = UsuarioFactory(username="controle1", email="controle@x.com", password="x", cpf="11111111111")
     user.groups.add(grupos["controle"])
     return user
 
@@ -66,7 +73,7 @@ def user_controle(grupos):
 @pytest.fixture
 def user_dat(grupos):
     """Usuário do grupo DAT."""
-    user = Usuario.objects.create_user(username="dat1", email="dat@x.com", password="x", cpf="22222222222")
+    user = UsuarioFactory(username="dat1", email="dat@x.com", password="x", cpf="22222222222")
     user.groups.add(grupos["dat"])
     return user
 
@@ -74,7 +81,7 @@ def user_dat(grupos):
 @pytest.fixture
 def user_coordenador(grupos):
     """Usuário do grupo Coordenador (sem permissão)."""
-    user = Usuario.objects.create_user(username="coord1", email="coord@x.com", password="x", cpf="33333333333")
+    user = UsuarioFactory(username="coord1", email="coord@x.com", password="x", cpf="33333333333")
     user.groups.add(grupos["coordenador"])
     return user
 
@@ -82,7 +89,7 @@ def user_coordenador(grupos):
 @pytest.fixture
 def user_formador(grupos):
     """Usuário do grupo Formador (sem permissão)."""
-    user = Usuario.objects.create_user(username="form1", email="form@x.com", password="x", cpf="44444444444")
+    user = UsuarioFactory(username="form1", email="form@x.com", password="x", cpf="44444444444")
     user.groups.add(grupos["formador"])
     return user
 
@@ -91,26 +98,20 @@ def user_formador(grupos):
 def dados_basicos(grupos):
     """Criar dados básicos para os testes."""
     # Formadores (usuários)
-    formador1 = Usuario.objects.create_user(username="ana.silva", email="ana@x.com", password="x", cpf="55555555555")
+    formador1 = UsuarioFactory(username="ana.silva", email="ana@x.com", password="x", cpf="55555555555")
     formador1.groups.add(grupos["formador"])
 
     # Municípios (3 UFs diferentes) com coordenadas para testes
-    mun_ce = Municipio.objects.create(
-        nome="Fortaleza", uf="CE", ibge_code="2304400", latitude=-3.717200, longitude=-38.543400
-    )
-    mun_sp = Municipio.objects.create(
-        nome="São Paulo", uf="SP", ibge_code="3550308", latitude=-23.550520, longitude=-46.633308
-    )
-    mun_ba = Municipio.objects.create(
-        nome="Salvador", uf="BA", ibge_code="2927408", latitude=-12.971400, longitude=-38.510800
-    )
+    mun_ce = MunicipioFactory(nome="Fortaleza", uf="CE", ibge_code="2304400", latitude=-3.717200, longitude=-38.543400)
+    mun_sp = MunicipioFactory(nome="São Paulo", uf="SP", ibge_code="3550308", latitude=-23.550520, longitude=-46.633308)
+    mun_ba = MunicipioFactory(nome="Salvador", uf="BA", ibge_code="2927408", latitude=-12.971400, longitude=-38.510800)
 
     # Projetos (fluxo='SUPER' para permitir testar diferentes status)
-    proj1 = Projeto.objects.create(nome="Vida & Matemática", codigo="P001", fluxo="SUPER")
-    proj2 = Projeto.objects.create(nome="TEMA", codigo="P002", fluxo="SUPER")
+    proj1 = ProjetoFactory(nome="Vida & Matemática", codigo="P001", fluxo="SUPER")
+    proj2 = ProjetoFactory(nome="TEMA", codigo="P002", fluxo="SUPER")
 
     # Tipos de evento
-    tipo1 = TipoEvento.objects.create(nome="Formação Inicial")
+    tipo1 = TipoEventoFactory(nome="Formação Inicial")
 
     return {
         "formador": formador1,
@@ -127,15 +128,13 @@ def solicitacoes_variedade(dados_basicos):
     formador = dados_basicos["formador"]
 
     # Criar um usuário coordenador para ser o criador
-    coordenador = Usuario.objects.create_user(
-        username="coord_test", email="coord_test@x.com", password="x", cpf="88888888888"
-    )
+    coordenador = UsuarioFactory(username="coord_test", email="coord_test@x.com", password="x", cpf="88888888888")
 
     solicitacoes = []
 
     # 3 aprovadas em CE, projeto Matemática
     for i in range(3):
-        sol = Solicitacao.objects.create(
+        sol = SolicitacaoFactory(
             usuario=coordenador,
             status="aprovado",
             inicio=now + timedelta(days=i),
@@ -149,7 +148,7 @@ def solicitacoes_variedade(dados_basicos):
 
     # 2 pendentes em SP, projeto TEMA
     for i in range(2):
-        sol = Solicitacao.objects.create(
+        sol = SolicitacaoFactory(
             usuario=coordenador,
             status="pendente",
             inicio=now + timedelta(days=10 + i),
@@ -162,7 +161,7 @@ def solicitacoes_variedade(dados_basicos):
         solicitacoes.append(sol)
 
     # 1 reprovada em BA, projeto Matemática
-    sol = Solicitacao.objects.create(
+    sol = SolicitacaoFactory(
         usuario=coordenador,
         status="reprovado",
         inicio=now + timedelta(days=20),
@@ -249,7 +248,7 @@ def test_map_metrics_formador_forbidden(user_formador):
 
 def test_map_metrics_superuser_allowed():
     """Superuser sempre tem acesso."""
-    user = Usuario.objects.create_superuser(username="admin", email="admin@x.com", password="x", cpf="99999999999")
+    user = UsuarioFactory(superuser=True)
     client = APIClient()
     client.force_authenticate(user=user)
 
@@ -378,17 +377,17 @@ def test_map_metrics_coordenadores_homonimos_nao_colidem_por_nome(user_diretoria
     client = APIClient()
     client.force_authenticate(user=user_diretoria)
 
-    projeto = Projeto.objects.create(nome="Projeto Homônimos", codigo="PH01", fluxo="SUPER")
-    tipo = TipoEvento.objects.create(nome="Tipo Homônimos")
+    projeto = ProjetoFactory(nome="Projeto Homônimos", codigo="PH01", fluxo="SUPER")
+    tipo = TipoEventoFactory(nome="Tipo Homônimos")
 
-    municipio_ce = Municipio.objects.create(
+    municipio_ce = MunicipioFactory(
         nome="Santa Maria",
         uf="CE",
         ibge_code="2300001",
         latitude=-3.12,
         longitude=-39.10,
     )
-    municipio_sp = Municipio.objects.create(
+    municipio_sp = MunicipioFactory(
         nome="Santa Maria",
         uf="SP",
         ibge_code="3500001",
@@ -396,21 +395,17 @@ def test_map_metrics_coordenadores_homonimos_nao_colidem_por_nome(user_diretoria
         longitude=-47.10,
     )
 
-    criador = Usuario.objects.create_user(
+    criador = UsuarioFactory(
         username="criador_homonimo",
         email="criador_homonimo@test.com",
         password="x",
         cpf="10101010101",
     )
-    coord_ce = Usuario.objects.create_user(
-        username="coord_ce", email="coord_ce@test.com", password="x", cpf="20202020202"
-    )
-    coord_sp = Usuario.objects.create_user(
-        username="coord_sp", email="coord_sp@test.com", password="x", cpf="30303030303"
-    )
+    coord_ce = UsuarioFactory(username="coord_ce", email="coord_ce@test.com", password="x", cpf="20202020202")
+    coord_sp = UsuarioFactory(username="coord_sp", email="coord_sp@test.com", password="x", cpf="30303030303")
 
     now = timezone.now()
-    sol_ce = Solicitacao.objects.create(
+    sol_ce = SolicitacaoFactory(
         usuario=criador,
         status="aprovado",
         inicio=now,
@@ -419,7 +414,7 @@ def test_map_metrics_coordenadores_homonimos_nao_colidem_por_nome(user_diretoria
         projeto=projeto,
         tipo_evento=tipo,
     )
-    sol_sp = Solicitacao.objects.create(
+    sol_sp = SolicitacaoFactory(
         usuario=criador,
         status="aprovado",
         inicio=now + timedelta(days=1),
@@ -448,9 +443,9 @@ def test_map_metrics_eventos_e_compras_separados_no_payload(user_diretoria):
     client = APIClient()
     client.force_authenticate(user=user_diretoria)
 
-    projeto = Projeto.objects.create(nome="Projeto Compras", codigo="PC01", fluxo="SUPER")
-    tipo = TipoEvento.objects.create(nome="Tipo Compras")
-    municipio = Municipio.objects.create(
+    projeto = ProjetoFactory(nome="Projeto Compras", codigo="PC01", fluxo="SUPER")
+    tipo = TipoEventoFactory(nome="Tipo Compras")
+    municipio = MunicipioFactory(
         nome="Maracanaú",
         uf="CE",
         ibge_code="2307650",
@@ -458,11 +453,11 @@ def test_map_metrics_eventos_e_compras_separados_no_payload(user_diretoria):
         longitude=-38.62,
     )
 
-    criador = Usuario.objects.create_user(
+    criador = UsuarioFactory(
         username="criador_compra", email="criador_compra@test.com", password="x", cpf="40404040404"
     )
     now = timezone.now()
-    Solicitacao.objects.create(
+    SolicitacaoFactory(
         usuario=criador,
         status="aprovado",
         inicio=now,

--- a/v2/backend/apps/core/tests/test_metrics_team_rbac.py
+++ b/v2/backend/apps/core/tests/test_metrics_team_rbac.py
@@ -24,13 +24,13 @@ Doc §3 da matriz canônica:
 
 from __future__ import annotations
 
-from django.contrib.auth.models import Group
 from django.core.cache import cache
 from rest_framework.test import APIClient
 
 import pytest
 
 from apps.core.models import Usuario
+from apps.core.tests.factories import GroupFactory, UsuarioFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -44,11 +44,9 @@ def _next_cpf() -> str:
 
 
 def _make_user(username: str, group_names: list[str]) -> Usuario:
-    user = Usuario.objects.create_user(
-        username=username, email=f"{username}@example.com", password="testpass123", cpf=_next_cpf()
-    )
+    user = UsuarioFactory(username=username, email=f"{username}@example.com", password="testpass123", cpf=_next_cpf())
     for gname in group_names:
-        group, _ = Group.objects.get_or_create(name=gname)
+        group = GroupFactory(name=gname)
         user.groups.add(group)
     return user
 
@@ -118,9 +116,7 @@ class TestExistingAccessPreserved:
 
     @pytest.mark.parametrize("endpoint", ENDPOINTS)
     def test_superuser_bypass(self, endpoint):
-        super_user = Usuario.objects.create_superuser(
-            username="super_metrics", email="sm@example.com", password="testpass123", cpf="99900099995"
-        )
+        super_user = UsuarioFactory(superuser=True)
         client = APIClient()
         client.force_authenticate(user=super_user)
         res = client.get(endpoint)

--- a/v2/backend/apps/core/tests/test_models_constraints.py
+++ b/v2/backend/apps/core/tests/test_models_constraints.py
@@ -16,13 +16,14 @@ from django.utils import timezone
 
 import pytest
 
-from apps.core.models import AvailabilityBlock, Municipio, Solicitacao, TipoEvento, Usuario
+from apps.core.models import AvailabilityBlock, Solicitacao
+from apps.core.tests.factories import MunicipioFactory, TipoEventoFactory, UsuarioFactory
 
 
 @pytest.fixture
 def usuario_test(db):
     """Cria um usuário de teste"""
-    return Usuario.objects.create_user(
+    return UsuarioFactory(
         username="testuser",
         email="test@example.com",
         password="testpass123",
@@ -33,13 +34,13 @@ def usuario_test(db):
 @pytest.fixture
 def tipo_evento_test(db):
     """Cria um tipo de evento de teste"""
-    return TipoEvento.objects.create(nome="Formação", descricao="Formação presencial")
+    return TipoEventoFactory(nome="Formação", descricao="Formação presencial")
 
 
 @pytest.fixture
 def municipio_test(db):
     """Cria um município de teste"""
-    return Municipio.objects.create(nome="Fortaleza", uf="CE")
+    return MunicipioFactory(nome="Fortaleza", uf="CE")
 
 
 @pytest.mark.django_db

--- a/v2/backend/apps/core/tests/test_monthly_with_deslocamento.py
+++ b/v2/backend/apps/core/tests/test_monthly_with_deslocamento.py
@@ -20,14 +20,16 @@ import pytest
 from apps.core.models import (
     AvailabilityBlock,
     Deslocamento,
-    Municipio,
     Participation,
-    Projeto,
-    Solicitacao,
-    TipoEvento,
-    Usuario,
 )
 from apps.core.services.monthly_grid_service import build_monthly_grid
+from apps.core.tests.factories import (
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 
 @pytest.mark.django_db
@@ -42,26 +44,26 @@ class TestMonthlyWithDeslocamento:
         self.tz = timezone.get_current_timezone()
 
         # Criar usuários
-        self.user_formador = Usuario.objects.create_user(
+        self.user_formador = UsuarioFactory(
             username="formador1",
             email="formador1@example.com",
             password="password123",
         )
 
         # Criar municipio, projeto, tipo_evento
-        self.municipio = Municipio.objects.create(
+        self.municipio = MunicipioFactory(
             nome="Fortaleza",
             uf="CE",
             ativo=True,
         )
 
-        self.projeto = Projeto.objects.create(
+        self.projeto = ProjetoFactory(
             nome="Projeto Teste",
             ativo=True,
             fluxo="SUPER",  # Required for monthly_grid_service.py filter
         )
 
-        self.tipo_evento = TipoEvento.objects.create(
+        self.tipo_evento = TipoEventoFactory(
             nome="Formação",
             cor="#FF0000",
         )
@@ -88,7 +90,7 @@ class TestMonthlyWithDeslocamento:
         )
 
         # Criar participation em OUTUBRO para incluir usuário na grade
-        solicitacao = Solicitacao.objects.create(
+        solicitacao = SolicitacaoFactory(
             usuario=self.user_formador,
             municipio=self.municipio,
             projeto=self.projeto,
@@ -134,7 +136,7 @@ class TestMonthlyWithDeslocamento:
         - Dia 15: código "E"
         """
         # Criar evento aprovado dia 10
-        solicitacao_day10 = Solicitacao.objects.create(
+        solicitacao_day10 = SolicitacaoFactory(
             usuario=self.user_formador,
             municipio=self.municipio,
             projeto=self.projeto,
@@ -159,7 +161,7 @@ class TestMonthlyWithDeslocamento:
         )
 
         # Criar evento aprovado dia 15 (sem deslocamento)
-        solicitacao_day15 = Solicitacao.objects.create(
+        solicitacao_day15 = SolicitacaoFactory(
             usuario=self.user_formador,
             municipio=self.municipio,
             projeto=self.projeto,
@@ -208,7 +210,7 @@ class TestMonthlyWithDeslocamento:
         - Dia 15: código "X"
         """
         # Dia 10: evento + bloqueio + deslocamento
-        solicitacao_day10 = Solicitacao.objects.create(
+        solicitacao_day10 = SolicitacaoFactory(
             usuario=self.user_formador,
             municipio=self.municipio,
             projeto=self.projeto,
@@ -240,7 +242,7 @@ class TestMonthlyWithDeslocamento:
         )
 
         # Dia 15: evento + bloqueio (sem deslocamento)
-        solicitacao_day15 = Solicitacao.objects.create(
+        solicitacao_day15 = SolicitacaoFactory(
             usuario=self.user_formador,
             municipio=self.municipio,
             projeto=self.projeto,
@@ -289,7 +291,7 @@ class TestMonthlyWithDeslocamento:
         - Dia 7: vazio → ""
         """
         # Dia 1: X
-        s1 = Solicitacao.objects.create(
+        s1 = SolicitacaoFactory(
             usuario=self.user_formador,
             municipio=self.municipio,
             projeto=self.projeto,
@@ -315,7 +317,7 @@ class TestMonthlyWithDeslocamento:
         )
 
         # Dia 2: D1
-        s2 = Solicitacao.objects.create(
+        s2 = SolicitacaoFactory(
             usuario=self.user_formador,
             municipio=self.municipio,
             projeto=self.projeto,
@@ -334,7 +336,7 @@ class TestMonthlyWithDeslocamento:
         )
 
         # Dia 3: 2
-        s3a = Solicitacao.objects.create(
+        s3a = SolicitacaoFactory(
             usuario=self.user_formador,
             municipio=self.municipio,
             projeto=self.projeto,
@@ -344,7 +346,7 @@ class TestMonthlyWithDeslocamento:
             status="aprovado",
         )
         Participation.objects.create(solicitacao=s3a, usuario=self.user_formador, role="FORMADOR")
-        s3b = Solicitacao.objects.create(
+        s3b = SolicitacaoFactory(
             usuario=self.user_formador,
             municipio=self.municipio,
             projeto=self.projeto,
@@ -356,7 +358,7 @@ class TestMonthlyWithDeslocamento:
         Participation.objects.create(solicitacao=s3b, usuario=self.user_formador, role="FORMADOR")
 
         # Dia 4: E
-        s4 = Solicitacao.objects.create(
+        s4 = SolicitacaoFactory(
             usuario=self.user_formador,
             municipio=self.municipio,
             projeto=self.projeto,
@@ -420,7 +422,7 @@ class TestMonthlyWithDeslocamento:
         )
 
         # Criar participation em OUTUBRO para incluir usuário na grade
-        solicitacao = Solicitacao.objects.create(
+        solicitacao = SolicitacaoFactory(
             usuario=self.user_formador,
             municipio=self.municipio,
             projeto=self.projeto,
@@ -470,7 +472,7 @@ class TestMonthlyWithDeslocamento:
         )
 
         # Criar participation em OUTUBRO para incluir usuário na grade
-        solicitacao = Solicitacao.objects.create(
+        solicitacao = SolicitacaoFactory(
             usuario=self.user_formador,
             municipio=self.municipio,
             projeto=self.projeto,

--- a/v2/backend/apps/core/tests/test_multi_sector_permissions.py
+++ b/v2/backend/apps/core/tests/test_multi_sector_permissions.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from django.contrib.auth.models import Group
 from django.core.cache import cache
 from django.test import TestCase
 from django.utils import timezone
@@ -25,14 +24,17 @@ from apps.core.models import (
     AvailabilityBlock,
     EquipeGerencia,
     Gerencia,
-    Municipio,
     Participation,
-    Projeto,
-    Solicitacao,
-    TipoEvento,
-    Usuario,
 )
 from apps.core.permissions import HasSectorAccess
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 
 class MockView:
@@ -52,22 +54,17 @@ class TestHasSectorAccessPermission(TestCase):
         self.permission = HasSectorAccess()
 
         # Criar grupos
-        self.controle_group, _ = Group.objects.get_or_create(name="Controle")
-        self.formador_group, _ = Group.objects.get_or_create(name="Formador")
+        self.controle_group = GroupFactory(name="Controle")
+        self.formador_group = GroupFactory(name="Formador")
 
         # Criar gerências
         self.gerencia_vidas = Gerencia.objects.create(nome="GERENCIA 2", nome_setor="Vidas")
         self.gerencia_fluir = Gerencia.objects.create(nome="GERENCIA 3", nome_setor="Fluir")
 
         # Criar usuários
-        self.superuser = Usuario.objects.create_superuser(
-            username="admin",
-            email="admin@test.com",
-            password="admin123",
-            cpf="00000000000",
-        )
+        self.superuser = UsuarioFactory(superuser=True)
 
-        self.user_controle = Usuario.objects.create_user(
+        self.user_controle = UsuarioFactory(
             username="controle_user",
             email="controle@test.com",
             password="test123",
@@ -75,7 +72,7 @@ class TestHasSectorAccessPermission(TestCase):
         )
         self.user_controle.groups.add(self.controle_group)
 
-        self.user_vidas = Usuario.objects.create_user(
+        self.user_vidas = UsuarioFactory(
             username="vidas_user",
             email="vidas@test.com",
             password="test123",
@@ -87,7 +84,7 @@ class TestHasSectorAccessPermission(TestCase):
             papel="FORMADOR",
         )
 
-        self.user_fluir = Usuario.objects.create_user(
+        self.user_fluir = UsuarioFactory(
             username="fluir_user",
             email="fluir@test.com",
             password="test123",
@@ -99,7 +96,7 @@ class TestHasSectorAccessPermission(TestCase):
             papel="FORMADOR",
         )
 
-        self.user_sem_gerencia = Usuario.objects.create_user(
+        self.user_sem_gerencia = UsuarioFactory(
             username="sem_gerencia",
             email="sem@test.com",
             password="test123",
@@ -183,20 +180,15 @@ class TestMonthlyAvailabilityViewMultiSector(TestCase):
         self.client = APIClient()
 
         # Criar grupos
-        self.controle_group, _ = Group.objects.get_or_create(name="Controle")
+        self.controle_group = GroupFactory(name="Controle")
 
         # Criar gerências
         self.gerencia_vidas = Gerencia.objects.create(nome="GERENCIA 2", nome_setor="Vidas")
 
         # Criar usuários
-        self.superuser = Usuario.objects.create_superuser(
-            username="admin",
-            email="admin@test.com",
-            password="admin123",
-            cpf="00000000000",
-        )
+        self.superuser = UsuarioFactory(superuser=True)
 
-        self.user_vidas = Usuario.objects.create_user(
+        self.user_vidas = UsuarioFactory(
             username="vidas_user",
             email="vidas@test.com",
             password="test123",
@@ -208,7 +200,7 @@ class TestMonthlyAvailabilityViewMultiSector(TestCase):
             papel="FORMADOR",
         )
 
-        self.user_controle = Usuario.objects.create_user(
+        self.user_controle = UsuarioFactory(
             username="controle_user",
             email="controle@test.com",
             password="test123",
@@ -264,7 +256,7 @@ class TestMonthlyAvailabilityViewMultiSector(TestCase):
 
         # Segunda gerência e usuário de outro setor
         gerencia_fluir = Gerencia.objects.create(nome="GERENCIA 3", nome_setor="Fluir")
-        user_fluir = Usuario.objects.create_user(
+        user_fluir = UsuarioFactory(
             username="fluir_user",
             email="fluir@test.com",
             password="test123",
@@ -276,12 +268,12 @@ class TestMonthlyAvailabilityViewMultiSector(TestCase):
             papel="FORMADOR",
         )
 
-        municipio = Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
-        projeto = Projeto.objects.create(nome="Projeto SUPER", fluxo="SUPER", ativo=True)
-        tipo_evento = TipoEvento.objects.create(nome="Formação")
+        municipio = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+        projeto = ProjetoFactory(nome="Projeto SUPER", fluxo="SUPER", ativo=True)
+        tipo_evento = TipoEventoFactory(nome="Formação")
 
         # Evento da gerência do usuário autenticado
-        sol_vidas = Solicitacao.objects.create(
+        sol_vidas = SolicitacaoFactory(
             usuario=self.user_vidas,
             municipio=municipio,
             projeto=projeto,
@@ -293,7 +285,7 @@ class TestMonthlyAvailabilityViewMultiSector(TestCase):
         Participation.objects.create(solicitacao=sol_vidas, usuario=self.user_vidas, role="FORMADOR")
 
         # Evento de outra gerência (não deve aparecer)
-        sol_fluir = Solicitacao.objects.create(
+        sol_fluir = SolicitacaoFactory(
             usuario=user_fluir,
             municipio=municipio,
             projeto=projeto,
@@ -355,8 +347,8 @@ class TestAvailabilityBlockViewSetMultiSector(TestCase):
         self.client = APIClient()
 
         # Criar grupos (get_or_create para evitar duplicatas)
-        self.controle_group, _ = Group.objects.get_or_create(name="Controle")
-        self.superintendencia_group, _ = Group.objects.get_or_create(name="Superintendência")
+        self.controle_group = GroupFactory(name="Controle")
+        self.superintendencia_group = GroupFactory(name="Superintendência")
 
         # Criar gerências com nomes únicos para este teste
         self.gerencia_vidas, _ = Gerencia.objects.get_or_create(
@@ -371,14 +363,9 @@ class TestAvailabilityBlockViewSetMultiSector(TestCase):
 
         unique_suffix = uuid.uuid4().hex[:8]
 
-        self.superuser = Usuario.objects.create_superuser(
-            username=f"admin_block_{unique_suffix}",
-            email=f"admin_block_{unique_suffix}@test.com",
-            password="admin123",
-            cpf=f"99{unique_suffix[:9]}",
-        )
+        self.superuser = UsuarioFactory(superuser=True)
 
-        self.user_vidas = Usuario.objects.create_user(
+        self.user_vidas = UsuarioFactory(
             username=f"vidas_block_{unique_suffix}",
             email=f"vidas_block_{unique_suffix}@test.com",
             password="test123",
@@ -391,7 +378,7 @@ class TestAvailabilityBlockViewSetMultiSector(TestCase):
         )
 
         # Usuário par na mesma gerência (usado para validar IDOR em update/delete)
-        self.user_vidas_peer = Usuario.objects.create_user(
+        self.user_vidas_peer = UsuarioFactory(
             username=f"vidas_peer_{unique_suffix}",
             email=f"vidas_peer_{unique_suffix}@test.com",
             password="test123",
@@ -403,7 +390,7 @@ class TestAvailabilityBlockViewSetMultiSector(TestCase):
             papel="FORMADOR",
         )
 
-        self.user_fluir = Usuario.objects.create_user(
+        self.user_fluir = UsuarioFactory(
             username=f"fluir_block_{unique_suffix}",
             email=f"fluir_block_{unique_suffix}@test.com",
             password="test123",
@@ -415,7 +402,7 @@ class TestAvailabilityBlockViewSetMultiSector(TestCase):
             papel="FORMADOR",
         )
 
-        self.user_controle = Usuario.objects.create_user(
+        self.user_controle = UsuarioFactory(
             username=f"controle_block_{unique_suffix}",
             email=f"controle_block_{unique_suffix}@test.com",
             password="test123",

--- a/v2/backend/apps/core/tests/test_municipios_admin_cache.py
+++ b/v2/backend/apps/core/tests/test_municipios_admin_cache.py
@@ -6,17 +6,14 @@ Tests for municipio cache invalidation through the admin API.
 
 from __future__ import annotations
 
-from uuid import uuid4
-
-from django.contrib.auth.models import Group
 from django.core.cache import cache
 from rest_framework import status
 from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import Municipio, Usuario
 from apps.core.services.options_cache import MUNICIPIOS_OPTIONS_CACHE_KEY
+from apps.core.tests.factories import MunicipioFactory, UsuarioFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -28,16 +25,7 @@ def api_client():
 
 @pytest.fixture
 def usuario_dat():
-    uid = uuid4().hex[:8]
-    user = Usuario.objects.create_user(
-        username=f"dat_{uid}",
-        email=f"dat_{uid}@example.com",
-        password="senha123",
-        cpf=str(uuid4().int % 10**11).zfill(11),
-    )
-    group_dat, _ = Group.objects.get_or_create(name="DAT")
-    user.groups.add(group_dat)
-    return user
+    return UsuarioFactory(groups=["DAT"])
 
 
 def test_dat_create_municipio_invalidates_options_cache(api_client, usuario_dat):
@@ -52,7 +40,7 @@ def test_dat_create_municipio_invalidates_options_cache(api_client, usuario_dat)
 
 
 def test_dat_update_municipio_invalidates_options_cache(api_client, usuario_dat):
-    municipio = Municipio.objects.create(nome="Caucaia", uf="CE", ibge_code="2303709", ativo=True)
+    municipio = MunicipioFactory(nome="Caucaia", uf="CE", ibge_code="2303709", ativo=True)
     cache.set(MUNICIPIOS_OPTIONS_CACHE_KEY, [{"id": municipio.id, "nome": "stale", "uf": "CE"}], timeout=300)
 
     api_client.force_authenticate(user=usuario_dat)
@@ -63,7 +51,7 @@ def test_dat_update_municipio_invalidates_options_cache(api_client, usuario_dat)
 
 
 def test_dat_delete_municipio_invalidates_options_cache(api_client, usuario_dat):
-    municipio = Municipio.objects.create(nome="Caucaia", uf="CE", ibge_code="2303709", ativo=True)
+    municipio = MunicipioFactory(nome="Caucaia", uf="CE", ibge_code="2303709", ativo=True)
     cache.set(MUNICIPIOS_OPTIONS_CACHE_KEY, [{"id": municipio.id, "nome": "stale", "uf": "CE"}], timeout=300)
 
     api_client.force_authenticate(user=usuario_dat)

--- a/v2/backend/apps/core/tests/test_notificacoes_acoes_service.py
+++ b/v2/backend/apps/core/tests/test_notificacoes_acoes_service.py
@@ -8,8 +8,6 @@ from __future__ import annotations
 
 from datetime import date
 
-from django.contrib.auth.models import Group
-
 import pytest
 
 from apps.core.models import (
@@ -18,14 +16,18 @@ from apps.core.models import (
     AcaoTemplateExecutor,
     AuditLog,
     CicloAcoes,
-    Municipio,
     NotificacaoInterna,
-    Projeto,
     Usuario,
 )
 from apps.core.services.notificacoes_acoes_service import AcoesNotificacaoDailyService
 from apps.core.services.prazo_engine_service import PrazoEngineService
 from apps.core.tasks import processar_notificacoes_acoes_diarias
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    UsuarioFactory,
+)
 
 
 @pytest.fixture
@@ -35,16 +37,12 @@ def user_factory(db):
     def _create(*, prefix: str, groups: list[str]) -> Usuario:
         counter["n"] += 1
         idx = counter["n"]
-        user = Usuario.objects.create_user(
+        return UsuarioFactory(
             username=f"{prefix}_{idx}",
             email=f"{prefix}_{idx}@example.com",
-            password="testpass123",
             cpf=f"{idx:011d}",
+            groups=groups,
         )
-        for group_name in groups:
-            group, _ = Group.objects.get_or_create(name=group_name)
-            user.groups.add(group)
-        return user
 
     return _create
 
@@ -52,8 +50,8 @@ def user_factory(db):
 @pytest.fixture
 def base_context(db, user_factory):
     creator = user_factory(prefix="creator", groups=["DAT"])
-    projeto = Projeto.objects.create(nome="Projeto Notificacoes")
-    municipio = Municipio.objects.create(nome="Fortaleza", uf="CE")
+    projeto = ProjetoFactory(nome="Projeto Notificacoes")
+    municipio = MunicipioFactory(nome="Fortaleza", uf="CE")
     ciclo = CicloAcoes.objects.create(
         projeto=projeto,
         municipio=municipio,
@@ -73,7 +71,7 @@ def _create_action(*, ciclo: CicloAcoes, ordem: int, anchor: date, executor_grou
         ref_evento_externo=f"EVENT_{ordem}",
         dias_prazo_uteis=1,
     )
-    group, _ = Group.objects.get_or_create(name=executor_group)
+    group = GroupFactory(name=executor_group)
     AcaoTemplateExecutor.objects.create(acao_template=template, group=group, ativo=True)
 
     action = AcaoInstancia.objects.create(

--- a/v2/backend/apps/core/tests/test_openapi.py
+++ b/v2/backend/apps/core/tests/test_openapi.py
@@ -16,7 +16,7 @@ from typing import Any
 from django.test import TestCase
 from rest_framework.test import APIClient
 
-from apps.core.models import Usuario
+from apps.core.tests.factories import UsuarioFactory
 
 
 class TestOpenAPISchema(TestCase):
@@ -27,11 +27,7 @@ class TestOpenAPISchema(TestCase):
         self.client = APIClient()
 
         # Create superuser for accessing schema
-        self.user = Usuario.objects.create_superuser(
-            username="admin_openapi",
-            email="admin_openapi@test.com",
-            password="testpass123",
-        )
+        self.user = UsuarioFactory(superuser=True)
         self.client.force_authenticate(user=self.user)
 
     def test_schema_endpoint_returns_200(self) -> None:
@@ -391,11 +387,7 @@ class TestSchemaErrors(TestCase):
         """Set up test fixtures."""
         self.client = APIClient()
 
-        self.user = Usuario.objects.create_superuser(
-            username="admin_schema_errors",
-            email="admin_schema_errors@test.com",
-            password="testpass123",
-        )
+        self.user = UsuarioFactory(superuser=True)
         self.client.force_authenticate(user=self.user)
 
     def test_schema_contains_error_responses(self) -> None:

--- a/v2/backend/apps/core/tests/test_pagination.py
+++ b/v2/backend/apps/core/tests/test_pagination.py
@@ -14,11 +14,16 @@ from datetime import timedelta
 from decimal import Decimal
 
 from django.test import TestCase
-from django.urls import reverse
 from django.utils import timezone
 from rest_framework.test import APIClient
 
-from apps.core.models import Municipio, Projeto, Solicitacao, TipoEvento, Usuario
+from apps.core.tests.factories import (
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 
 class TestGCalListPagination(TestCase):
@@ -29,29 +34,25 @@ class TestGCalListPagination(TestCase):
         self.client = APIClient()
 
         # Create superuser with permission
-        self.user = Usuario.objects.create_superuser(
-            username="admin_pagination",
-            email="admin_pagination@test.com",
-            password="testpass123",
-        )
+        self.user = UsuarioFactory(superuser=True)
         self.client.force_authenticate(user=self.user)
 
         # Create required objects
-        self.municipio = Municipio.objects.create(
+        self.municipio = MunicipioFactory(
             nome="Test City",
             uf="CE",
             latitude=Decimal("-3.7172"),
             longitude=Decimal("-38.5433"),
         )
-        self.tipo_evento = TipoEvento.objects.create(nome="Test Type")
-        self.projeto = Projeto.objects.create(nome="Test Project")
+        self.tipo_evento = TipoEventoFactory(nome="Test Type")
+        self.projeto = ProjetoFactory(nome="Test Project")
 
     def test_gcal_list_returns_paginated_response(self) -> None:
         """GCalListView should return paginated response with count, next, results."""
         # Create 10 approved solicitações
         now = timezone.now()
         for i in range(10):
-            Solicitacao.objects.create(
+            SolicitacaoFactory(
                 usuario=self.user,
                 status="aprovado",
                 municipio=self.municipio,
@@ -76,7 +77,7 @@ class TestGCalListPagination(TestCase):
         """GCalListView should respect page_size parameter."""
         now = timezone.now()
         for i in range(15):
-            Solicitacao.objects.create(
+            SolicitacaoFactory(
                 usuario=self.user,
                 status="aprovado",
                 municipio=self.municipio,
@@ -100,7 +101,7 @@ class TestGCalListPagination(TestCase):
         now = timezone.now()
         # Create just a few items
         for i in range(5):
-            Solicitacao.objects.create(
+            SolicitacaoFactory(
                 usuario=self.user,
                 status="aprovado",
                 municipio=self.municipio,
@@ -128,17 +129,13 @@ class TestMetricsMapLimit(TestCase):
         self.client = APIClient()
 
         # Create superuser with permission
-        self.user = Usuario.objects.create_superuser(
-            username="admin_metrics_limit",
-            email="admin_metrics_limit@test.com",
-            password="testpass123",
-        )
+        self.user = UsuarioFactory(superuser=True)
         self.client.force_authenticate(user=self.user)
 
         # Create municipios with coordinates
         self.municipios = []
         for i in range(20):
-            m = Municipio.objects.create(
+            m = MunicipioFactory(
                 nome=f"City {i}",
                 uf="CE",
                 latitude=Decimal("-3.7172") + Decimal(str(i * 0.1)),
@@ -146,13 +143,13 @@ class TestMetricsMapLimit(TestCase):
             )
             self.municipios.append(m)
 
-        self.tipo_evento = TipoEvento.objects.create(nome="Test Type")
-        self.projeto = Projeto.objects.create(nome="Test Project")
+        self.tipo_evento = TipoEventoFactory(nome="Test Type")
+        self.projeto = ProjetoFactory(nome="Test Project")
 
         # Create solicitações for different municipios
         now = timezone.now()
         for i, municipio in enumerate(self.municipios):
-            Solicitacao.objects.create(
+            SolicitacaoFactory(
                 usuario=self.user,
                 status="aprovado",
                 municipio=municipio,

--- a/v2/backend/apps/core/tests/test_partial_updates_and_checkview.py
+++ b/v2/backend/apps/core/tests/test_partial_updates_and_checkview.py
@@ -18,7 +18,15 @@ from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import AvailabilityBlock, Municipio, Projeto, Solicitacao, TipoEvento, Usuario
+from apps.core.models import AvailabilityBlock
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 pytestmark = pytest.mark.django_db
 
@@ -26,31 +34,29 @@ pytestmark = pytest.mark.django_db
 @pytest.fixture
 def municipio():
     """Fixture para criar município de teste."""
-    return Municipio.objects.create(nome="Fortaleza", uf="CE")
+    return MunicipioFactory(nome="Fortaleza", uf="CE")
 
 
 @pytest.fixture
 def tipo_evento():
     """Fixture para criar tipo de evento de teste."""
-    return TipoEvento.objects.create(nome="Formação")
+    return TipoEventoFactory(nome="Formação")
 
 
 @pytest.fixture
 def projeto():
     """Fixture para criar projeto de teste."""
-    return Projeto.objects.create(nome="Projeto Teste", descricao="Desc")
+    return ProjetoFactory(nome="Projeto Teste", descricao="Desc")
 
 
 def auth_client(user=None):
     """Issue #1222 (Epic 1): user adicionado ao grupo Controle (que tem
     `view_all_availability`) para CRUD de bloqueios e operate_preagenda
     para acessar /api/solicitacoes/."""
-    from django.contrib.auth.models import Group
-
     client = APIClient()
     if user is None:
-        user = Usuario.objects.create_user(username="u1", email="u1@x.com", password="x")
-        grupo_controle, _ = Group.objects.get_or_create(name="Controle")
+        user = UsuarioFactory(username="u1", email="u1@x.com", password="x")
+        grupo_controle = GroupFactory(name="Controle")
         user.groups.add(grupo_controle)
     client.force_authenticate(user=user)
     return client, user
@@ -65,7 +71,7 @@ def test_partial_update_solicitacao_only_observacoes_ok(municipio, tipo_evento):
     """
     c, u = auth_client()
     now = timezone.now()
-    s = Solicitacao.objects.create(
+    s = SolicitacaoFactory(
         usuario=u,
         municipio=municipio,
         tipo_evento=tipo_evento,
@@ -115,12 +121,10 @@ def test_availability_check_invalid_user_id_returns_400():
     Para validar parâmetros (400), usuário deve ter permissão.
     Adiciona usuário ao grupo Controle para passar RBAC (403→400).
     """
-    from django.contrib.auth.models import Group
-
     c, u = auth_client()
 
     # Dar permissão ao usuário (evitar 403 antes de validar parâmetros)
-    grupo_controle, _ = Group.objects.get_or_create(name="Controle")
+    grupo_controle = GroupFactory(name="Controle")
     u.groups.add(grupo_controle)
 
     now = timezone.now()
@@ -147,12 +151,10 @@ def test_availability_check_invalid_municipio_id_returns_400():
     Para validar parâmetros (400), usuário deve ter permissão.
     Adiciona usuário ao grupo Controle para passar RBAC (403→400).
     """
-    from django.contrib.auth.models import Group
-
     c, u = auth_client()
 
     # Dar permissão ao usuário (evitar 403 antes de validar parâmetros)
-    grupo_controle, _ = Group.objects.get_or_create(name="Controle")
+    grupo_controle = GroupFactory(name="Controle")
     u.groups.add(grupo_controle)
 
     now = timezone.now()
@@ -177,12 +179,10 @@ def test_availability_check_missing_dates_returns_400():
     Para validar parâmetros (400), usuário deve ter permissão.
     Adiciona usuário ao grupo Controle para passar RBAC (403→400).
     """
-    from django.contrib.auth.models import Group
-
     c, u = auth_client()
 
     # Dar permissão ao usuário (evitar 403 antes de validar parâmetros)
-    grupo_controle, _ = Group.objects.get_or_create(name="Controle")
+    grupo_controle = GroupFactory(name="Controle")
     u.groups.add(grupo_controle)
 
     url = reverse("core:availability-check")
@@ -207,12 +207,10 @@ def test_availability_check_fim_before_inicio_returns_400():
     Para validar parâmetros (400), usuário deve ter permissão.
     Adiciona usuário ao grupo Controle para passar RBAC (403→400).
     """
-    from django.contrib.auth.models import Group
-
     c, u = auth_client()
 
     # Dar permissão ao usuário (evitar 403 antes de validar parâmetros)
-    grupo_controle, _ = Group.objects.get_or_create(name="Controle")
+    grupo_controle = GroupFactory(name="Controle")
     u.groups.add(grupo_controle)
 
     now = timezone.now()

--- a/v2/backend/apps/core/tests/test_participation_uniqueness.py
+++ b/v2/backend/apps/core/tests/test_participation_uniqueness.py
@@ -10,13 +10,18 @@ Valida:
 
 from __future__ import annotations
 
-from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
-from django.utils import timezone
 
 import pytest
 
-from apps.core.models import Municipio, Participation, Projeto, Solicitacao, TipoEvento
+from apps.core.models import Participation
+from apps.core.tests.factories import (
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 pytestmark = pytest.mark.django_db
 
@@ -28,32 +33,29 @@ def factory_solicitacao():
     """
 
     def _factory(**kwargs):
-        User = get_user_model()
-        user = User.objects.create_user(
+        user = UsuarioFactory(
             username="solicita_user",
             email="solicita@example.com",
             password="testpass123",
             cpf="12345678901",
         )
 
-        municipio = Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
+        municipio = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
 
-        tipo_evento = TipoEvento.objects.create(nome="Formação", descricao="Formação continuada")
+        tipo_evento = TipoEventoFactory(nome="Formação", descricao="Formação continuada")
 
-        projeto = Projeto.objects.create(nome="Teste Projeto", ativo=True)
+        projeto = ProjetoFactory(nome="Teste Projeto", ativo=True)
 
         defaults = {
             "usuario": user,
             "municipio": municipio,
             "tipo_evento": tipo_evento,
             "projeto": projeto,
-            "inicio": timezone.now(),
-            "fim": timezone.now() + timezone.timedelta(hours=2),
             "status": "pendente",
         }
         defaults.update(kwargs)
 
-        return Solicitacao.objects.create(**defaults)
+        return SolicitacaoFactory(**defaults)
 
     return _factory
 
@@ -63,8 +65,7 @@ def test_participation_unique_constraint(factory_solicitacao):
     Testa que UniqueConstraint impede duplicação de papel por (solicitacao, usuario, role).
     """
     solicitacao = factory_solicitacao()
-    User = get_user_model()
-    user = User.objects.create_user(
+    user = UsuarioFactory(
         username="formador1",
         email="formador1@example.com",
         password="testpass123",
@@ -92,8 +93,7 @@ def test_participation_allows_different_roles_same_user(factory_solicitacao):
     Testa que o mesmo usuário pode ter múltiplos papéis DIFERENTES na mesma solicitação.
     """
     solicitacao = factory_solicitacao()
-    User = get_user_model()
-    user = User.objects.create_user(
+    user = UsuarioFactory(
         username="multi_role",
         email="multi@example.com",
         password="testpass123",
@@ -123,8 +123,7 @@ def test_participation_cascade_delete_on_solicitacao(factory_solicitacao):
     Testa que deletar Solicitacao deleta Participations em cascata.
     """
     solicitacao = factory_solicitacao()
-    User = get_user_model()
-    user = User.objects.create_user(
+    user = UsuarioFactory(
         username="cascade_test",
         email="cascade@example.com",
         password="testpass123",
@@ -150,8 +149,7 @@ def test_participation_protect_on_usuario_delete(factory_solicitacao):
     Testa que deletar Usuario com Participations deve ser PROTEGIDO (PROTECT).
     """
     solicitacao = factory_solicitacao()
-    User = get_user_model()
-    user = User.objects.create_user(
+    user = UsuarioFactory(
         username="protect_test",
         email="protect@example.com",
         password="testpass123",

--- a/v2/backend/apps/core/tests/test_permissao_funcional.py
+++ b/v2/backend/apps/core/tests/test_permissao_funcional.py
@@ -6,7 +6,6 @@ Testes para modelo e seed de PermissaoFuncional (issue #827).
 
 from __future__ import annotations
 
-from django.contrib.auth.models import Group
 from django.core.management import call_command
 from django.db import IntegrityError
 
@@ -14,6 +13,7 @@ import pytest
 
 from apps.core.models import PermissaoFuncional
 from apps.core.services.functional_permissions_seed import FUNCTIONAL_PERMISSIONS_SEED, seed_functional_permissions
+from apps.core.tests.factories import GroupFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -51,8 +51,8 @@ def test_permissao_funcional_is_system_default_true():
 
 
 def test_permissao_funcional_groups_m2m():
-    g1, _ = Group.objects.get_or_create(name="Grupo Teste 1")
-    g2, _ = Group.objects.get_or_create(name="Grupo Teste 2")
+    g1 = GroupFactory(name="Grupo Teste 1")
+    g2 = GroupFactory(name="Grupo Teste 2")
     perm = PermissaoFuncional.objects.create(
         codename="permissao_m2m",
         label="Permissão M2M",

--- a/v2/backend/apps/core/tests/test_permissions_hasperm.py
+++ b/v2/backend/apps/core/tests/test_permissions_hasperm.py
@@ -15,14 +15,15 @@ Ver v2/docs/plans/rbac-refactor/epic-2-hasperm.md e master-plan §3.3.
 
 from __future__ import annotations
 
-from django.contrib.auth.models import AnonymousUser, Group
+from django.contrib.auth.models import AnonymousUser
 from rest_framework.request import Request
 from rest_framework.test import APIRequestFactory
 
 import pytest
 
-from apps.core.models import PermissaoFuncional, Usuario
+from apps.core.models import PermissaoFuncional
 from apps.core.permissions import HasPerm
+from apps.core.tests.factories import GroupFactory, UsuarioFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -50,7 +51,7 @@ def seeded_permission():
 @pytest.fixture
 def group_with_permission(seeded_permission):
     """Cria um group Django associado à permission de teste."""
-    group, _ = Group.objects.get_or_create(name="TestCapabilityGroup")
+    group = GroupFactory(name="TestCapabilityGroup")
     seeded_permission.groups.add(group)
     return group
 
@@ -58,7 +59,7 @@ def group_with_permission(seeded_permission):
 @pytest.fixture
 def user_with_capability(group_with_permission):
     """Usuário cuja associação de group lhe dá a permissão funcional."""
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username="cap_user",
         email="cap@test.com",
         password="x",
@@ -71,7 +72,7 @@ def user_with_capability(group_with_permission):
 @pytest.fixture
 def user_without_capability():
     """Usuário autenticado mas sem a permissão de teste."""
-    return Usuario.objects.create_user(
+    return UsuarioFactory(
         username="no_cap_user",
         email="nocap@test.com",
         password="x",
@@ -82,12 +83,7 @@ def user_without_capability():
 @pytest.fixture
 def superuser():
     """Superuser — sempre passa em HasPerm (bypass)."""
-    return Usuario.objects.create_superuser(
-        username="su",
-        email="su@test.com",
-        password="x",
-        cpf="10000000003",
-    )
+    return UsuarioFactory(superuser=True)
 
 
 @pytest.fixture

--- a/v2/backend/apps/core/tests/test_plano_formacoes.py
+++ b/v2/backend/apps/core/tests/test_plano_formacoes.py
@@ -16,36 +16,30 @@ from __future__ import annotations
 from datetime import date
 from decimal import Decimal
 
-from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 
 import pytest
 
-from apps.core.models import Acompanhamento, Formacao, Municipio, PlanoFormacoes, Projeto, Prova
-
-User = get_user_model()
+from apps.core.models import Acompanhamento, Formacao, PlanoFormacoes, Prova
+from apps.core.tests.factories import MunicipioFactory, ProjetoFactory, UsuarioFactory
 
 
 @pytest.fixture
 def user(db):
     """Create a test user with DAT permissions."""
-    from django.contrib.auth.models import Group
-
-    user = User.objects.create_user(
+    # Add to DAT group for permissions
+    return UsuarioFactory(
         username="testuser",
         cpf="12345678901",
         password="testpass123",
+        groups=["DAT"],
     )
-    # Add to DAT group for permissions
-    dat_group, _ = Group.objects.get_or_create(name="DAT")
-    user.groups.add(dat_group)
-    return user
 
 
 @pytest.fixture
 def municipio(db):
     """Create a test municipio."""
-    return Municipio.objects.create(
+    return MunicipioFactory(
         nome="Municipio Teste",
         uf="CE",
     )
@@ -54,7 +48,7 @@ def municipio(db):
 @pytest.fixture
 def projeto(db):
     """Create a test projeto."""
-    return Projeto.objects.create(
+    return ProjetoFactory(
         nome="Projeto Teste",
         fluxo="NAO_SUPER",
     )
@@ -385,11 +379,11 @@ class TestPlanoFormacoesAPI:
         client.force_login(user)
 
         # Create another municipio to avoid unique constraint
-        mun2 = Municipio.objects.create(
+        mun2 = MunicipioFactory(
             nome="Municipio 2",
             uf="CE",
         )
-        proj2 = Projeto.objects.create(
+        proj2 = ProjetoFactory(
             nome="Projeto 2",
             fluxo="NAO_SUPER",
         )

--- a/v2/backend/apps/core/tests/test_pr13_delegated_availability_blocks.py
+++ b/v2/backend/apps/core/tests/test_pr13_delegated_availability_blocks.py
@@ -27,13 +27,13 @@ from __future__ import annotations
 import itertools
 from datetime import timedelta
 
-from django.contrib.auth.models import Group
 from django.utils import timezone
 from rest_framework.test import APIClient
 
 import pytest
 
 from apps.core.models import AuditLog, AvailabilityBlock, Usuario
+from apps.core.tests.factories import UsuarioFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -43,18 +43,14 @@ _CPF_COUNTER = itertools.count(72000000000)
 
 def _user_in_groups(*group_names: str, label: str = "user", is_active: bool = True) -> Usuario:
     cpf = str(next(_CPF_COUNTER)).zfill(11)
-    user = Usuario.objects.create_user(
+    return UsuarioFactory(
         username=f"{label}_{cpf}",
         email=f"{label}_{cpf}@example.com",
         password="testpass",
         cpf=cpf,
+        is_active=is_active,
+        groups=list(group_names),
     )
-    user.is_active = is_active
-    user.save()
-    for name in group_names:
-        group, _ = Group.objects.get_or_create(name=name)
-        user.groups.add(group)
-    return user
 
 
 def _formador(label: str = "formador", is_active: bool = True) -> Usuario:
@@ -137,12 +133,7 @@ class TestDelegationAllowed:
         assert block.created_by_id == delegate.id
 
     def test_superuser_delega_para_formador(self):
-        delegate = Usuario.objects.create_superuser(
-            username="su_pr13",
-            email="su_pr13@example.com",
-            password="x",
-            cpf="72099999999",
-        )
+        delegate = UsuarioFactory(superuser=True)
         target = _formador(label="target_su")
         client = APIClient()
         client.force_authenticate(delegate)

--- a/v2/backend/apps/core/tests/test_pr16_admin_group_capability.py
+++ b/v2/backend/apps/core/tests/test_pr16_admin_group_capability.py
@@ -28,6 +28,7 @@ import pytest
 from apps.core.models import AuditLog, PermissaoFuncional, Usuario
 from apps.core.services.functional_permissions_seed import seed_functional_permissions
 from apps.core.services.rbac_permissions import get_user_functional_permissions
+from apps.core.tests.factories import GroupFactory, UsuarioFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -38,16 +39,14 @@ ADMIN_LIST_URL = "/admin/core/permissaofuncional/"
 
 def _make_user(*, is_superuser: bool = False, is_staff: bool = False, label: str = "u") -> Usuario:
     cpf = str(next(_CPF_COUNTER)).zfill(11)
-    user = Usuario.objects.create_user(
+    return UsuarioFactory(
         username=f"{label}_{cpf}",
         email=f"{label}_{cpf}@test.com",
         password="testpass",
         cpf=cpf,
+        is_superuser=is_superuser,
+        is_staff=is_staff or is_superuser,
     )
-    user.is_superuser = is_superuser
-    user.is_staff = is_staff or is_superuser
-    user.save()
-    return user
 
 
 @pytest.fixture
@@ -89,12 +88,12 @@ def capability() -> PermissaoFuncional:
 
 @pytest.fixture
 def group_diretoria(db) -> Group:
-    return Group.objects.get_or_create(name="Diretoria")[0]
+    return GroupFactory(name="Diretoria")
 
 
 @pytest.fixture
 def group_dat(db) -> Group:
-    return Group.objects.get_or_create(name="DAT")[0]
+    return GroupFactory(name="DAT")
 
 
 # ============================================================================

--- a/v2/backend/apps/core/tests/test_pr3_approvals_policy.py
+++ b/v2/backend/apps/core/tests/test_pr3_approvals_policy.py
@@ -26,13 +26,19 @@ from __future__ import annotations
 
 import itertools
 
-from django.contrib.auth.models import Group
 from django.urls import reverse
 from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import Municipio, Projeto, Solicitacao, TipoEvento, Usuario
+from apps.core.models import Solicitacao, Usuario
+from apps.core.tests.factories import (
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 pytestmark = pytest.mark.django_db
 
@@ -42,24 +48,21 @@ _CPF_COUNTER = itertools.count(70000000000)
 
 def _user_in_groups(*group_names: str, label: str = "user") -> Usuario:
     cpf = str(next(_CPF_COUNTER)).zfill(11)
-    user = Usuario.objects.create_user(
+    return UsuarioFactory(
         username=f"{label}_{cpf}",
         email=f"{label}_{cpf}@example.com",
         password="testpass",
         cpf=cpf,
+        groups=list(group_names),
     )
-    for name in group_names:
-        group, _ = Group.objects.get_or_create(name=name)
-        user.groups.add(group)
-    return user
 
 
 @pytest.fixture
 def pendente_solicitacao() -> Solicitacao:
     """Cria uma Solicitação pendente que pode ser aprovada/reprovada."""
-    municipio = Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
-    projeto = Projeto.objects.create(nome="Projeto Aprov", codigo="APR", fluxo="SUPER", ativo=True)
-    tipo_evento = TipoEvento.objects.create(nome="Formação")
+    municipio = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+    projeto = ProjetoFactory(nome="Projeto Aprov", codigo="APR", fluxo="SUPER", ativo=True)
+    tipo_evento = TipoEventoFactory(nome="Formação")
     requester = _user_in_groups("Coordenador", label="requester")
 
     from datetime import timedelta
@@ -69,7 +72,7 @@ def pendente_solicitacao() -> Solicitacao:
     inicio = timezone.now() + timedelta(days=2)
     fim = inicio + timedelta(hours=2)
 
-    return Solicitacao.objects.create(
+    return SolicitacaoFactory(
         projeto=projeto,
         municipio=municipio,
         tipo_evento=tipo_evento,
@@ -234,13 +237,7 @@ def test_forbidden_personas_get_403_on_batch_reject(persona, pendente_solicitaca
 
 
 def test_superuser_can_approve(pendente_solicitacao):
-    cpf = str(next(_CPF_COUNTER)).zfill(11)
-    user = Usuario.objects.create_superuser(
-        username=f"super_pr3_{cpf}",
-        email=f"super_pr3_{cpf}@example.com",
-        password="testpass",
-        cpf=cpf,
-    )
+    user = UsuarioFactory(superuser=True)
     client = APIClient()
     client.force_authenticate(user=user)
 

--- a/v2/backend/apps/core/tests/test_pr4_produto_viewset_cap_gate.py
+++ b/v2/backend/apps/core/tests/test_pr4_produto_viewset_cap_gate.py
@@ -26,12 +26,12 @@ from __future__ import annotations
 
 import itertools
 
-from django.contrib.auth.models import Group
 from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import Produto, Projeto, Usuario
+from apps.core.models import Produto
+from apps.core.tests.factories import ProjetoFactory, UsuarioFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -39,23 +39,20 @@ pytestmark = pytest.mark.django_db
 _CPF_COUNTER = itertools.count(60000000000)
 
 
-def _user_in_groups(*group_names: str, label: str = "user") -> Usuario:
+def _user_in_groups(*group_names: str, label: str = "user"):
     cpf = str(next(_CPF_COUNTER)).zfill(11)
-    user = Usuario.objects.create_user(
+    return UsuarioFactory(
         username=f"{label}_{cpf}",
         email=f"{label}_{cpf}@example.com",
         password="testpass",
         cpf=cpf,
+        groups=list(group_names),
     )
-    for name in group_names:
-        group, _ = Group.objects.get_or_create(name=name)
-        user.groups.add(group)
-    return user
 
 
 @pytest.fixture
 def produto():
-    projeto = Projeto.objects.create(nome="Projeto Test", codigo="PT", ativo=True)
+    projeto = ProjetoFactory(nome="Projeto Test", codigo="PT", ativo=True)
     return Produto.objects.create(codigo="P001", nome="Produto Teste", projeto=projeto, ativo=True)
 
 
@@ -97,13 +94,7 @@ def test_allowed_personas_can_retrieve_produto(persona, produto):
 
 
 def test_superuser_can_list_produtos(produto):
-    cpf = str(next(_CPF_COUNTER)).zfill(11)
-    user = Usuario.objects.create_superuser(
-        username=f"super_pr4_{cpf}",
-        email=f"super_pr4_{cpf}@example.com",
-        password="testpass",
-        cpf=cpf,
-    )
+    user = UsuarioFactory(superuser=True)
     client = APIClient()
     client.force_authenticate(user=user)
 
@@ -164,7 +155,7 @@ def test_anonymous_blocked_on_list():
 
 def test_dat_can_create_produto():
     user = _user_in_groups("DAT", label="dat_writer")
-    projeto = Projeto.objects.create(nome="Proj W", codigo="PW", ativo=True)
+    projeto = ProjetoFactory(nome="Proj W", codigo="PW", ativo=True)
     client = APIClient()
     client.force_authenticate(user=user)
 
@@ -178,7 +169,7 @@ def test_dat_can_create_produto():
 
 def test_coordenador_cannot_create_produto():
     user = _user_in_groups("Coordenador", label="coord_writer")
-    projeto = Projeto.objects.create(nome="Proj W2", codigo="PW2", ativo=True)
+    projeto = ProjetoFactory(nome="Proj W2", codigo="PW2", ativo=True)
     client = APIClient()
     client.force_authenticate(user=user)
 

--- a/v2/backend/apps/core/tests/test_pr5_usuario_lookup_cap_gate.py
+++ b/v2/backend/apps/core/tests/test_pr5_usuario_lookup_cap_gate.py
@@ -33,12 +33,11 @@ from __future__ import annotations
 
 import itertools
 
-from django.contrib.auth.models import Group
 from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import Usuario
+from apps.core.tests.factories import UsuarioFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -46,37 +45,32 @@ pytestmark = pytest.mark.django_db
 _CPF_COUNTER = itertools.count(50000000000)
 
 
-def _user_in_groups(*group_names: str, label: str = "user") -> Usuario:
+def _user_in_groups(*group_names: str, label: str = "user"):
     cpf = str(next(_CPF_COUNTER)).zfill(11)
-    user = Usuario.objects.create_user(
+    return UsuarioFactory(
         username=f"{label}_{cpf}",
         email=f"{label}_{cpf}@example.com",
         password="testpass",
         cpf=cpf,
         first_name=label.capitalize(),
         last_name="User",
+        groups=list(group_names),
     )
-    for name in group_names:
-        group, _ = Group.objects.get_or_create(name=name)
-        user.groups.add(group)
-    return user
 
 
 @pytest.fixture
 def target_formador():
     """Usuário-alvo para a busca."""
     cpf = str(next(_CPF_COUNTER)).zfill(11)
-    user = Usuario.objects.create_user(
+    return UsuarioFactory(
         username=f"target_{cpf}",
         email=f"maria_alvo_{cpf}@example.com",
         password="testpass",
         cpf=cpf,
         first_name="Maria",
         last_name="Silva",
+        groups=["Formador"],
     )
-    formador, _ = Group.objects.get_or_create(name="Formador")
-    user.groups.add(formador)
-    return user
 
 
 # =============================================================================
@@ -106,13 +100,7 @@ def test_allowed_personas_can_lookup(persona, target_formador):
 
 
 def test_superuser_can_lookup(target_formador):
-    cpf = str(next(_CPF_COUNTER)).zfill(11)
-    user = Usuario.objects.create_superuser(
-        username=f"super_pr5_{cpf}",
-        email=f"super_pr5_{cpf}@example.com",
-        password="testpass",
-        cpf=cpf,
-    )
+    user = UsuarioFactory(superuser=True)
     client = APIClient()
     client.force_authenticate(user=user)
     response = client.get("/api/lookup/usuarios/?q=Maria")

--- a/v2/backend/apps/core/tests/test_pr6_audit_logs_policy.py
+++ b/v2/backend/apps/core/tests/test_pr6_audit_logs_policy.py
@@ -27,12 +27,12 @@ from __future__ import annotations
 
 import itertools
 
-from django.contrib.auth.models import Group
 from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import AuditLog, Usuario
+from apps.core.models import AuditLog
+from apps.core.tests.factories import UsuarioFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -40,18 +40,15 @@ pytestmark = pytest.mark.django_db
 _CPF_COUNTER = itertools.count(40000000000)
 
 
-def _user_in_groups(*group_names: str, label: str = "user") -> Usuario:
+def _user_in_groups(*group_names: str, label: str = "user"):
     cpf = str(next(_CPF_COUNTER)).zfill(11)
-    user = Usuario.objects.create_user(
+    return UsuarioFactory(
         username=f"{label}_{cpf}",
         email=f"{label}_{cpf}@example.com",
         password="testpass",
         cpf=cpf,
+        groups=list(group_names),
     )
-    for name in group_names:
-        group, _ = Group.objects.get_or_create(name=name)
-        user.groups.add(group)
-    return user
 
 
 @pytest.fixture
@@ -94,13 +91,7 @@ def test_allowed_personas_can_list_audit_logs(persona, audit_log_record):
 
 
 def test_superuser_can_list_audit_logs(audit_log_record):
-    cpf = str(next(_CPF_COUNTER)).zfill(11)
-    user = Usuario.objects.create_superuser(
-        username=f"super_pr6_{cpf}",
-        email=f"super_pr6_{cpf}@example.com",
-        password="testpass",
-        cpf=cpf,
-    )
+    user = UsuarioFactory(superuser=True)
     client = APIClient()
     client.force_authenticate(user=user)
     response = client.get("/api/audit-logs/")
@@ -155,13 +146,7 @@ def test_redaction_works_for_allowed_personas(persona, audit_log_record):
     label, group_names = persona
 
     if label == "superuser_redaction":
-        cpf = str(next(_CPF_COUNTER)).zfill(11)
-        user = Usuario.objects.create_superuser(
-            username=f"super_red_{cpf}",
-            email=f"super_red_{cpf}@example.com",
-            password="testpass",
-            cpf=cpf,
-        )
+        user = UsuarioFactory(superuser=True)
         expected_full_payload = True
     else:
         user = _user_in_groups(*group_names, label=label)

--- a/v2/backend/apps/core/tests/test_pr7_projeto_fluxo_required.py
+++ b/v2/backend/apps/core/tests/test_pr7_projeto_fluxo_required.py
@@ -24,13 +24,12 @@ from __future__ import annotations
 
 import itertools
 
-from django.contrib.auth.models import Group
 from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import Projeto, Usuario
 from apps.core.serializers.organizacao import ProjetoSerializer
+from apps.core.tests.factories import ProjetoFactory, UsuarioFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -38,18 +37,16 @@ pytestmark = pytest.mark.django_db
 _CPF_COUNTER = itertools.count(30000000000)
 
 
-def _dat_user() -> Usuario:
+def _dat_user():
     """DAT puro — tem cap `manage_admin_registries` para acessar ProjetoViewSet."""
     cpf = str(next(_CPF_COUNTER)).zfill(11)
-    user = Usuario.objects.create_user(
+    return UsuarioFactory(
         username=f"dat_pr7_{cpf}",
         email=f"dat_pr7_{cpf}@example.com",
         password="testpass",
         cpf=cpf,
+        groups=["DAT"],
     )
-    grupo, _ = Group.objects.get_or_create(name="DAT")
-    user.groups.add(grupo)
-    return user
 
 
 # =============================================================================
@@ -141,7 +138,7 @@ def test_api_patch_without_fluxo_keeps_current_value():
     client = APIClient()
     client.force_authenticate(user=user)
 
-    projeto = Projeto.objects.create(nome="P PATCH", fluxo="SUPER", ativo=True)
+    projeto = ProjetoFactory(nome="P PATCH", fluxo="SUPER", ativo=True)
 
     response = client.patch(
         f"/api/projetos/{projeto.id}/",
@@ -159,7 +156,7 @@ def test_api_patch_with_invalid_fluxo_returns_400():
     client = APIClient()
     client.force_authenticate(user=user)
 
-    projeto = Projeto.objects.create(nome="P PATCH inválido", fluxo="SUPER", ativo=True)
+    projeto = ProjetoFactory(nome="P PATCH inválido", fluxo="SUPER", ativo=True)
 
     response = client.patch(
         f"/api/projetos/{projeto.id}/",
@@ -210,7 +207,7 @@ def test_resolve_initial_status_super_returns_pendente():
     """Regression: PR 7 não muda regra de status inicial — SUPER → pendente."""
     from apps.core.services.solicitacao_create import resolve_initial_status
 
-    projeto = Projeto.objects.create(nome="P SUPER reg", fluxo="SUPER", ativo=True)
+    projeto = ProjetoFactory(nome="P SUPER reg", fluxo="SUPER", ativo=True)
     decision = resolve_initial_status(projeto=projeto)
     assert decision.status == "pendente", f"got={decision.status}"
 
@@ -219,6 +216,6 @@ def test_resolve_initial_status_nao_super_returns_aprovado():
     """Regression: NAO_SUPER → aprovado (auto-aprovação preservada)."""
     from apps.core.services.solicitacao_create import resolve_initial_status
 
-    projeto = Projeto.objects.create(nome="P NAO_SUPER reg", fluxo="NAO_SUPER", ativo=True)
+    projeto = ProjetoFactory(nome="P NAO_SUPER reg", fluxo="NAO_SUPER", ativo=True)
     decision = resolve_initial_status(projeto=projeto)
     assert decision.status == "aprovado", f"got={decision.status}"

--- a/v2/backend/apps/core/tests/test_pr8_nova_solicitacao.py
+++ b/v2/backend/apps/core/tests/test_pr8_nova_solicitacao.py
@@ -15,14 +15,21 @@ from __future__ import annotations
 
 from datetime import date
 
-from django.contrib.auth.models import Group
 from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import Compra, Municipio, Projeto, Solicitacao, TipoEvento, Usuario
+from apps.core.models import Compra
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 pytestmark = pytest.mark.django_db
 
@@ -33,22 +40,22 @@ class TestSolicitacaoNewFields:
     def test_solicitacao_has_new_fields(self):
         """PR 8/N: Solicitacao deve ter todos os novos campos"""
         # Arrange
-        user = Usuario.objects.create_user(
+        user = UsuarioFactory(
             username="coord1",
             password="pass123",
             cpf="12345678901",
             first_name="João",
             last_name="Coordenador",
         )
-        municipio = Municipio.objects.create(nome="Fortaleza", uf="CE")
-        projeto = Projeto.objects.create(nome="Projeto Teste")
-        tipo_evento = TipoEvento.objects.create(nome="Formação")
+        municipio = MunicipioFactory(nome="Fortaleza", uf="CE")
+        projeto = ProjetoFactory(nome="Projeto Teste")
+        tipo_evento = TipoEventoFactory(nome="Formação")
 
         inicio = timezone.now()
         fim = inicio + timezone.timedelta(hours=2)
 
         # Act
-        solicitacao = Solicitacao.objects.create(
+        solicitacao = SolicitacaoFactory(
             usuario=user,
             municipio=municipio,
             projeto=projeto,
@@ -80,11 +87,11 @@ class TestOptionsAPI:
         """GET /api/options/municipios/ deve retornar apenas municípios ativos"""
         # Arrange
         client = APIClient()
-        user = Usuario.objects.create_user(username="user1", password="pass", cpf="11111111111")
+        user = UsuarioFactory(username="user1", password="pass", cpf="11111111111")
         client.force_authenticate(user=user)
 
-        Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
-        Municipio.objects.create(nome="Inativo City", uf="XX", ativo=False)
+        MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+        MunicipioFactory(nome="Inativo City", uf="XX", ativo=False)
 
         # Act
         response = client.get("/api/options/municipios/")
@@ -109,12 +116,12 @@ class TestAvailabilityCheckMany:
         """POST /api/availability/check-many/ deve retornar ok=true quando todos disponíveis"""
         # Arrange
         client = APIClient()
-        user1 = Usuario.objects.create_user(username="user1", password="pass", cpf="11111111111")
-        user2 = Usuario.objects.create_user(username="user2", password="pass", cpf="22222222222")
-        coord = Usuario.objects.create_user(username="coord", password="pass", cpf="33333333333")
+        user1 = UsuarioFactory(username="user1", password="pass", cpf="11111111111")
+        user2 = UsuarioFactory(username="user2", password="pass", cpf="22222222222")
+        coord = UsuarioFactory(username="coord", password="pass", cpf="33333333333")
 
         # P2.2: check-many endpoint requires HasPerm("operate_preagenda") permission
-        controle_group, _ = Group.objects.get_or_create(name="Controle")
+        controle_group = GroupFactory(name="Controle")
         coord.groups.add(controle_group)
 
         client.force_authenticate(user=coord)
@@ -156,13 +163,13 @@ class TestSolicitacaoRBAC:
         """PR 8/N: Coordenador pode criar solicitação"""
         # Arrange
         client = APIClient()
-        coord = Usuario.objects.create_user(username="coord1", password="pass", cpf="11111111111")
-        group_coord, _ = Group.objects.get_or_create(name="Coordenador")
+        coord = UsuarioFactory(username="coord1", password="pass", cpf="11111111111")
+        group_coord = GroupFactory(name="Coordenador")
         coord.groups.add(group_coord)
 
-        tipo_evento = TipoEvento.objects.create(nome="Formação")
-        municipio = Municipio.objects.create(nome="Fortaleza", uf="CE")
-        projeto = Projeto.objects.create(nome="Projeto X", fluxo="SUPER")  # SUPER=pendente
+        tipo_evento = TipoEventoFactory(nome="Formação")
+        municipio = MunicipioFactory(nome="Fortaleza", uf="CE")
+        projeto = ProjetoFactory(nome="Projeto X", fluxo="SUPER")  # SUPER=pendente
         Compra.objects.create(
             codigo="COMP-COORD-001",
             projeto=projeto,
@@ -208,11 +215,11 @@ class TestSolicitacaoRBAC:
         """PR 8/N: Formador NÃO pode criar solicitação"""
         # Arrange
         client = APIClient()
-        formador = Usuario.objects.create_user(username="formador1", password="pass", cpf="11111111111")
-        group_formador, _ = Group.objects.get_or_create(name="Formador")
+        formador = UsuarioFactory(username="formador1", password="pass", cpf="11111111111")
+        group_formador = GroupFactory(name="Formador")
         formador.groups.add(group_formador)
 
-        tipo_evento = TipoEvento.objects.create(nome="Formação")
+        tipo_evento = TipoEventoFactory(nome="Formação")
         client.force_authenticate(user=formador)
 
         inicio = timezone.now() + timezone.timedelta(days=1)
@@ -239,8 +246,8 @@ class TestSolicitacaoRBAC:
         """PR 8/N: Superuser pode criar solicitação"""
         # Arrange
         client = APIClient()
-        superuser = Usuario.objects.create_superuser(username="admin", password="pass", cpf="11111111111")
-        tipo_evento = TipoEvento.objects.create(nome="Formação")
+        superuser = UsuarioFactory(superuser=True)
+        tipo_evento = TipoEventoFactory(nome="Formação")
         client.force_authenticate(user=superuser)
 
         inicio = timezone.now() + timezone.timedelta(days=1)
@@ -264,13 +271,13 @@ class TestSolicitacaoRBAC:
     def test_coordenador_sem_compra_para_projeto_recebe_400(self):
         """Coordenador não pode criar solicitação quando município+projeto não têm compra."""
         client = APIClient()
-        coord = Usuario.objects.create_user(username="coord2", password="pass", cpf="22222222222")
-        group_coord, _ = Group.objects.get_or_create(name="Coordenador")
+        coord = UsuarioFactory(username="coord2", password="pass", cpf="22222222222")
+        group_coord = GroupFactory(name="Coordenador")
         coord.groups.add(group_coord)
 
-        tipo_evento = TipoEvento.objects.create(nome="Acompanhamento")
-        municipio = Municipio.objects.create(nome="Sobral", uf="CE")
-        projeto = Projeto.objects.create(nome="Projeto Y", fluxo="SUPER")
+        tipo_evento = TipoEventoFactory(nome="Acompanhamento")
+        municipio = MunicipioFactory(nome="Sobral", uf="CE")
+        projeto = ProjetoFactory(nome="Projeto Y", fluxo="SUPER")
 
         client.force_authenticate(user=coord)
 

--- a/v2/backend/apps/core/tests/test_pr_security_validate_no_stack_trace.py
+++ b/v2/backend/apps/core/tests/test_pr_security_validate_no_stack_trace.py
@@ -10,23 +10,22 @@ mensagem genérica.
 
 from __future__ import annotations
 
-from django.contrib.auth.models import Group
 from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import Usuario
+from apps.core.tests.factories import GroupFactory, UsuarioFactory
 
 
 @pytest.fixture
 def authenticated_client(db) -> APIClient:
-    user = Usuario.objects.create_user(  # type: ignore[attr-defined]
+    user = UsuarioFactory(
         username="validate_user",
         email="validate.user@example.com",
         password="testpass123",
         cpf="12345678901",
     )
-    coord_group, _ = Group.objects.get_or_create(name="Coordenador")
+    coord_group = GroupFactory(name="Coordenador")
     user.groups.add(coord_group)
     client = APIClient()
     client.force_authenticate(user=user)

--- a/v2/backend/apps/core/tests/test_prazo_engine_service.py
+++ b/v2/backend/apps/core/tests/test_prazo_engine_service.py
@@ -12,13 +12,14 @@ from django.utils import timezone
 
 import pytest
 
-from apps.core.models import AcaoInstancia, AcaoTemplate, CicloAcoes, Municipio, Projeto, Usuario
+from apps.core.models import AcaoInstancia, AcaoTemplate, CicloAcoes
 from apps.core.services.prazo_engine_service import PrazoEngineService
+from apps.core.tests.factories import MunicipioFactory, ProjetoFactory, UsuarioFactory
 
 
 @pytest.fixture
 def usuario(db):
-    return Usuario.objects.create_user(
+    return UsuarioFactory(
         username="prazo_user",
         email="prazo_user@example.com",
         password="testpass123",
@@ -28,8 +29,8 @@ def usuario(db):
 
 @pytest.fixture
 def ciclo(db, usuario):
-    projeto = Projeto.objects.create(nome="Projeto Prazo Engine")
-    municipio = Municipio.objects.create(nome="Municipio Prazo Engine", uf="CE")
+    projeto = ProjetoFactory(nome="Projeto Prazo Engine")
+    municipio = MunicipioFactory(nome="Municipio Prazo Engine", uf="CE")
     return CicloAcoes.objects.create(
         projeto=projeto,
         municipio=municipio,

--- a/v2/backend/apps/core/tests/test_preagenda_permissions.py
+++ b/v2/backend/apps/core/tests/test_preagenda_permissions.py
@@ -14,36 +14,42 @@ from __future__ import annotations
 
 from datetime import timedelta
 
-from django.contrib.auth.models import Group
 from django.utils import timezone
 from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import Municipio, Projeto, Solicitacao, TipoEvento, Usuario
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 pytestmark = pytest.mark.django_db
 
 
 def make_user_in_group(name="Controle"):
     """Cria usuário em um grupo específico."""
-    u = Usuario.objects.create_user(
+    u = UsuarioFactory(
         username=f"user{name.lower()}",
         email=f"{name.lower()}@test.com",
         password="x",
         cpf=f"9999999999{name[:1]}",
     )
-    g, _ = Group.objects.get_or_create(name=name)
+    g = GroupFactory(name=name)
     u.groups.add(g)
     return u
 
 
 def _make_approved_solicitacao(user):
     """Cria solicitação aprovada para testes."""
-    tipo = TipoEvento.objects.create(nome="Formação")
-    mun = Municipio.objects.create(nome="Acarape", uf="CE", ativo=True)
-    proj = Projeto.objects.create(nome="Gestão Escolar", ativo=True)
-    s = Solicitacao.objects.create(
+    tipo = TipoEventoFactory(nome="Formação")
+    mun = MunicipioFactory(nome="Acarape", uf="CE", ativo=True)
+    proj = ProjetoFactory(nome="Gestão Escolar", ativo=True)
+    s = SolicitacaoFactory(
         usuario=user,
         tipo_evento=tipo,
         municipio=mun,
@@ -62,7 +68,7 @@ def test_preview_publish_denied_unauthenticated():
     - Sem autenticação → 401 ou 403 para preview e publish
     - DRF pode retornar 403 se a permissão da classe for verificada primeiro
     """
-    u = Usuario.objects.create_user(
+    u = UsuarioFactory(
         username="plain",
         email="plain@test.com",
         password="x",
@@ -87,7 +93,7 @@ def test_preview_publish_denied_without_group():
 
     - Usuário autenticado sem grupo → 403 para preview e publish
     """
-    u = Usuario.objects.create_user(
+    u = UsuarioFactory(
         username="plain",
         email="plain@test.com",
         password="x",
@@ -157,12 +163,12 @@ def test_preview_publish_allowed_for_superuser():
     - Preview → 200
     - Publish → 202 (ou 409 se apply_blocked)
     """
-    u = Usuario.objects.create_user(
+    u = UsuarioFactory(
         username="superuser",
         email="super@test.com",
         password="x",
         cpf="77777777777",
-        is_superuser=True,
+        superuser=True,
     )
     s = _make_approved_solicitacao(u)
     client = APIClient()

--- a/v2/backend/apps/core/tests/test_preagenda_publish_api.py
+++ b/v2/backend/apps/core/tests/test_preagenda_publish_api.py
@@ -24,11 +24,18 @@ from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import AuditLog, Municipio, Participation, Projeto, Solicitacao, TipoEvento, Usuario
+from apps.core.models import AuditLog, Participation
 from apps.core.services.gcal_sync_service import (
     apply_one_solicitacao,
     build_attendees_for_solicitacao,
     build_preview_for_solicitacao,
+)
+from apps.core.tests.factories import (
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
 )
 
 pytestmark = pytest.mark.django_db
@@ -43,37 +50,29 @@ def api_client():
 @pytest.fixture
 def user_super():
     """Usuário Superintendência."""
-    from django.contrib.auth.models import Group
-
-    user = Usuario.objects.create_user(
+    return UsuarioFactory(
         username="super_user",
         email="super@example.com",
         password="test123",
         cpf="11111111111",
         first_name="Super",
         last_name="User",
+        groups=["Superintendência"],
     )
-    group, _ = Group.objects.get_or_create(name="Superintendência")
-    user.groups.add(group)
-    return user
 
 
 @pytest.fixture
 def user_coord():
     """Usuário Coordenador (sem permissão para preview/publish)."""
-    from django.contrib.auth.models import Group
-
-    user = Usuario.objects.create_user(
+    return UsuarioFactory(
         username="coord_user",
         email="coord@example.com",
         password="test123",
         cpf="22222222222",
         first_name="Coord",
         last_name="User",
+        groups=["Coordenador"],
     )
-    group, _ = Group.objects.get_or_create(name="Coordenador")
-    user.groups.add(group)
-    return user
 
 
 @pytest.fixture
@@ -88,24 +87,24 @@ def setup_solicitacao():
     tz = timezone.get_current_timezone()
 
     # Dependências
-    municipio = Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
-    projeto = Projeto.objects.create(nome="Gestão Escolar", ativo=True)
-    tipo_evento = TipoEvento.objects.create(nome="Formação")
+    municipio = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+    projeto = ProjetoFactory(nome="Gestão Escolar", ativo=True)
+    tipo_evento = TipoEventoFactory(nome="Formação")
 
     # Usuários
-    coord = Usuario.objects.create_user(
+    coord = UsuarioFactory(
         username="coord",
         email="coord@example.com",
         password="test123",
         cpf="33333333333",
     )
-    formador = Usuario.objects.create_user(
+    formador = UsuarioFactory(
         username="formador",
         email="formador@example.com",
         password="test123",
         cpf="44444444444",
     )
-    acompanha = Usuario.objects.create_user(
+    acompanha = UsuarioFactory(
         username="acompanha",
         email="acompanha@example.com",
         password="test123",
@@ -113,7 +112,7 @@ def setup_solicitacao():
     )
 
     # Solicitação aprovada
-    sol = Solicitacao.objects.create(
+    sol = SolicitacaoFactory(
         usuario=coord,
         municipio=municipio,
         projeto=projeto,

--- a/v2/backend/apps/core/tests/test_project_dedup_migration.py
+++ b/v2/backend/apps/core/tests/test_project_dedup_migration.py
@@ -32,6 +32,7 @@ migration_module = importlib.import_module("apps.core.migrations.0036_consolidat
 consolidate_projetos = migration_module.consolidate_projetos
 
 
+@pytest.mark.migrations
 @pytest.mark.django_db(transaction=True)
 class TestProjectDedupMigration:
     """Testes para migration 0036_consolidate_duplicate_projetos."""

--- a/v2/backend/apps/core/tests/test_projeto_is_test_filter.py
+++ b/v2/backend/apps/core/tests/test_projeto_is_test_filter.py
@@ -14,31 +14,29 @@ Tests:
 
 from __future__ import annotations
 
-from django.contrib.auth.models import Group
 from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import Projeto, Usuario
+from apps.core.models import Projeto
+from apps.core.tests.factories import ProjetoFactory, UsuarioFactory
 
 
 @pytest.fixture
 def dat_user(db):
     """Create DAT user for CRUD permissions."""
-    user = Usuario.objects.create_user(
+    return UsuarioFactory(
         username="dat_user",
         email="dat@example.com",
         password="testpass123",
+        groups=["DAT"],
     )
-    dat_group, _ = Group.objects.get_or_create(name="DAT")
-    user.groups.add(dat_group)
-    return user
 
 
 @pytest.fixture
 def regular_user(db):
     """Create regular authenticated user for options endpoints."""
-    return Usuario.objects.create_user(
+    return UsuarioFactory(
         username="regular_user",
         email="user@example.com",
         password="testpass123",
@@ -49,15 +47,15 @@ def regular_user(db):
 def projetos_mixed(db):
     """Create mix of production and test projects."""
     # Production projects
-    prod1 = Projeto.objects.create(nome="CIRANDAR", fluxo="SUPER", ativo=True, is_test=False)
-    prod2 = Projeto.objects.create(nome="ACERTA MATEMÁTICA", fluxo="NAO_SUPER", ativo=True, is_test=False)
+    prod1 = ProjetoFactory(nome="CIRANDAR", fluxo="SUPER", ativo=True, is_test=False)
+    prod2 = ProjetoFactory(nome="ACERTA MATEMÁTICA", fluxo="NAO_SUPER", ativo=True, is_test=False)
 
     # Test projects
-    test1 = Projeto.objects.create(nome="SMOKE SUPER", fluxo="SUPER", ativo=True, is_test=True)
-    test2 = Projeto.objects.create(nome="TESTE E2E", fluxo="SUPER", ativo=True, is_test=True)
+    test1 = ProjetoFactory(nome="SMOKE SUPER", fluxo="SUPER", ativo=True, is_test=True)
+    test2 = ProjetoFactory(nome="TESTE E2E", fluxo="SUPER", ativo=True, is_test=True)
 
     # Inactive project (should be filtered by options endpoint anyway)
-    inactive = Projeto.objects.create(nome="INACTIVE", fluxo="SUPER", ativo=False, is_test=False)
+    inactive = ProjetoFactory(nome="INACTIVE", fluxo="SUPER", ativo=False, is_test=False)
 
     return {
         "production": [prod1, prod2],

--- a/v2/backend/apps/core/tests/test_promote_municipios_referencia_command.py
+++ b/v2/backend/apps/core/tests/test_promote_municipios_referencia_command.py
@@ -15,6 +15,7 @@ import pytest
 
 from apps.core.models import Municipio, MunicipioReferencia
 from apps.core.services.options_cache import MUNICIPIOS_OPTIONS_CACHE_KEY
+from apps.core.tests.factories import MunicipioFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -85,7 +86,7 @@ def test_promote_municipios_referencia_apply_is_idempotent():
 
 
 def test_promote_municipios_referencia_apply_updates_existing_normalized_match():
-    municipio = Municipio.objects.create(nome="Sao Paulo", uf="SP", ibge_code=None, ativo=False)
+    municipio = MunicipioFactory(nome="Sao Paulo", uf="SP", ibge_code=None, ativo=False)
     MunicipioReferencia.objects.create(
         nome="Sao Paulo",
         uf="SP",
@@ -108,7 +109,7 @@ def test_promote_municipios_referencia_apply_updates_existing_normalized_match()
 
 
 def test_promote_municipios_referencia_prefers_existing_ibge_code_match():
-    Municipio.objects.create(nome="Fortaleza", uf="CE", ibge_code="2304400", ativo=False)
+    MunicipioFactory(nome="Fortaleza", uf="CE", ibge_code="2304400", ativo=False)
     MunicipioReferencia.objects.create(
         nome="Fortaleza",
         uf="CE",
@@ -130,7 +131,7 @@ def test_promote_municipios_referencia_prefers_existing_ibge_code_match():
 
 
 def test_promote_municipios_referencia_does_not_match_by_name_without_uf():
-    Municipio.objects.create(nome="Fortaleza", uf="CE", ibge_code=None, ativo=True)
+    MunicipioFactory(nome="Fortaleza", uf="CE", ibge_code=None, ativo=True)
     MunicipioReferencia.objects.create(
         nome="Fortaleza",
         uf="PI",
@@ -187,7 +188,7 @@ def test_promote_municipios_referencia_include_inactive_refs_creates_inactive_ro
 
 
 def test_promote_municipios_referencia_apply_detects_code_owned_by_other():
-    Municipio.objects.create(nome="Aquiraz", uf="CE", ibge_code="2301000", ativo=True)
+    MunicipioFactory(nome="Aquiraz", uf="CE", ibge_code="2301000", ativo=True)
     MunicipioReferencia.objects.create(
         nome="Eusebio",
         uf="CE",
@@ -206,8 +207,8 @@ def test_promote_municipios_referencia_apply_detects_code_owned_by_other():
 
 
 def test_promote_municipios_referencia_apply_detects_ambiguous_existing_candidates():
-    Municipio.objects.create(nome="Santo Antonio", uf="CE", ibge_code=None, ativo=True)
-    Municipio.objects.create(nome="Santo Antônio", uf="CE", ibge_code=None, ativo=True)
+    MunicipioFactory(nome="Santo Antonio", uf="CE", ibge_code=None, ativo=True)
+    MunicipioFactory(nome="Santo Antônio", uf="CE", ibge_code=None, ativo=True)
     MunicipioReferencia.objects.create(
         nome="Santo Antonio",
         uf="CE",
@@ -225,7 +226,7 @@ def test_promote_municipios_referencia_apply_detects_ambiguous_existing_candidat
 
 
 def test_promote_municipios_referencia_apply_detects_mismatched_existing_code():
-    Municipio.objects.create(nome="Fortaleza", uf="CE", ibge_code="2304401", ativo=True)
+    MunicipioFactory(nome="Fortaleza", uf="CE", ibge_code="2304401", ativo=True)
     MunicipioReferencia.objects.create(
         nome="Fortaleza",
         uf="CE",

--- a/v2/backend/apps/core/tests/test_query_optimization.py
+++ b/v2/backend/apps/core/tests/test_query_optimization.py
@@ -11,15 +11,20 @@ from __future__ import annotations
 
 import uuid
 
-from django.contrib.auth import get_user_model
 from django.db import connection
 from django.test import TestCase, override_settings
 from django.test.utils import CaptureQueriesContext
 from rest_framework.test import APIClient
 
-from apps.core.models import AvailabilityBlock, Municipio, Participation, Projeto, Solicitacao, TipoEvento
-
-Usuario = get_user_model()
+from apps.core.models import AvailabilityBlock, Participation
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 
 def unique_cpf() -> str:
@@ -33,7 +38,7 @@ class TestAvailabilityBlockQueryOptimization(TestCase):
 
     def setUp(self):
         self.client = APIClient()
-        self.user = Usuario.objects.create_user(
+        self.user = UsuarioFactory(
             username="testuser_avail",
             password="testpass123",
             is_superuser=True,
@@ -82,7 +87,7 @@ class TestAvailabilityCheckManyQueryOptimization(TestCase):
     def setUp(self):
         self.client = APIClient()
         # Create a user with the right permissions
-        self.user = Usuario.objects.create_user(
+        self.user = UsuarioFactory(
             username="testuser_check",
             password="testpass123",
             is_superuser=True,  # Superuser has all permissions
@@ -93,7 +98,7 @@ class TestAvailabilityCheckManyQueryOptimization(TestCase):
         # Create test users
         self.test_users = []
         for i in range(10):
-            u = Usuario.objects.create_user(
+            u = UsuarioFactory(
                 username=f"formador_check_{i}",
                 password="testpass123",
                 cpf=unique_cpf(),
@@ -146,35 +151,33 @@ class TestUpdateFormadoresQueryOptimization(TestCase):
         self.client = APIClient()
 
         # Create coordenador user
-        self.coord = Usuario.objects.create_user(
+        self.coord = UsuarioFactory(
             username="coord_update_test",
             password="testpass123",
             cpf=unique_cpf(),
         )
         # Add to Coordenador group
-        from django.contrib.auth.models import Group
-
-        coord_group, _ = Group.objects.get_or_create(name="Coordenador")
+        coord_group = GroupFactory(name="Coordenador")
         self.coord.groups.add(coord_group)
         self.client.force_authenticate(user=self.coord)
 
         # Create required related objects
-        self.municipio = Municipio.objects.create(
+        self.municipio = MunicipioFactory(
             nome=f"Fortaleza Update {uuid.uuid4().hex[:8]}",
             uf="CE",
         )
-        self.projeto = Projeto.objects.create(
+        self.projeto = ProjetoFactory(
             nome=f"Test Project Update {uuid.uuid4().hex[:8]}",
             fluxo="NAO_SUPER",
         )
-        self.tipo_evento = TipoEvento.objects.create(
+        self.tipo_evento = TipoEventoFactory(
             nome=f"Formação Update {uuid.uuid4().hex[:8]}",
         )
 
         # Create formadores
         self.formadores = []
         for i in range(10):
-            u = Usuario.objects.create_user(
+            u = UsuarioFactory(
                 username=f"formador_upd_{uuid.uuid4().hex[:8]}",
                 password="testpass123",
                 cpf=unique_cpf(),
@@ -182,7 +185,7 @@ class TestUpdateFormadoresQueryOptimization(TestCase):
             self.formadores.append(u)
 
         # Create solicitacao
-        self.solicitacao = Solicitacao.objects.create(
+        self.solicitacao = SolicitacaoFactory(
             usuario=self.coord,
             municipio=self.municipio,
             projeto=self.projeto,
@@ -242,7 +245,7 @@ class TestSolicitacaoListQueryOptimization(TestCase):
 
     def setUp(self):
         self.client = APIClient()
-        self.user = Usuario.objects.create_user(
+        self.user = UsuarioFactory(
             username=f"testuser_list_{uuid.uuid4().hex[:8]}",
             password="testpass123",
             is_superuser=True,
@@ -251,21 +254,21 @@ class TestSolicitacaoListQueryOptimization(TestCase):
         self.client.force_authenticate(user=self.user)
 
         # Create required related objects
-        self.municipio = Municipio.objects.create(
+        self.municipio = MunicipioFactory(
             nome=f"Fortaleza List {uuid.uuid4().hex[:8]}",
             uf="CE",
         )
-        self.projeto = Projeto.objects.create(
+        self.projeto = ProjetoFactory(
             nome=f"Test List {uuid.uuid4().hex[:8]}",
             fluxo="NAO_SUPER",
         )
-        self.tipo_evento = TipoEvento.objects.create(
+        self.tipo_evento = TipoEventoFactory(
             nome=f"Formação List {uuid.uuid4().hex[:8]}",
         )
 
         # Create 20 solicitações
         for i in range(20):
-            Solicitacao.objects.create(
+            SolicitacaoFactory(
                 usuario=self.user,
                 municipio=self.municipio,
                 projeto=self.projeto,

--- a/v2/backend/apps/core/tests/test_query_optimization_mp4.py
+++ b/v2/backend/apps/core/tests/test_query_optimization_mp4.py
@@ -21,7 +21,15 @@ from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import Municipio, Projeto, Solicitacao, TipoEvento, Usuario
+from apps.core.models import Solicitacao, Usuario
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 if TYPE_CHECKING:
     from django.contrib.auth.models import User
@@ -30,8 +38,8 @@ if TYPE_CHECKING:
 @pytest.fixture
 def grupos(db: None) -> dict[str, Group]:
     """Cria grupos necessários."""
-    controle, _ = Group.objects.get_or_create(name="Controle")
-    superintendencia, _ = Group.objects.get_or_create(name="Superintendência")
+    controle = GroupFactory(name="Controle")
+    superintendencia = GroupFactory(name="Superintendência")
     return {"controle": controle, "superintendencia": superintendencia}
 
 
@@ -41,7 +49,7 @@ def usuario_controle(db: None, grupos: dict[str, Group]) -> Usuario:
     import uuid
 
     uid = uuid.uuid4().hex[:8]
-    usuario = Usuario.objects.create_user(
+    usuario = UsuarioFactory(
         username=f"controle_qopt_{uid}",
         email=f"controle_qopt_{uid}@test.com",
         password="senha123",
@@ -57,7 +65,7 @@ def usuario_super(db: None, grupos: dict[str, Group]) -> Usuario:
     import uuid
 
     uid = uuid.uuid4().hex[:8]
-    usuario = Usuario.objects.create_user(
+    usuario = UsuarioFactory(
         username=f"super_qopt_{uid}",
         email=f"super_qopt_{uid}@test.com",
         password="senha123",
@@ -71,15 +79,15 @@ def usuario_super(db: None, grupos: dict[str, Group]) -> Usuario:
 def solicitacoes_published(db: None, usuario_controle: User, usuario_super: User) -> list[Solicitacao]:
     """Cria 10 solicitações PUBLISHED para testar N+1."""
     # Criar dependências
-    municipio = Municipio.objects.create(nome="Salvador", uf="BA", ibge_code="2927408")
-    projeto = Projeto.objects.create(nome="ACERTA", codigo="ACERTA", fluxo="NAO_SUPER")
-    tipo_evento = TipoEvento.objects.create(nome="Formação")
+    municipio = MunicipioFactory(nome="Salvador", uf="BA", ibge_code="2927408")
+    projeto = ProjetoFactory(nome="ACERTA", codigo="ACERTA", fluxo="NAO_SUPER")
+    tipo_evento = TipoEventoFactory(nome="Formação")
 
     # Criar 10 solicitações
     solicitacoes = []
     now = timezone.now()
     for i in range(10):
-        sol = Solicitacao.objects.create(
+        sol = SolicitacaoFactory(
             inicio=now + timedelta(hours=i),
             fim=now + timedelta(hours=i + 2),
             municipio=municipio,

--- a/v2/backend/apps/core/tests/test_rbac_endpoints.py
+++ b/v2/backend/apps/core/tests/test_rbac_endpoints.py
@@ -18,14 +18,20 @@ from __future__ import annotations
 from datetime import timedelta
 from uuid import uuid4
 
-from django.contrib.auth.models import Group
 from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import Municipio, Projeto, Solicitacao, TipoEvento, Usuario
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 pytestmark = pytest.mark.django_db
 
@@ -33,28 +39,28 @@ pytestmark = pytest.mark.django_db
 @pytest.fixture
 def grupo_superintendencia():
     """Grupo Superintendência."""
-    grupo, _ = Group.objects.get_or_create(name="Superintendência")
+    grupo = GroupFactory(name="Superintendência")
     return grupo
 
 
 @pytest.fixture
 def grupo_dat():
     """Grupo DAT."""
-    grupo, _ = Group.objects.get_or_create(name="DAT")
+    grupo = GroupFactory(name="DAT")
     return grupo
 
 
 @pytest.fixture
 def grupo_formador():
     """Grupo Formador."""
-    grupo, _ = Group.objects.get_or_create(name="Formador")
+    grupo = GroupFactory(name="Formador")
     return grupo
 
 
 @pytest.fixture
 def grupo_gerente():
     """Função Gerente (PR 3, 2026-04-29 — composite Gerente+Sup aprova)."""
-    grupo, _ = Group.objects.get_or_create(name="Gerente")
+    grupo = GroupFactory(name="Gerente")
     return grupo
 
 
@@ -63,7 +69,7 @@ def user_superintendencia(grupo_superintendencia, grupo_gerente):
     """PR 3 hardening RBAC: composite Gerente da Superintendência (Setor
     Superintendência + Função Gerente). Sup puro sem Função não aprova mais."""
     uid = uuid4().hex[:8]
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username=f"super_rbac_{uid}",
         email=f"super_rbac_{uid}@test.com",
         password="testpass123",
@@ -78,7 +84,7 @@ def user_dat(grupo_dat):
     """PR 3 hardening RBAC: DAT NÃO aprova mais (regra anterior PA-02 Adaptada
     foi descontinuada). Mantém o nome `user_dat` para os testes invertidos."""
     uid = uuid4().hex[:8]
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username=f"dat_rbac_{uid}",
         email=f"dat_rbac_{uid}@test.com",
         password="testpass123",
@@ -92,7 +98,7 @@ def user_dat(grupo_dat):
 def user_formador(grupo_formador):
     """Usuário do grupo Formador (sem permissão de aprovação)."""
     uid = uuid4().hex[:8]
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username=f"formador_rbac_{uid}",
         email=f"formador_rbac_{uid}@test.com",
         password="testpass123",
@@ -105,15 +111,12 @@ def user_formador(grupo_formador):
 @pytest.fixture
 def solicitacao_pendente(user_formador):
     """Solicitação pendente para testes RBAC."""
-    municipio, _ = Municipio.objects.get_or_create(nome="Fortaleza RBAC", defaults={"uf": "CE", "ativo": True})
-    projeto, _ = Projeto.objects.get_or_create(
-        nome="Projeto RBAC SUPER",
-        defaults={"ativo": True, "fluxo": "SUPER"},
-    )
-    tipo_evento, _ = TipoEvento.objects.get_or_create(nome="Formação RBAC")
+    municipio = MunicipioFactory(nome="Fortaleza RBAC", uf="CE", ativo=True)
+    projeto = ProjetoFactory(nome="Projeto RBAC SUPER", ativo=True, fluxo="SUPER")
+    tipo_evento = TipoEventoFactory(nome="Formação RBAC")
 
     now = timezone.now()
-    return Solicitacao.objects.create(
+    return SolicitacaoFactory(
         usuario=user_formador,
         municipio=municipio,
         projeto=projeto,
@@ -199,15 +202,12 @@ class TestRBACApprovalEndpoints:
 
     def test_dat_cannot_reject(self, user_dat, user_formador):
         """PR 3 hardening RBAC (2026-04-29): DAT NÃO reprova mais."""
-        municipio, _ = Municipio.objects.get_or_create(nome="Fortaleza RBAC", defaults={"uf": "CE", "ativo": True})
-        projeto, _ = Projeto.objects.get_or_create(
-            nome="Projeto RBAC SUPER",
-            defaults={"ativo": True, "fluxo": "SUPER"},
-        )
-        tipo_evento, _ = TipoEvento.objects.get_or_create(nome="Formação RBAC")
+        municipio = MunicipioFactory(nome="Fortaleza RBAC", uf="CE", ativo=True)
+        projeto = ProjetoFactory(nome="Projeto RBAC SUPER", ativo=True, fluxo="SUPER")
+        tipo_evento = TipoEventoFactory(nome="Formação RBAC")
 
         now = timezone.now()
-        solicitacao = Solicitacao.objects.create(
+        solicitacao = SolicitacaoFactory(
             usuario=user_formador,
             municipio=municipio,
             projeto=projeto,
@@ -244,15 +244,12 @@ class TestRBACApprovalEndpoints:
     def test_gerente_superintendencia_can_reject(self, user_superintendencia, user_formador):
         """PR 3 hardening RBAC: Gerente da Superintendência reprova."""
         # Criar nova solicitação para este teste
-        municipio, _ = Municipio.objects.get_or_create(nome="Fortaleza RBAC", defaults={"uf": "CE", "ativo": True})
-        projeto, _ = Projeto.objects.get_or_create(
-            nome="Projeto RBAC SUPER",
-            defaults={"ativo": True, "fluxo": "SUPER"},
-        )
-        tipo_evento, _ = TipoEvento.objects.get_or_create(nome="Formação RBAC")
+        municipio = MunicipioFactory(nome="Fortaleza RBAC", uf="CE", ativo=True)
+        projeto = ProjetoFactory(nome="Projeto RBAC SUPER", ativo=True, fluxo="SUPER")
+        tipo_evento = TipoEventoFactory(nome="Formação RBAC")
 
         now = timezone.now()
-        solicitacao = Solicitacao.objects.create(
+        solicitacao = SolicitacaoFactory(
             usuario=user_formador,
             municipio=municipio,
             projeto=projeto,

--- a/v2/backend/apps/core/tests/test_rbac_functional_permissions.py
+++ b/v2/backend/apps/core/tests/test_rbac_functional_permissions.py
@@ -6,7 +6,6 @@ Testes da Fase 2 RBAC funcional (#828).
 
 from __future__ import annotations
 
-from django.contrib.auth.models import Group
 from django.core.cache import cache
 from rest_framework.test import APIRequestFactory
 
@@ -14,6 +13,7 @@ import pytest
 
 from apps.core.models import PermissaoFuncional, Usuario
 from apps.core.permissions import HasPerm, IsGerenteSuperintendencia
+from apps.core.tests.factories import GroupFactory, UsuarioFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -30,8 +30,8 @@ def _request_with_user(factory: APIRequestFactory, user: Usuario):
 
 
 def test_functional_permission_allows_access_via_group_mapping():
-    dat_group, _ = Group.objects.get_or_create(name="DAT")
-    user = Usuario.objects.create_user(
+    dat_group = GroupFactory(name="DAT")
+    user = UsuarioFactory(
         username="dat_funcperm",
         email="dat_funcperm@test.com",
         password="test123",
@@ -44,7 +44,7 @@ def test_functional_permission_allows_access_via_group_mapping():
 
 
 def test_functional_permission_denies_user_without_mapping():
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username="sem_funcperm",
         email="sem_funcperm@test.com",
         password="test123",
@@ -57,8 +57,8 @@ def test_functional_permission_denies_user_without_mapping():
 
 def test_functional_permission_cache_hit_miss(django_assert_num_queries):
     cache.clear()
-    dat_group, _ = Group.objects.get_or_create(name="DAT")
-    user = Usuario.objects.create_user(
+    dat_group = GroupFactory(name="DAT")
+    user = UsuarioFactory(
         username="cache_funcperm",
         email="cache_funcperm@test.com",
         password="test123",
@@ -78,8 +78,8 @@ def test_functional_permission_cache_hit_miss(django_assert_num_queries):
 
 def test_cache_invalidated_when_user_groups_change():
     cache.clear()
-    dat_group, _ = Group.objects.get_or_create(name="DAT")
-    user = Usuario.objects.create_user(
+    dat_group = GroupFactory(name="DAT")
+    user = UsuarioFactory(
         username="invalidate_user_groups",
         email="invalidate_user_groups@test.com",
         password="test123",
@@ -97,8 +97,8 @@ def test_cache_invalidated_when_user_groups_change():
 
 def test_cache_invalidated_when_permission_m2m_changes():
     cache.clear()
-    dat_group, _ = Group.objects.get_or_create(name="DAT")
-    user = Usuario.objects.create_user(
+    dat_group = GroupFactory(name="DAT")
+    user = UsuarioFactory(
         username="invalidate_perm_m2m",
         email="invalidate_perm_m2m@test.com",
         password="test123",
@@ -128,8 +128,8 @@ def test_cache_invalidated_when_permission_m2m_changes():
 
 def test_cache_invalidated_when_permission_saved():
     cache.clear()
-    dat_group, _ = Group.objects.get_or_create(name="DAT")
-    user = Usuario.objects.create_user(
+    dat_group = GroupFactory(name="DAT")
+    user = UsuarioFactory(
         username="invalidate_perm_save",
         email="invalidate_perm_save@test.com",
         password="test123",
@@ -160,8 +160,8 @@ def test_cache_invalidated_when_permission_saved():
 
 def test_cache_invalidated_when_permission_deleted():
     cache.clear()
-    dat_group, _ = Group.objects.get_or_create(name="DAT")
-    user = Usuario.objects.create_user(
+    dat_group = GroupFactory(name="DAT")
+    user = UsuarioFactory(
         username="invalidate_perm_delete",
         email="invalidate_perm_delete@test.com",
         password="test123",
@@ -190,10 +190,10 @@ def test_cache_invalidated_when_permission_deleted():
 
 
 def test_is_gerente_superintendencia_requires_funcperm_and_gerente_group():
-    super_group, _ = Group.objects.get_or_create(name="Superintendência")
-    gerente_group, _ = Group.objects.get_or_create(name="Gerente")
+    super_group = GroupFactory(name="Superintendência")
+    gerente_group = GroupFactory(name="Gerente")
 
-    user_ok = Usuario.objects.create_user(
+    user_ok = UsuarioFactory(
         username="gerente_super_ok",
         email="gerente_super_ok@test.com",
         password="test123",
@@ -201,7 +201,7 @@ def test_is_gerente_superintendencia_requires_funcperm_and_gerente_group():
     )
     user_ok.groups.add(super_group, gerente_group)
 
-    user_without_gerente = Usuario.objects.create_user(
+    user_without_gerente = UsuarioFactory(
         username="gerente_super_no_gerente",
         email="gerente_super_no_gerente@test.com",
         password="test123",
@@ -209,7 +209,7 @@ def test_is_gerente_superintendencia_requires_funcperm_and_gerente_group():
     )
     user_without_gerente.groups.add(super_group)
 
-    user_without_super = Usuario.objects.create_user(
+    user_without_super = UsuarioFactory(
         username="gerente_super_no_super",
         email="gerente_super_no_super@test.com",
         password="test123",

--- a/v2/backend/apps/core/tests/test_rbac_helpers.py
+++ b/v2/backend/apps/core/tests/test_rbac_helpers.py
@@ -19,12 +19,13 @@ Ver v2/docs/plans/rbac-refactor/epic-3-hardcoded.md e master-plan §4.
 
 from __future__ import annotations
 
-from django.contrib.auth.models import AnonymousUser, Group
+from django.contrib.auth.models import AnonymousUser
 
 import pytest
 
-from apps.core.models import PermissaoFuncional, Usuario
+from apps.core.models import PermissaoFuncional
 from apps.core.rbac_helpers import user_has_all_perms, user_has_any_perm
+from apps.core.tests.factories import GroupFactory, UsuarioFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -64,21 +65,21 @@ def perm_b():
 
 @pytest.fixture
 def group_with_a(perm_a):
-    group, _ = Group.objects.get_or_create(name="TestGroupA")
+    group = GroupFactory(name="TestGroupA")
     perm_a.groups.add(group)
     return group
 
 
 @pytest.fixture
 def group_with_b(perm_b):
-    group, _ = Group.objects.get_or_create(name="TestGroupB")
+    group = GroupFactory(name="TestGroupB")
     perm_b.groups.add(group)
     return group
 
 
 @pytest.fixture
 def user_with_a(group_with_a):
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username="user_a",
         email="a@test.com",
         password="x",
@@ -90,7 +91,7 @@ def user_with_a(group_with_a):
 
 @pytest.fixture
 def user_with_a_and_b(group_with_a, group_with_b):
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username="user_ab",
         email="ab@test.com",
         password="x",
@@ -102,7 +103,7 @@ def user_with_a_and_b(group_with_a, group_with_b):
 
 @pytest.fixture
 def user_empty():
-    return Usuario.objects.create_user(
+    return UsuarioFactory(
         username="user_empty",
         email="empty@test.com",
         password="x",
@@ -112,12 +113,7 @@ def user_empty():
 
 @pytest.fixture
 def superuser():
-    return Usuario.objects.create_superuser(
-        username="su",
-        email="su@test.com",
-        password="x",
-        cpf="30000000004",
-    )
+    return UsuarioFactory(superuser=True)
 
 
 # ============================================================================

--- a/v2/backend/apps/core/tests/test_rbac_layer3_parity.py
+++ b/v2/backend/apps/core/tests/test_rbac_layer3_parity.py
@@ -13,13 +13,13 @@ Ver v2/docs/plans/rbac-refactor/epic-3-hardcoded.md §3.2.
 
 from __future__ import annotations
 
-from django.contrib.auth.models import Group
 from django.core.management import call_command
 
 import pytest
 
 from apps.core.models import Usuario
 from apps.core.rbac_helpers import user_has_any_perm
+from apps.core.tests.factories import UsuarioFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -34,16 +34,13 @@ def rbac_seeded():
 
 
 def _user_with_groups(username: str, groups: list[str]) -> Usuario:
-    u = Usuario.objects.create_user(
+    return UsuarioFactory(
         username=username,
         email=f"{username}@test.com",
         password="x",
         cpf=username.rjust(11, "9")[-11:],
+        groups=groups,
     )
-    for gname in groups:
-        group, _ = Group.objects.get_or_create(name=gname)
-        u.groups.add(group)
-    return u
 
 
 # ============================================================================

--- a/v2/backend/apps/core/tests/test_rbac_matrix_living.py
+++ b/v2/backend/apps/core/tests/test_rbac_matrix_living.py
@@ -13,7 +13,6 @@ dedicados (`test_deslocamento_rbac.py`, `test_availability_monthly_rbac.py`).
 
 from __future__ import annotations
 
-from django.contrib.auth.models import Group
 from django.core.cache import cache
 from rest_framework.test import APIClient
 
@@ -35,6 +34,7 @@ from apps.core.rbac.matrix import (
     expand_matrix,
     format_failure_message,
 )
+from apps.core.tests.factories import UsuarioFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -63,21 +63,16 @@ def _make_user_for_actor(actor: str) -> Usuario:
     GERENTE retorne 200 na Matriz Viva. DAT recebe cap global (sem fixture).
     """
     if actor == SUPERUSER:
-        return Usuario.objects.create_superuser(
-            username=f"matrix_super_{_USER_COUNTER['i']:06d}",
-            email=f"matrix_super_{_USER_COUNTER['i']:06d}@example.com",
-            password="testpass123",
+        return UsuarioFactory(
+            superuser=True,
             cpf=_next_cpf(),
         )
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username=f"matrix_{actor.lower().replace(' ', '_')}_{_USER_COUNTER['i']:06d}",
         email=f"matrix_{actor.lower().replace(' ', '_')}_{_USER_COUNTER['i']:06d}@example.com",
-        password="testpass123",
         cpf=_next_cpf(),
+        groups=ACTOR_GROUPS[actor],
     )
-    for gname in ACTOR_GROUPS[actor]:
-        group, _ = Group.objects.get_or_create(name=gname)
-        user.groups.add(group)
 
     # D8 + D9 + PR 8: Coord/Apoio/Gerente* precisam de vínculo organizacional
     # para passar HasSectorAccess na grade mensal.
@@ -109,10 +104,9 @@ def _make_user_for_actor(actor: str) -> Usuario:
             # Apoio: check constraint `apoio_requires_supervisor` exige
             # `coordenador_supervisor` (FK Usuario) não-nulo. Criamos um Coord
             # auxiliar para servir de supervisor.
-            supervisor_user = Usuario.objects.create_user(
+            supervisor_user = UsuarioFactory(
                 username=f"matrix_supervisor_{_USER_COUNTER['i']:06d}",
                 email=f"matrix_supervisor_{_USER_COUNTER['i']:06d}@example.com",
-                password="testpass123",
                 cpf=_next_cpf(),
             )
             EquipeGerencia.objects.create(

--- a/v2/backend/apps/core/tests/test_rbac_matrix_scope.py
+++ b/v2/backend/apps/core/tests/test_rbac_matrix_scope.py
@@ -20,12 +20,12 @@ from __future__ import annotations
 
 import itertools
 
-from django.contrib.auth.models import Group
 from rest_framework.test import APIClient
 
 import pytest
 
 from apps.core.models import EquipeGerencia, Gerencia, Usuario
+from apps.core.tests.factories import UsuarioFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -35,16 +35,13 @@ _CPF_COUNTER = itertools.count(20000000000)
 
 def _user_in_groups(*group_names: str, label: str = "user") -> Usuario:
     cpf = str(next(_CPF_COUNTER)).zfill(11)
-    user = Usuario.objects.create_user(
+    return UsuarioFactory(
         username=f"{label}_{cpf}",
         email=f"{label}_{cpf}@example.com",
         password="testpass",
         cpf=cpf,
+        groups=list(group_names),
     )
-    for name in group_names:
-        group, _ = Group.objects.get_or_create(name=name)
-        user.groups.add(group)
-    return user
 
 
 def _attach_equipe(user: Usuario, gerencia: Gerencia, papel: str = "GERENTE") -> EquipeGerencia:

--- a/v2/backend/apps/core/tests/test_rbac_permissions.py
+++ b/v2/backend/apps/core/tests/test_rbac_permissions.py
@@ -21,6 +21,7 @@ import pytest
 
 from apps.core.constants import FUNCAO_GROUPS, SETOR_GROUPS
 from apps.core.models import Usuario
+from apps.core.tests.factories import GroupFactory, UsuarioFactory
 
 
 class TestRBACConstants(TestCase):
@@ -76,15 +77,15 @@ class TestCanApproveSuperLogic(TestCase):
 
         # Criar todos os grupos
         for setor in SETOR_GROUPS:
-            Group.objects.get_or_create(name=setor)
+            GroupFactory(name=setor)
         for funcao in FUNCAO_GROUPS:
-            Group.objects.get_or_create(name=funcao)
+            GroupFactory(name=funcao)
 
     def _create_user_with_groups(
         self, username: str, setores: list, funcoes: list, is_superuser: bool = False
     ) -> Usuario:
         """Helper para criar usuário com grupos específicos."""
-        user = Usuario.objects.create_user(
+        user = UsuarioFactory(
             username=username,
             email=f"{username}@test.com",
             password="test123",
@@ -250,13 +251,13 @@ class TestApiMeEndpoint(TestCase):
 
         # Criar grupos
         for setor in SETOR_GROUPS:
-            Group.objects.get_or_create(name=setor)
+            GroupFactory(name=setor)
         for funcao in FUNCAO_GROUPS:
-            Group.objects.get_or_create(name=funcao)
+            GroupFactory(name=funcao)
 
     def test_api_me_returns_setores_and_funcoes(self):
         """Endpoint /api/me/ deve retornar setores e funcoes separados."""
-        user = Usuario.objects.create_user(
+        user = UsuarioFactory(
             username="test_user",
             email="test@test.com",
             password="test123",
@@ -276,7 +277,7 @@ class TestApiMeEndpoint(TestCase):
 
     def test_api_me_separates_groups_correctly(self):
         """Endpoint /api/me/ deve separar corretamente setores e funções."""
-        user = Usuario.objects.create_user(
+        user = UsuarioFactory(
             username="mixed_user",
             email="mixed@test.com",
             password="test123",
@@ -306,7 +307,7 @@ class TestApiMeEndpoint(TestCase):
 
     def test_is_superintendencia_with_setor(self):
         """is_superintendencia deve ser True se usuário está no setor Superintendência."""
-        user = Usuario.objects.create_user(
+        user = UsuarioFactory(
             username="super_user",
             email="super@test.com",
             password="test123",
@@ -322,7 +323,7 @@ class TestApiMeEndpoint(TestCase):
 
     def test_is_superintendencia_with_superuser(self):
         """is_superintendencia deve ser True se usuário é superuser."""
-        user = Usuario.objects.create_user(
+        user = UsuarioFactory(
             username="admin_user",
             email="admin@test.com",
             password="test123",
@@ -338,7 +339,7 @@ class TestApiMeEndpoint(TestCase):
 
     def test_is_superintendencia_without_setor(self):
         """is_superintendencia deve ser False se usuário não está no setor."""
-        user = Usuario.objects.create_user(
+        user = UsuarioFactory(
             username="dat_user",
             email="dat@test.com",
             password="test123",

--- a/v2/backend/apps/core/tests/test_rbac_policies.py
+++ b/v2/backend/apps/core/tests/test_rbac_policies.py
@@ -18,8 +18,7 @@ from __future__ import annotations
 import re
 from typing import Iterable
 
-from django.contrib.auth import get_user_model
-from django.contrib.auth.models import AnonymousUser, Group
+from django.contrib.auth.models import AnonymousUser
 from rest_framework import permissions as drf_permissions
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.test import APIRequestFactory
@@ -29,6 +28,7 @@ import pytest
 from apps.core.models import PermissaoFuncional
 from apps.core.rbac import policies as policies_module
 from apps.core.rbac.policies import ACCESS_POLICIES, _PolicyPermission
+from apps.core.tests.factories import GroupFactory, UsuarioFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -76,8 +76,7 @@ def _next_cpf() -> str:
 
 def _make_user(username: str, *codenames: str):
     """Cria User autenticado e atribui capabilities via PermissaoFuncional groups."""
-    User = get_user_model()
-    user = User.objects.create_user(
+    user = UsuarioFactory(
         username=username,
         email=f"{username}@example.com",
         password="testpass123",
@@ -85,7 +84,7 @@ def _make_user(username: str, *codenames: str):
     )
     if codenames:
         # Atribui capabilities via grupo dedicado (consistent com pattern atual)
-        group, _ = Group.objects.get_or_create(name=f"test-group-{username}")
+        group = GroupFactory(name=f"test-group-{username}")
         user.groups.add(group)
         for code in codenames:
             perm = PermissaoFuncional.objects.filter(codename=code).first()
@@ -239,13 +238,7 @@ class TestPolicySmoke:
     @pytest.mark.parametrize("policy_cls", _all_policy_classes(), ids=lambda c: c.__name__)
     def test_allows_superuser(self, policy_cls, seeded_db):
         """Superuser bypass (mesma semântica de HasPerm)."""
-        User = get_user_model()
-        super_user = User.objects.create_superuser(
-            username="super_test",
-            email="super_test@example.com",
-            password="testpass123",
-            cpf="99900000999",
-        )
+        super_user = UsuarioFactory(superuser=True)
         req = _request_for(super_user)
         assert policy_cls().has_permission(req, view=object()) is True
 

--- a/v2/backend/apps/core/tests/test_rbac_seed.py
+++ b/v2/backend/apps/core/tests/test_rbac_seed.py
@@ -21,7 +21,8 @@ from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import Municipio, PermissaoFuncional, Projeto, Solicitacao, TipoEvento, Usuario
+from apps.core.models import PermissaoFuncional, Usuario
+from apps.core.tests.factories import MunicipioFactory, ProjetoFactory, TipoEventoFactory, UsuarioFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -40,13 +41,13 @@ def run_seed_rbac():
 def dados_basicos():
     """Criar dados básicos para os testes."""
     # Municípios
-    mun_ce = Municipio.objects.create(nome="Fortaleza", uf="CE", ibge_code="2304400")
+    mun_ce = MunicipioFactory(nome="Fortaleza", uf="CE", ibge_code="2304400")
 
     # Projetos
-    proj1 = Projeto.objects.create(nome="Alfabetização", codigo="P001")
+    proj1 = ProjetoFactory(nome="Alfabetização", codigo="P001")
 
     # Tipos de evento
-    tipo1 = TipoEvento.objects.create(nome="Formação Inicial")
+    tipo1 = TipoEventoFactory(nome="Formação Inicial")
 
     return {
         "municipio": mun_ce,
@@ -199,7 +200,7 @@ def test_endpoint_municipios_dat_allowed(run_seed_rbac):
     """Issue #1222 (Epic 1): DAT acessa /api/municipios/ via `manage_admin_registries`
     (cadastro admin DAT puro). `seed_rbac` cria grupo DAT mas não atribui
     funcperms por default; explicitamente atribui aqui pra simular estado realista."""
-    user = Usuario.objects.create_user(username="dat1", email="dat@x.com", password="x", cpf="11111111111")
+    user = UsuarioFactory(username="dat1", email="dat@x.com", password="x", cpf="11111111111")
     dat = Group.objects.get(name="DAT")
     PermissaoFuncional.objects.get(codename="manage_admin_registries").groups.add(dat)
     user.groups.add(dat)
@@ -215,7 +216,7 @@ def test_endpoint_municipios_dat_allowed(run_seed_rbac):
 
 def test_endpoint_municipios_coordenador_forbidden(run_seed_rbac):
     """Coordenador NÃO tem acesso a /api/municipios/ (endpoint protegido por HasPerm("manage_purchases_and_materials"))."""
-    user = Usuario.objects.create_user(username="coord1", email="coord@x.com", password="x", cpf="22222222222")
+    user = UsuarioFactory(username="coord1", email="coord@x.com", password="x", cpf="22222222222")
     coord = Group.objects.get(name="Coordenador")
     user.groups.add(coord)
 
@@ -247,7 +248,7 @@ def test_endpoint_import_compras_dat_allowed(run_seed_rbac):
     portanto os vínculos cap↔grupo precisam ser explicitamente reatribuídos no
     teste (mesmo padrão do test obsoleto `*_controle_allowed`).
     """
-    user = Usuario.objects.create_user(username="dat1", email="dat@x.com", password="x", cpf="66666666666")
+    user = UsuarioFactory(username="dat1", email="dat@x.com", password="x", cpf="66666666666")
     dat = Group.objects.get(name="DAT")
     PermissaoFuncional.objects.get(codename="import_spreadsheet").groups.add(dat)
     user.groups.add(dat)
@@ -269,7 +270,7 @@ def test_endpoint_import_compras_controle_forbidden(run_seed_rbac):
     `manage_purchases_and_materials`, o gate atual é `import_spreadsheet`
     (DAT-only) — Controle continua 403.
     """
-    user = Usuario.objects.create_user(username="controle1", email="controle@x.com", password="x", cpf="55555555555")
+    user = UsuarioFactory(username="controle1", email="controle@x.com", password="x", cpf="55555555555")
     controle = Group.objects.get(name="Controle")
     # Reatribuir caps que Controle teria por seed em produção (já que
     # seed_rbac.py usa assign_default_groups=False).
@@ -288,7 +289,7 @@ def test_endpoint_import_compras_controle_forbidden(run_seed_rbac):
 
 def test_endpoint_import_compras_coordenador_forbidden(run_seed_rbac):
     """Coordenador NÃO tem acesso ao endpoint de import compras."""
-    user = Usuario.objects.create_user(username="coord1", email="coord@x.com", password="x", cpf="77777777777")
+    user = UsuarioFactory(username="coord1", email="coord@x.com", password="x", cpf="77777777777")
     coord = Group.objects.get(name="Coordenador")
     user.groups.add(coord)
 
@@ -305,7 +306,7 @@ def test_endpoint_import_compras_coordenador_forbidden(run_seed_rbac):
 
 def test_superuser_bypasses_all_permissions(run_seed_rbac):
     """Superuser sempre tem acesso, independente de grupos."""
-    user = Usuario.objects.create_superuser(username="admin", email="admin@x.com", password="x", cpf="99999999999")
+    user = UsuarioFactory(superuser=True)
 
     client = APIClient()
     client.force_authenticate(user=user)

--- a/v2/backend/apps/core/tests/test_rbac_service_whitelist.py
+++ b/v2/backend/apps/core/tests/test_rbac_service_whitelist.py
@@ -8,13 +8,12 @@ from __future__ import annotations
 
 from typing import Any, cast
 
-from django.contrib.auth.models import Group
-
 import pytest
 
 from apps.core.constants import ALLOWED_USER_GROUPS
 from apps.core.models import PermissaoFuncional
 from apps.core.services.rbac_service import get_assignable_group_names, invalidate_assignable_groups_cache
+from apps.core.tests.factories import GroupFactory
 
 
 @pytest.mark.django_db
@@ -30,7 +29,7 @@ class TestRBACServiceWhitelist:
         assert ALLOWED_USER_GROUPS.issubset(names)
 
     def test_dynamic_group_with_functional_permission_is_included(self) -> None:
-        group, _ = Group.objects.get_or_create(name="GrupoDinamicoService")
+        group = GroupFactory(name="GrupoDinamicoService")
         permission, _ = PermissaoFuncional.objects.get_or_create(
             codename="pode_usar_grupo_dinamico_service",
             defaults={
@@ -47,7 +46,7 @@ class TestRBACServiceWhitelist:
         assert "GrupoDinamicoService" in names
 
     def test_cache_is_invalidated_on_permission_group_change(self) -> None:
-        group, _ = Group.objects.get_or_create(name="GrupoCacheInvalidation")
+        group = GroupFactory(name="GrupoCacheInvalidation")
         permission, _ = PermissaoFuncional.objects.get_or_create(
             codename="pode_invalidate_assignable_cache",
             defaults={

--- a/v2/backend/apps/core/tests/test_reports.py
+++ b/v2/backend/apps/core/tests/test_reports.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 
-from django.contrib.auth.models import Group
 from django.core.cache import cache
 from django.urls import reverse
 from django.utils import timezone
@@ -29,7 +28,14 @@ from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import Municipio, Projeto, Solicitacao, TipoEvento, Usuario
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 pytestmark = pytest.mark.django_db
 
@@ -51,18 +57,18 @@ def clear_cache():
 def grupos():
     """Criar grupos necessários para os testes."""
     return {
-        "superintendencia": Group.objects.get_or_create(name="Superintendência")[0],
-        "controle": Group.objects.get_or_create(name="Controle")[0],
-        "dat": Group.objects.get_or_create(name="DAT")[0],
-        "coordenador": Group.objects.get_or_create(name="Coordenador")[0],
-        "formador": Group.objects.get_or_create(name="Formador")[0],
+        "superintendencia": GroupFactory(name="Superintendência"),
+        "controle": GroupFactory(name="Controle"),
+        "dat": GroupFactory(name="DAT"),
+        "coordenador": GroupFactory(name="Coordenador"),
+        "formador": GroupFactory(name="Formador"),
     }
 
 
 @pytest.fixture
 def user_super(grupos):
     """Usuário do grupo Superintendência."""
-    user = Usuario.objects.create_user(username="super1", email="super@x.com", password="x", cpf="11111111111")
+    user = UsuarioFactory(username="super1", email="super@x.com", password="x", cpf="11111111111")
     user.groups.add(grupos["superintendencia"])
     return user
 
@@ -70,7 +76,7 @@ def user_super(grupos):
 @pytest.fixture
 def user_controle(grupos):
     """Usuário do grupo Controle."""
-    user = Usuario.objects.create_user(username="controle1", email="controle@x.com", password="x", cpf="22222222222")
+    user = UsuarioFactory(username="controle1", email="controle@x.com", password="x", cpf="22222222222")
     user.groups.add(grupos["controle"])
     return user
 
@@ -78,7 +84,7 @@ def user_controle(grupos):
 @pytest.fixture
 def user_dat(grupos):
     """Usuário do grupo DAT."""
-    user = Usuario.objects.create_user(username="dat1", email="dat@x.com", password="x", cpf="33333333333")
+    user = UsuarioFactory(username="dat1", email="dat@x.com", password="x", cpf="33333333333")
     user.groups.add(grupos["dat"])
     return user
 
@@ -86,7 +92,7 @@ def user_dat(grupos):
 @pytest.fixture
 def user_coordenador(grupos):
     """Usuário do grupo Coordenador (sem permissão)."""
-    user = Usuario.objects.create_user(username="coord1", email="coord@x.com", password="x", cpf="44444444444")
+    user = UsuarioFactory(username="coord1", email="coord@x.com", password="x", cpf="44444444444")
     user.groups.add(grupos["coordenador"])
     return user
 
@@ -94,7 +100,7 @@ def user_coordenador(grupos):
 @pytest.fixture
 def user_formador(grupos):
     """Usuário do grupo Formador (sem permissão)."""
-    user = Usuario.objects.create_user(username="form1", email="form@x.com", password="x", cpf="55555555555")
+    user = UsuarioFactory(username="form1", email="form@x.com", password="x", cpf="55555555555")
     user.groups.add(grupos["formador"])
     return user
 
@@ -103,25 +109,25 @@ def user_formador(grupos):
 def dados_basicos(grupos):
     """Criar dados básicos para os testes."""
     # Formadores (usuários)
-    formador1 = Usuario.objects.create_user(username="ana.silva", email="ana@x.com", password="x", cpf="66666666666")
+    formador1 = UsuarioFactory(username="ana.silva", email="ana@x.com", password="x", cpf="66666666666")
     formador1.groups.add(grupos["formador"])
 
-    formador2 = Usuario.objects.create_user(username="joao.santos", email="joao@x.com", password="x", cpf="77777777777")
+    formador2 = UsuarioFactory(username="joao.santos", email="joao@x.com", password="x", cpf="77777777777")
     formador2.groups.add(grupos["formador"])
 
     # Municípios
-    mun_ce = Municipio.objects.create(nome="Fortaleza", uf="CE", ibge_code="2304400")
-    mun_pe = Municipio.objects.create(nome="Recife", uf="PE", ibge_code="2611606")
-    mun_ba = Municipio.objects.create(nome="Salvador", uf="BA", ibge_code="2927408")
+    mun_ce = MunicipioFactory(nome="Fortaleza", uf="CE", ibge_code="2304400")
+    mun_pe = MunicipioFactory(nome="Recife", uf="PE", ibge_code="2611606")
+    mun_ba = MunicipioFactory(nome="Salvador", uf="BA", ibge_code="2927408")
 
     # Projetos (fluxo='SUPER' para permitir testar diferentes status)
-    proj1 = Projeto.objects.create(nome="Alfabetização Ceará", codigo="P001", fluxo="SUPER")
-    proj2 = Projeto.objects.create(nome="Matemática", codigo="P002", fluxo="SUPER")
-    proj3 = Projeto.objects.create(nome="Ciências", codigo="P003", fluxo="SUPER")
+    proj1 = ProjetoFactory(nome="Alfabetização Ceará", codigo="P001", fluxo="SUPER")
+    proj2 = ProjetoFactory(nome="Matemática", codigo="P002", fluxo="SUPER")
+    proj3 = ProjetoFactory(nome="Ciências", codigo="P003", fluxo="SUPER")
 
     # Tipos de evento
-    tipo1 = TipoEvento.objects.create(nome="Formação Inicial")
-    tipo2 = TipoEvento.objects.create(nome="Formação Continuada")
+    tipo1 = TipoEventoFactory(nome="Formação Inicial")
+    tipo2 = TipoEventoFactory(nome="Formação Continuada")
 
     return {
         "formadores": [formador1, formador2],
@@ -137,15 +143,13 @@ def solicitacoes_variedade(dados_basicos):
     now = timezone.now()
     formador = dados_basicos["formadores"][0]
     # Criar um usuário coordenador para ser o criador das solicitações
-    coordenador = Usuario.objects.create_user(
-        username="coord_test", email="coord_test@x.com", password="x", cpf="88888888888"
-    )
+    coordenador = UsuarioFactory(username="coord_test", email="coord_test@x.com", password="x", cpf="88888888888")
 
     solicitacoes = []
 
     # 3 aprovadas em CE, projeto Alfabetização, últimas 2 semanas
     for i in range(3):
-        sol = Solicitacao.objects.create(
+        sol = SolicitacaoFactory(
             usuario=coordenador,
             status="aprovado",
             inicio=now - timedelta(days=7),
@@ -159,7 +163,7 @@ def solicitacoes_variedade(dados_basicos):
 
     # 2 pendentes em PE, projeto Matemática, últimas 4 semanas (dentro do range de 30 dias)
     for i in range(2):
-        sol = Solicitacao.objects.create(
+        sol = SolicitacaoFactory(
             usuario=coordenador,
             status="pendente",
             inicio=now - timedelta(days=20),
@@ -172,7 +176,7 @@ def solicitacoes_variedade(dados_basicos):
         solicitacoes.append(sol)
 
     # 1 reprovada em BA, projeto Ciências (dentro do range de 30 dias)
-    sol = Solicitacao.objects.create(
+    sol = SolicitacaoFactory(
         usuario=coordenador,
         status="reprovado",
         inicio=now - timedelta(days=25),  # Mudei de 35 para 25 dias
@@ -185,7 +189,7 @@ def solicitacoes_variedade(dados_basicos):
     solicitacoes.append(sol)
 
     # 1 aprovada antiga (fora do range de 30 dias)
-    sol = Solicitacao.objects.create(
+    sol = SolicitacaoFactory(
         usuario=coordenador,
         status="aprovado",
         inicio=now - timedelta(days=60),
@@ -272,7 +276,7 @@ def test_status_counts_formador_forbidden(user_formador, clear_cache):
 
 def test_superuser_always_has_access(clear_cache):
     """Superuser sempre tem acesso, mesmo sem grupo."""
-    user = Usuario.objects.create_superuser(username="admin", email="admin@x.com", password="x", cpf="99999999999")
+    user = UsuarioFactory(superuser=True)
     client = APIClient()
     client.force_authenticate(user=user)
 
@@ -590,9 +594,9 @@ def test_by_uf_ignores_null_municipio(user_super, dados_basicos, clear_cache):
     tipo = dados_basicos["tipos"][0]
 
     # Criar um usuário para a solicitação
-    coord = Usuario.objects.create_user(username="coord_mun", email="coord_mun@x.com", password="x", cpf="99888777666")
+    coord = UsuarioFactory(username="coord_mun", email="coord_mun@x.com", password="x", cpf="99888777666")
 
-    sol = Solicitacao.objects.create(
+    sol = SolicitacaoFactory(
         usuario=coord,
         status="aprovado",
         inicio=timezone.now(),

--- a/v2/backend/apps/core/tests/test_resolvers_normalize.py
+++ b/v2/backend/apps/core/tests/test_resolvers_normalize.py
@@ -7,8 +7,8 @@ são normalizados antes do lookup em Projeto.
 
 import pytest
 
-from apps.core.models import Projeto
 from apps.core.services.resolvers import normalize_projeto_name, resolve_projeto
+from apps.core.tests.factories import ProjetoFactory
 
 # ---------------------------------------------------------------------------
 # normalize_projeto_name — unit tests (sem DB)
@@ -74,9 +74,9 @@ class TestResolveProjetoWithYearPrefix:
 
     @pytest.fixture(autouse=True)
     def create_projetos(self, db: None) -> None:
-        Projeto.objects.create(nome="Novo Lendo", fluxo="NAO_SUPER", ativo=True)
-        Projeto.objects.create(nome="Fluir das Emoções N1", fluxo="SUPER", ativo=True)
-        Projeto.objects.create(nome="Sou da Paz", fluxo="NAO_SUPER", ativo=True)
+        ProjetoFactory(nome="Novo Lendo", fluxo="NAO_SUPER", ativo=True)
+        ProjetoFactory(nome="Fluir das Emoções N1", fluxo="SUPER", ativo=True)
+        ProjetoFactory(nome="Sou da Paz", fluxo="NAO_SUPER", ativo=True)
 
     def test_resolve_com_prefixo_2026(self):
         projeto = resolve_projeto("2026 Novo Lendo")

--- a/v2/backend/apps/core/tests/test_response_consistency.py
+++ b/v2/backend/apps/core/tests/test_response_consistency.py
@@ -18,8 +18,14 @@ from django.test import TestCase
 from django.utils import timezone
 from rest_framework.test import APIClient
 
-from apps.core.models import Municipio, Projeto, Solicitacao, TipoEvento, Usuario
 from apps.core.responses import APIResponse
+from apps.core.tests.factories import (
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 
 class TestAPIResponseFactory(TestCase):
@@ -89,27 +95,23 @@ class TestReportsResponseConsistency(TestCase):
         self.client = APIClient()
 
         # Create superuser with permission
-        self.user = Usuario.objects.create_superuser(
-            username="admin_consistency",
-            email="admin_consistency@test.com",
-            password="testpass123",
-        )
+        self.user = UsuarioFactory(superuser=True)
         self.client.force_authenticate(user=self.user)
 
         # Create required objects
-        self.municipio = Municipio.objects.create(
+        self.municipio = MunicipioFactory(
             nome="Test City",
             uf="CE",
             latitude=Decimal("-3.7172"),
             longitude=Decimal("-38.5433"),
         )
-        self.tipo_evento = TipoEvento.objects.create(nome="Test Type")
-        self.projeto = Projeto.objects.create(nome="Test Project")
+        self.tipo_evento = TipoEventoFactory(nome="Test Type")
+        self.projeto = ProjetoFactory(nome="Test Project")
 
         # Create some solicitações
         now = timezone.now()
         for i in range(5):
-            Solicitacao.objects.create(
+            SolicitacaoFactory(
                 usuario=self.user,
                 status="aprovado",
                 municipio=self.municipio,

--- a/v2/backend/apps/core/tests/test_sec_enum_audit.py
+++ b/v2/backend/apps/core/tests/test_sec_enum_audit.py
@@ -11,15 +11,12 @@ Covers:
 
 from __future__ import annotations
 
-from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Group
 from django.test import TestCase
 from rest_framework.test import APIClient
 
 from apps.core.models import AuditLog
 from apps.core.serializers.auditoria import _mask_email, _mask_ip, _redact_details
-
-User = get_user_model()
+from apps.core.tests.factories import GroupFactory, UsuarioFactory
 
 _cpf_counter = 0
 
@@ -37,9 +34,14 @@ class TestUsuarioOptionsNoEmail(TestCase):
     """SEC-ENUM-01: /api/options/usuarios/ must not return email field."""
 
     def setUp(self):
-        self.user = User.objects.create_user("enum_test", "enum@test.com", "pass1234", cpf=_next_cpf())
-        User.objects.create_user(
-            "target_user", "target@secret.com", "pass1234", first_name="Target", last_name="User", cpf=_next_cpf()
+        self.user = UsuarioFactory(username="enum_test", email="enum@test.com", password="pass1234", cpf=_next_cpf())
+        UsuarioFactory(
+            username="target_user",
+            email="target@secret.com",
+            password="pass1234",
+            first_name="Target",
+            last_name="User",
+            cpf=_next_cpf(),
         )
         self.client = APIClient()
         self.client.force_authenticate(user=self.user)
@@ -64,11 +66,18 @@ class TestUsuarioLookupNoEmail(TestCase):
     """
 
     def setUp(self):
-        coord_group, _ = Group.objects.get_or_create(name="Coordenador")
-        self.user = User.objects.create_user("lookup_test", "lookup@test.com", "pass1234", cpf=_next_cpf())
+        coord_group = GroupFactory(name="Coordenador")
+        self.user = UsuarioFactory(
+            username="lookup_test", email="lookup@test.com", password="pass1234", cpf=_next_cpf()
+        )
         self.user.groups.add(coord_group)
-        User.objects.create_user(
-            "lookup_target", "target@secret.com", "pass1234", first_name="Maria", last_name="Silva", cpf=_next_cpf()
+        UsuarioFactory(
+            username="lookup_target",
+            email="target@secret.com",
+            password="pass1234",
+            first_name="Maria",
+            last_name="Silva",
+            cpf=_next_cpf(),
         )
         self.client = APIClient()
         self.client.force_authenticate(user=self.user)
@@ -100,22 +109,26 @@ class TestEmailSearchRestriction(TestCase):
 
     def setUp(self):
         # Create groups
-        self.formador_group, _ = Group.objects.get_or_create(name="Formador")
-        self.coord_group, _ = Group.objects.get_or_create(name="Coordenador")
+        self.formador_group = GroupFactory(name="Formador")
+        self.coord_group = GroupFactory(name="Coordenador")
 
         # Create formador user
-        self.formador = User.objects.create_user("formador1", "formador@test.com", "pass1234", cpf=_next_cpf())
+        self.formador = UsuarioFactory(
+            username="formador1", email="formador@test.com", password="pass1234", cpf=_next_cpf()
+        )
         self.formador.groups.add(self.formador_group)
 
         # Create coordenador user
-        self.coordenador = User.objects.create_user("coord1", "coord@test.com", "pass1234", cpf=_next_cpf())
+        self.coordenador = UsuarioFactory(
+            username="coord1", email="coord@test.com", password="pass1234", cpf=_next_cpf()
+        )
         self.coordenador.groups.add(self.coord_group)
 
         # Create target user with distinct email
-        User.objects.create_user(
-            "target_email",
-            "distinct.email@example.com",
-            "pass1234",
+        UsuarioFactory(
+            username="target_email",
+            email="distinct.email@example.com",
+            password="pass1234",
             first_name="Ana",
             last_name="Costa",
             cpf=_next_cpf(),
@@ -201,14 +214,18 @@ class TestAuditLogViewSetRedaction(TestCase):
 
     def setUp(self):
         # Create groups for HasPerm("operate_preagenda") permission
-        self.controle_group, _ = Group.objects.get_or_create(name="Controle")
+        self.controle_group = GroupFactory(name="Controle")
 
         # Create controle user (can read audit logs but not superuser)
-        self.controle_user = User.objects.create_user("controle_audit", "c@test.com", "pass1234", cpf=_next_cpf())
+        self.controle_user = UsuarioFactory(
+            username="controle_audit", email="c@test.com", password="pass1234", cpf=_next_cpf()
+        )
         self.controle_user.groups.add(self.controle_group)
 
         # Create superuser
-        self.superuser = User.objects.create_superuser("super_audit", "s@test.com", "pass1234", cpf=_next_cpf())
+        self.superuser = UsuarioFactory(
+            superuser=True, username="super_audit", email="s@test.com", password="pass1234", cpf=_next_cpf()
+        )
 
         # Create audit log with PII
         self.audit = AuditLog.objects.create(

--- a/v2/backend/apps/core/tests/test_solicitacao_approval_concurrency.py
+++ b/v2/backend/apps/core/tests/test_solicitacao_approval_concurrency.py
@@ -15,30 +15,37 @@ from datetime import timedelta
 from types import SimpleNamespace
 from uuid import uuid4
 
-from django.contrib.auth.models import Group
 from django.db import close_old_connections
 from django.utils import timezone
 
 import pytest
 
 from apps.core.exceptions import ValidationAPIError
-from apps.core.models import AuditLog, Municipio, Projeto, Solicitacao, TipoEvento, Usuario
+from apps.core.models import AuditLog, Solicitacao, Usuario
 from apps.core.services.solicitacao_approval import approve_solicitacao, batch_approve_solicitacoes
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 
 @pytest.fixture
 def grupos():
     return {
-        "Superintendência": Group.objects.get_or_create(name="Superintendência")[0],
-        "Gerente": Group.objects.get_or_create(name="Gerente")[0],
-        "Coordenador": Group.objects.get_or_create(name="Coordenador")[0],
+        "Superintendência": GroupFactory(name="Superintendência"),
+        "Gerente": GroupFactory(name="Gerente"),
+        "Coordenador": GroupFactory(name="Coordenador"),
     }
 
 
 @pytest.fixture
 def usuario_superintendencia(grupos):
     uid = uuid4().hex[:8]
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username=f"super_conc_{uid}",
         password="senha123",
         cpf=str(uuid4().int % 10**11).zfill(11),
@@ -52,7 +59,7 @@ def usuario_superintendencia(grupos):
 @pytest.fixture
 def usuario_coordenador(grupos):
     uid = uuid4().hex[:8]
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username=f"coord_conc_{uid}",
         password="senha123",
         cpf=str(uuid4().int % 10**11).zfill(11),
@@ -64,13 +71,13 @@ def usuario_coordenador(grupos):
 
 @pytest.fixture
 def municipio():
-    return Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
+    return MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
 
 
 @pytest.fixture
 def projeto_super():
     uid = uuid4().hex[:8]
-    return Projeto.objects.create(
+    return ProjetoFactory(
         nome=f"Projeto Concorrencia {uid}",
         codigo=f"PC{uid[:5]}",
         fluxo="SUPER",
@@ -80,7 +87,7 @@ def projeto_super():
 
 @pytest.fixture
 def tipo_evento():
-    return TipoEvento.objects.get_or_create(nome="Formacao Concorrencia")[0]
+    return TipoEventoFactory(nome="Formacao Concorrencia")
 
 
 @pytest.mark.django_db(transaction=True)
@@ -98,7 +105,7 @@ def test_approve_solicitacao_allows_single_winner_under_concurrency(
     - exactly 1 approval wins
     - exactly 1 AuditLog APPROVE is created for the solicitacao
     """
-    solicitacao = Solicitacao.objects.create(
+    solicitacao = SolicitacaoFactory(
         usuario=usuario_coordenador,
         municipio=municipio,
         projeto=projeto_super,
@@ -160,7 +167,7 @@ def test_batch_approve_solicitacoes_blocks_double_approval_race(
     - second call returns the item as already processed
     - only one APPROVE AuditLog is persisted
     """
-    solicitacao = Solicitacao.objects.create(
+    solicitacao = SolicitacaoFactory(
         usuario=usuario_coordenador,
         municipio=municipio,
         projeto=projeto_super,

--- a/v2/backend/apps/core/tests/test_solicitacao_create_service.py
+++ b/v2/backend/apps/core/tests/test_solicitacao_create_service.py
@@ -12,14 +12,20 @@ from django.utils import timezone
 
 import pytest
 
-from apps.core.models import Municipio, Projeto, Solicitacao, TipoEvento, Usuario
+from apps.core.models import Solicitacao
 from apps.core.services.solicitacao_create import resolve_initial_status
+from apps.core.tests.factories import (
+    MunicipioFactory,
+    ProjetoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 pytestmark = pytest.mark.django_db
 
 
 def test_resolve_initial_status_nao_super_returns_aprovado():
-    projeto = Projeto.objects.create(nome="Projeto NS", fluxo="NAO_SUPER", ativo=True)
+    projeto = ProjetoFactory(nome="Projeto NS", fluxo="NAO_SUPER", ativo=True)
 
     decision = resolve_initial_status(projeto=projeto)
 
@@ -29,7 +35,7 @@ def test_resolve_initial_status_nao_super_returns_aprovado():
 
 
 def test_resolve_initial_status_super_returns_pendente():
-    projeto = Projeto.objects.create(nome="Projeto SUPER", fluxo="SUPER", ativo=True)
+    projeto = ProjetoFactory(nome="Projeto SUPER", fluxo="SUPER", ativo=True)
 
     decision = resolve_initial_status(projeto=projeto)
 
@@ -39,15 +45,15 @@ def test_resolve_initial_status_super_returns_pendente():
 
 
 def test_model_create_without_status_no_longer_auto_approves_nao_super():
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username="status_model_test",
         password="testpass123",
         cpf="12312312312",
         email="status_model_test@example.com",
     )
-    municipio = Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
-    projeto = Projeto.objects.create(nome="Projeto NS Model", fluxo="NAO_SUPER", ativo=True)
-    tipo_evento = TipoEvento.objects.create(nome="Formacao")
+    municipio = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+    projeto = ProjetoFactory(nome="Projeto NS Model", fluxo="NAO_SUPER", ativo=True)
+    tipo_evento = TipoEventoFactory(nome="Formacao")
 
     solicitacao = Solicitacao.objects.create(
         usuario=user,

--- a/v2/backend/apps/core/tests/test_solicitacao_edit.py
+++ b/v2/backend/apps/core/tests/test_solicitacao_edit.py
@@ -31,14 +31,21 @@ from __future__ import annotations
 from datetime import timedelta
 from uuid import uuid4
 
-from django.contrib.auth.models import Group
 from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import AuditLog, Municipio, Participation, Projeto, Solicitacao, TipoEvento, Usuario
+from apps.core.models import AuditLog, Participation, Solicitacao
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 pytestmark = pytest.mark.django_db
 
@@ -51,21 +58,21 @@ pytestmark = pytest.mark.django_db
 @pytest.fixture
 def grupo_superintendencia():
     """Grupo Superintendência para testes."""
-    group, _ = Group.objects.get_or_create(name="Superintendência")
+    group = GroupFactory(name="Superintendência")
     return group
 
 
 @pytest.fixture
 def grupo_dat():
     """Grupo DAT para testes."""
-    group, _ = Group.objects.get_or_create(name="DAT")
+    group = GroupFactory(name="DAT")
     return group
 
 
 @pytest.fixture
 def grupo_coordenador():
     """Grupo Coordenador para testes."""
-    group, _ = Group.objects.get_or_create(name="Coordenador")
+    group = GroupFactory(name="Coordenador")
     return group
 
 
@@ -73,7 +80,7 @@ def grupo_coordenador():
 def usuario_owner(grupo_coordenador):
     """Usuário dono da solicitação (Coordenador)."""
     cpf = str(uuid4().int % 10**11).zfill(11)
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username=f"owner_{uuid4().hex[:8]}",
         email=f"owner_{uuid4().hex[:8]}@test.com",
         password="testpass123",
@@ -88,7 +95,7 @@ def usuario_owner(grupo_coordenador):
 def usuario_outro(grupo_coordenador):
     """Outro usuário comum (não é owner nem privilegiado)."""
     cpf = str(uuid4().int % 10**11).zfill(11)
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username=f"outro_{uuid4().hex[:8]}",
         email=f"outro_{uuid4().hex[:8]}@test.com",
         password="testpass123",
@@ -102,7 +109,7 @@ def usuario_outro(grupo_coordenador):
 @pytest.fixture
 def grupo_gerente():
     """Issue #1222 (Epic 1): grupo Gerente tem edit_solicitation_as_owner_or_privileged."""
-    group, _ = Group.objects.get_or_create(name="Gerente")
+    group = GroupFactory(name="Gerente")
     return group
 
 
@@ -112,7 +119,7 @@ def usuario_superintendencia(grupo_superintendencia, grupo_gerente):
     edit/delete, fixture adiciona grupo Gerente que tem
     `edit_solicitation_as_owner_or_privileged` no seed realinhado."""
     cpf = str(uuid4().int % 10**11).zfill(11)
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username=f"super_{uuid4().hex[:8]}",
         email=f"super_{uuid4().hex[:8]}@test.com",
         password="testpass123",
@@ -128,7 +135,7 @@ def usuario_dat(grupo_dat, grupo_gerente):
     """Issue #1222 (Epic 1): fixture adiciona grupo Gerente para preservar
     tests legacy de 'privileged' edit/delete."""
     cpf = str(uuid4().int % 10**11).zfill(11)
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username=f"dat_{uuid4().hex[:8]}",
         email=f"dat_{uuid4().hex[:8]}@test.com",
         password="testpass123",
@@ -142,7 +149,7 @@ def usuario_dat(grupo_dat, grupo_gerente):
 @pytest.fixture
 def municipio():
     """Município para testes."""
-    return Municipio.objects.create(
+    return MunicipioFactory(
         nome=f"Município {uuid4().hex[:8]}",
         uf="CE",
     )
@@ -151,7 +158,7 @@ def municipio():
 @pytest.fixture
 def projeto():
     """Projeto para testes (SUPER para evitar auto-aprovação)."""
-    return Projeto.objects.create(
+    return ProjetoFactory(
         nome=f"Projeto {uuid4().hex[:8]}",
         fluxo="SUPER",
     )
@@ -160,7 +167,7 @@ def projeto():
 @pytest.fixture
 def projeto_nao_super():
     """Projeto NAO_SUPER para testes (auto-aprovação)."""
-    return Projeto.objects.create(
+    return ProjetoFactory(
         nome=f"Projeto NAO_SUPER {uuid4().hex[:8]}",
         fluxo="NAO_SUPER",
     )
@@ -169,7 +176,7 @@ def projeto_nao_super():
 @pytest.fixture
 def tipo_evento():
     """Tipo de evento para testes."""
-    return TipoEvento.objects.create(
+    return TipoEventoFactory(
         nome=f"Tipo {uuid4().hex[:8]}",
     )
 
@@ -177,7 +184,7 @@ def tipo_evento():
 @pytest.fixture
 def solicitacao_editavel(usuario_owner, municipio, projeto, tipo_evento):
     """Solicitação editável (pendente ou aprovada, não publicada)."""
-    return Solicitacao.objects.create(
+    return SolicitacaoFactory(
         usuario=usuario_owner,
         municipio=municipio,
         projeto=projeto,
@@ -194,7 +201,7 @@ def solicitacao_editavel(usuario_owner, municipio, projeto, tipo_evento):
 @pytest.fixture
 def solicitacao_publicada(usuario_owner, municipio, projeto, tipo_evento):
     """Solicitação já publicada no GCal (não editável)."""
-    return Solicitacao.objects.create(
+    return SolicitacaoFactory(
         usuario=usuario_owner,
         municipio=municipio,
         projeto=projeto,
@@ -211,7 +218,7 @@ def solicitacao_publicada(usuario_owner, municipio, projeto, tipo_evento):
 @pytest.fixture
 def solicitacao_reprovada(usuario_owner, municipio, projeto, tipo_evento):
     """Solicitação reprovada (não editável)."""
-    return Solicitacao.objects.create(
+    return SolicitacaoFactory(
         usuario=usuario_owner,
         municipio=municipio,
         projeto=projeto,
@@ -562,7 +569,7 @@ class TestSolicitacaoEditFields:
 @pytest.fixture
 def grupo_formador():
     """Grupo Formador para testes."""
-    group, _ = Group.objects.get_or_create(name="Formador")
+    group = GroupFactory(name="Formador")
     return group
 
 
@@ -570,7 +577,7 @@ def grupo_formador():
 def formador_1(grupo_formador):
     """Formador 1 para testes."""
     cpf = str(uuid4().int % 10**11).zfill(11)
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username=f"formador1_{uuid4().hex[:8]}",
         email=f"formador1_{uuid4().hex[:8]}@test.com",
         password="testpass123",
@@ -587,7 +594,7 @@ def formador_1(grupo_formador):
 def formador_2(grupo_formador):
     """Formador 2 para testes."""
     cpf = str(uuid4().int % 10**11).zfill(11)
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username=f"formador2_{uuid4().hex[:8]}",
         email=f"formador2_{uuid4().hex[:8]}@test.com",
         password="testpass123",
@@ -604,7 +611,7 @@ def formador_2(grupo_formador):
 def formador_3(grupo_formador):
     """Formador 3 para testes."""
     cpf = str(uuid4().int % 10**11).zfill(11)
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username=f"formador3_{uuid4().hex[:8]}",
         email=f"formador3_{uuid4().hex[:8]}@test.com",
         password="testpass123",
@@ -620,7 +627,7 @@ def formador_3(grupo_formador):
 @pytest.fixture
 def solicitacao_com_formador(usuario_owner, municipio, projeto, tipo_evento, formador_1):
     """Solicitação com um formador já associado."""
-    sol = Solicitacao.objects.create(
+    sol = SolicitacaoFactory(
         usuario=usuario_owner,
         municipio=municipio,
         projeto=projeto,
@@ -914,7 +921,7 @@ class TestSolicitacaoDelete:
     ):
         """Pode excluir solicitação NAO_SUPER aprovada (se não publicada)."""
         # Criar solicitação NAO_SUPER já aprovada para validar regra de exclusão.
-        sol = Solicitacao.objects.create(
+        sol = SolicitacaoFactory(
             usuario=usuario_owner,
             municipio=municipio,
             projeto=projeto_nao_super,
@@ -939,7 +946,7 @@ class TestSolicitacaoDelete:
     ):
         """Pode excluir solicitação NAO_SUPER reprovada (se não publicada)."""
         # Criar e reprovar solicitação NAO_SUPER.
-        sol = Solicitacao.objects.create(
+        sol = SolicitacaoFactory(
             usuario=usuario_owner,
             municipio=municipio,
             projeto=projeto_nao_super,

--- a/v2/backend/apps/core/tests/test_solicitacao_fluxo.py
+++ b/v2/backend/apps/core/tests/test_solicitacao_fluxo.py
@@ -17,13 +17,20 @@ from __future__ import annotations
 
 from datetime import date
 
-from django.contrib.auth.models import Group
 from django.utils import timezone
 from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import Compra, Municipio, Projeto, Solicitacao, TipoEvento, Usuario
+from apps.core.models import Compra, Projeto, Solicitacao
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 
 @pytest.fixture
@@ -36,11 +43,11 @@ def api_client():
 def grupos():
     """Cria grupos Django."""
     grupos = {
-        "Coordenador": Group.objects.get_or_create(name="Coordenador")[0],
-        "Superintendência": Group.objects.get_or_create(name="Superintendência")[0],
-        "Controle": Group.objects.get_or_create(name="Controle")[0],
-        "DAT": Group.objects.get_or_create(name="DAT")[0],
-        "Gerente": Group.objects.get_or_create(name="Gerente")[0],
+        "Coordenador": GroupFactory(name="Coordenador"),
+        "Superintendência": GroupFactory(name="Superintendência"),
+        "Controle": GroupFactory(name="Controle"),
+        "DAT": GroupFactory(name="DAT"),
+        "Gerente": GroupFactory(name="Gerente"),
     }
     return grupos
 
@@ -48,9 +55,7 @@ def grupos():
 @pytest.fixture
 def usuario_coordenador(grupos):
     """Usuário com perfil Coordenador."""
-    user = Usuario.objects.create_user(
-        username="coord1", password="senha123", cpf="11111111111", email="coord@test.com"
-    )
+    user = UsuarioFactory(username="coord1", password="senha123", cpf="11111111111", email="coord@test.com")
     user.groups.add(grupos["Coordenador"])
     return user
 
@@ -59,9 +64,7 @@ def usuario_coordenador(grupos):
 def usuario_superintendencia(grupos):
     """Gerente da Superintendência (PR 3 hardening RBAC, 2026-04-29):
     composite Setor `Superintendência` + Função `Gerente`."""
-    user = Usuario.objects.create_user(
-        username="super1", password="senha123", cpf="22222222222", email="super@test.com"
-    )
+    user = UsuarioFactory(username="super1", password="senha123", cpf="22222222222", email="super@test.com")
     user.groups.add(grupos["Superintendência"], grupos["Gerente"])
     return user
 
@@ -69,25 +72,25 @@ def usuario_superintendencia(grupos):
 @pytest.fixture
 def municipio():
     """Município de teste."""
-    return Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
+    return MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
 
 
 @pytest.fixture
 def projeto_super():
     """Projeto com fluxo SUPER (requer aprovação)."""
-    return Projeto.objects.create(nome="ACerta", codigo="ACERTA", fluxo="SUPER", ativo=True)
+    return ProjetoFactory(nome="ACerta", codigo="ACERTA", fluxo="SUPER", ativo=True)
 
 
 @pytest.fixture
 def projeto_outros():
     """Projeto com fluxo NAO_SUPER (auto-aprovado)."""
-    return Projeto.objects.create(nome="Alfabetização Ceará", codigo="ALFCE", fluxo="NAO_SUPER", ativo=True)
+    return ProjetoFactory(nome="Alfabetização Ceará", codigo="ALFCE", fluxo="NAO_SUPER", ativo=True)
 
 
 @pytest.fixture
 def tipo_evento():
     """Tipo de evento de teste."""
-    return TipoEvento.objects.create(nome="Formação Inicial")
+    return TipoEventoFactory(nome="Formação Inicial")
 
 
 @pytest.fixture
@@ -314,13 +317,13 @@ class TestPreAgendaFiltroPorFluxo:
         - Sem filtro retorna ambos
         """
         # Criar usuário Controle (tem acesso à pré-agenda)
-        usuario_controle = Usuario.objects.create_user(
+        usuario_controle = UsuarioFactory(
             username="controle1", password="senha123", cpf="33333333333", email="controle@test.com"
         )
         usuario_controle.groups.add(grupos["Controle"])
 
         # Criar 2 solicitações: 1 SUPER (pendente→aprovado) + 1 NAO_SUPER (auto-aprovado)
-        sol_super = Solicitacao.objects.create(
+        sol_super = SolicitacaoFactory(
             usuario=usuario_coordenador,
             municipio=municipio,
             projeto=projeto_super,
@@ -331,7 +334,7 @@ class TestPreAgendaFiltroPorFluxo:
             status="aprovado",  # Manualmente aprovada para teste
         )
 
-        sol_outros = Solicitacao.objects.create(
+        sol_outros = SolicitacaoFactory(
             usuario=usuario_coordenador,
             municipio=municipio,
             projeto=projeto_outros,
@@ -379,13 +382,13 @@ class TestSerializerFluxo:
         - Valor = Projeto.fluxo (SUPER ou NAO_SUPER)
         """
         # Criar usuário Controle
-        usuario_controle = Usuario.objects.create_user(
+        usuario_controle = UsuarioFactory(
             username="controle1", password="senha123", cpf="33333333333", email="controle@test.com"
         )
         usuario_controle.groups.add(grupos["Controle"])
 
         # Criar solicitação SUPER aprovada
-        sol = Solicitacao.objects.create(
+        sol = SolicitacaoFactory(
             usuario=usuario_coordenador,
             municipio=municipio,
             projeto=projeto_super,
@@ -415,13 +418,13 @@ class TestSerializerFluxo:
         - Solicitação sem projeto → fluxo='NAO_SUPER' (fallback)
         """
         # Criar usuário Controle
-        usuario_controle = Usuario.objects.create_user(
+        usuario_controle = UsuarioFactory(
             username="controle2", password="senha123", cpf="44444444444", email="controle2@test.com"
         )
         usuario_controle.groups.add(grupos["Controle"])
 
         # Criar solicitação SEM projeto (cenário raro, mas testável)
-        sol = Solicitacao.objects.create(
+        sol = SolicitacaoFactory(
             usuario=usuario_coordenador,
             municipio=municipio,
             projeto=None,  # Sem projeto

--- a/v2/backend/apps/core/tests/test_solicitacao_online_mode.py
+++ b/v2/backend/apps/core/tests/test_solicitacao_online_mode.py
@@ -13,25 +13,31 @@ from __future__ import annotations
 
 from datetime import timedelta
 
-from django.contrib.auth.models import Group
 from django.utils import timezone
 from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import Municipio, Projeto, Solicitacao, TipoEvento, Usuario
+from apps.core.models import Solicitacao
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 
 @pytest.fixture
 def usuario_coordenador():
     """Usuário coordenador para criar solicitações"""
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username="coordenador_test",
         email="coordenador@test.com",
         password="testpass",
         cpf="33333333333",
     )
-    grupo, _ = Group.objects.get_or_create(name="Coordenador")
+    grupo = GroupFactory(name="Coordenador")
     user.groups.add(grupo)
     return user
 
@@ -39,9 +45,9 @@ def usuario_coordenador():
 @pytest.fixture
 def fixtures_basicas():
     """Fixtures básicas para criar solicitações"""
-    municipio = Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
-    projeto = Projeto.objects.create(nome="Projeto Teste", ativo=True)
-    tipo_evento = TipoEvento.objects.create(nome="Formação")
+    municipio = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+    projeto = ProjetoFactory(nome="Projeto Teste", ativo=True)
+    tipo_evento = TipoEventoFactory(nome="Formação")
 
     return {
         "municipio": municipio,

--- a/v2/backend/apps/core/tests/test_solicitacao_participations_api.py
+++ b/v2/backend/apps/core/tests/test_solicitacao_participations_api.py
@@ -11,13 +11,19 @@ Valida:
 
 from __future__ import annotations
 
-from django.contrib.auth import get_user_model
 from django.utils import timezone
 from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import Municipio, Participation, Projeto, Solicitacao, TipoEvento
+from apps.core.models import Participation
+from apps.core.tests.factories import (
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 pytestmark = pytest.mark.django_db
 
@@ -29,34 +35,21 @@ def factory_solicitacao():
     """
 
     def _factory(**kwargs):
-        User = get_user_model()
-
         # Usuario criador (se não fornecido)
         if "usuario" not in kwargs:
-            user = User.objects.create_user(
-                username=f"user_{timezone.now().timestamp()}",
-                email=f"user{timezone.now().timestamp()}@example.com",
-                password="testpass123",
-                cpf=f"{int(timezone.now().timestamp()) % 100000000000}",
-            )
-            kwargs["usuario"] = user
+            kwargs["usuario"] = UsuarioFactory()
 
         # Municipio
         if "municipio" not in kwargs:
-            municipio, _ = Municipio.objects.get_or_create(nome="Fortaleza", uf="CE", defaults={"ativo": True})
-            kwargs["municipio"] = municipio
+            kwargs["municipio"] = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
 
         # TipoEvento
         if "tipo_evento" not in kwargs:
-            tipo_evento, _ = TipoEvento.objects.get_or_create(
-                nome="Formação", defaults={"descricao": "Formação continuada"}
-            )
-            kwargs["tipo_evento"] = tipo_evento
+            kwargs["tipo_evento"] = TipoEventoFactory(nome="Formação", descricao="Formação continuada")
 
         # Projeto
         if "projeto" not in kwargs:
-            projeto, _ = Projeto.objects.get_or_create(nome="Teste Projeto", defaults={"ativo": True})
-            kwargs["projeto"] = projeto
+            kwargs["projeto"] = ProjetoFactory(nome="Teste Projeto", ativo=True)
 
         # Datas
         if "inicio" not in kwargs:
@@ -68,7 +61,7 @@ def factory_solicitacao():
         if "status" not in kwargs:
             kwargs["status"] = "pendente"
 
-        return Solicitacao.objects.create(**kwargs)
+        return SolicitacaoFactory(**kwargs)
 
     return _factory
 
@@ -78,9 +71,8 @@ def test_solicitacao_list_includes_participations(factory_solicitacao):
     Testa que listagem de Solicitacoes inclui campo 'participations' (read-only).
     """
     solicitacao = factory_solicitacao()
-    User = get_user_model()
 
-    u1 = User.objects.create_user(
+    u1 = UsuarioFactory(
         username="coordenador1",
         email="coord1@example.com",
         password="testpass123",
@@ -88,7 +80,7 @@ def test_solicitacao_list_includes_participations(factory_solicitacao):
         first_name="Coordenador",
         last_name="Um",
     )
-    u2 = User.objects.create_user(
+    u2 = UsuarioFactory(
         username="formador1",
         email="formador1@example.com",
         password="testpass123",
@@ -102,12 +94,7 @@ def test_solicitacao_list_includes_participations(factory_solicitacao):
 
     client = APIClient()
     # Autenticar como superuser para ver todas as solicitações
-    superuser = User.objects.create_superuser(
-        username="admin",
-        email="admin@example.com",
-        password="admin123",
-        cpf="00000000000",
-    )
+    superuser = UsuarioFactory(superuser=True)
     client.force_authenticate(user=superuser)
 
     resp = client.get("/api/solicitacoes/")
@@ -147,9 +134,8 @@ def test_solicitacao_detail_includes_participations(factory_solicitacao):
     Testa que detalhes de uma Solicitacao incluem campo 'participations'.
     """
     solicitacao = factory_solicitacao()
-    User = get_user_model()
 
-    u1 = User.objects.create_user(
+    u1 = UsuarioFactory(
         username="convidado1",
         email="convidado@example.com",
         password="testpass123",
@@ -167,12 +153,7 @@ def test_solicitacao_detail_includes_participations(factory_solicitacao):
     )
 
     client = APIClient()
-    superuser = User.objects.create_superuser(
-        username="admin2",
-        email="admin2@example.com",
-        password="admin123",
-        cpf="00000000001",
-    )
+    superuser = UsuarioFactory(superuser=True)
     client.force_authenticate(user=superuser)
 
     resp = client.get(f"/api/solicitacoes/{solicitacao.id}/")
@@ -195,15 +176,9 @@ def test_solicitacao_api_no_formadores_field(factory_solicitacao):
     Testa que campo 'formadores' NÃO aparece no payload (prefetch removido).
     """
     solicitacao = factory_solicitacao()
-    User = get_user_model()
 
     client = APIClient()
-    superuser = User.objects.create_superuser(
-        username="admin3",
-        email="admin3@example.com",
-        password="admin123",
-        cpf="00000000002",
-    )
+    superuser = UsuarioFactory(superuser=True)
     client.force_authenticate(user=superuser)
 
     resp = client.get(f"/api/solicitacoes/{solicitacao.id}/")

--- a/v2/backend/apps/core/tests/test_solicitacao_pr15.py
+++ b/v2/backend/apps/core/tests/test_solicitacao_pr15.py
@@ -16,13 +16,20 @@ from __future__ import annotations
 
 from datetime import date
 
-from django.contrib.auth.models import Group
 from django.utils import timezone
 from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import Compra, Municipio, Participation, Projeto, Solicitacao, TipoEvento, Usuario
+from apps.core.models import Compra, Participation
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 
 @pytest.fixture
@@ -35,11 +42,11 @@ def api_client():
 def grupos():
     """Cria grupos Django."""
     grupos = {
-        "Coordenador": Group.objects.get_or_create(name="Coordenador")[0],
-        "Superintendência": Group.objects.get_or_create(name="Superintendência")[0],
-        "Controle": Group.objects.get_or_create(name="Controle")[0],
-        "DAT": Group.objects.get_or_create(name="DAT")[0],
-        "Gerente": Group.objects.get_or_create(name="Gerente")[0],
+        "Coordenador": GroupFactory(name="Coordenador"),
+        "Superintendência": GroupFactory(name="Superintendência"),
+        "Controle": GroupFactory(name="Controle"),
+        "DAT": GroupFactory(name="DAT"),
+        "Gerente": GroupFactory(name="Gerente"),
     }
     return grupos
 
@@ -47,9 +54,7 @@ def grupos():
 @pytest.fixture
 def usuario_coordenador(grupos):
     """Usuário com perfil Coordenador."""
-    user = Usuario.objects.create_user(
-        username="coord1", password="senha123", cpf="11111111111", email="coord@test.com"
-    )
+    user = UsuarioFactory(username="coord1", password="senha123", cpf="11111111111", email="coord@test.com")
     user.groups.add(grupos["Coordenador"])
     return user
 
@@ -58,9 +63,7 @@ def usuario_coordenador(grupos):
 def usuario_superintendencia(grupos):
     """Gerente da Superintendência (PR 3 hardening RBAC, 2026-04-29):
     composite Setor `Superintendência` + Função `Gerente`."""
-    user = Usuario.objects.create_user(
-        username="super1", password="senha123", cpf="22222222222", email="super@test.com"
-    )
+    user = UsuarioFactory(username="super1", password="senha123", cpf="22222222222", email="super@test.com")
     user.groups.add(grupos["Superintendência"], grupos["Gerente"])
     return user
 
@@ -68,9 +71,7 @@ def usuario_superintendencia(grupos):
 @pytest.fixture
 def usuario_controle(grupos):
     """Usuário com perfil Controle."""
-    user = Usuario.objects.create_user(
-        username="controle1", password="senha123", cpf="33333333333", email="controle@test.com"
-    )
+    user = UsuarioFactory(username="controle1", password="senha123", cpf="33333333333", email="controle@test.com")
     user.groups.add(grupos["Controle"])
     return user
 
@@ -78,25 +79,25 @@ def usuario_controle(grupos):
 @pytest.fixture
 def municipio():
     """Município de teste."""
-    return Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
+    return MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
 
 
 @pytest.fixture
 def projeto_super():
     """Projeto com fluxo SUPER (requer aprovação)."""
-    return Projeto.objects.create(nome="ACerta", codigo="ACERTA", fluxo="SUPER", ativo=True)
+    return ProjetoFactory(nome="ACerta", codigo="ACERTA", fluxo="SUPER", ativo=True)
 
 
 @pytest.fixture
 def projeto_nao_super():
     """Projeto com fluxo NAO_SUPER (auto-aprovado)."""
-    return Projeto.objects.create(nome="Alfabetização Ceará", codigo="ALFCE", fluxo="NAO_SUPER", ativo=True)
+    return ProjetoFactory(nome="Alfabetização Ceará", codigo="ALFCE", fluxo="NAO_SUPER", ativo=True)
 
 
 @pytest.fixture
 def tipo_evento():
     """TipoEvento de teste."""
-    return TipoEvento.objects.create(nome="Formação")
+    return TipoEventoFactory(nome="Formação")
 
 
 @pytest.fixture
@@ -122,7 +123,7 @@ class TestFiltroMine:
     ):
         """mine=true retorna apenas solicitações do usuário, mesmo para super."""
         # Criar solicitação do coordenador
-        sol_coord = Solicitacao.objects.create(
+        sol_coord = SolicitacaoFactory(
             usuario=usuario_coordenador,
             municipio=municipio,
             projeto=projeto_super,
@@ -133,7 +134,7 @@ class TestFiltroMine:
         )
 
         # Criar solicitação da superintendência
-        sol_super = Solicitacao.objects.create(
+        sol_super = SolicitacaoFactory(
             usuario=usuario_superintendencia,
             municipio=municipio,
             projeto=projeto_super,
@@ -167,7 +168,7 @@ class TestFiltroFlow:
         self, api_client, usuario_coordenador, municipio, projeto_super, projeto_nao_super, tipo_evento
     ):
         """flow=SUPER retorna apenas solicitações de projetos SUPER."""
-        sol_super = Solicitacao.objects.create(
+        sol_super = SolicitacaoFactory(
             usuario=usuario_coordenador,
             municipio=municipio,
             projeto=projeto_super,
@@ -177,7 +178,7 @@ class TestFiltroFlow:
             status="pendente",
         )
 
-        sol_nao_super = Solicitacao.objects.create(
+        sol_nao_super = SolicitacaoFactory(
             usuario=usuario_coordenador,
             municipio=municipio,
             projeto=projeto_nao_super,
@@ -212,7 +213,7 @@ class TestFiltroStatusAlias:
         self, api_client, usuario_coordenador, municipio, projeto_super, tipo_evento
     ):
         """status=pending retorna solicitações pendentes."""
-        sol_pendente = Solicitacao.objects.create(
+        sol_pendente = SolicitacaoFactory(
             usuario=usuario_coordenador,
             municipio=municipio,
             projeto=projeto_super,
@@ -234,7 +235,7 @@ class TestFiltroStatusAlias:
         self, api_client, usuario_coordenador, municipio, projeto_nao_super, tipo_evento
     ):
         """status=approved retorna solicitações aprovadas."""
-        sol_aprovado = Solicitacao.objects.create(
+        sol_aprovado = SolicitacaoFactory(
             usuario=usuario_coordenador,
             municipio=municipio,
             projeto=projeto_nao_super,
@@ -256,7 +257,7 @@ class TestFiltroStatusAlias:
         self, api_client, usuario_coordenador, usuario_superintendencia, municipio, projeto_super, tipo_evento
     ):
         """status=rejected retorna solicitações reprovadas."""
-        sol_reprovado = Solicitacao.objects.create(
+        sol_reprovado = SolicitacaoFactory(
             usuario=usuario_coordenador,
             municipio=municipio,
             projeto=projeto_super,
@@ -432,7 +433,7 @@ class TestReasonAlias:
         self, api_client, usuario_coordenador, usuario_superintendencia, municipio, projeto_super, tipo_evento
     ):
         """approve aceita 'reason' como alias para 'justificativa'."""
-        sol = Solicitacao.objects.create(
+        sol = SolicitacaoFactory(
             usuario=usuario_coordenador,
             municipio=municipio,
             projeto=projeto_super,
@@ -455,7 +456,7 @@ class TestReasonAlias:
         self, api_client, usuario_coordenador, usuario_superintendencia, municipio, projeto_super, tipo_evento
     ):
         """reject aceita 'reason' como alias para 'justificativa'."""
-        sol = Solicitacao.objects.create(
+        sol = SolicitacaoFactory(
             usuario=usuario_coordenador,
             municipio=municipio,
             projeto=projeto_super,
@@ -481,7 +482,7 @@ class TestFluxoFallback:
 
     def test_fluxo_fallback_is_nao_super(self, api_client, usuario_coordenador, municipio, tipo_evento):
         """Solicitação sem projeto retorna fluxo=NAO_SUPER."""
-        sol = Solicitacao.objects.create(
+        sol = SolicitacaoFactory(
             usuario=usuario_coordenador,
             municipio=municipio,
             projeto=None,  # Sem projeto

--- a/v2/backend/apps/core/tests/test_solicitacao_serializer_meet_link.py
+++ b/v2/backend/apps/core/tests/test_solicitacao_serializer_meet_link.py
@@ -14,25 +14,32 @@ from __future__ import annotations
 from datetime import timedelta
 from unittest.mock import patch
 
-from django.contrib.auth.models import Group
 from django.utils import timezone
 from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import Municipio, Projeto, Solicitacao, TipoEvento, Usuario
+from apps.core.models import Solicitacao
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 
 @pytest.fixture
 def usuario_controle():
     """Usuário do grupo Controle"""
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username="controle_test",
         email="controle@test.com",
         password="testpass",
         cpf="11111111111",
     )
-    grupo, _ = Group.objects.get_or_create(name="Controle")
+    grupo = GroupFactory(name="Controle")
     user.groups.add(grupo)
     return user
 
@@ -40,12 +47,12 @@ def usuario_controle():
 @pytest.fixture
 def solicitacao_com_meet_link(usuario_controle):
     """Solicitação aprovada com meet_link preenchido"""
-    municipio = Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
-    projeto = Projeto.objects.create(nome="Projeto Teste", ativo=True)
-    tipo_evento = TipoEvento.objects.create(nome="Formação")
+    municipio = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+    projeto = ProjetoFactory(nome="Projeto Teste", ativo=True)
+    tipo_evento = TipoEventoFactory(nome="Formação")
 
     now = timezone.now()
-    sol = Solicitacao.objects.create(
+    sol = SolicitacaoFactory(
         usuario=usuario_controle,
         municipio=municipio,
         projeto=projeto,
@@ -99,12 +106,12 @@ class TestSolicitacaoSerializerMeetLink:
 
         Resultado esperado: Response contém meet_link=null
         """
-        municipio = Municipio.objects.create(nome="São Paulo", uf="SP", ativo=True)
-        projeto = Projeto.objects.create(nome="Projeto Teste", ativo=True)
-        tipo_evento = TipoEvento.objects.create(nome="Reunião")
+        municipio = MunicipioFactory(nome="São Paulo", uf="SP", ativo=True)
+        projeto = ProjetoFactory(nome="Projeto Teste", ativo=True)
+        tipo_evento = TipoEventoFactory(nome="Reunião")
 
         now = timezone.now()
-        sol = Solicitacao.objects.create(
+        sol = SolicitacaoFactory(
             usuario=usuario_controle,
             municipio=municipio,
             projeto=projeto,
@@ -157,9 +164,9 @@ class TestSolicitacaoSerializerMeetLink:
 
         Resultado esperado: meet_link continua null (não foi setado via POST)
         """
-        municipio = Municipio.objects.create(nome="Recife", uf="PE", ativo=True)
-        projeto = Projeto.objects.create(nome="Projeto Teste", ativo=True)
-        tipo_evento = TipoEvento.objects.create(nome="Workshop")
+        municipio = MunicipioFactory(nome="Recife", uf="PE", ativo=True)
+        projeto = ProjetoFactory(nome="Projeto Teste", ativo=True)
+        tipo_evento = TipoEventoFactory(nome="Workshop")
 
         client = APIClient()
         client.force_authenticate(user=usuario_controle)

--- a/v2/backend/apps/core/tests/test_solicitacoes_filters.py
+++ b/v2/backend/apps/core/tests/test_solicitacoes_filters.py
@@ -11,14 +11,19 @@ Cobertura:
 
 from __future__ import annotations
 
-from django.contrib.auth.models import Group
 from django.urls import reverse
 from django.utils import timezone
 from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import Municipio, Projeto, Solicitacao, TipoEvento, Usuario
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 pytestmark = pytest.mark.django_db
 
@@ -26,18 +31,18 @@ pytestmark = pytest.mark.django_db
 @pytest.fixture
 def setup_data():
     """Cria dados de teste para filtros."""
-    municipio_fortaleza = Municipio.objects.create(nome="Fortaleza", uf="CE")
-    municipio_caucaia = Municipio.objects.create(nome="Caucaia", uf="CE")
-    tipo_evento = TipoEvento.objects.create(nome="Formação")
+    municipio_fortaleza = MunicipioFactory(nome="Fortaleza", uf="CE")
+    municipio_caucaia = MunicipioFactory(nome="Caucaia", uf="CE")
+    tipo_evento = TipoEventoFactory(nome="Formação")
 
-    user_joao = Usuario.objects.create_user(
+    user_joao = UsuarioFactory(
         username="joao",
         email="joao@x.com",
         password="x",
         first_name="João",
         cpf="12345678901",
     )
-    user_maria = Usuario.objects.create_user(
+    user_maria = UsuarioFactory(
         username="maria",
         email="maria@x.com",
         password="x",
@@ -49,10 +54,11 @@ def setup_data():
     now = timezone.now()
 
     # Pendente, Fortaleza, João
-    s1 = Solicitacao.objects.create(
+    s1 = SolicitacaoFactory(
         usuario=user_joao,
         municipio=municipio_fortaleza,
         tipo_evento=tipo_evento,
+        projeto=None,
         inicio=now,
         fim=now + timezone.timedelta(hours=2),
         status="pendente",
@@ -60,10 +66,11 @@ def setup_data():
     )
 
     # Aprovado, Fortaleza, Maria
-    s2 = Solicitacao.objects.create(
+    s2 = SolicitacaoFactory(
         usuario=user_maria,
         municipio=municipio_fortaleza,
         tipo_evento=tipo_evento,
+        projeto=None,
         inicio=now + timezone.timedelta(days=1),
         fim=now + timezone.timedelta(days=1, hours=2),
         status="aprovado",
@@ -71,10 +78,11 @@ def setup_data():
     )
 
     # Pendente, Caucaia, João
-    s3 = Solicitacao.objects.create(
+    s3 = SolicitacaoFactory(
         usuario=user_joao,
         municipio=municipio_caucaia,
         tipo_evento=tipo_evento,
+        projeto=None,
         inicio=now + timezone.timedelta(days=2),
         fim=now + timezone.timedelta(days=2, hours=2),
         status="pendente",
@@ -82,10 +90,11 @@ def setup_data():
     )
 
     # Reprovado, Fortaleza, Maria
-    s4 = Solicitacao.objects.create(
+    s4 = SolicitacaoFactory(
         usuario=user_maria,
         municipio=municipio_fortaleza,
         tipo_evento=tipo_evento,
+        projeto=None,
         inicio=now + timezone.timedelta(days=3),
         fim=now + timezone.timedelta(days=3, hours=2),
         status="reprovado",
@@ -93,8 +102,8 @@ def setup_data():
     )
 
     # Criar grupo Superintendência
-    super_group, _ = Group.objects.get_or_create(name="Superintendência")
-    user_admin = Usuario.objects.create_user(username="admin", email="admin@x.com", password="x", cpf="11111111111")
+    super_group = GroupFactory(name="Superintendência")
+    user_admin = UsuarioFactory(username="admin", email="admin@x.com", password="x", cpf="11111111111")
     user_admin.groups.add(super_group)
 
     return {

--- a/v2/backend/apps/core/tests/test_upload_validation.py
+++ b/v2/backend/apps/core/tests/test_upload_validation.py
@@ -13,24 +13,20 @@ from __future__ import annotations
 
 import io
 
-from django.contrib.auth.models import Group
 from django.core.files.uploadedfile import SimpleUploadedFile
 from rest_framework import status
 from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import Usuario
+from apps.core.tests.factories import UsuarioFactory
 
 
 @pytest.fixture
 def dat_user(db):
     """Usuário em grupo DAT (PR-A1 DAT-Imports: detentor de import_spreadsheet
     + manage_admin_registries via seed_functional_permissions)."""
-    user = Usuario.objects.create_user(username="dat1", password="test123", email="dat@example.com")
-    group, _ = Group.objects.get_or_create(name="DAT")
-    user.groups.add(group)
-    return user
+    return UsuarioFactory(username="dat1", password="test123", email="dat@example.com", groups=["DAT"])
 
 
 @pytest.fixture

--- a/v2/backend/apps/core/tests/test_versioning.py
+++ b/v2/backend/apps/core/tests/test_versioning.py
@@ -19,7 +19,7 @@ from rest_framework.response import Response
 from rest_framework.test import APIClient
 
 from apps.core.deprecation import deprecated_endpoint
-from apps.core.models import Usuario
+from apps.core.tests.factories import UsuarioFactory
 
 
 class TestAPIVersioning(TestCase):
@@ -30,7 +30,7 @@ class TestAPIVersioning(TestCase):
         self.client = APIClient()
 
         # Create a user for authenticated endpoints
-        self.user = Usuario.objects.create_user(
+        self.user = UsuarioFactory(
             username="test_versioning",
             email="test_versioning@test.com",
             password="testpass123",

--- a/v2/backend/apps/core/tests/test_views_auth.py
+++ b/v2/backend/apps/core/tests/test_views_auth.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 from unittest.mock import patch
 from uuid import uuid4
 
-from django.contrib.auth.models import Group
 from django.core.cache import cache
 from django.test import override_settings
 from rest_framework import status
@@ -26,7 +25,8 @@ from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import AuditLog, Usuario
+from apps.core.models import AuditLog
+from apps.core.tests.factories import UsuarioFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -44,7 +44,7 @@ def usuario_ativo():
     """Usuário ativo para testes de login."""
     uid = uuid4().hex
     cpf = str(uuid4().int % 10**11).zfill(11)
-    return Usuario.objects.create_user(
+    return UsuarioFactory(
         username=f"user_{uid}",
         email=f"user_{uid}@example.com",
         password="testpass123",
@@ -58,7 +58,7 @@ def usuario_inativo():
     """Usuário inativo para testes de bloqueio."""
     uid = uuid4().hex
     cpf = str(uuid4().int % 10**11).zfill(11)
-    return Usuario.objects.create_user(
+    return UsuarioFactory(
         username=f"inactive_{uid}",
         email=f"inactive_{uid}@example.com",
         password="testpass123",
@@ -72,16 +72,14 @@ def usuario_superintendencia():
     """Usuário do grupo Superintendência."""
     uid = uuid4().hex
     cpf = str(uuid4().int % 10**11).zfill(11)
-    user = Usuario.objects.create_user(
+    return UsuarioFactory(
         username=f"super_{uid}",
         email=f"super_{uid}@example.com",
         password="testpass123",
         cpf=cpf,
         is_active=True,
+        groups=["Superintendência"],
     )
-    grupo, _ = Group.objects.get_or_create(name="Superintendência")
-    user.groups.add(grupo)
-    return user
 
 
 @pytest.fixture

--- a/v2/backend/apps/core/tests/test_views_metrics_coverage.py
+++ b/v2/backend/apps/core/tests/test_views_metrics_coverage.py
@@ -19,14 +19,21 @@ from __future__ import annotations
 from datetime import timedelta
 from uuid import uuid4
 
-from django.contrib.auth.models import Group
 from django.urls import reverse
 from django.utils import timezone
 from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import Municipio, Participation, Projeto, Solicitacao, TipoEvento, Usuario
+from apps.core.models import Participation
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 pytestmark = pytest.mark.django_db
 
@@ -40,14 +47,14 @@ pytestmark = pytest.mark.django_db
 def grupos():
     """Create required groups for tests."""
     return {
-        "diretoria": Group.objects.get_or_create(name="Diretoria")[0],
-        "controle": Group.objects.get_or_create(name="Controle")[0],
-        "dat": Group.objects.get_or_create(name="DAT")[0],
-        "superintendencia": Group.objects.get_or_create(name="Superintendência")[0],
-        "coordenador": Group.objects.get_or_create(name="Coordenador")[0],
-        "formador": Group.objects.get_or_create(name="Formador")[0],
-        "gerente": Group.objects.get_or_create(name="Gerente")[0],
-        "gerencia": Group.objects.get_or_create(name="Gerência")[0],
+        "diretoria": GroupFactory(name="Diretoria"),
+        "controle": GroupFactory(name="Controle"),
+        "dat": GroupFactory(name="DAT"),
+        "superintendencia": GroupFactory(name="Superintendência"),
+        "coordenador": GroupFactory(name="Coordenador"),
+        "formador": GroupFactory(name="Formador"),
+        "gerente": GroupFactory(name="Gerente"),
+        "gerencia": GroupFactory(name="Gerência"),
     }
 
 
@@ -58,7 +65,7 @@ def user_controle(grupos):
     no seed realinhado. Este endpoint metrics/map é alimentado por dashboards
     da Diretoria — gating real de UI fica no menu condicional do frontend."""
     uid = uuid4().hex[:8]
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username=f"controle_{uid}",
         email=f"controle_{uid}@test.com",
         password="test123",
@@ -74,7 +81,7 @@ def user_gerencia(grupos):
     adicionado a Diretoria (que tem `supervise_operations` no seed
     realinhado, perm exigida por /metrics/team/formadores/)."""
     uid = uuid4().hex[:8]
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username=f"gerencia_{uid}",
         email=f"gerencia_{uid}@test.com",
         password="test123",
@@ -88,21 +95,21 @@ def user_gerencia(grupos):
 def municipios():
     """Create municipalities in different states."""
     return {
-        "fortaleza": Municipio.objects.create(
+        "fortaleza": MunicipioFactory(
             nome="Fortaleza",
             uf="CE",
             ibge_code=f"23{uuid4().hex[:5]}",
             latitude=-3.717200,
             longitude=-38.543400,
         ),
-        "caucaia": Municipio.objects.create(
+        "caucaia": MunicipioFactory(
             nome="Caucaia",
             uf="CE",
             ibge_code=f"23{uuid4().hex[:5]}",
             latitude=-3.736111,
             longitude=-38.653889,
         ),
-        "sao_paulo": Municipio.objects.create(
+        "sao_paulo": MunicipioFactory(
             nome="São Paulo",
             uf="SP",
             ibge_code=f"35{uuid4().hex[:5]}",
@@ -115,7 +122,7 @@ def municipios():
 @pytest.fixture
 def projeto():
     """Create a test project."""
-    return Projeto.objects.create(
+    return ProjetoFactory(
         nome=f"Projeto Test {uuid4().hex[:6]}",
         codigo=f"PT{uuid4().hex[:4].upper()}",
         fluxo="SUPER",
@@ -125,14 +132,14 @@ def projeto():
 @pytest.fixture
 def tipo_evento():
     """Create an event type."""
-    return TipoEvento.objects.create(nome=f"Tipo {uuid4().hex[:6]}")
+    return TipoEventoFactory(nome=f"Tipo {uuid4().hex[:6]}")
 
 
 @pytest.fixture
 def coordenador_user(grupos):
     """Create a coordinator user with first/last name."""
     uid = uuid4().hex[:8]
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username=f"coord_{uid}",
         email=f"coord_{uid}@test.com",
         password="test123",
@@ -148,7 +155,7 @@ def coordenador_user(grupos):
 def formador_sem_nome(grupos):
     """Create a formador without first_name/last_name (for fallback test)."""
     uid = uuid4().hex[:8]
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username=f"formador_anonimo_{uid}",
         email=f"formador_{uid}@test.com",
         password="test123",
@@ -164,7 +171,7 @@ def formador_sem_nome(grupos):
 def formador_com_nome(grupos):
     """Create a formador with first_name/last_name."""
     uid = uuid4().hex[:8]
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username=f"formador_nomeado_{uid}",
         email=f"formador_nome_{uid}@test.com",
         password="test123",
@@ -184,7 +191,7 @@ def solicitacoes_ce(municipios, projeto, tipo_evento, coordenador_user, formador
 
     # Create user to be the creator
     uid = uuid4().hex[:8]
-    criador = Usuario.objects.create_user(
+    criador = UsuarioFactory(
         username=f"criador_{uid}",
         email=f"criador_{uid}@test.com",
         password="test123",
@@ -193,7 +200,7 @@ def solicitacoes_ce(municipios, projeto, tipo_evento, coordenador_user, formador
 
     # Create 3 solicitations in Fortaleza-CE
     for i in range(3):
-        sol = Solicitacao.objects.create(
+        sol = SolicitacaoFactory(
             usuario=criador,
             status="aprovado",
             inicio=now + timedelta(days=i),
@@ -221,7 +228,7 @@ def solicitacoes_ce(municipios, projeto, tipo_evento, coordenador_user, formador
         solicitacoes.append(sol)
 
     # Create 1 solicitation in Caucaia-CE
-    sol = Solicitacao.objects.create(
+    sol = SolicitacaoFactory(
         usuario=criador,
         status="aprovado",
         inicio=now + timedelta(days=10),
@@ -253,14 +260,14 @@ def solicitacao_sp(municipios, projeto, tipo_evento, grupos):
     now = timezone.now()
 
     uid = uuid4().hex[:8]
-    criador = Usuario.objects.create_user(
+    criador = UsuarioFactory(
         username=f"criador_sp_{uid}",
         email=f"criador_sp_{uid}@test.com",
         password="test123",
         cpf=f"7{uid[:10].ljust(10, '0')}",
     )
 
-    sol = Solicitacao.objects.create(
+    sol = SolicitacaoFactory(
         usuario=criador,
         status="aprovado",
         inicio=now + timedelta(days=20),
@@ -597,7 +604,7 @@ class TestMetricsMapCoordinators:
 
         # Create coordinator without name
         uid = uuid4().hex[:8]
-        coord_sem_nome = Usuario.objects.create_user(
+        coord_sem_nome = UsuarioFactory(
             username=f"coord_anonimo_{uid}",
             email=f"coord_anonimo_{uid}@test.com",
             password="test123",
@@ -608,14 +615,14 @@ class TestMetricsMapCoordinators:
         coord_sem_nome.groups.add(grupos["coordenador"])
 
         # Create solicitation with this coordinator
-        criador = Usuario.objects.create_user(
+        criador = UsuarioFactory(
             username=f"criador_x_{uid}",
             email=f"criador_x_{uid}@test.com",
             password="test123",
             cpf=f"9{uid[:10].ljust(10, '0')}",
         )
 
-        sol = Solicitacao.objects.create(
+        sol = SolicitacaoFactory(
             usuario=criador,
             status="aprovado",
             inicio=timezone.now(),
@@ -690,14 +697,14 @@ class TestFormadoresMetricsUsernameFallback:
 
         # Create solicitation with formador_sem_nome
         uid = uuid4().hex[:8]
-        criador = Usuario.objects.create_user(
+        criador = UsuarioFactory(
             username=f"criador_form_{uid}",
             email=f"criador_form_{uid}@test.com",
             password="test123",
             cpf=f"1{uid[:10].ljust(10, '1')}",
         )
 
-        sol = Solicitacao.objects.create(
+        sol = SolicitacaoFactory(
             usuario=criador,
             status="aprovado",
             inicio=timezone.now() - timedelta(days=5),

--- a/v2/backend/apps/core/tests/test_views_options.py
+++ b/v2/backend/apps/core/tests/test_views_options.py
@@ -23,13 +23,19 @@ from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import DATArea, DATCoordenador, Municipio, Produto, Projeto, TipoEvento, Usuario
+from apps.core.models import DATArea, DATCoordenador, Produto, Usuario
+from apps.core.tests.factories import (
+    MunicipioFactory,
+    ProjetoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 
 @pytest.fixture
 def projeto_base():
     """Base project for tests that require Projeto FK."""
-    return Projeto.objects.create(
+    return ProjetoFactory(
         nome="Projeto Base",
         codigo="BASE",
         ativo=True,
@@ -47,7 +53,7 @@ def api_client():
 def usuario_autenticado():
     """Authenticated user for API requests."""
     uid = uuid4().hex[:8]
-    return Usuario.objects.create_user(
+    return UsuarioFactory(
         username=f"user_{uid}",
         password="senha123",
         cpf=str(uuid4().int % 10**11).zfill(11),
@@ -75,7 +81,7 @@ class TestUsuariosOptions:
     def test_returns_active_users(self, api_client, usuario_autenticado):
         """Returns list of active users."""
         # Create additional active users
-        user1 = Usuario.objects.create_user(
+        user1 = UsuarioFactory(
             username="formador1",
             password="senha123",
             cpf="11111111111",
@@ -84,7 +90,7 @@ class TestUsuariosOptions:
             last_name="Silva",
             is_active=True,
         )
-        user2 = Usuario.objects.create_user(
+        user2 = UsuarioFactory(
             username="formador2",
             password="senha123",
             cpf="22222222222",
@@ -94,7 +100,7 @@ class TestUsuariosOptions:
             is_active=True,
         )
         # Create inactive user (should not appear)
-        Usuario.objects.create_user(
+        UsuarioFactory(
             username="inativo",
             password="senha123",
             cpf="33333333333",
@@ -402,7 +408,7 @@ class TestMunicipiosOptionsCache:
 
     def test_cache_hit_returns_cached_data(self, api_client, usuario_autenticado):
         """Municipios endpoint returns cached data on cache hit."""
-        Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
+        MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
 
         api_client.force_authenticate(user=usuario_autenticado)
 
@@ -426,7 +432,7 @@ class TestProjetosOptionsCache:
 
     def test_cache_hit_returns_cached_data(self, api_client, usuario_autenticado):
         """Projetos endpoint returns cached data on cache hit."""
-        Projeto.objects.create(nome="Teste", codigo="TST", ativo=True, is_test=False)
+        ProjetoFactory(nome="Teste", codigo="TST", ativo=True, is_test=False)
 
         api_client.force_authenticate(user=usuario_autenticado)
 
@@ -445,8 +451,8 @@ class TestProjetosOptionsCache:
 
     def test_include_test_param_uses_different_cache(self, api_client, usuario_autenticado):
         """include_test=true uses separate cache key."""
-        Projeto.objects.create(nome="Normal", codigo="NRM", ativo=True, is_test=False)
-        Projeto.objects.create(nome="Test Project", codigo="TST2", ativo=True, is_test=True)
+        ProjetoFactory(nome="Normal", codigo="NRM", ativo=True, is_test=False)
+        ProjetoFactory(nome="Test Project", codigo="TST2", ativo=True, is_test=True)
 
         api_client.force_authenticate(user=usuario_autenticado)
 
@@ -478,7 +484,7 @@ class TestTiposEventoOptionsCache:
 
     def test_cache_hit_returns_cached_data(self, api_client, usuario_autenticado):
         """Tipos evento endpoint returns cached data on cache hit."""
-        TipoEvento.objects.create(nome="Formação")
+        TipoEventoFactory(nome="Formação")
 
         api_client.force_authenticate(user=usuario_autenticado)
 

--- a/v2/backend/apps/core/tests/test_views_solicitacao_coverage.py
+++ b/v2/backend/apps/core/tests/test_views_solicitacao_coverage.py
@@ -18,13 +18,20 @@ from __future__ import annotations
 from datetime import date, timedelta
 from uuid import uuid4
 
-from django.contrib.auth.models import Group
 from django.utils import timezone
 from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import AuditLog, Compra, Municipio, Participation, Projeto, Solicitacao, TipoEvento, Usuario
+from apps.core.models import AuditLog, Compra, Participation
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 
 @pytest.fixture
@@ -37,11 +44,11 @@ def api_client():
 def grupos():
     """Create Django groups."""
     return {
-        "Coordenador": Group.objects.get_or_create(name="Coordenador")[0],
-        "Superintendência": Group.objects.get_or_create(name="Superintendência")[0],
-        "Controle": Group.objects.get_or_create(name="Controle")[0],
-        "DAT": Group.objects.get_or_create(name="DAT")[0],
-        "Gerente": Group.objects.get_or_create(name="Gerente")[0],
+        "Coordenador": GroupFactory(name="Coordenador"),
+        "Superintendência": GroupFactory(name="Superintendência"),
+        "Controle": GroupFactory(name="Controle"),
+        "DAT": GroupFactory(name="DAT"),
+        "Gerente": GroupFactory(name="Gerente"),
     }
 
 
@@ -49,7 +56,7 @@ def grupos():
 def usuario_coordenador(grupos):
     """User with Coordenador role."""
     uid = uuid4().hex[:8]
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username=f"coord_{uid}",
         password="senha123",
         cpf=str(uuid4().int % 10**11).zfill(11),
@@ -63,7 +70,7 @@ def usuario_coordenador(grupos):
 def usuario_gerente_superintendencia(grupos):
     """User with Superintendência role (also Gerente) for batch approve/reject tests."""
     uid = uuid4().hex[:8]
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username=f"gerente_super_{uid}",
         password="senha123",
         cpf=str(uuid4().int % 10**11).zfill(11),
@@ -79,7 +86,7 @@ def usuario_superintendencia(grupos):
     """Gerente da Superintendência (PR 3 hardening RBAC, 2026-04-29):
     composite Setor `Superintendência` + Função `Gerente`."""
     uid = uuid4().hex[:8]
-    user = Usuario.objects.create_user(
+    user = UsuarioFactory(
         username=f"super_{uid}",
         password="senha123",
         cpf=str(uuid4().int % 10**11).zfill(11),
@@ -93,7 +100,7 @@ def usuario_superintendencia(grupos):
 def usuario_formador(grupos):
     """User to be used as formador."""
     uid = uuid4().hex[:8]
-    return Usuario.objects.create_user(
+    return UsuarioFactory(
         username=f"formador_{uid}",
         password="senha123",
         cpf=str(uuid4().int % 10**11).zfill(11),
@@ -104,14 +111,14 @@ def usuario_formador(grupos):
 @pytest.fixture
 def municipio():
     """Test municipality."""
-    return Municipio.objects.create(nome="Fortaleza", uf="CE", ativo=True)
+    return MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
 
 
 @pytest.fixture
 def projeto_super():
     """Project with SUPER flow (requires approval)."""
     uid = uuid4().hex[:8]
-    return Projeto.objects.create(
+    return ProjetoFactory(
         nome=f"Projeto SUPER {uid}",
         codigo=f"SUPER{uid[:4]}",
         fluxo="SUPER",
@@ -122,7 +129,7 @@ def projeto_super():
 @pytest.fixture
 def tipo_evento():
     """Test event type."""
-    return TipoEvento.objects.get_or_create(nome="Formação")[0]
+    return TipoEventoFactory(nome="Formação")
 
 
 @pytest.fixture
@@ -158,7 +165,7 @@ class TestGetClientIP:
         tipo_evento,
     ):
         """X-Forwarded-For header is correctly extracted (line 36)."""
-        sol = Solicitacao.objects.create(
+        sol = SolicitacaoFactory(
             usuario=usuario_coordenador,
             municipio=municipio,
             projeto=projeto_super,
@@ -192,7 +199,7 @@ class TestGetClientIP:
         tipo_evento,
     ):
         """X-Real-IP header is correctly extracted (line 39)."""
-        sol = Solicitacao.objects.create(
+        sol = SolicitacaoFactory(
             usuario=usuario_coordenador,
             municipio=municipio,
             projeto=projeto_super,
@@ -234,20 +241,20 @@ class TestSolicitacaoFilters:
         tipo_evento,
     ):
         """Sector filter works correctly (line 134)."""
-        projeto_acerta = Projeto.objects.create(
+        projeto_acerta = ProjetoFactory(
             nome="ACerta Teste",
             codigo="ACERTA",
             fluxo="SUPER",
             ativo=True,
         )
-        projeto_vidas = Projeto.objects.create(
+        projeto_vidas = ProjetoFactory(
             nome="Vidas Teste",
             codigo="VIDAS",
             fluxo="SUPER",
             ativo=True,
         )
 
-        sol_acerta = Solicitacao.objects.create(
+        sol_acerta = SolicitacaoFactory(
             usuario=usuario_coordenador,
             municipio=municipio,
             projeto=projeto_acerta,
@@ -256,7 +263,7 @@ class TestSolicitacaoFilters:
             fim=timezone.now() + timedelta(days=1, hours=2),
             status="pendente",
         )
-        sol_vidas = Solicitacao.objects.create(
+        sol_vidas = SolicitacaoFactory(
             usuario=usuario_coordenador,
             municipio=municipio,
             projeto=projeto_vidas,
@@ -286,7 +293,7 @@ class TestSolicitacaoFilters:
         """date_from filter works correctly (lines 137-142)."""
         today = timezone.now().date()
 
-        sol_past = Solicitacao.objects.create(
+        sol_past = SolicitacaoFactory(
             usuario=usuario_coordenador,
             municipio=municipio,
             projeto=projeto_super,
@@ -295,7 +302,7 @@ class TestSolicitacaoFilters:
             fim=timezone.now() - timedelta(days=10) + timedelta(hours=2),
             status="pendente",
         )
-        sol_future = Solicitacao.objects.create(
+        sol_future = SolicitacaoFactory(
             usuario=usuario_coordenador,
             municipio=municipio,
             projeto=projeto_super,
@@ -323,7 +330,7 @@ class TestSolicitacaoFilters:
         tipo_evento,
     ):
         """Invalid date_from format is ignored (lines 141-142)."""
-        Solicitacao.objects.create(
+        SolicitacaoFactory(
             usuario=usuario_coordenador,
             municipio=municipio,
             projeto=projeto_super,
@@ -351,7 +358,7 @@ class TestSolicitacaoFilters:
         """date_to filter works correctly (lines 145-150)."""
         today = timezone.now().date()
 
-        sol_past = Solicitacao.objects.create(
+        sol_past = SolicitacaoFactory(
             usuario=usuario_coordenador,
             municipio=municipio,
             projeto=projeto_super,
@@ -360,7 +367,7 @@ class TestSolicitacaoFilters:
             fim=timezone.now() - timedelta(days=5) + timedelta(hours=2),
             status="pendente",
         )
-        sol_future = Solicitacao.objects.create(
+        sol_future = SolicitacaoFactory(
             usuario=usuario_coordenador,
             municipio=municipio,
             projeto=projeto_super,
@@ -388,7 +395,7 @@ class TestSolicitacaoFilters:
         tipo_evento,
     ):
         """Invalid date_to format is ignored (lines 149-150)."""
-        Solicitacao.objects.create(
+        SolicitacaoFactory(
             usuario=usuario_coordenador,
             municipio=municipio,
             projeto=projeto_super,
@@ -414,7 +421,7 @@ class TestSolicitacaoFilters:
         tipo_evento,
     ):
         """q search filter works correctly (lines 153-154)."""
-        sol = Solicitacao.objects.create(
+        sol = SolicitacaoFactory(
             usuario=usuario_coordenador,
             municipio=municipio,
             projeto=projeto_super,
@@ -667,7 +674,7 @@ class TestApproveRejectEdgeCases:
         tipo_evento,
     ):
         """Approving already approved solicitation returns 400 (line 284)."""
-        sol = Solicitacao.objects.create(
+        sol = SolicitacaoFactory(
             usuario=usuario_coordenador,
             municipio=municipio,
             projeto=projeto_super,
@@ -693,7 +700,7 @@ class TestApproveRejectEdgeCases:
         tipo_evento,
     ):
         """Rejecting already rejected solicitation returns 400 (line 350)."""
-        sol = Solicitacao.objects.create(
+        sol = SolicitacaoFactory(
             usuario=usuario_coordenador,
             municipio=municipio,
             projeto=projeto_super,
@@ -722,7 +729,7 @@ class TestApproveRejectEdgeCases:
         tipo_evento,
     ):
         """Approving rejected solicitation returns 400 (status must be pendente)."""
-        sol = Solicitacao.objects.create(
+        sol = SolicitacaoFactory(
             usuario=usuario_coordenador,
             municipio=municipio,
             projeto=projeto_super,
@@ -748,7 +755,7 @@ class TestApproveRejectEdgeCases:
         tipo_evento,
     ):
         """Rejecting approved solicitation returns 400 (status must be pendente)."""
-        sol = Solicitacao.objects.create(
+        sol = SolicitacaoFactory(
             usuario=usuario_coordenador,
             municipio=municipio,
             projeto=projeto_super,
@@ -787,7 +794,7 @@ class TestBatchApprove:
         tipo_evento,
     ):
         """Batch approve multiple solicitations successfully."""
-        sol1 = Solicitacao.objects.create(
+        sol1 = SolicitacaoFactory(
             usuario=usuario_coordenador,
             municipio=municipio,
             projeto=projeto_super,
@@ -796,7 +803,7 @@ class TestBatchApprove:
             fim=timezone.now() + timedelta(days=1, hours=2),
             status="pendente",
         )
-        sol2 = Solicitacao.objects.create(
+        sol2 = SolicitacaoFactory(
             usuario=usuario_coordenador,
             municipio=municipio,
             projeto=projeto_super,
@@ -876,7 +883,7 @@ class TestBatchApprove:
         tipo_evento,
     ):
         """Batch approve handles already approved solicitations."""
-        sol_pendente = Solicitacao.objects.create(
+        sol_pendente = SolicitacaoFactory(
             usuario=usuario_coordenador,
             municipio=municipio,
             projeto=projeto_super,
@@ -885,7 +892,7 @@ class TestBatchApprove:
             fim=timezone.now() + timedelta(days=1, hours=2),
             status="pendente",
         )
-        sol_aprovado = Solicitacao.objects.create(
+        sol_aprovado = SolicitacaoFactory(
             usuario=usuario_coordenador,
             municipio=municipio,
             projeto=projeto_super,
@@ -920,7 +927,7 @@ class TestBatchApprove:
         tipo_evento,
     ):
         """Batch approve handles non-existent ids."""
-        sol = Solicitacao.objects.create(
+        sol = SolicitacaoFactory(
             usuario=usuario_coordenador,
             municipio=municipio,
             projeto=projeto_super,
@@ -965,7 +972,7 @@ class TestBatchReject:
         tipo_evento,
     ):
         """Batch reject multiple solicitations successfully."""
-        sol1 = Solicitacao.objects.create(
+        sol1 = SolicitacaoFactory(
             usuario=usuario_coordenador,
             municipio=municipio,
             projeto=projeto_super,
@@ -974,7 +981,7 @@ class TestBatchReject:
             fim=timezone.now() + timedelta(days=1, hours=2),
             status="pendente",
         )
-        sol2 = Solicitacao.objects.create(
+        sol2 = SolicitacaoFactory(
             usuario=usuario_coordenador,
             municipio=municipio,
             projeto=projeto_super,
@@ -1054,7 +1061,7 @@ class TestBatchReject:
         tipo_evento,
     ):
         """Batch reject handles already rejected solicitations."""
-        sol_pendente = Solicitacao.objects.create(
+        sol_pendente = SolicitacaoFactory(
             usuario=usuario_coordenador,
             municipio=municipio,
             projeto=projeto_super,
@@ -1063,7 +1070,7 @@ class TestBatchReject:
             fim=timezone.now() + timedelta(days=1, hours=2),
             status="pendente",
         )
-        sol_reprovado = Solicitacao.objects.create(
+        sol_reprovado = SolicitacaoFactory(
             usuario=usuario_coordenador,
             municipio=municipio,
             projeto=projeto_super,
@@ -1098,7 +1105,7 @@ class TestBatchReject:
         tipo_evento,
     ):
         """Batch reject handles non-existent ids."""
-        sol = Solicitacao.objects.create(
+        sol = SolicitacaoFactory(
             usuario=usuario_coordenador,
             municipio=municipio,
             projeto=projeto_super,

--- a/v2/backend/conftest.py
+++ b/v2/backend/conftest.py
@@ -34,11 +34,19 @@ def ensure_rbac_seed(db):
 
     Guarda de 1 query: no-op quando o seed ja existe (caso comum -> sem overhead). So
     re-semeia (idempotente) quando o vinculo group x capability sumiu (pos-truncate).
+
+    `ensure_base_groups()` restaura tambem os 18 grupos base (setor + funcao) que o
+    truncate apaga. Necessario sob `pytest --no-migrations`, onde os grupos vem do
+    fixture de sessao (nao das migrations RunPython). #1404.
     """
     from apps.core.models import PermissaoFuncional
-    from apps.core.services.functional_permissions_seed import seed_functional_permissions
+    from apps.core.services.functional_permissions_seed import (
+        ensure_base_groups,
+        seed_functional_permissions,
+    )
 
     if not PermissaoFuncional.objects.filter(groups__isnull=False).exists():
+        ensure_base_groups()
         seed_functional_permissions(assign_default_groups=True)
         # O groups.set do seed dispara m2m_changed e popula o buffer de auditoria de
         # capability; essas mudancas sao infraestrutura de teste (nao operacoes

--- a/v2/backend/pytest.ini
+++ b/v2/backend/pytest.ini
@@ -15,6 +15,7 @@ django_db_suffix = _{worker_id}
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')
     performance: marks tests as performance tests (deselect with '-m "not performance"')
+    migrations: tests que exercitam funcoes de data-migration RunPython (rodam no job migrate-integrity COM migrations; tambem passam sob --no-migrations). #1404
 
 # =============================================================================
 # Coverage Configuration (Issues #268, #850)


### PR DESCRIPTION
## Resumo

Última peça do roadmap CI/CD+Performance (M1–M3 mergeados): habilita `pytest --no-migrations` no caminho rápido do CI (corta o setup de DB) e migra os seeds essenciais de data-migrations para fixtures/factory_boy. Fecha #1404. É também a correção-raiz do seed-truncation do xdist (#1402).

### O que muda
- **Seeds RBAC via fixtures**: `ensure_base_groups()` (SSOT em `functional_permissions_seed.py`) cria os 18 grupos base; chamado pelas fixtures de sessão e por `ensure_rbac_seed` (pós-truncate). Sob `--no-migrations` os seeds vêm das fixtures, não das 24 RunPython.
- **factory_boy**: `apps/core/tests/factories.py` (Usuario/Municipio/Projeto/TipoEvento/Solicitacao/Group), tipadas `DjangoModelFactory[Model]` (factory-boy tem `py.typed` → consumidores recebem o tipo concreto, pyright strict ok). **141 arquivos de teste** migrados de `Model.objects.create()`/`get_or_create()` para factories (drop-in, mesmos kwargs). Criações que validam constraint/serializer/API ou de models não-alvo (Produto/Compra/AuditLog/Participation/Formacao/AcaoTemplate/…) mantidas explícitas.
- **Gate de CI flipado**: `backend-tests-core` + `backend-tests-ingest-devtools` usam `run_migrations: false` + `--no-migrations`.
- **Rede de segurança**: novo job `backend-migrate-integrity` (`run_migrations: true`, `-m migrations`) exercita a cadeia RunPython em DB limpo — pega migration quebrada **antes** do deploy. Gated pelo required `backend-tests` (needs + assert), sem mexer no ruleset.
- **Marker `migrations`** nos 4 arquivos que exercitam funções RunPython diretamente.

### Medição (baseline reproduzível)
| Cenário | setup pytest | wall-clock |
|---|---|---|
| COM migrations (`--create-db`) | 9.76s | 12.7s |
| SEM migrations (`--no-migrations`) | 3.02s | 4.9s |

→ **~69% menos** no setup de DB (por criação de DB; em CI pago a cada job).

### Validação local
- `pytest --no-migrations` (core): **2719 passed, 43 skipped**
- `pytest` COM migrations (core, deploy-safe): **2719 passed, 43 skipped**
- `pytest --no-migrations` (dev_tools): **42 passed**
- `pytest -m migrations` (integrity): **27 passed**
- flake8 F-codes (undefined/unused/redef) em `apps/core/tests/`: **0**

Closes #1404.

---

## Staging Gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

`make staging-full` executado localmente (sub-targets no Windows: precheck → build → up → test → down):

```text
[1/8] Backend readyz:  PASS
[2/8] Backend version: PASS (v=staging-local)
[3/8] CSRF endpoint:   PASS
[4/8] Auth pipeline:   PASS (HTTP 400)
[5/8] Celery worker:   PASS
[6/8] Celery beat:     PASS
[7/8] Frontend HTTP:   PASS
[8/8] Frontend health: PASS
ALL 8 CHECKS PASSED
```
