### PR TITLE
ci(codecov): ativar free tier como analytics informational

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Aprender Sistema
 
 [![CI](https://github.com/matheusnorjosa/aprender_sistema/actions/workflows/ci.yaml/badge.svg)](https://github.com/matheusnorjosa/aprender_sistema/actions/workflows/ci.yaml)
+[![codecov](https://codecov.io/gh/matheusnorjosa/aprender_sistema/graph/badge.svg)](https://codecov.io/gh/matheusnorjosa/aprender_sistema)
 [![Python 3.12](https://img.shields.io/badge/python-3.12-blue.svg)](https://www.python.org/downloads/)
 [![Django 5.2](https://img.shields.io/badge/django-5.2-green.svg)](https://www.djangoproject.com/)
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,31 @@
+# Codecov configuration — Aprender Sistema
+#
+# Coverage analytics aqui sao INFORMATIONAL ONLY. O gate de cobertura
+# autoritativo (>= 85%) e enforcado no CI pelo job `[required] backend tests`
+# (passo coverage combine em .github/workflows/ci.yaml). O Codecov NUNCA bloqueia
+# um PR neste repo — ele fornece feedback de patch/diff e tendencias, nada mais.
+#
+# Fluxo completo do CI: v2/docs/specs/infra/ci.spec.md
+
+coverage:
+  status:
+    project:
+      default:
+        target: 85%          # espelha o gate real do CI
+        informational: true  # nunca bloqueia o PR (o gate vive no CI)
+    patch:
+      default:
+        informational: true  # feedback de cobertura do diff, sem bloquear
+
+comment:
+  layout: "diff, flags, files"
+  require_changes: false     # comenta sempre que houver upload (visibilidade do patch)
+
+# Apenas o backend sobe cobertura (flag "backend" em ci.yaml). carryforward
+# evita que um PR sem impacto em backend (backend-tests pulado) apareca como
+# queda de cobertura — o Codecov reaproveita o ultimo upload conhecido.
+flags:
+  backend:
+    paths:
+      - v2/backend/
+    carryforward: true

--- a/v2/docs/specs/infra/ci.spec.md
+++ b/v2/docs/specs/infra/ci.spec.md
@@ -1,9 +1,10 @@
 ---
 title: CI/CD (GitHub Actions)
 status: canonical
-last_verified: 2026-06-19
+last_verified: 2026-06-22
 sources_of_truth:
   - .github/workflows/ci.yaml
+  - codecov.yml
   - .github/workflows/deploy.yaml
   - .github/workflows/_backend-test.yml
   - .github/workflows/backend-xdist-canary.yml
@@ -71,7 +72,7 @@ A nomenclatura dos checks é o contrato de governança: `[required]` bloqueia me
 1. `backend-impact` decide se a suíte backend roda (PR sem impacto em backend pula os jobs pesados; push/dispatch sempre full).
 2. `lint` + `rbac-lint` (rápidos, paralelos).
 3. `backend-tests-core` e `backend-tests-ingest-devtools` rodam via reusable com `-n auto --dist loadscope`, cada um emitindo um artifact de cobertura.
-4. `backend-tests` baixa os dois artifacts, faz `coverage combine`, exige ≥85% e sobe para o Codecov.
+4. `backend-tests` baixa os dois artifacts, faz `coverage combine`, **exige ≥85% (gate bloqueante)** e sobe a cobertura para o Codecov (analytics **informational**, não bloqueia PR — config em `codecov.yml`; upload só quando o secret `CODECOV_TOKEN` existe).
 5. `backend-typecheck` (pyright em `apps/core config`) e `docker-parity-backend` (smoke em imagem `Dockerfile.prod`) rodam em paralelo.
 6. `tests` agrega: verde só se todos passaram (ou todos `skipped` quando sem impacto).
 7. `frontend-ci` (react doctor + build/lint + checklist) e `staging-gate-audit` (evidência no corpo) completam o gate.


### PR DESCRIPTION
## Contexto

O repo é público (Apache-2.0) → Codecov free tier é grátis e ilimitado. A infra de upload **já existia** em `ci.yaml` (step `Upload coverage to Codecov`, guard #1475), mas o secret `CODECOV_TOKEN` nunca tinha sido configurado → o upload era **sempre pulado** e nenhuma cobertura chegava ao dashboard. A spec `ci.spec.md` afirmava "sobe para o Codecov", o que era falso na prática.

O secret `CODECOV_TOKEN` agora foi configurado (repo ativado em codecov.io). Este PR fecha o loop do lado do repo.

## Mudanças

- **`codecov.yml`** (novo): `project` e `patch` em `informational: true` → **Codecov NUNCA bloqueia um PR**. O gate de cobertura autoritativo (≥85%) continua sendo o job `[required] backend tests` (passo coverage combine), não o Codecov. Flag `backend` com `carryforward: true` para que um PR sem impacto em backend (job `backend-tests` pulado pelo `backend-impact`) não apareça como queda de cobertura. **Validado contra o validador oficial do Codecov ("Valid!").**
- **`README.md`**: badge de cobertura do Codecov (sinal de qualidade para visitantes do OSS).
- **`v2/docs/specs/infra/ci.spec.md`**: passo 4 do fluxo esclarece **gate bloqueante (≥85%) vs Codecov informational**; `last_verified` → 2026-06-22; `codecov.yml` adicionado a `sources_of_truth`.

## Por que informational

Single-dev + gate de 85% já enforçado localmente no CI. O valor do Codecov aqui é **feedback de patch/diff** ("as linhas novas deste PR não estão testadas") + **badge** + tendências — não um segundo gate bloqueante. Manter `informational` evita ruído de status checks duplicados.

## Verificação

- `python scripts/check_doc_links.py` → **OK** (0 links quebrados)
- `python scripts/check_doc_frontmatter.py` → **OK** (frontmatter válido)
- `codecov.yml` → **Valid!** (validador oficial codecov.io)
- Escopo: só `codecov.yml` (raiz), `README.md`, `v2/docs/specs/` — **nenhum arquivo em `v2/backend/apps/`**, portanto o staging gate não se aplica.

Após o merge, o próximo run de CI com impacto em backend fará o primeiro upload real ao Codecov.