### PR TITLE
refactor(backend): rename ETL_ settings to IMPORT_ + de-stale CI labels

### DIFF
--- a/.github/workflows/_backend-test.yml
+++ b/.github/workflows/_backend-test.yml
@@ -9,7 +9,7 @@
 #   - upload de artifact
 #
 # Consumido por:
-#   - ci.yaml: backend-tests-core, backend-tests-ingest-devtools
+#   - ci.yaml: backend-tests-core, backend-tests-devtools
 #   - backend-xdist-canary.yml: xdist-canary (via strategy.matrix no caller)
 #
 # Fora de escopo (carve-out documentado): ci.yaml::docker-parity-backend usa env/topologia
@@ -53,7 +53,7 @@ on:
         type: string
         default: ""
       fail_on_test_error:
-        description: "Se true, o job falha quando o pytest falha (gates core/ingest). O canary usa false (non-blocking): exit real fica no metadata/report."
+        description: "Se true, o job falha quando o pytest falha (gates core/devtools). O canary usa false (non-blocking): exit real fica no metadata/report."
         type: boolean
         default: true
       emit_canary_metadata:
@@ -95,7 +95,7 @@ jobs:
     timeout-minutes: ${{ inputs.runner_timeout }}
 
     services:
-      # SSOT: bump de versao aqui cobre core/ingest/canary (#1401).
+      # SSOT: bump de versao aqui cobre core/devtools/canary (#1401).
       postgres:
         image: postgres:15.13
         env:
@@ -144,8 +144,8 @@ jobs:
           echo "GCAL_CLIENT=fake" >> "$GITHUB_ENV"
           echo "GCAL_SEND_UPDATES=none" >> "$GITHUB_ENV"
           echo "FEATURE_AUTO_APPLY_ENABLED=false" >> "$GITHUB_ENV"
-          echo "ETL_OUTPUT_DIR=${{ github.workspace }}/v2/backend/out_etl" >> "$GITHUB_ENV"
-          echo "ETL_DATA_DIR=${{ github.workspace }}/v2/backend/data/csv-import" >> "$GITHUB_ENV"
+          echo "IMPORT_OUTPUT_DIR=${{ github.workspace }}/v2/backend/out_etl" >> "$GITHUB_ENV"
+          echo "IMPORT_DATA_DIR=${{ github.workspace }}/v2/backend/data/csv-import" >> "$GITHUB_ENV"
           echo "PYTHONDONTWRITEBYTECODE=1" >> "$GITHUB_ENV"
 
       - name: Validate test paths (no /app hardcoded)
@@ -245,7 +245,7 @@ jobs:
             echo "- Exit code: ${TEST_EXIT}"
           } >> "${GITHUB_STEP_SUMMARY}"
 
-          # core/ingest sao gates reais (falham quando o pytest falha). O canary e
+          # core/devtools sao gates reais (falham quando o pytest falha). O canary e
           # non-blocking (fail_on_test_error=false): o exit real vive no metadata/report
           # da issue #677 e o job segue verde, preservando o contrato original.
           if [ "${FAIL_ON_TEST_ERROR}" = "true" ]; then

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -234,10 +234,10 @@ jobs:
       artifact_if_no_files: error
 
   # ----------------------------------------------------------------
-  # Job 2b: Backend tests - ingest/devtools suite (paralelo, xdist -n auto)
+  # Job 2b: Backend tests - dev_tools suite (paralelo, xdist -n auto)
   # ----------------------------------------------------------------
-  backend-tests-ingest-devtools:
-    name: "[info] backend tests ingest/devtools (runner)"
+  backend-tests-devtools:
+    name: "[info] backend tests dev_tools (runner)"
     needs:
       - backend-impact
     if: needs.backend-impact.outputs.backend_changed == 'true'
@@ -248,16 +248,16 @@ jobs:
       pytest_paths: apps/dev_tools/tests
       run_migrations: false  # --no-migrations: schema dos models, sem replay das RunPython. #1404.
       pytest_extra_args: -n auto --dist loadscope --no-migrations  # xdist #1403 + --no-migrations #1404.
-      coverage_file: .coverage.ingest_devtools
-      summary_title: Backend Ingest/DevTools Tests Runtime
-      artifact_name: backend-coverage-ingest-devtools
-      artifact_paths: v2/backend/.coverage.ingest_devtools
+      coverage_file: .coverage.devtools
+      summary_title: Backend DevTools Tests Runtime
+      artifact_name: backend-coverage-devtools
+      artifact_paths: v2/backend/.coverage.devtools
       artifact_if_no_files: error
 
   # ----------------------------------------------------------------
   # Job 2b2: Migrate-integrity — rede de seguranca da cadeia RunPython.
   #
-  # Os gates core/ingest rodam com --no-migrations (schema dos models, setup
+  # Os gates core/devtools rodam com --no-migrations (schema dos models, setup
   # rapido, #1404). Isso NAO exercita `manage.py migrate`, mas dev/prod aplicam
   # a cadeia real de migrations no deploy. Este job preenche essa lacuna:
   # run_migrations=true aplica as 24 RunPython em DB limpo (falha aqui = migration
@@ -292,7 +292,7 @@ jobs:
     needs:
       - backend-impact
       - backend-tests-core
-      - backend-tests-ingest-devtools
+      - backend-tests-devtools
       - backend-migrate-integrity
     if: always() && needs.backend-impact.outputs.backend_changed == 'true'
     env:
@@ -310,8 +310,8 @@ jobs:
           echo "backend-tests-core failed with result=${{ needs.backend-tests-core.result }}" >&2
           exit 1
         fi
-        if [ "${{ needs.backend-tests-ingest-devtools.result }}" != "success" ]; then
-          echo "backend-tests-ingest-devtools failed with result=${{ needs.backend-tests-ingest-devtools.result }}" >&2
+        if [ "${{ needs.backend-tests-devtools.result }}" != "success" ]; then
+          echo "backend-tests-devtools failed with result=${{ needs.backend-tests-devtools.result }}" >&2
           exit 1
         fi
         if [ "${{ needs.backend-migrate-integrity.result }}" != "success" ]; then
@@ -333,24 +333,24 @@ jobs:
         cd v2/backend
 
         CORE_COV="/tmp/backend-coverage/backend-coverage-core/.coverage.core"
-        INGEST_COV="/tmp/backend-coverage/backend-coverage-ingest-devtools/.coverage.ingest_devtools"
+        DEVTOOLS_COV="/tmp/backend-coverage/backend-coverage-devtools/.coverage.devtools"
 
-        if [ ! -f "$CORE_COV" ] || [ ! -f "$INGEST_COV" ]; then
+        if [ ! -f "$CORE_COV" ] || [ ! -f "$DEVTOOLS_COV" ]; then
           echo "Missing coverage artifact(s) for combination." >&2
           ls -R /tmp/backend-coverage || true
           exit 1
         fi
 
         cp "$CORE_COV" .coverage.core
-        cp "$INGEST_COV" .coverage.ingest_devtools
+        cp "$DEVTOOLS_COV" .coverage.devtools
 
-        coverage combine .coverage.core .coverage.ingest_devtools
+        coverage combine .coverage.core .coverage.devtools
         coverage report --fail-under=85
         coverage xml -o coverage.xml
 
         {
           echo "### Backend Coverage Combine"
-          echo "- Source artifacts: core + ingest/devtools"
+          echo "- Source artifacts: core + dev_tools"
           echo "- Threshold enforced: 85%"
           echo "- Output XML: v2/backend/coverage.xml"
         } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,6 +1,6 @@
 name: Security Scan
 
-# Security Audit 2025-01: Container and dependency vulnerability scanning
+# Security: Container and dependency vulnerability scanning
 # Refs:
 # - https://github.com/shieldfy/API-Security-Checklist
 # - https://github.com/The-Art-of-Hacking/h4cker

--- a/v2/backend/apps/core/admin.py
+++ b/v2/backend/apps/core/admin.py
@@ -94,7 +94,7 @@ class UsuarioAdmin(admin.ModelAdmin):
 
         # Também salvar em out_etl para auditoria
         try:
-            out_dir = Path(settings.ETL_OUTPUT_DIR)
+            out_dir = Path(settings.IMPORT_OUTPUT_DIR)
             out_dir.mkdir(parents=True, exist_ok=True)
             csv_path = out_dir / "usuarios_sem_cpf.csv"
 
@@ -116,7 +116,7 @@ class UsuarioAdmin(admin.ModelAdmin):
         except Exception as e:
             # Se falhar ao salvar em out_etl, apenas retornar o CSV via HTTP
             logger = logging.getLogger(__name__)
-            logger.warning(f"Failed to save audit file to {settings.ETL_OUTPUT_DIR}: {e}")
+            logger.warning(f"Failed to save audit file to {settings.IMPORT_OUTPUT_DIR}: {e}")
 
         return response
 

--- a/v2/backend/config/settings.py
+++ b/v2/backend/config/settings.py
@@ -700,13 +700,16 @@ AVAILABILITY_DAILY_LIMIT_HOURS = int(os.getenv("AVAILABILITY_DAILY_LIMIT_HOURS",
 # RD-04: Buffer de deslocamento entre municípios distintos (minutos)
 TRAVEL_BUFFER_MINUTES = int(os.getenv("TRAVEL_BUFFER_MINUTES", "120"))
 
-# Import/Export directories (used by core admin audit + import services)
-ETL_OUTPUT_DIR = os.getenv("ETL_OUTPUT_DIR", str(BASE_DIR / "out_etl"))
-ETL_DATA_DIR = os.getenv("ETL_DATA_DIR", str(BASE_DIR / "data" / "csv-import"))
+# Import/Export directories (used by core admin audit + import services).
+# IMPORT_* é o nome canônico; os nomes legados ETL_* (vestígio do ETL removido,
+# #967/#971) seguem honrados como fallback de env para não quebrar deployments
+# que ainda os definam (ex.: Portainer).
+IMPORT_OUTPUT_DIR = os.getenv("IMPORT_OUTPUT_DIR") or os.getenv("ETL_OUTPUT_DIR") or str(BASE_DIR / "out_etl")
+IMPORT_DATA_DIR = os.getenv("IMPORT_DATA_DIR") or os.getenv("ETL_DATA_DIR") or str(BASE_DIR / "data" / "csv-import")
 
-# ETL: Diretório padrão para importação de arquivos (backwards compatibility)
-# NOTE: ETL_DATA_DIR é o padrão preferido. DATA_IMPORT_DIR mantido para
-# compatibilidade com management commands existentes (etl_all, etl_load_xlsx).
+# DATA_IMPORT_DIR: default legado de path de importação, mantido para
+# compatibilidade com o default histórico do importer. (Não há mais comandos
+# etl_all/etl_load_xlsx — ETL legado foi REMOVIDO, #967/#971.)
 DATA_IMPORT_DIR = os.getenv("DATA_IMPORT_DIR", "/app/data/csv-import")
 
 # ================================================================

--- a/v2/docs/TESTING_POLICY.md
+++ b/v2/docs/TESTING_POLICY.md
@@ -8,8 +8,8 @@ Este documento consolida práticas e contratos adotados nos testes para manter o
 - **Settings**: `DJANGO_SETTINGS_MODULE=config.settings`, `ENVIRONMENT=testing`, `REQUIRE_DOCKER=0`
 - **Integrações externas**:
   - `GCAL_CLIENT=fake`, `GCAL_SEND_UPDATES=none`
-- **Diretórios de ETL**:
-  - `ETL_OUTPUT_DIR` e `ETL_DATA_DIR` resolvidos no workspace do CI
+- **Diretórios de import**:
+  - `IMPORT_OUTPUT_DIR` e `IMPORT_DATA_DIR` resolvidos no workspace do CI
 - **Paths**:
   - Nunca usar `/app` hardcoded em testes
   - Preferir `Path(settings.BASE_DIR)` para paths absolutos
@@ -82,7 +82,7 @@ csv_path = Path(settings.BASE_DIR) / "apps/core/data/projetos_fluxo.csv"
 - Hardcoded `/app` (específico de container, não funciona localmente)
 
 **Artefatos de ETL**:
-- Devem ser gravados sob `ETL_OUTPUT_DIR` ou `BASE_DIR`, nunca em `/app`
+- Devem ser gravados sob `IMPORT_OUTPUT_DIR` ou `BASE_DIR`, nunca em `/app`
 
 ## Princípios
 

--- a/v2/docs/analysis/COVERAGE_POLICY.md
+++ b/v2/docs/analysis/COVERAGE_POLICY.md
@@ -20,9 +20,9 @@ Observed on the last backend-touching main run before this policy unification
 | Slice | Coverage |
 |-------|---------:|
 | `apps/core` (core suite alone) | 87% |
-| `apps/dev_tools` (ingest/devtools suite alone) | 9% (low because the suite
+| `apps/dev_tools` (dev_tools suite alone) | 9% (low because the suite
 exercises a narrow slice of `apps/` — combine step is the authoritative number) |
-| **Combined (core + ingest/devtools)** | **90%** |
+| **Combined (core + dev_tools)** | **90%** |
 
 The 85% gate leaves a 5-point headroom above the current combined baseline.
 

--- a/v2/docs/specs/infra/ci.spec.md
+++ b/v2/docs/specs/infra/ci.spec.md
@@ -36,7 +36,7 @@ A nomenclatura dos checks é o contrato de governança: `[required]` bloqueia me
 
 ## Fonte de verdade no código
 
-- **Gate principal de PR** — [`.github/workflows/ci.yaml`](../../../../.github/workflows/ci.yaml): backend impact detector, lint, rbac-lint, testes backend (split core + ingest/devtools), combine de cobertura, pyright, docker parity e o agregador `[required] tests`.
+- **Gate principal de PR** — [`.github/workflows/ci.yaml`](../../../../.github/workflows/ci.yaml): backend impact detector, lint, rbac-lint, testes backend (split core + dev_tools), combine de cobertura, pyright, docker parity e o agregador `[required] tests`.
 - **Reusable de teste backend** — [`.github/workflows/_backend-test.yml`](../../../../.github/workflows/_backend-test.yml): SSOT do setup de teste (services postgres/redis, env vars, `migrate`, dirs, `pytest`, artifact). Consumido por `ci.yaml` e pelo canary (#1401).
 - **Canary xdist (não-bloqueante)** — [`.github/workflows/backend-xdist-canary.yml`](../../../../.github/workflows/backend-xdist-canary.yml) + report [`v2/scripts/xdist_canary_report.py`](../../../../v2/scripts/xdist_canary_report.py).
 - **Gate de staging (evidência)** — [`.github/workflows/staging-gate-audit.yml`](../../../../.github/workflows/staging-gate-audit.yml).
@@ -49,7 +49,7 @@ A nomenclatura dos checks é o contrato de governança: `[required]` bloqueia me
 
 - **Checks `[required]` (gate de merge em `main`)** — devem ficar obrigatórios no ruleset `Protect main`: `[required] tests`, `[required] lint`, `[required] backend rbac-lint`, `[required] build/lint do frontend`, `[required] checklist tests (meta, a11y, security)`, `[required] dependency review`, `[required] architecture dependency guardrails`, `[required] Python Dependencies`, `[required] Frontend Dependencies`, `[required] Container Scan`, `[required] Secret Detection`, `[required] staging gate evidence`. SSOT: [`ci-check-policy.md`](../../../../docs/operations/ci-check-policy.md).
 - **Least-privilege do `GITHUB_TOKEN`** — workflow-level default = `contents: read`; cada job que precisa de mais declara o seu (#1397). Em `deploy.yaml`, `contents: write` existe **apenas** no job `tag_and_release` (git tag + `gh release`); o job que builda/pusha imagem fica em `contents: read` (desacopla `contents:write` de alvo de supply-chain). No canary, `issues: write` vive só no job `canary-report` que comenta na issue #677.
-- **Cobertura backend ≥ 85%** — `coverage combine` dos dois jobs (core + ingest/devtools) com `coverage report --fail-under=85`. Falha abaixo do limiar bloqueia o gate.
+- **Cobertura backend ≥ 85%** — `coverage combine` dos dois jobs (core + dev_tools) com `coverage report --fail-under=85`. Falha abaixo do limiar bloqueia o gate.
 - **Paralelização xdist no gate (M3, #1402/#1403)** — gate usa `pytest -n auto --dist loadscope` (~15min→~5min). `loadscope` mantém testes da mesma classe/módulo no mesmo worker. Habilitado **só** após a suíte estabilizar (causa raiz: `transaction=True` truncava o seed RBAC; fix de re-seed pós-truncate). O canary cobre a matriz `workers×dist` mas **nunca** bloqueia (`fail_on_test_error=false`).
 - **Backend impact detector (fail-safe)** — eventos não-PR (push/dispatch) forçam `backend_changed=true` (modo full seguro); PR sem base/head SHA também. O agregador `[required] tests` exige que os jobs backend ou tenham passado (impacto) ou tenham `skipped` (sem impacto) — nunca silenciosamente verde por engano.
 - **Docker parity (#1401 carve-out)** — `docker-parity-backend` NÃO consome o reusable: usa topologia de container (`host.docker.internal`, `REQUIRE_DOCKER=1`, migrate in-container, build via buildx). Versões de postgres/redis aqui devem ser sincronizadas manualmente com o `services` do reusable (SSOT das versões: `postgres:15.13`, `redis:7.4`).
@@ -60,7 +60,7 @@ A nomenclatura dos checks é o contrato de governança: `[required]` bloqueia me
 
 ## API / Interface
 
-- **CI (`ci.yaml`)** — dispara em `push`/`pull_request` para `main`. Jobs: `backend-impact`, `lint`, `rbac-lint`, `backend-tests-core`, `backend-tests-ingest-devtools`, `backend-tests` (combine+threshold), `backend-typecheck`, `docker-parity-backend`, `tests` (agregador `[required]`).
+- **CI (`ci.yaml`)** — dispara em `push`/`pull_request` para `main`. Jobs: `backend-impact`, `lint`, `rbac-lint`, `backend-tests-core`, `backend-tests-devtools`, `backend-tests` (combine+threshold), `backend-typecheck`, `docker-parity-backend`, `tests` (agregador `[required]`).
 - **Reusable (`_backend-test.yml`)** — `workflow_call` com inputs: `pytest_paths`, `pytest_extra_args`, `coverage_file`, `validate_test_paths`, `fail_on_test_error`, `emit_canary_metadata`, `artifact_name`/`artifact_paths` (obrigatórios), entre outros. Roda em Python 3.12 com `COVERAGE_CORE=sysmon` (sys.monitoring do 3.12, #1399).
 - **Canary (`backend-xdist-canary.yml`)** — `schedule` (cron `20 10 * * *`), `workflow_dispatch` e `push` em paths do próprio canary. Matriz `workers=[2,auto] × dist=[loadscope,loadfile]`; publica snapshot na issue #677.
 - **Deploy (`deploy.yaml`)** — `push` em `main` → staging-auto; `workflow_dispatch` com `target_environment` (staging|production), `promotion_tag`, `rollback_tag`. Interface detalhada (modos, gate de promoção, polling): [`deploy.spec.md`](./deploy.spec.md).
@@ -71,7 +71,7 @@ A nomenclatura dos checks é o contrato de governança: `[required]` bloqueia me
 
 1. `backend-impact` decide se a suíte backend roda (PR sem impacto em backend pula os jobs pesados; push/dispatch sempre full).
 2. `lint` + `rbac-lint` (rápidos, paralelos).
-3. `backend-tests-core` e `backend-tests-ingest-devtools` rodam via reusable com `-n auto --dist loadscope`, cada um emitindo um artifact de cobertura.
+3. `backend-tests-core` e `backend-tests-devtools` rodam via reusable com `-n auto --dist loadscope`, cada um emitindo um artifact de cobertura.
 4. `backend-tests` baixa os dois artifacts, faz `coverage combine`, **exige ≥85% (gate bloqueante)** e sobe a cobertura para o Codecov (analytics **informational**, não bloqueia PR — config em `codecov.yml`; upload só quando o secret `CODECOV_TOKEN` existe).
 5. `backend-typecheck` (pyright em `apps/core config`) e `docker-parity-backend` (smoke em imagem `Dockerfile.prod`) rodam em paralelo.
 6. `tests` agrega: verde só se todos passaram (ou todos `skipped` quando sem impacto).


### PR DESCRIPTION
## Summary

- Renomeia os settings `ETL_OUTPUT_DIR`/`ETL_DATA_DIR` → `IMPORT_OUTPUT_DIR`/`IMPORT_DATA_DIR` (vestígio do ETL legado removido, #967/#971). Mantém **fallback backward-compat**: lê o nome novo **OU** o legado `ETL_*` via `os.getenv`, então deployments que ainda definam `ETL_*` (ex.: Portainer) seguem funcionando — **zero mudança de comportamento**.
- `apps/core/admin.py` (único consumidor de código) migrado para `settings.IMPORT_OUTPUT_DIR`; `_backend-test.yml` passa a setar `IMPORT_*`.
- **De-stale do label "ingest"** no CI: job `backend-tests-ingest-devtools` → `backend-tests-devtools` (+ coverage `.coverage.devtools`, artifact, `needs`, refs do agregador). É `[info]`, **não-required** → sem impacto no ruleset de branch protection.
- Corrige comentário falso em `settings.py` (citava `etl_all`/`etl_load_xlsx`, comandos inexistentes) e remove rótulo de data em `security-scan.yml`.
- Docs vivos sincronizados: `ci.spec.md`, `TESTING_POLICY.md`, `COVERAGE_POLICY.md`.

Diretórios físicos `out_etl`/`csv-import` mantidos (só os nomes de env var/label mudaram).

## Test plan

- `manage.py check` → **System check identified no issues** ✅
- `settings.IMPORT_OUTPUT_DIR` / `IMPORT_DATA_DIR` carregam no container (`/app/out_etl`, `/app/data/csv-import`) ✅
- ripgrep: **0 refs** a `settings.ETL_*` / `ETL_*` no source (fora o fallback `os.getenv`) ✅
- YAML válido em `ci.yaml` / `_backend-test.yml` / `security-scan.yml` ✅
- `.pyc` órfão de `test_assign_cpf_command` (source já deletado) confirmado — sem teste vivo afetado ✅
- CI completo (backend tests core+devtools, coverage ≥85%, pyright, docker-parity) roda neste PR.

## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidência — `make staging-full` local (build imagens prod backend+frontend a partir do commit `8d7787be`, up + migrate completo, smoke):

```
==============================================
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
==============================================
```

## Notes

- Sem migration, sem alteração de banco.
- Staging gate executado com sucesso (8/8) — PR promovido a Ready.
