### PR TITLE
chore(deps): dependabot em modo somente-seguranca (version updates OFF)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,11 @@
 # 🤖 Dependabot Configuration - Sistema Aprender
-# Automatically keep dependencies up to date
+#
+# MODO SOMENTE-SEGURANCA (2026-07): `open-pull-requests-limit: 0` em todos os ecossistemas
+# DESLIGA os version updates de rotina (bumps sem CVE). Os "Dependabot security updates"
+# (correcao de vulnerabilidade) sao um setting do REPO — independem deste arquivo — e seguem
+# ON, com limite interno proprio de 10 PRs. Resultado: so vem PR quando ha CVE/advisory.
+# Para reativar bumps de rotina de um ecossistema, volte o limit para > 0.
+# groups/ignore/directories abaixo ficam PRESERVADOS (inertes com limit 0) p/ facilitar o revert.
 # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates
 
 version: 2
@@ -71,7 +77,7 @@ updates:
           - "patch"
 
     # PR configuration
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 0  # MODO SOMENTE-SEGURANCA: version updates OFF (CVE segue via security updates do repo)
     
     # Commit message prefix
     commit-message:
@@ -119,7 +125,7 @@ updates:
           - "minor"
           - "patch"
     
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0  # MODO SOMENTE-SEGURANCA (ver cabecalho)
 
     commit-message:
       prefix: "docker"
@@ -173,7 +179,7 @@ updates:
           - "minor"
           - "patch"
     
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0  # MODO SOMENTE-SEGURANCA (ver cabecalho)
     
     commit-message:
       prefix: "ci"


### PR DESCRIPTION
## O que muda

`open-pull-requests-limit: 0` nos 3 ecossistemas do `dependabot.yml` (pip, docker, github-actions) → **desliga os version updates de rotina** (bumps sem CVE, que geravam a rajada semanal de PRs).

## O que continua

**Dependabot security updates** (correção de vulnerabilidade) e **Dependabot alerts** são settings do **repositório** (ambos já ON, verificados via API) — independem deste arquivo. Têm limite interno próprio de 10 PRs. Resultado: **só vem PR quando há CVE/advisory** numa dependência que usamos.

## Trade-off

Sem os version updates de rotina, SHAs de GitHub Actions e tags de imagem-base **não se atualizam sozinhos** — só quando há CVE. Para CVE de SO já estamos cobertos pelo `apt/apk upgrade` por `GIT_SHA` no build. `groups`/`ignore`/`directories` ficam preservados (inertes) para revert de 1 linha.

Doc: setting `open-pull-requests-limit` a 0 desabilita version updates (GitHub docs).
