### PR TITLE
feat(auth): perfil do usuario + troca de senha self-service

### DIFF
--- a/v2/backend/apps/core/models/auditoria.py
+++ b/v2/backend/apps/core/models/auditoria.py
@@ -48,6 +48,7 @@ class AuditLog(models.Model):
         LOGOUT = "LOGOUT", "Logout"
         LOGIN_FAILED = "LOGIN_FAILED", "Login falhou"
         LOGIN_BLOCKED = "LOGIN_BLOCKED", "Login bloqueado"
+        CHANGE_PASSWORD = "CHANGE_PASSWORD", "Trocar senha"
 
         # GCal lifecycle
         PREVIEW_GCAL = "PREVIEW_GCAL", "Preview GCal"

--- a/v2/backend/apps/core/serializers/usuario.py
+++ b/v2/backend/apps/core/serializers/usuario.py
@@ -282,6 +282,37 @@ class UsuarioAdminSerializer(serializers.ModelSerializer):
         return value
 
 
+class ChangePasswordSerializer(serializers.Serializer):
+    """Troca de senha self-service (POST /api/me/change-password/).
+
+    Valida a senha atual (``check_password`` do usuario no contexto) e a nova senha
+    com os validadores do Django (``AUTH_PASSWORD_VALIDATORS``), reusando o mesmo
+    padrao de ``UsuarioAdminSerializer.validate_password``. NAO persiste — a view chama
+    ``set_password`` + ``update_session_auth_hash``.
+    """
+
+    old_password = serializers.CharField(write_only=True, trim_whitespace=False)
+    new_password = serializers.CharField(write_only=True, trim_whitespace=False)
+
+    def validate_new_password(self, value: str) -> str:
+        if len(value) < 8:
+            raise serializers.ValidationError("A senha deve ter no minimo 8 caracteres.")
+        user = getattr(self.context.get("request"), "user", None)
+        try:
+            validate_password(value, user=user)
+        except ValidationError as e:
+            raise serializers.ValidationError(list(e.messages))
+        return value
+
+    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
+        user = getattr(self.context.get("request"), "user", None)
+        if user is None or not user.check_password(attrs["old_password"]):
+            raise serializers.ValidationError({"old_password": "Senha atual incorreta."})
+        if attrs["old_password"] == attrs["new_password"]:
+            raise serializers.ValidationError({"new_password": "A nova senha deve ser diferente da senha atual."})
+        return attrs
+
+
 class GroupSerializer(serializers.ModelSerializer):
     """
     Serializer for Django Group model (Admin CRUD).

--- a/v2/backend/apps/core/serializers/usuario.py
+++ b/v2/backend/apps/core/serializers/usuario.py
@@ -297,15 +297,15 @@ class ChangePasswordSerializer(serializers.Serializer):
     def validate_new_password(self, value: str) -> str:
         if len(value) < 8:
             raise serializers.ValidationError("A senha deve ter no minimo 8 caracteres.")
-        user = getattr(self.context.get("request"), "user", None)
         try:
-            validate_password(value, user=user)
+            validate_password(value)
         except ValidationError as e:
             raise serializers.ValidationError(list(e.messages))
         return value
 
     def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
-        user = getattr(self.context.get("request"), "user", None)
+        request = self.context.get("request")
+        user = request.user if request is not None else None
         if user is None or not user.check_password(attrs["old_password"]):
             raise serializers.ValidationError({"old_password": "Senha atual incorreta."})
         if attrs["old_password"] == attrs["new_password"]:

--- a/v2/backend/apps/core/tests/test_me_change_password.py
+++ b/v2/backend/apps/core/tests/test_me_change_password.py
@@ -1,0 +1,80 @@
+"""Testes do endpoint self-service de troca de senha: POST /api/me/change-password/.
+
+Cobre: sucesso + auditoria, senha atual errada, senha nova fraca (validate_password
+do Django), nova == atual, e não autenticado. Login do sistema é por CPF + senha
+(auth_backends.CPFOrUsernameBackend); qualquer usuário logado pode trocar a própria senha.
+"""
+
+# pyright: reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportAttributeAccessIssue=false, reportUnknownParameterType=false, reportMissingParameterType=false
+
+from __future__ import annotations
+
+from rest_framework import status
+from rest_framework.test import APIClient
+
+import pytest
+
+from apps.core.models import AuditLog
+from apps.core.tests.factories import UsuarioFactory
+
+URL = "/api/me/change-password/"
+
+
+def _client(user) -> APIClient:
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+@pytest.mark.django_db
+class TestChangePassword:
+    def test_troca_com_sucesso_e_audita(self):
+        user = UsuarioFactory(password="SenhaAtual123!")
+        resp = _client(user).post(
+            URL, {"old_password": "SenhaAtual123!", "new_password": "N0vaSenh@Forte"}, format="json"
+        )
+        assert resp.status_code == status.HTTP_200_OK
+        user.refresh_from_db()
+        assert user.check_password("N0vaSenh@Forte")
+        assert not user.check_password("SenhaAtual123!")
+        audit = AuditLog.objects.filter(usuario=user, action=AuditLog.Action.CHANGE_PASSWORD)
+        assert audit.exists()
+        # A senha NUNCA pode vazar nos detalhes do audit.
+        details_str = str(audit.first().details)
+        assert "N0vaSenh@Forte" not in details_str
+        assert "SenhaAtual123!" not in details_str
+
+    def test_senha_atual_incorreta_400_e_nao_altera(self):
+        user = UsuarioFactory(password="SenhaAtual123!")
+        resp = _client(user).post(URL, {"old_password": "errada", "new_password": "N0vaSenh@Forte"}, format="json")
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+        assert "old_password" in resp.data["errors"]
+        user.refresh_from_db()
+        assert user.check_password("SenhaAtual123!")  # inalterada
+
+    def test_senha_nova_fraca_dispara_validate_password_400(self):
+        # "12345678": passa no min-length mas o NumericPasswordValidator do Django rejeita.
+        user = UsuarioFactory(password="SenhaAtual123!")
+        resp = _client(user).post(URL, {"old_password": "SenhaAtual123!", "new_password": "12345678"}, format="json")
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+        assert "new_password" in resp.data["errors"]
+        user.refresh_from_db()
+        assert user.check_password("SenhaAtual123!")
+
+    def test_senha_nova_igual_atual_400(self):
+        user = UsuarioFactory(password="SenhaAtual123!")
+        resp = _client(user).post(
+            URL, {"old_password": "SenhaAtual123!", "new_password": "SenhaAtual123!"}, format="json"
+        )
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+        assert "new_password" in resp.data["errors"]
+
+    def test_campos_faltando_400(self):
+        user = UsuarioFactory(password="SenhaAtual123!")
+        resp = _client(user).post(URL, {"old_password": "SenhaAtual123!"}, format="json")
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+        assert "new_password" in resp.data["errors"]
+
+    def test_nao_autenticado_rejeitado(self):
+        resp = APIClient().post(URL, {"old_password": "x", "new_password": "N0vaSenh@Forte"}, format="json")
+        assert resp.status_code in (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN)

--- a/v2/backend/apps/core/tests/test_me_change_password.py
+++ b/v2/backend/apps/core/tests/test_me_change_password.py
@@ -5,7 +5,7 @@ do Django), nova == atual, e não autenticado. Login do sistema é por CPF + sen
 (auth_backends.CPFOrUsernameBackend); qualquer usuário logado pode trocar a própria senha.
 """
 
-# pyright: reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportAttributeAccessIssue=false, reportUnknownParameterType=false, reportMissingParameterType=false
+# pyright: reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportAttributeAccessIssue=false, reportUnknownParameterType=false, reportMissingParameterType=false, reportOptionalMemberAccess=false, reportIndexIssue=false
 
 from __future__ import annotations
 

--- a/v2/backend/apps/core/urls.py
+++ b/v2/backend/apps/core/urls.py
@@ -40,7 +40,7 @@ from .views import (  # ASQ-005: async imports; DAT Module ViewSets; Plano Forma
 )
 
 # Imports de módulos isolados (GAP-001 fix)
-from .views.me import MeEventsListView, MePoliciesView
+from .views.me import ChangePasswordView, MeEventsListView, MePoliciesView
 from .views.stats import HomeStatsView
 from .views_auth import csrf_token, login, logout, ping
 from .views_availability import AvailabilityBlockViewSet, AvailabilityCheckManyView, AvailabilityCheckView
@@ -163,6 +163,7 @@ urlpatterns = [
     path("me/", CurrentUserView.as_view(), name="current-user"),
     path("me/events/", MeEventsListView.as_view(), name="me-events"),
     path("me/policies/", MePoliciesView.as_view(), name="me-policies"),
+    path("me/change-password/", ChangePasswordView.as_view(), name="me-change-password"),
     path("rbac/meta/", RBACMetaView.as_view(), name="rbac-meta"),
     path("stats/home/", HomeStatsView.as_view(), name="stats-home"),
     # CSRF Token (Issue #135)

--- a/v2/backend/apps/core/views/me.py
+++ b/v2/backend/apps/core/views/me.py
@@ -19,6 +19,8 @@ Type-checked with Pyright (strict mode).
 
 from __future__ import annotations
 
+from typing import cast
+
 from django.contrib.auth import update_session_auth_hash
 from django.db.models import QuerySet
 from rest_framework import generics, serializers
@@ -30,7 +32,7 @@ from rest_framework.views import APIView
 from drf_spectacular.utils import extend_schema, extend_schema_view, inline_serializer
 
 from apps.core.api_schemas import COMMON_ERROR_RESPONSES
-from apps.core.models import AuditLog, Solicitacao
+from apps.core.models import AuditLog, Solicitacao, Usuario
 from apps.core.rbac.policies import resolve_public_policies
 from apps.core.serializers.me import MeEventSerializer
 from apps.core.serializers.usuario import ChangePasswordSerializer
@@ -159,8 +161,9 @@ class ChangePasswordView(APIView):
     def post(self, request: Request) -> Response:
         serializer = ChangePasswordSerializer(data=request.data, context={"request": request})
         serializer.is_valid(raise_exception=True)
-        user = request.user
-        user.set_password(serializer.validated_data["new_password"])
+        user = cast(Usuario, request.user)
+        new_password = cast(str, serializer.validated_data["new_password"])
+        user.set_password(new_password)
         user.save(update_fields=["password"])
         # SessionAuthentication: mantem a sessao atual valida e invalida as demais.
         update_session_auth_hash(request, user)

--- a/v2/backend/apps/core/views/me.py
+++ b/v2/backend/apps/core/views/me.py
@@ -15,10 +15,11 @@ frontend para menu condicional, redirects, mensagens de erro genéricas.
 Type-checked with Pyright (strict mode).
 """
 
-# pyright: reportUnknownVariableType=false, reportUnknownMemberType=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportMissingTypeArgument=false
+# pyright: reportUnknownVariableType=false, reportUnknownMemberType=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false, reportMissingTypeArgument=false, reportOptionalSubscript=false, reportIndexIssue=false
 
 from __future__ import annotations
 
+from django.contrib.auth import update_session_auth_hash
 from django.db.models import QuerySet
 from rest_framework import generics, serializers
 from rest_framework.permissions import IsAuthenticated
@@ -29,9 +30,10 @@ from rest_framework.views import APIView
 from drf_spectacular.utils import extend_schema, extend_schema_view, inline_serializer
 
 from apps.core.api_schemas import COMMON_ERROR_RESPONSES
-from apps.core.models import Solicitacao
+from apps.core.models import AuditLog, Solicitacao
 from apps.core.rbac.policies import resolve_public_policies
 from apps.core.serializers.me import MeEventSerializer
+from apps.core.serializers.usuario import ChangePasswordSerializer
 
 
 @extend_schema_view(
@@ -126,3 +128,52 @@ class MePoliciesView(APIView):
 
     def get(self, request: Request) -> Response:
         return Response(resolve_public_policies(request.user))
+
+
+class ChangePasswordView(APIView):
+    """Troca self-service da propria senha.
+
+    POST /api/me/change-password/
+
+    Login e por CPF + senha (SessionAuthentication). Qualquer usuario autenticado troca
+    a propria senha: valida a senha atual + a nova (validadores do Django), atualiza o
+    hash da sessao (mantem a atual viva; invalida as OUTRAS) e audita (PA-05,
+    CHANGE_PASSWORD). Nunca loga a senha.
+    """
+
+    permission_classes = [IsAuthenticated]
+    throttle_scope = "change_password"
+
+    @extend_schema(
+        summary="Trocar a propria senha",
+        request=ChangePasswordSerializer,
+        responses={
+            200: inline_serializer(
+                name="ChangePasswordResponse",
+                fields={"detail": serializers.CharField()},
+            ),
+            401: COMMON_ERROR_RESPONSES[401],
+        },
+        tags=["me"],
+    )
+    def post(self, request: Request) -> Response:
+        serializer = ChangePasswordSerializer(data=request.data, context={"request": request})
+        serializer.is_valid(raise_exception=True)
+        user = request.user
+        user.set_password(serializer.validated_data["new_password"])
+        user.save(update_fields=["password"])
+        # SessionAuthentication: mantem a sessao atual valida e invalida as demais.
+        update_session_auth_hash(request, user)
+        AuditLog.objects.create(
+            usuario=user,
+            action=AuditLog.Action.CHANGE_PASSWORD,
+            model_name="Usuario",
+            details={
+                "ip_address": (
+                    request.META.get("HTTP_X_FORWARDED_FOR", "").split(",")[0].strip()
+                    or request.META.get("REMOTE_ADDR", "")
+                ),
+                "user_agent": request.META.get("HTTP_USER_AGENT", "")[:200],
+            },
+        )
+        return Response({"detail": "Senha alterada com sucesso."})

--- a/v2/backend/config/settings.py
+++ b/v2/backend/config/settings.py
@@ -470,6 +470,8 @@ REST_FRAMEWORK = {
         # relaxado fora dela para não atrapalhar dev / testes E2E multi-role.
         # Sobrescrito abaixo com valor ambiente-dependente.
         "login": "10/minute",
+        # Troca de senha self-service: defesa contra brute-force do old_password.
+        "change_password": "20/min",
     },
     # Custom exception handler for standardized error responses
     "EXCEPTION_HANDLER": "apps.core.exceptions.custom_exception_handler",
@@ -540,6 +542,8 @@ if ENVIRONMENT == "development":
         # desenvolvimento manual (12+ logins em sequência). Em prod mantém
         # 10/min contra brute force (ver bloco DEFAULT_THROTTLE_RATES acima).
         "login": "1000/minute",
+        # Troca de senha: relaxado em dev/testes (prod usa 20/min, bloco acima).
+        "change_password": "200/min",
     }
 
 # ================================================================

--- a/v2/frontend/src/api/me.ts
+++ b/v2/frontend/src/api/me.ts
@@ -72,3 +72,30 @@ export async function getMyEvents(
 export async function getMyPolicies(): Promise<string[]> {
   return await fetchAPI<string[]>('/me/policies/');
 }
+
+/**
+ * Payload da troca de senha self-service.
+ */
+export interface ChangePasswordPayload {
+  old_password: string;
+  new_password: string;
+}
+
+/**
+ * Troca a própria senha (`POST /api/me/change-password/`).
+ *
+ * Backend valida a senha atual (`check_password`) e a nova senha com os
+ * validadores do Django (`AUTH_PASSWORD_VALIDATORS`), mantém a sessão viva
+ * (`update_session_auth_hash`) e audita (PA-05). Login é por CPF + senha.
+ *
+ * @param payload - senha atual + nova senha
+ * @returns `{ detail }` de sucesso; em erro, `fetchAPI` lança com a mensagem do backend.
+ */
+export async function changeMyPassword(
+  payload: ChangePasswordPayload
+): Promise<{ detail: string }> {
+  return await fetchAPI<{ detail: string }>('/me/change-password/', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+}

--- a/v2/frontend/src/components/AppHeader.tsx
+++ b/v2/frontend/src/components/AppHeader.tsx
@@ -97,10 +97,15 @@ export function AppHeader({
         }}
       />
       <div className="flex items-center gap-4" style={{ whiteSpace: 'nowrap', marginLeft: 'auto' }}>
-        <div className="flex items-center gap-2">
+        <Link
+          to="/perfil"
+          className="flex items-center gap-2"
+          style={{ color: 'inherit' }}
+          title="Meu perfil"
+        >
           <UserOutlined />
           <Text strong>{user.name || user.username || 'Usuário'}</Text>
-        </div>
+        </Link>
         {canAcoesInternas && (
           <Popover
             trigger="click"

--- a/v2/frontend/src/components/AppRoutes.tsx
+++ b/v2/frontend/src/components/AppRoutes.tsx
@@ -14,6 +14,7 @@ const ControlePage = lazy(() => import('../pages/Controle/ControlePage'));
 // /dat/importacoes. O componente continua existindo para o card "Cadastros
 // DAT" dentro de ImportacoesPage; remoção definitiva fica em PR-D.
 const DATImportacoesPage = lazy(() => import('../pages/DAT/ImportacoesPage'));
+const PerfilPage = lazy(() => import('../pages/Perfil/PerfilPage'));
 const NewSolicitacaoWizard = lazy(() => import('../pages/Solicitacoes/NewSolicitacaoWizard'));
 const EditSolicitacaoPage = lazy(() => import('../pages/Solicitacoes/EditSolicitacaoPage'));
 const MySolicitacoesPage = lazy(() => import('../pages/Solicitacoes/MySolicitacoesPage'));
@@ -127,6 +128,7 @@ export function AppRoutes({ user, permissions, policies }: AppRoutesProps): JSX.
         <Route path="/solicitacoes/bloqueios" element={access.canAccessBlocks ? <DisponibilidadeBlocks /> : <Forbidden />} />
         <Route path="/solicitacoes/deslocamentos" element={access.can('view_all_availability') || canControle || canCoordenador || canDAT ? <DeslocamentosPage /> : <Forbidden />} />
         <Route path="/solicitacoes/meus-eventos" element={user ? <MeusEventosPage /> : <Forbidden />} />
+        <Route path="/perfil" element={user ? <PerfilPage user={user} /> : <Forbidden />} />
 
         {/* Redirects de URLs legadas → novas (preserva deep-links/bookmarks) */}
         <Route path="/aprovacoes" element={<Navigate to="/solicitacoes/aprovacoes" replace />} />

--- a/v2/frontend/src/pages/Perfil/PerfilPage.tsx
+++ b/v2/frontend/src/pages/Perfil/PerfilPage.tsx
@@ -1,0 +1,151 @@
+/**
+ * Página de Perfil do usuário autenticado (`/perfil`).
+ *
+ * MVP: exibe os dados da conta (nome, CPF mascarado, e-mail, setores/funções) e
+ * permite **trocar a própria senha** (self-service). Resolve a dívida de segurança
+ * do go-live (usuários importados com senha padrão só podiam trocar via admin).
+ *
+ * Acessível a qualquer usuário logado. Login do sistema é por CPF + senha.
+ */
+
+import { useState } from 'react';
+import { Button, Card, Descriptions, Form, Input, Space, Tag, Typography, message } from 'antd';
+import { LockOutlined, UserOutlined } from '@ant-design/icons';
+
+import type { CurrentUser } from '../../types/usuario';
+import { changeMyPassword } from '../../api/me';
+
+const { Title } = Typography;
+
+interface ChangePasswordForm {
+  senha_atual: string;
+  nova_senha: string;
+  confirmar: string;
+}
+
+/** Mascara o CPF (LGPD): mostra só os 3 primeiros e os 2 últimos dígitos. */
+export function maskCpf(value: string): string {
+  const digits = (value ?? '').replace(/\D/g, '');
+  if (digits.length !== 11) return value;
+  return `${digits.slice(0, 3)}.***.***-${digits.slice(9, 11)}`;
+}
+
+function TagList({ items }: { items: readonly string[] }) {
+  if (!items || items.length === 0) return <span>—</span>;
+  return (
+    <>
+      {items.map((it) => (
+        <Tag key={it}>{it}</Tag>
+      ))}
+    </>
+  );
+}
+
+export default function PerfilPage({ user }: { user: CurrentUser }) {
+  const [form] = Form.useForm<ChangePasswordForm>();
+  const [saving, setSaving] = useState(false);
+
+  const onFinish = async (values: ChangePasswordForm) => {
+    setSaving(true);
+    try {
+      await changeMyPassword({
+        old_password: values.senha_atual,
+        new_password: values.nova_senha,
+      });
+      message.success('Senha alterada com sucesso.');
+      form.resetFields();
+    } catch (error) {
+      message.error((error as Error).message || 'Não foi possível alterar a senha.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <section className="p-6 bg-gray-100 min-h-full" aria-labelledby="perfil-title">
+      <Space direction="vertical" size="large" style={{ width: '100%', maxWidth: 640 }}>
+        <Title id="perfil-title" level={3}>
+          Meu perfil
+        </Title>
+
+        <Card title={
+          <span>
+            <UserOutlined /> Meus dados
+          </span>
+        }>
+          <Descriptions column={1} size="small">
+            <Descriptions.Item label="Nome">{user.name || user.username}</Descriptions.Item>
+            <Descriptions.Item label="CPF">{maskCpf(user.username)}</Descriptions.Item>
+            <Descriptions.Item label="E-mail">{user.email || '—'}</Descriptions.Item>
+            <Descriptions.Item label="Setores">
+              <TagList items={user.setores} />
+            </Descriptions.Item>
+            <Descriptions.Item label="Funções">
+              <TagList items={user.funcoes} />
+            </Descriptions.Item>
+          </Descriptions>
+        </Card>
+
+        <Card title={
+          <span>
+            <LockOutlined /> Trocar senha
+          </span>
+        }>
+          <Form<ChangePasswordForm> form={form} layout="vertical" autoComplete="off" onFinish={onFinish}>
+            <Form.Item
+              name="senha_atual"
+              label="Senha atual"
+              rules={[{ required: true, message: 'Informe a senha atual.' }]}
+            >
+              <Input.Password placeholder="Senha atual" autoComplete="current-password" />
+            </Form.Item>
+
+            <Form.Item
+              name="nova_senha"
+              label="Nova senha"
+              rules={[
+                { required: true, message: 'Informe a nova senha.' },
+                { min: 8, message: 'A senha deve ter no mínimo 8 caracteres.' },
+                ({ getFieldValue }) => ({
+                  validator(_, value) {
+                    if (value && value === getFieldValue('senha_atual')) {
+                      return Promise.reject(new Error('A nova senha deve ser diferente da atual.'));
+                    }
+                    return Promise.resolve();
+                  },
+                }),
+              ]}
+            >
+              <Input.Password placeholder="Nova senha" autoComplete="new-password" />
+            </Form.Item>
+
+            <Form.Item
+              name="confirmar"
+              label="Confirmar nova senha"
+              dependencies={['nova_senha']}
+              rules={[
+                { required: true, message: 'Confirme a nova senha.' },
+                ({ getFieldValue }) => ({
+                  validator(_, value) {
+                    if (!value || value === getFieldValue('nova_senha')) {
+                      return Promise.resolve();
+                    }
+                    return Promise.reject(new Error('As senhas não conferem.'));
+                  },
+                }),
+              ]}
+            >
+              <Input.Password placeholder="Confirmar nova senha" autoComplete="new-password" />
+            </Form.Item>
+
+            <Form.Item>
+              <Button type="primary" htmlType="submit" icon={<LockOutlined />} loading={saving}>
+                Alterar senha
+              </Button>
+            </Form.Item>
+          </Form>
+        </Card>
+      </Space>
+    </section>
+  );
+}

--- a/v2/frontend/src/pages/Perfil/__tests__/PerfilPage.test.tsx
+++ b/v2/frontend/src/pages/Perfil/__tests__/PerfilPage.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { message } from 'antd';
+
+const { changeMyPasswordMock } = vi.hoisted(() => ({
+  changeMyPasswordMock: vi.fn(),
+}));
+
+vi.mock('../../../api/me', () => ({
+  changeMyPassword: changeMyPasswordMock,
+}));
+
+import PerfilPage from '../PerfilPage';
+import type { CurrentUser } from '../../../types/usuario';
+
+function makeUser(overrides: Partial<CurrentUser> = {}): CurrentUser {
+  return {
+    id: 1,
+    username: '04944374305',
+    email: 'coord@aprendereditora.com.br',
+    first_name: 'Amanda',
+    last_name: 'Rodrigues',
+    name: 'Amanda Rodrigues',
+    groups: ['Coordenador'],
+    setores: ['Vidas'],
+    funcoes: ['Coordenador'],
+    is_superuser: false,
+    is_superintendencia: false,
+    can_approve_super: false,
+    permissions: [],
+    ...overrides,
+  };
+}
+
+function renderPage(user: CurrentUser = makeUser()) {
+  return render(
+    <MemoryRouter>
+      <PerfilPage user={user} />
+    </MemoryRouter>
+  );
+}
+
+function fill(placeholder: string, value: string) {
+  fireEvent.change(screen.getByPlaceholderText(placeholder), { target: { value } });
+}
+
+describe('PerfilPage', () => {
+  beforeEach(() => {
+    changeMyPasswordMock.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  test('mostra os dados do usuário com CPF mascarado', async () => {
+    renderPage();
+    expect(await screen.findByText('Amanda Rodrigues')).toBeInTheDocument();
+    // CPF mascarado (LGPD): 3 primeiros + 2 últimos.
+    expect(screen.getByText('049.***.***-05')).toBeInTheDocument();
+    expect(screen.getByText('coord@aprendereditora.com.br')).toBeInTheDocument();
+  });
+
+  test('submit válido chama changeMyPassword e avisa sucesso', async () => {
+    changeMyPasswordMock.mockResolvedValueOnce({ detail: 'Senha alterada com sucesso.' });
+    const successSpy = vi.spyOn(message, 'success');
+    renderPage();
+
+    fill('Senha atual', 'SenhaAtual123!');
+    fill('Nova senha', 'N0vaSenh@Forte');
+    fill('Confirmar nova senha', 'N0vaSenh@Forte');
+    fireEvent.click(screen.getByRole('button', { name: /alterar senha/i }));
+
+    await waitFor(() =>
+      expect(changeMyPasswordMock).toHaveBeenCalledWith({
+        old_password: 'SenhaAtual123!',
+        new_password: 'N0vaSenh@Forte',
+      })
+    );
+    await waitFor(() => expect(successSpy).toHaveBeenCalled());
+  });
+
+  test('confirmação divergente bloqueia o submit (não chama a API)', async () => {
+    renderPage();
+
+    fill('Senha atual', 'SenhaAtual123!');
+    fill('Nova senha', 'N0vaSenh@Forte');
+    fill('Confirmar nova senha', 'Diferente123!');
+    fireEvent.click(screen.getByRole('button', { name: /alterar senha/i }));
+
+    expect(await screen.findByText('As senhas não conferem.')).toBeInTheDocument();
+    expect(changeMyPasswordMock).not.toHaveBeenCalled();
+  });
+
+  test('erro do backend exibe message.error', async () => {
+    changeMyPasswordMock.mockRejectedValueOnce(new Error('Senha atual incorreta.'));
+    const errorSpy = vi.spyOn(message, 'error');
+    renderPage();
+
+    fill('Senha atual', 'errada');
+    fill('Nova senha', 'N0vaSenh@Forte');
+    fill('Confirmar nova senha', 'N0vaSenh@Forte');
+    fireEvent.click(screen.getByRole('button', { name: /alterar senha/i }));
+
+    await waitFor(() => expect(changeMyPasswordMock).toHaveBeenCalled());
+    await waitFor(() => expect(errorSpy).toHaveBeenCalled());
+  });
+});


### PR DESCRIPTION
## O quê

Adiciona a página **`/perfil`** (qualquer usuário logado) com os dados da conta e **troca de senha self-service**.

## Por quê

O go-live importou usuários com uma **senha padrão compartilhada** e não havia forma self-service de trocá-la — só um admin conseguia, via o CRUD administrativo. Senha compartilhada e persistente é dívida de segurança numa plataforma com poderes de aprovação (PA). Esta PR permite que cada usuário defina a própria senha.

## Mudanças

**Backend**
- `POST /api/me/change-password/` (`SessionAuthentication` + `IsAuthenticated`): valida a senha atual (`check_password`) e a nova (`AUTH_PASSWORD_VALIDATORS` do Django), mantém a sessão viva (`update_session_auth_hash` — invalida as outras sessões do usuário) e audita (`AuditLog.Action.CHANGE_PASSWORD`). Throttle scope `change_password`.
- `ChangePasswordSerializer` (reusa o padrão de `validate_password`) + novo valor no enum `AuditLog.Action`.

**Frontend**
- Página `PerfilPage` (Card + form Ant Design; **CPF mascarado** por LGPD), rota `/perfil` (qualquer logado), link no header, `changeMyPassword()` em `api/me`.

## Segurança (django-security)

`old_password` obrigatório (defende contra sessão sequestrada) · `validate_password` (min 8, comum, numérica, similaridade) · `update_session_auth_hash` · CSRF via SessionAuth · AuditLog **sem** vazar a senha · throttle. Não altera grupos/permissões.

## Testes (local, TDD)

- **Backend** `test_me_change_password.py` **6/6** (sucesso + audit, senha atual errada, senha fraca → `validate_password`, nova == atual, campos faltando, não autenticado). Regressão `me` + `auth_backends` **22/22**.
- **Frontend** `PerfilPage.test.tsx` **4/4**; `AppRoutes` **130/130**; `tsc --noEmit` limpo; `eslint` limpo; `vite build` ✓.
- Backend `black` / `isort` / `flake8` limpos nos arquivos tocados.

## Follow-ups (fora desta PR)

Forçar troca no 1º login (`must_change_password`); editar email/telefone no perfil; reset de senha por e-mail.

## Staging Gate

_Pendente — rodar `make staging-full` (8/8) e anexar a evidência antes de sair de draft._
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `70ac0c19`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
