### PR TITLE
fix(logging): django.request em ERROR + formatter nao serializa request (incidente prod)

### DIFF
--- a/v2/backend/apps/core/tests/test_logging_config.py
+++ b/v2/backend/apps/core/tests/test_logging_config.py
@@ -14,10 +14,15 @@ from __future__ import annotations
 
 import json
 import logging
+from typing import Any
 
 from pythonjsonlogger.jsonlogger import JsonFormatter
 
-from config.settings import LOGGING
+from config.settings import LOGGING as _RAW_LOGGING
+
+# LOGGING e um dict heterogeneo -> pyright infere __getitem__ estrito (so slice).
+# Tipar como dict[str, Any] libera o acesso por chave string nos asserts abaixo.
+LOGGING: dict[str, Any] = _RAW_LOGGING
 
 
 def _build_json_formatter() -> JsonFormatter:

--- a/v2/backend/apps/core/tests/test_logging_config.py
+++ b/v2/backend/apps/core/tests/test_logging_config.py
@@ -1,0 +1,88 @@
+"""Testes da config de logging (config.settings.LOGGING).
+
+Regressao do incidente 2026-07-06: uma rajada de respostas 4xx logadas como
+WARNING pelo `django.request`, com o formatter JSON serializando o objeto
+`request` inteiro por linha, saturou os workers do gunicorn em producao (504) e
+ainda vazava dados de requisicao para o log (LGPD). Estes testes travam as duas
+correcoes: (1) `django.request` em ERROR (4xx nao floodam; 5xx seguem); (2) o
+formatter JSON nao serializa o objeto `request`.
+"""
+
+# pyright: reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportAttributeAccessIssue=false, reportMissingParameterType=false, reportUnknownParameterType=false, reportIndexIssue=false
+
+from __future__ import annotations
+
+import json
+import logging
+
+from pythonjsonlogger.jsonlogger import JsonFormatter
+
+from config.settings import LOGGING
+
+
+def _build_json_formatter() -> JsonFormatter:
+    """Instancia o formatter JSON exatamente como o dictConfig faria."""
+    conf = LOGGING["formatters"]["json"]
+    return JsonFormatter(
+        conf["format"],
+        reserved_attrs=conf["reserved_attrs"],
+        timestamp=conf.get("timestamp", False),
+    )
+
+
+def _record(name: str, level: int, msg: str) -> logging.LogRecord:
+    record = logging.LogRecord(name=name, level=level, pathname=__file__, lineno=1, msg=msg, args=None, exc_info=None)
+    # Extras injetados pelos filtros (RequestIDFilter/ContextFilter):
+    record.request_id = "N/A"
+    record.environment = "test"
+    record.service = "web"
+    return record
+
+
+def test_formatter_json_nao_serializa_o_objeto_request():
+    """O objeto `request` NUNCA pode ir para o log (bloat + LGPD)."""
+    formatter = _build_json_formatter()
+    record = _record("django.request", logging.ERROR, "Forbidden: /api/me/")
+    # django.request.log_response injeta estes extras em respostas 4xx/5xx:
+    record.request = {"cookies": "sessionid=SEGREDO", "META": {"HTTP_AUTHORIZATION": "Bearer TOKEN"}}
+    record.status_code = 403
+
+    out = json.loads(formatter.format(record))
+
+    assert "request" not in out, "objeto request vazou para o log (LGPD/bloat)"
+    assert "SEGREDO" not in json.dumps(out), "dados sensiveis do request vazaram para o log"
+    assert "TOKEN" not in json.dumps(out)
+    # status_code (escalar util) permanece sendo logado.
+    assert out.get("status_code") == 403
+
+
+def test_formatter_json_omite_taskname():
+    """taskName (Py3.12, sempre None em contexto sync) e ruido; nao deve aparecer."""
+    formatter = _build_json_formatter()
+    record = _record("apps", logging.INFO, "evento ok")
+    record.taskName = None
+
+    out = json.loads(formatter.format(record))
+
+    assert "taskName" not in out
+
+
+def test_django_request_logger_em_error_nao_faz_flood_de_4xx():
+    """django.request em ERROR: 4xx (WARNING) param de floodar; 5xx (ERROR) seguem."""
+    logger_conf = LOGGING["loggers"]["django.request"]
+    assert logger_conf["level"] == "ERROR"
+    # propagate=False evita dupla emissao (nao sobe para o logger "django").
+    assert logger_conf["propagate"] is False
+
+
+def test_formatter_json_mantem_campos_uteis():
+    """A correcao nao pode remover os campos estruturados legitimos."""
+    formatter = _build_json_formatter()
+    record = _record("apps", logging.INFO, "evento ok")
+
+    out = json.loads(formatter.format(record))
+
+    assert out["message"] == "evento ok"
+    assert out["request_id"] == "N/A"
+    assert out["environment"] == "test"
+    assert out["service"] == "web"

--- a/v2/backend/config/settings.py
+++ b/v2/backend/config/settings.py
@@ -12,6 +12,8 @@ import os
 import sys
 from pathlib import Path
 
+from pythonjsonlogger.jsonlogger import RESERVED_ATTRS as _PJL_RESERVED_ATTRS
+
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
@@ -591,6 +593,13 @@ LOGGING = {
         "json": {
             "()": "pythonjsonlogger.jsonlogger.JsonFormatter",
             "format": "%(asctime)s %(levelname)s %(name)s %(message)s %(request_id)s %(environment)s %(service)s",
+            # python-json-logger 2.0.7 faz merge de TODO atributo nao-reservado do
+            # LogRecord no JSON. django.request.log_response injeta extra={"request":
+            # <WSGIRequest>, ...} em respostas 4xx/5xx -> sem isto, cada linha
+            # serializa o request inteiro (bloat + custo alto por log + vazamento
+            # LGPD). Excluimos "request" e "taskName" (ruido Py3.12); status_code
+            # (escalar util) continua sendo logado. Ver incidente 2026-07-06.
+            "reserved_attrs": (*_PJL_RESERVED_ATTRS, "request", "taskName"),
             "timestamp": True,
         },
         # Fallback para desenvolvimento local (human-readable)
@@ -633,6 +642,16 @@ LOGGING = {
         "django": {
             "handlers": ["console_json"] if ENVIRONMENT in ["production", "staging"] else ["console"],
             "level": os.getenv("DJANGO_LOG_LEVEL", "INFO"),
+            "propagate": False,
+        },
+        # django.request loga TODA resposta 4xx como WARNING (django/utils/log.py
+        # log_response). Um flood de 4xx (scans 404, polling deslogado de /api/me/)
+        # saturava os workers do gunicorn -> 504 em prod (incidente 2026-07-06).
+        # Fixo em ERROR: 5xx seguem logando (server errors), 4xx param de floodar.
+        # propagate=False evita dupla emissao (nao sobe pro logger "django").
+        "django.request": {
+            "handlers": ["console_json"] if ENVIRONMENT in ["production", "staging"] else ["console"],
+            "level": "ERROR",
             "propagate": False,
         },
         "apps": {


### PR DESCRIPTION
## Contexto — incidente de produção (2026-07-06)

Durante uma operação em prod o site ficou indisponível: **504 Gateway Timeout** em todos os endpoints (incl. login/`/api/csrf/`). O `readyz` interno (localhost) chegou a dar timeout — os workers do gunicorn saturaram. Redis e Postgres estavam saudáveis o tempo todo; **não** era infra de dependência nem egress.

## Causa raiz

Duas causas somadas, ambas de configuração de logging em `config/settings.py`:

1. **Volume não-limitado**: `django.request` loga **toda** resposta 4xx como `WARNING` (`django/utils/log.py:log_response`), sem amostragem. Uma rajada de 4xx (polling de `/api/me/` por aba deslogada, scans de 404, `Invalid HTTP_HOST`, etc.) vira uma enxurrada de WARNINGs.
2. **Inchaço + LGPD**: o formatter JSON (`python-json-logger==2.0.7`) faz merge de **todos** os atributos não-reservados do `LogRecord`. O `log_response` injeta `extra={"request": <WSGIRequest>, "status_code": ...}`, então **cada linha 4xx/5xx serializava o objeto `request` inteiro** — caro de gerar (satura CPU/IO) e ainda **vazava dados da requisição para o log (LGPD)**.

Não há bug de recursão/concatenação; a "mensagem repetida milhares de vezes" era a **rajada de linhas idênticas** inchadas.

## Correção (durável)

- **`django.request` em `ERROR`**: 5xx (server errors) seguem logando; 4xx param de floodar. `propagate=False` evita dupla emissão.
- **`reserved_attrs` no formatter JSON**: exclui `request` (bloat + LGPD) e `taskName` (ruído Py3.12) do merge de extras. `status_code` (escalar útil) continua sendo logado.

## Mitigação já aplicada em prod (stopgap)

Para estancar o incidente sem rebuild, foi setado **`DJANGO_LOG_LEVEL=ERROR`** no env do Portainer + recreate. Validado **sob carga** (60 × `/api/me/` 403 concorrentes → `readyz` estável ~7 ms). Este PR é o fix durável baked no código; após o deploy, o env stopgap pode ser removido.

## Testes (TDD)

`apps/core/tests/test_logging_config.py` — 4 testes:
- formatter **não** serializa o objeto `request` (assert que dados sensíveis não vazam);
- formatter omite `taskName`;
- `django.request` em `ERROR` + `propagate=False`;
- campos estruturados legítimos preservados (`message`/`request_id`/`environment`/`service`).

Local: **4/4 verdes**; black/isort/flake8 limpos.

## Deploy

- **Sem migration.**
- `settings.py` está dentro da imagem → precisa **rebuild + `workflow_dispatch`** para prod.
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `91bfa497`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
