### PR TITLE
fix(gcal): timeout explicito no transporte httplib2 dos clients (Onda 1 hardening)

### DIFF
--- a/v2/backend/apps/core/services/gcal_google_client.py
+++ b/v2/backend/apps/core/services/gcal_google_client.py
@@ -17,7 +17,9 @@ from typing import TypeVar
 
 from django.conf import settings
 
+import httplib2
 from google.oauth2 import service_account
+from google_auth_httplib2 import AuthorizedHttp
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 
@@ -78,8 +80,12 @@ class GoogleCalendarClient(CalendarClientAdapter):
         # Criar credentials
         self.credentials = service_account.Credentials.from_service_account_info(creds_data, scopes=self.SCOPES)
 
-        # Build service
-        self.service = build("calendar", "v3", credentials=self.credentials, cache_discovery=False)
+        # Build service com timeout explicito no transporte httplib2 (GCAL_HTTP_TIMEOUT,
+        # default 10s) em vez do default de 60s do googleapiclient -> num stall de rede a
+        # chamada .execute() falha ~6x mais rapido e libera o worker do gunicorn (incidente
+        # 2026-07-06). AuthorizedHttp reaplica as credenciais sobre o http com timeout.
+        authorized_http = AuthorizedHttp(self.credentials, http=httplib2.Http(timeout=settings.GCAL_HTTP_TIMEOUT))
+        self.service = build("calendar", "v3", http=authorized_http, cache_discovery=False)
 
         logger.info("GoogleCalendarClient initialized with Service Account")
 

--- a/v2/backend/apps/core/services/gcal_oauth_client.py
+++ b/v2/backend/apps/core/services/gcal_oauth_client.py
@@ -18,7 +18,9 @@ from typing import TYPE_CHECKING, Any
 from django.conf import settings
 from django.utils import timezone
 
+import httplib2
 from google.oauth2.credentials import Credentials
+from google_auth_httplib2 import AuthorizedHttp
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 
@@ -100,8 +102,12 @@ class OAuthCalendarClient(CalendarClientAdapter):
             scopes=self.SCOPES,
         )
 
-        # Build service
-        self.service = build("calendar", "v3", credentials=self.credentials, cache_discovery=False)
+        # Build service com timeout explicito no transporte httplib2 (GCAL_HTTP_TIMEOUT,
+        # default 10s) em vez do default de 60s do googleapiclient -> num stall de rede a
+        # chamada .execute() falha ~6x mais rapido e libera o worker do gunicorn (incidente
+        # 2026-07-06). AuthorizedHttp reaplica as credenciais sobre o http com timeout.
+        authorized_http = AuthorizedHttp(self.credentials, http=httplib2.Http(timeout=settings.GCAL_HTTP_TIMEOUT))
+        self.service = build("calendar", "v3", http=authorized_http, cache_discovery=False)
 
         # Armazenar referência ao credential para logging
         self.credential = credential

--- a/v2/backend/apps/core/tests/test_gcal_http_timeout.py
+++ b/v2/backend/apps/core/tests/test_gcal_http_timeout.py
@@ -28,7 +28,7 @@ def test_setting_gcal_http_timeout_e_inteiro_positivo():
 def test_google_client_aplica_timeout_no_transporte(monkeypatch, settings):
     """GoogleCalendarClient (Service Account) constroi o service com o timeout."""
     settings.GCAL_HTTP_TIMEOUT = 13
-    captured: dict = {}
+    captured: dict[str, object] = {}
 
     monkeypatch.setattr(
         "apps.core.services.gcal_google_client.service_account.Credentials.from_service_account_info",
@@ -51,7 +51,7 @@ def test_google_client_aplica_timeout_no_transporte(monkeypatch, settings):
 def test_oauth_client_aplica_timeout_no_transporte(monkeypatch, settings):
     """OAuthCalendarClient (o client de prod, GCAL_AUTH_MODE=oauth) usa o timeout."""
     settings.GCAL_HTTP_TIMEOUT = 9
-    captured: dict = {}
+    captured: dict[str, object] = {}
 
     monkeypatch.setenv("GCAL_OAUTH_CLIENT_ID", "cid")
     monkeypatch.setenv("GCAL_OAUTH_CLIENT_SECRET", "secret")

--- a/v2/backend/apps/core/tests/test_gcal_http_timeout.py
+++ b/v2/backend/apps/core/tests/test_gcal_http_timeout.py
@@ -1,0 +1,78 @@
+"""Testes do timeout no transporte dos clients Google Calendar.
+
+Regressao do incidente 2026-07-06: os clients usavam o default de 60s do googleapiclient
+no transporte httplib2 (`build_http`/`DEFAULT_HTTP_TIMEOUT_SEC`), alto demais p/ o
+request-path -> num stall de rede uma rajada de chamadas segurava os workers do gunicorn
+por ate 60s (endpoints /api/integrations/google/calendars, /events, /api/gcal/calendars,
+/api/gcal/health). Estes testes travam que AMBOS os clients (Service Account e OAuth)
+constroem o service com `settings.GCAL_HTTP_TIMEOUT` (default 10s) no transporte. O
+`build` do googleapiclient e mockado; a asercao checa o timeout do http subjacente.
+"""
+
+# pyright: reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportAttributeAccessIssue=false, reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportOptionalMemberAccess=false
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from django.conf import settings as django_settings
+from django.utils import timezone
+
+
+def test_setting_gcal_http_timeout_e_inteiro_positivo():
+    """O timeout tem que ser inteiro positivo (0 = socket nao-bloqueante, quebraria tudo)."""
+    assert isinstance(django_settings.GCAL_HTTP_TIMEOUT, int)
+    assert django_settings.GCAL_HTTP_TIMEOUT > 0
+
+
+def test_google_client_aplica_timeout_no_transporte(monkeypatch, settings):
+    """GoogleCalendarClient (Service Account) constroi o service com o timeout."""
+    settings.GCAL_HTTP_TIMEOUT = 13
+    captured: dict = {}
+
+    monkeypatch.setattr(
+        "apps.core.services.gcal_google_client.service_account.Credentials.from_service_account_info",
+        lambda info, scopes: object(),
+    )
+    monkeypatch.setattr(
+        "apps.core.services.gcal_google_client.build",
+        lambda *a, **k: captured.update(http=k.get("http"), cache_discovery=k.get("cache_discovery")) or object(),
+    )
+
+    from apps.core.services.gcal_google_client import GoogleCalendarClient
+
+    GoogleCalendarClient(credentials_json='{"type": "service_account"}')
+
+    # AuthorizedHttp expoe o transporte subjacente em .http; o timeout tem que estar la.
+    assert captured["http"].http.timeout == 13
+    assert captured["cache_discovery"] is False
+
+
+def test_oauth_client_aplica_timeout_no_transporte(monkeypatch, settings):
+    """OAuthCalendarClient (o client de prod, GCAL_AUTH_MODE=oauth) usa o timeout."""
+    settings.GCAL_HTTP_TIMEOUT = 9
+    captured: dict = {}
+
+    monkeypatch.setenv("GCAL_OAUTH_CLIENT_ID", "cid")
+    monkeypatch.setenv("GCAL_OAUTH_CLIENT_SECRET", "secret")
+    monkeypatch.setattr("apps.core.services.google_oauth._decrypt_token", lambda enc: "tok")
+    monkeypatch.setattr(
+        "apps.core.services.gcal_oauth_client.build",
+        lambda *a, **k: captured.update(http=k.get("http")) or object(),
+    )
+
+    from apps.core.models import GoogleOAuthCredential
+
+    # Instancia NAO-salva (sem DB): isinstance passa, is_expired()=False evita refresh.
+    cred = GoogleOAuthCredential(
+        google_email="op@aprendereditora.com.br",
+        token_expiry=timezone.now() + timedelta(hours=1),
+        access_token_encrypted=b"enc-access",
+        refresh_token_encrypted=b"enc-refresh",
+    )
+
+    from apps.core.services.gcal_oauth_client import OAuthCalendarClient
+
+    OAuthCalendarClient(cred)
+
+    assert captured["http"].http.timeout == 9

--- a/v2/backend/config/settings.py
+++ b/v2/backend/config/settings.py
@@ -683,6 +683,14 @@ GCAL_CLIENT = os.getenv("GCAL_CLIENT", "fake")
 # Note: GCAL_CLIENT must be 'google' for either mode to work
 GCAL_AUTH_MODE = os.getenv("GCAL_AUTH_MODE", "service_account")
 
+# Timeout (segundos) do transporte httplib2 nas chamadas ao Google Calendar API.
+# Incidente 2026-07-06: o default do googleapiclient e 60s por operacao de socket
+# (build_http / DEFAULT_HTTP_TIMEOUT_SEC), alto demais p/ o request-path -> num stall
+# de rede uma rajada de chamadas segura os workers do gunicorn (gthread, 2 threads/
+# worker) por ate 60s = 504. Reduzido p/ 10s configuravel (libera o worker ~6x mais
+# rapido); aplicado via AuthorizedHttp nos clients GCal.
+GCAL_HTTP_TIMEOUT = int(os.getenv("GCAL_HTTP_TIMEOUT", "10"))
+
 # Google Calendar sendUpdates parameter (RF05/RF06 - PR19)
 # Controls whether email notifications are sent to attendees:
 # - 'none': No emails (default, recommended for testing)

--- a/v2/backend/requirements-prod.txt
+++ b/v2/backend/requirements-prod.txt
@@ -49,6 +49,7 @@ google-api-python-client==2.197.0
 google-auth==2.55.0
 google-auth-httplib2==0.4.0
 google-auth-oauthlib==1.4.0
+httplib2==0.31.2  # import direto nos clients GCal (transporte http com timeout)
 
 # Production Server
 gunicorn==23.0.0

--- a/v2/backend/requirements.txt
+++ b/v2/backend/requirements.txt
@@ -58,6 +58,7 @@ google-api-python-client==2.197.0
 google-auth==2.55.0
 google-auth-httplib2==0.4.0
 google-auth-oauthlib==1.4.0
+httplib2==0.31.2  # import direto nos clients GCal (transporte http com timeout)
 
 # ================================================================
 # Production Server


### PR DESCRIPTION
## Contexto (Onda 1 do hardening pós-incidente 2026-07-06)

Durante o incidente de 06/07, a tentativa de "Conectar Google" pendurou os workers do gunicorn. O #1503 corrigiu a metade "logging" (flood de 4xx). Este PR corrige a metade **"chamada externa sem limite adequado no request-path"**.

## Causa

Os 2 clients do Google Calendar construíam `build("calendar", "v3", credentials=...)`. Sem um `http` explícito, o `googleapiclient` usa `build_http()` → `httplib2.Http(timeout=DEFAULT_HTTP_TIMEOUT_SEC=60)`. **60s por operação de socket é alto demais para o request-path**: num stall de rede, uma rajada de chamadas segura os workers do gunicorn (`gthread`, 2 threads/worker) por até 60s → exaustão do pool → **504**.

Endpoints afetados (síncronos, atingem o Google): `GET /api/integrations/google/calendars`, `/events`, `/api/gcal/calendars`, `/api/gcal/health`.

## Correção

- **`GCAL_HTTP_TIMEOUT`** (default **10s**, configurável via env) aplicado nos 2 clients via `AuthorizedHttp(cred, http=httplib2.Http(timeout=...))`.
- **Auth idêntica**: `AuthorizedHttp` é exatamente a classe que o `_auth.authorized_http` interno usa quando se passa `credentials=`; a mudança só troca o **número** do timeout (60s→10s). Passar `http=` sem `credentials=` respeita o guard "mutually exclusive" do `build()`.
- **Retry**: `socket.timeout` não é `HttpError` → não entra no `_retry_with_backoff` (429/5xx) → propaga em ~10s (fail-fast, libera o worker). No **Celery**, o retry continua na camada de task (`GCalStatus.ERROR` + task de reprocesso, `max_retries=10`) — melhoria líquida (antes o worker pendurava).
- **`httplib2` pinado** em `requirements.txt`/`requirements-prod.txt` (agora é import direto).

## Verificação

- Testes de regressão (`apps/core/tests/test_gcal_http_timeout.py`): ambos os clients (Service Account + OAuth) constroem o service com `settings.GCAL_HTTP_TIMEOUT` no transporte (asserção sobre `AuthorizedHttp.http.timeout`, com valores não-default 13/9).
- Suíte GCal/OAuth completa: **414 passed** (local).
- Revisão adversarial (2 agentes) confirmou: paridade de auth contra a lib instalada, timeout de fato aplicado ao socket, refresh 401 intacto, discovery estático (sem rede), thread-safe (clients por-request).

## Deploy

- **Sem migration.** Precisa rebuild + `workflow_dispatch` para prod.
- Após o deploy, **destrava o smoke do GCal** (a operação que pendurou hoje passa a falhar rápido em vez de exaurir workers).
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `2fed7639`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
