### PR TITLE
fix(throttle): scope oauth orfao + sentinela de rate-limit (Onda 2 hardening)

### DIFF
--- a/v2/backend/apps/core/tests/test_google_oauth.py
+++ b/v2/backend/apps/core/tests/test_google_oauth.py
@@ -433,24 +433,30 @@ class TestGoogleOAuthEndpoints:
             "GCAL_OAUTH_REDIRECT_URI": "http://localhost:8002/api/oauth/google/callback/",
         },
     )
-    def test_google_oauth_start_throttling(self, db):
+    def test_google_oauth_start_throttling(self, db, monkeypatch):
         """
-        GAP-3: Rate limiting 10 req/h em /oauth/google/start/.
+        GAP-3: Rate limiting em /oauth/google/start/.
 
         Valida:
         - Primeiras 10 requests → 302 Redirect (sucesso)
         - 11ª request → 429 Too Many Requests
 
-        Nota: Requer configuração de throttle em settings.py:
-        REST_FRAMEWORK['DEFAULT_THROTTLE_RATES']['oauth'] = '10/hour'
+        O rate de 'oauth' vem de DEFAULT_THROTTLE_RATES (10/hour em prod). Como dev/testes
+        relaxam p/ 1000/hour, este teste forca 10/hour via monkeypatch para exercitar o
+        limite. O rate hardcodado saiu da OAuthThrottle na Onda 2 (scope-driven); ver
+        test_throttle_scopes_sentinela.
 
         IMPORTANTE: Cria usuário único para evitar conflito de throttle
         com outros testes que usam usuario_controle fixture.
         """
         # Limpar cache de throttle antes do teste
+        from django.conf import settings
         from django.core.cache import cache
 
         cache.clear()
+        # Forca o limite de 10/hour (dev relaxa p/ 1000/hour). Mutar o dict in-place e
+        # visto pelo SimpleRateThrottle.THROTTLE_RATES (mesma referencia); monkeypatch restaura.
+        monkeypatch.setitem(settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"], "oauth", "10/hour")
 
         # Criar usuário único para este teste (evitar throttle compartilhado)
         unique_user = UsuarioFactory(

--- a/v2/backend/apps/core/tests/test_throttle_scopes_sentinela.py
+++ b/v2/backend/apps/core/tests/test_throttle_scopes_sentinela.py
@@ -1,0 +1,126 @@
+"""Sentinela da config de throttle (rate-limit) do DRF.
+
+Esta classe de bug ja mordeu 2x nesta base:
+- `change_password` (#1502): definido no dict base mas ausente do override de dev, que
+  SUBSTITUI o dict inteiro (`if ENVIRONMENT == "development"`) -> runtime quebrava com
+  "No default throttle rate set for 'change_password' scope".
+- `oauth`: usado em `OAuthThrottle.scope` mas ausente dos dicts (so funcionava por causa
+  de um `rate` hardcodado na classe).
+
+Estes testes barram AMBOS os modos de falha, para o CI reprovar antes de chegar em prod:
+1. os dicts base e dev de `DEFAULT_THROTTLE_RATES` tem exatamente as mesmas chaves;
+2. todo scope de throttle USADO em views (`throttle_scope = "..."` ou `scope = "..."`
+   numa classe *Throttle) tem rate definido em `DEFAULT_THROTTLE_RATES`.
+"""
+
+# pyright: reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportAttributeAccessIssue=false
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from django.conf import settings
+
+
+def _throttle_base_name(base: ast.expr) -> str:
+    """Nome da classe-base (Name `UserRateThrottle` ou Attribute `throttling.UserRateThrottle`)."""
+    if isinstance(base, ast.Name):
+        return base.id
+    if isinstance(base, ast.Attribute):
+        return base.attr
+    return ""
+
+
+def _str_const(node: ast.expr | None) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def _assign_targets_value(node: ast.AST) -> tuple[list[ast.expr], ast.expr | None]:
+    """Normaliza Assign (`x = v`) e AnnAssign (`x: T = v`) para (targets, value).
+
+    Cobrir AnnAssign importa: num codebase Pyright-strict, `throttle_scope: str = "x"`
+    e `scope: ClassVar[str] = "x"` sao idiomaticos e nao seriam `ast.Assign`.
+    """
+    if isinstance(node, ast.Assign):
+        return node.targets, node.value
+    if isinstance(node, ast.AnnAssign):
+        return [node.target], node.value  # value pode ser None (anotacao pura)
+    return [], None
+
+
+def _collect_used_scopes() -> set[str]:
+    """Varre apps/**/*.py (menos testes) coletando scopes de throttle efetivamente usados.
+
+    Cobre `throttle_scope = "X"` / `throttle_scope: str = "X"` / `foo.throttle_scope = "X"`
+    e `scope = "X"` / `scope: ... = "X"` dentro de classes custom `*Throttle`.
+    """
+    apps_dir = Path(settings.BASE_DIR) / "apps"
+    scopes: set[str] = set()
+    for py in apps_dir.rglob("*.py"):
+        posix = py.as_posix()
+        if "/tests/" in posix or py.name.startswith("test_"):
+            continue
+        try:
+            tree = ast.parse(py.read_text(encoding="utf-8"))
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            # `throttle_scope = "X"` (atributo de view) OU `foo.throttle_scope = "X"`.
+            targets, value = _assign_targets_value(node)
+            for tgt in targets:
+                name = tgt.id if isinstance(tgt, ast.Name) else tgt.attr if isinstance(tgt, ast.Attribute) else None
+                if name == "throttle_scope":
+                    literal = _str_const(value)
+                    if literal:
+                        scopes.add(literal)
+            # `scope = "X"` dentro de uma classe custom *Throttle (LoginThrottle, OAuthThrottle...).
+            if isinstance(node, ast.ClassDef) and any(_throttle_base_name(b).endswith("Throttle") for b in node.bases):
+                for stmt in node.body:
+                    s_targets, s_value = _assign_targets_value(stmt)
+                    if any(isinstance(t, ast.Name) and t.id == "scope" for t in s_targets):
+                        literal = _str_const(s_value)
+                        if literal:
+                            scopes.add(literal)
+    return scopes
+
+
+def _throttle_rate_dicts_from_source() -> list[set[str]]:
+    """Chaves de cada dict literal de throttle no settings.py (identificado por conter anon+user)."""
+    src = (Path(settings.BASE_DIR) / "config" / "settings.py").read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    dicts: list[set[str]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Dict):
+            keys = {v for v in (_str_const(k) for k in node.keys) if v is not None}
+            if {"anon", "user"} <= keys:
+                dicts.append(keys)
+    return dicts
+
+
+def test_dicts_base_e_dev_de_throttle_tem_as_mesmas_chaves():
+    """O bloco `if ENVIRONMENT==development` SUBSTITUI o dict inteiro -> chaves devem casar."""
+    dicts = _throttle_rate_dicts_from_source()
+    assert len(dicts) >= 2, "esperava >= 2 dicts DEFAULT_THROTTLE_RATES (base + override de dev)"
+    base = dicts[0]
+    for other in dicts[1:]:
+        diff = base ^ other
+        assert not diff, (
+            f"DEFAULT_THROTTLE_RATES base e dev divergem nas chaves: {sorted(diff)}. "
+            "Como o override de dev substitui o dict inteiro, TODA chave precisa existir "
+            "nos dois blocos (senao o scope some em um dos ambientes)."
+        )
+
+
+def test_todo_scope_de_throttle_usado_tem_rate_definido():
+    """Scope usado numa view sem rate no dict = 'No default throttle rate set' em runtime."""
+    rates = settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]
+    used = _collect_used_scopes()
+    assert used, "nao encontrei nenhum scope de throttle usado — o coletor pode ter quebrado"
+    missing = used - set(rates)
+    assert not missing, (
+        f"Scopes de throttle usados em views sem rate em DEFAULT_THROTTLE_RATES: {sorted(missing)}. "
+        "Adicione o rate no dict base E no override de dev (config/settings.py)."
+    )

--- a/v2/backend/apps/core/views_oauth.py
+++ b/v2/backend/apps/core/views_oauth.py
@@ -223,7 +223,10 @@ class OAuthThrottle(UserRateThrottle):
     GAP-3: Prevenir abuso com 10 requests/hora por usuário.
     """
 
-    rate = "10/hour"
+    # rate NAO hardcodado: vem de settings.DEFAULT_THROTTLE_RATES["oauth"] via
+    # SimpleRateThrottle.get_rate() -> self.scope (10/hour em prod, relaxado em dev).
+    # Scope orfao (usado sem rate no dict) quebraria em runtime; ver o teste
+    # sentinela test_throttle_scopes_sentinela.py.
     scope = "oauth"
 
 

--- a/v2/backend/config/settings.py
+++ b/v2/backend/config/settings.py
@@ -474,6 +474,8 @@ REST_FRAMEWORK = {
         "login": "10/minute",
         # Troca de senha self-service: defesa contra brute-force do old_password.
         "change_password": "20/min",
+        # OAuth connect (GAP-3): conectar conta Google no /pre-agenda, anti-abuso por usuario.
+        "oauth": "10/hour",
     },
     # Custom exception handler for standardized error responses
     "EXCEPTION_HANDLER": "apps.core.exceptions.custom_exception_handler",
@@ -546,6 +548,8 @@ if ENVIRONMENT == "development":
         "login": "1000/minute",
         # Troca de senha: relaxado em dev/testes (prod usa 20/min, bloco acima).
         "change_password": "200/min",
+        # OAuth connect: relaxado em dev/testes (prod usa 10/hour, bloco acima).
+        "oauth": "1000/hour",
     }
 
 # ================================================================


### PR DESCRIPTION
## Contexto (Onda 2 do hardening pós-incidente 2026-07-06)

Auditoria de rate-limit encontrou o scope de throttle **`oauth` órfão**: usado em `OAuthThrottle.scope = "oauth"` (`views_oauth.py`) mas **ausente de `DEFAULT_THROTTLE_RATES`**. Só não quebrava porque a classe tinha um `rate = "10/hour"` hardcodado. É **a mesma classe de bug** do `change_password` (#1502), que sumia do override de dev (`if ENVIRONMENT == "development"` **substitui o dict inteiro**) e quebrava em runtime com `No default throttle rate set for '...' scope`.

## Correção

- **`oauth` adicionado aos DOIS dicts**: base `10/hour`, dev `1000/hour` (relax de 100x, padrão do `login`).
- **Removido o `rate` hardcodado** da `OAuthThrottle` → agora scope-driven via `SimpleRateThrottle.get_rate()`, consistente com a `LoginThrottle`.
- **Teste sentinela** (`test_throttle_scopes_sentinela.py`, AST) que **barra no CI** os dois modos de falha:
  1. `DEFAULT_THROTTLE_RATES` base e dev com **chaves divergentes** (pega o bug do `change_password`);
  2. **scope de throttle usado sem rate** definido (pega o bug do `oauth`).
  Cobre `throttle_scope = "X"`, `foo.throttle_scope = "X"`, e `scope = "X"` em classes `*Throttle` — incluindo formas anotadas (`ast.AnnAssign`).
- `test_google_oauth_start_throttling` agora força `oauth=10/hour` via `monkeypatch` (dev relaxa p/ 1000/hour).

## Verificação

- Sentinela: 2/2. Suíte oauth/throttle/login: **128 passed, 6 skipped**.
- Revisão adversarial: sentinela pegaria os 2 bugs históricos, sem falso-positivo (`cache_scope`, `SCOPES` do Google, `models.CharField(scope=...)` não casam) nem falso-negativo no código atual; robustecido p/ `AnnAssign`.

## Nota (fora de escopo)
`gcal_read` e `export` são rates definidos mas nunca usados (config morta, inofensiva). O sentinela corretamente não os sinaliza (testa `usado ⊆ definido`, não o inverso). Limpeza opcional futura.

## Deploy
Sem migration. Precisa rebuild + `workflow_dispatch` para prod.
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `34ab08f1`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
