### PR TITLE
chore(gcal): resumir payload no log + cap 500 no publish-batch (Onda 3 hardening)

### DIFF
--- a/v2/backend/apps/core/services/gcal/sync.py
+++ b/v2/backend/apps/core/services/gcal/sync.py
@@ -264,9 +264,12 @@ def upsert_one(
 
             if not dry_run:
                 try:
+                    # Resumo em vez do payload inteiro: evita inflar/floodar o log se
+                    # DEBUG for ligado por engano E nao vaza os e-mails dos attendees (LGPD).
                     logger.debug(
                         f"🔍 GCal INSERT #{s.id} - calendar_id={calendar_id}, "
-                        f"event_id={deterministic_eid}, payload={payload}"
+                        f"event_id={deterministic_eid}, summary={str(payload.get('summary', ''))[:80]!r}, "
+                        f"attendees={len(payload.get('attendees', []))}, online={'conferenceData' in payload}"
                     )
                     # RF05: Retry com backoff exponencial (PR19)
                     created = _retry_with_circuit_breaker(

--- a/v2/backend/apps/core/tests/test_gcal_batch_operations.py
+++ b/v2/backend/apps/core/tests/test_gcal_batch_operations.py
@@ -574,3 +574,21 @@ def test_batch_resync_valida_limite_500_ids(api_client, usuario_controle):
     # Validar 400
     assert response.status_code == http_status.HTTP_400_BAD_REQUEST
     assert "Limite de 500 IDs" in response.data["detail"]
+
+
+@pytest.mark.django_db
+@override_settings(GCAL_CLIENT="google", GCAL_AUTH_MODE="service_account")
+def test_batch_publish_valida_limite_500_ids(api_client, usuario_controle):
+    """Publish-batch valida limite de 500 IDs (Onda 3 hardening — espelha reapply/resync)."""
+    api_client.force_authenticate(user=usuario_controle)
+
+    solicitacao_ids = list(range(1, 502))  # 501 IDs
+
+    response = api_client.post(
+        "/api/gcal/publish-batch/",
+        {"solicitacao_ids": solicitacao_ids, "dry_run": False, "apply_blocked": True},
+        format="json",
+    )
+
+    assert response.status_code == http_status.HTTP_400_BAD_REQUEST
+    assert "Limite de 500 IDs" in response.data["detail"]

--- a/v2/backend/apps/core/views_gcal/batch.py
+++ b/v2/backend/apps/core/views_gcal/batch.py
@@ -89,6 +89,10 @@ class GCalPublishBatchView(APIView):
                 {"detail": "solicitacao_ids deve ser um array não-vazio de IDs"}, status=status.HTTP_400_BAD_REQUEST
             )
 
+        # Limitar a 500 IDs (espelha reapply/resync; evita rajada de INSERTs + logs por request)
+        if len(solicitacao_ids) > 500:
+            return Response({"detail": "Limite de 500 IDs por requisição"}, status=status.HTTP_400_BAD_REQUEST)
+
         # Buscar solicitações
         solicitacoes = Solicitacao.objects.filter(id__in=solicitacao_ids).select_related("projeto", "municipio")
 


### PR DESCRIPTION
## Contexto (Onda 3 do hardening pós-incidente 2026-07-06 — defense-in-depth)

Achados de baixa severidade da auditoria de logging, fechando a superfície de flood/LGPD.

## Correções

- **`services/gcal/sync.py`**: o log DEBUG do INSERT dumpava o **payload inteiro do evento** (descrição até 5000 chars + lista de attendees com e-mails). É suprimido em prod (logger `apps` em INFO), mas se `DEBUG`/`DJANGO_LOG_LEVEL=DEBUG` for ligado por engano (viola CP-08), volta a inflar o log **e vaza e-mails dos attendees (LGPD)**. Agora loga só `summary` truncado (80) + contagem de attendees + flag `online`.
- **`views_gcal/batch.py` (publish-batch)**: adicionado **cap de 500 IDs** por request (o reapply/resync já tinham; o publish não). Evita rajada de INSERTs + logs num único request.
- **Teste** do cap do publish-batch (espelha `test_batch_reapply/resync_valida_limite_500_ids`).

## Verificação
- `test_batch_publish_valida_limite_500_ids` + 13 testes de batch verdes; regressão gcal/sync/batch: **398 passed**.

## Deploy
Sem migration. Precisa rebuild + `workflow_dispatch` para prod.
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `7ace6625`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
