### PR TITLE
fix(gcal): retry cap no request-path + timeout OAuth 5s + backfill de testes (Onda 4a)

### DIFF
--- a/v2/backend/apps/core/services/gcal/sync.py
+++ b/v2/backend/apps/core/services/gcal/sync.py
@@ -264,11 +264,13 @@ def upsert_one(
 
             if not dry_run:
                 try:
-                    # Resumo em vez do payload inteiro: evita inflar/floodar o log se
-                    # DEBUG for ligado por engano E nao vaza os e-mails dos attendees (LGPD).
+                    # So escalares nao-sensiveis derivados do nosso DB (id da Solicitacao +
+                    # event_id deterministico) + contagem/flag. Evita inflar/floodar o log se
+                    # DEBUG for ligado por engano e NAO expoe e-mails de attendee, o titulo do
+                    # evento (pode conter nome de pessoa) nem o calendar_id
+                    # (LGPD + CodeQL py/clear-text-logging-sensitive-data).
                     logger.debug(
-                        f"🔍 GCal INSERT #{s.id} - calendar_id={calendar_id}, "
-                        f"event_id={deterministic_eid}, summary={str(payload.get('summary', ''))[:80]!r}, "
+                        f"🔍 GCal INSERT #{s.id} - event_id={deterministic_eid}, "
                         f"attendees={len(payload.get('attendees', []))}, online={'conferenceData' in payload}"
                     )
                     # RF05: Retry com backoff exponencial (PR19)

--- a/v2/backend/apps/core/services/gcal_google_client.py
+++ b/v2/backend/apps/core/services/gcal_google_client.py
@@ -288,7 +288,7 @@ class GoogleCalendarClient(CalendarClientAdapter):
                 for cal in items
             ]
 
-        return self._retry_with_backoff(_list_calendars)
+        return self._retry_with_backoff(_list_calendars, max_retries=settings.GCAL_REQUEST_MAX_RETRIES)
 
     def list_events(
         self,
@@ -340,7 +340,7 @@ class GoogleCalendarClient(CalendarClientAdapter):
                 for evt in items
             ]
 
-        return self._retry_with_backoff(_list_events)
+        return self._retry_with_backoff(_list_events, max_retries=settings.GCAL_REQUEST_MAX_RETRIES)
 
     def health_check(self) -> JsonDict:
         """

--- a/v2/backend/apps/core/services/gcal_oauth_client.py
+++ b/v2/backend/apps/core/services/gcal_oauth_client.py
@@ -357,7 +357,7 @@ class OAuthCalendarClient(CalendarClientAdapter):
                 for cal in items
             ]
 
-        return self._retry_with_backoff(_list_calendars)
+        return self._retry_with_backoff(_list_calendars, max_retries=settings.GCAL_REQUEST_MAX_RETRIES)
 
     def list_events(
         self,
@@ -410,7 +410,7 @@ class OAuthCalendarClient(CalendarClientAdapter):
                 for evt in items
             ]
 
-        return self._retry_with_backoff(_list_events)
+        return self._retry_with_backoff(_list_events, max_retries=settings.GCAL_REQUEST_MAX_RETRIES)
 
     def health_check(self) -> JsonDict:
         """

--- a/v2/backend/apps/core/services/oauth/oauth_flow.py
+++ b/v2/backend/apps/core/services/oauth/oauth_flow.py
@@ -294,7 +294,7 @@ def exchange_code_for_tokens(code: str) -> dict:
     logger.info("🔐 Trocando authorization code por tokens (grant_type=authorization_code)")
 
     try:
-        response: requests.Response = requests.post(token_url, data=payload, timeout=10)
+        response: requests.Response = requests.post(token_url, data=payload, timeout=settings.GCAL_OAUTH_TOKEN_TIMEOUT)
         response.raise_for_status()
         data: dict[str, Any] = response.json()
 
@@ -310,7 +310,9 @@ def exchange_code_for_tokens(code: str) -> dict:
         access_token: str = data["access_token"]
         userinfo_url: str = "https://www.googleapis.com/oauth2/v2/userinfo"
         headers: dict[str, str] = {"Authorization": f"Bearer {access_token}"}
-        userinfo_response: requests.Response = requests.get(userinfo_url, headers=headers, timeout=10)
+        userinfo_response: requests.Response = requests.get(
+            userinfo_url, headers=headers, timeout=settings.GCAL_OAUTH_TOKEN_TIMEOUT
+        )
         userinfo_response.raise_for_status()
         userinfo: dict[str, Any] = userinfo_response.json()
 

--- a/v2/backend/apps/core/services/oauth/token_manager.py
+++ b/v2/backend/apps/core/services/oauth/token_manager.py
@@ -172,7 +172,9 @@ def refresh_access_token_safe(credential: GoogleOAuthCredential) -> GoogleOAuthC
         logger.info(f"🔄 Refreshing access token para {cred.google_email}")
 
         try:
-            response: requests.Response = requests.post(token_url, data=payload, timeout=10)
+            response: requests.Response = requests.post(
+                token_url, data=payload, timeout=settings.GCAL_OAUTH_TOKEN_TIMEOUT
+            )
             response.raise_for_status()
             data: dict[str, Any] = response.json()
 
@@ -252,7 +254,7 @@ def revoke_token(credential: GoogleOAuthCredential) -> bool:
 
         logger.info(f"🔓 Revogando refresh token para {credential.google_email}")
 
-        response: requests.Response = requests.post(revoke_url, data=payload, timeout=10)
+        response: requests.Response = requests.post(revoke_url, data=payload, timeout=settings.GCAL_OAUTH_TOKEN_TIMEOUT)
 
         # 200 OK: revogado com sucesso
         # 400 Bad Request: token já inválido (ok, continuar)

--- a/v2/backend/apps/core/tests/test_gcal_http_timeout.py
+++ b/v2/backend/apps/core/tests/test_gcal_http_timeout.py
@@ -76,3 +76,38 @@ def test_oauth_client_aplica_timeout_no_transporte(monkeypatch, settings):
     OAuthCalendarClient(cred)
 
     assert captured["http"].http.timeout == 9
+
+
+def test_gcal_settings_defaults_no_ambiente_limpo():
+    """Defaults REAIS dos 3 settings GCal com as envs ausentes, via subprocess isolado.
+
+    Robusto vs estado do CI: os settings sao avaliados no IMPORT, entao um assert in-process
+    dependeria do estado de env do processo de teste. Subprocess com env limpa afirma os
+    defaults de fato (HTTP_TIMEOUT=10, REQUEST_MAX_RETRIES=1, OAUTH_TOKEN_TIMEOUT=5), sem
+    recarregar o settings (que tem side effects no import).
+    """
+    import os
+    import subprocess
+    import sys
+
+    overridable = {"GCAL_HTTP_TIMEOUT", "GCAL_REQUEST_MAX_RETRIES", "GCAL_OAUTH_TOKEN_TIMEOUT"}
+    env = {k: v for k, v in os.environ.items() if k not in overridable}
+    env["DJANGO_SETTINGS_MODULE"] = "config.settings"
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import django; django.setup(); "
+            "from django.conf import settings as s; "
+            "print('GCAL_HTTP_TIMEOUT_DEFAULT=%d' % s.GCAL_HTTP_TIMEOUT); "
+            "print('GCAL_REQUEST_MAX_RETRIES_DEFAULT=%d' % s.GCAL_REQUEST_MAX_RETRIES); "
+            "print('GCAL_OAUTH_TOKEN_TIMEOUT_DEFAULT=%d' % s.GCAL_OAUTH_TOKEN_TIMEOUT)",
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "GCAL_HTTP_TIMEOUT_DEFAULT=10" in proc.stdout
+    assert "GCAL_REQUEST_MAX_RETRIES_DEFAULT=1" in proc.stdout
+    assert "GCAL_OAUTH_TOKEN_TIMEOUT_DEFAULT=5" in proc.stdout

--- a/v2/backend/apps/core/tests/test_gcal_insert_log_lgpd.py
+++ b/v2/backend/apps/core/tests/test_gcal_insert_log_lgpd.py
@@ -1,0 +1,67 @@
+"""Guard LGPD do log de INSERT do sync GCal.
+
+O #1506 trocou o dump do payload inteiro por um resumo (summary[:80] + contagem de
+attendees + flag online). Este teste TRAVA essa garantia: o log de INSERT NAO pode
+conter e-mail de attendee nem a descricao completa do evento.
+
+Gotcha (por que handler direto e nao caplog): o logger `apps` tem propagate=False
+(config/settings.py) e `apps.core.services.gcal.sync` herda dele -> o registro nao sobe
+ate a raiz onde o caplog escuta. Anexamos um handler direto no logger do modulo +
+setLevel(DEBUG) (mesmo padrao de test_db_retry.py).
+"""
+
+# pyright: reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportAttributeAccessIssue=false, reportMissingParameterType=false, reportUnknownParameterType=false
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from apps.core.services.gcal import sync as sync_module
+from apps.core.services.gcal.sync import upsert_one
+from apps.core.services.gcal_fake_client import FakeCalendarClient
+from apps.core.tests.factories import SolicitacaoFactory
+
+
+@pytest.mark.django_db
+def test_insert_log_nao_vaza_email_nem_descricao_lgpd():
+    sol = SolicitacaoFactory(status="aprovado", external_event_id=None)
+    email_secreto = "attendee-secreto-lgpd@example.com"
+    desc_secreta = "CONFIDENCIAL_LGPD_NAO_DEVE_VAZAR " * 20  # descricao longa
+    payload = {
+        "summary": "Fortaleza - CE Online [ACERTA]",
+        "description": desc_secreta,
+        "attendees": [{"email": email_secreto}, {"email": "outro@example.com"}],
+        "start": {"dateTime": "2026-08-01T09:00:00-03:00", "timeZone": "America/Fortaleza"},
+        "end": {"dateTime": "2026-08-01T12:00:00-03:00", "timeZone": "America/Fortaleza"},
+    }
+
+    captured: list[logging.LogRecord] = []
+
+    class _Cap(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            captured.append(record)
+
+    handler = _Cap(level=logging.DEBUG)
+    sync_module.logger.addHandler(handler)
+    old_level = sync_module.logger.level
+    sync_module.logger.setLevel(logging.DEBUG)  # senao o debug e suprimido (herda INFO de 'apps')
+    try:
+        outcome = upsert_one(
+            client=FakeCalendarClient(), calendar_id="cal", s=sol, dry_run=False, no_delete=False, payload=payload
+        )
+    finally:
+        sync_module.logger.removeHandler(handler)
+        sync_module.logger.setLevel(old_level)
+
+    assert outcome.action == "CREATE"
+    insert_msgs = [r.getMessage() for r in captured if "GCal INSERT" in r.getMessage()]
+    # Nao-vacuidade: sem isto os `not in` passariam a toa se o log deixasse de ser emitido.
+    assert insert_msgs, "log de INSERT nao foi emitido"
+    txt = "\n".join(insert_msgs)
+
+    assert email_secreto not in txt, "LGPD: e-mail do attendee vazou no log"
+    assert "CONFIDENCIAL_LGPD" not in txt, "descricao completa vazou no log"
+    assert "Fortaleza - CE Online [ACERTA]" in txt  # summary[:80] esta (dentro do repr)
+    assert "attendees=2" in txt and "online=False" in txt  # contagem + flag estao

--- a/v2/backend/apps/core/tests/test_gcal_insert_log_lgpd.py
+++ b/v2/backend/apps/core/tests/test_gcal_insert_log_lgpd.py
@@ -1,8 +1,11 @@
 """Guard LGPD do log de INSERT do sync GCal.
 
-O #1506 trocou o dump do payload inteiro por um resumo (summary[:80] + contagem de
-attendees + flag online). Este teste TRAVA essa garantia: o log de INSERT NAO pode
-conter e-mail de attendee nem a descricao completa do evento.
+O #1506 trocou o dump do payload inteiro por um resumo; a Onda 4 removeu tambem o
+summary/titulo e o calendar_id (CodeQL py/clear-text-logging-sensitive-data + defesa a
+mais, pois o titulo pode conter nome de pessoa). Restam so escalares nao-sensiveis:
+id da Solicitacao, event_id deterministico, contagem de attendees e flag online. Este
+teste TRAVA a garantia: o log de INSERT NAO pode conter e-mail de attendee, a descricao
+completa NEM o titulo do evento.
 
 Gotcha (por que handler direto e nao caplog): o logger `apps` tem propagate=False
 (config/settings.py) e `apps.core.services.gcal.sync` herda dele -> o registro nao sobe
@@ -63,5 +66,8 @@ def test_insert_log_nao_vaza_email_nem_descricao_lgpd():
 
     assert email_secreto not in txt, "LGPD: e-mail do attendee vazou no log"
     assert "CONFIDENCIAL_LGPD" not in txt, "descricao completa vazou no log"
-    assert "Fortaleza - CE Online [ACERTA]" in txt  # summary[:80] esta (dentro do repr)
+    # Nem o titulo do evento entra no log (pode conter nome de pessoa; py/clear-text-logging).
+    assert "Fortaleza - CE Online [ACERTA]" not in txt, "titulo/summary do evento vazou no log"
+    # Correlacao preservada sem dado sensivel: id da Solicitacao + event_id + contagem + flag.
+    assert f"#{sol.id}" in txt and "event_id=" in txt
     assert "attendees=2" in txt and "online=False" in txt  # contagem + flag estao

--- a/v2/backend/apps/core/tests/test_gcal_request_resilience.py
+++ b/v2/backend/apps/core/tests/test_gcal_request_resilience.py
@@ -1,0 +1,144 @@
+"""Testes de resiliencia do request-path do GCal (Onda 4 hardening).
+
+(1) Retry cap: as operacoes de LEITURA (list_calendars/list_events), que rodam no
+    request-path, usam settings.GCAL_REQUEST_MAX_RETRIES (default 1) em vez do 3 dos
+    writes — para o backoff de 429/5xx nao empilhar ~7s sobre o GCAL_HTTP_TIMEOUT e
+    segurar o worker do gunicorn (incidente 2026-07-06).
+(2) Timeout OAuth: os requests ao endpoint de token do Google usam
+    settings.GCAL_OAUTH_TOKEN_TIMEOUT (nao um literal hardcodado).
+"""
+
+# pyright: reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportAttributeAccessIssue=false, reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownLambdaType=false, reportOptionalMemberAccess=false
+
+from __future__ import annotations
+
+import re
+from datetime import timedelta
+from pathlib import Path
+
+from django.conf import settings as django_settings
+from django.utils import timezone
+
+
+def _build_google_client(monkeypatch):
+    monkeypatch.setattr(
+        "apps.core.services.gcal_google_client.service_account.Credentials.from_service_account_info",
+        lambda info, scopes: object(),
+    )
+    monkeypatch.setattr("apps.core.services.gcal_google_client.build", lambda *a, **k: object())
+    from apps.core.services.gcal_google_client import GoogleCalendarClient
+
+    return GoogleCalendarClient(credentials_json='{"type": "service_account"}')
+
+
+def _build_oauth_client(monkeypatch):
+    monkeypatch.setenv("GCAL_OAUTH_CLIENT_ID", "cid")
+    monkeypatch.setenv("GCAL_OAUTH_CLIENT_SECRET", "secret")
+    monkeypatch.setattr("apps.core.services.google_oauth._decrypt_token", lambda enc: "tok")
+    monkeypatch.setattr("apps.core.services.gcal_oauth_client.build", lambda *a, **k: object())
+    from apps.core.models import GoogleOAuthCredential
+
+    cred = GoogleOAuthCredential(
+        google_email="op@aprendereditora.com.br",
+        token_expiry=timezone.now() + timedelta(hours=1),
+        access_token_encrypted=b"x",
+        refresh_token_encrypted=b"y",
+    )
+    from apps.core.services.gcal_oauth_client import OAuthCalendarClient
+
+    return OAuthCalendarClient(cred)
+
+
+def test_google_client_list_usa_request_max_retries(monkeypatch, settings):
+    settings.GCAL_REQUEST_MAX_RETRIES = 2  # valor distintivo do default (1): prova que le do setting
+    client = _build_google_client(monkeypatch)
+    seen: list[int] = []
+    monkeypatch.setattr(client, "_retry_with_backoff", lambda func, max_retries=3: seen.append(max_retries) or [])
+
+    client.list_calendars()
+    client.list_events("cal")
+
+    assert seen == [2, 2]  # ambas as leituras usam o valor do setting (nao o default 3, nem um literal)
+
+
+def test_oauth_client_list_usa_request_max_retries(monkeypatch, settings):
+    settings.GCAL_REQUEST_MAX_RETRIES = 2  # valor distintivo do default (1): prova que le do setting
+    client = _build_oauth_client(monkeypatch)
+    seen: list[int] = []
+    monkeypatch.setattr(client, "_retry_with_backoff", lambda func, max_retries=3: seen.append(max_retries) or [])
+
+    client.list_calendars()
+    client.list_events("cal")
+
+    assert seen == [2, 2]  # usa o valor do setting (nao o default 3, nem um literal)
+
+
+def test_writes_nao_sao_capados_seguem_no_default_3():
+    """Guard: insert/update/delete (celery-path) NAO devem passar max_retries (ficam em 3)."""
+    src_oauth = (Path(django_settings.BASE_DIR) / "apps" / "core" / "services" / "gcal_oauth_client.py").read_text(
+        encoding="utf-8"
+    )
+    src_google = (Path(django_settings.BASE_DIR) / "apps" / "core" / "services" / "gcal_google_client.py").read_text(
+        encoding="utf-8"
+    )
+    for src in (src_oauth, src_google):
+        # so os _list_* devem passar max_retries; insert/update/delete/get nao.
+        for fn in ("_insert", "_update", "_delete", "_get"):
+            assert (
+                f"_retry_with_backoff({fn}, max_retries=" not in src
+            ), f"{fn} nao deve ser capado (celery-path mantem resiliencia em 3)"
+
+
+def test_oauth_requests_usam_setting_de_timeout_nao_literal():
+    """Os requests do fluxo OAuth (exchange/userinfo/refresh/revoke) nao hardcodam timeout."""
+    base = Path(django_settings.BASE_DIR) / "apps" / "core" / "services" / "oauth"
+    for name in ("oauth_flow.py", "token_manager.py"):
+        src = (base / name).read_text(encoding="utf-8")
+        hardcoded = re.findall(r"requests\.(?:get|post)\([^)]*timeout\s*=\s*\d", src)
+        assert not hardcoded, f"{name}: requests com timeout hardcodado: {hardcoded}"
+        assert "settings.GCAL_OAUTH_TOKEN_TIMEOUT" in src, f"{name} nao usa GCAL_OAUTH_TOKEN_TIMEOUT"
+
+
+def test_exchange_code_passa_oauth_token_timeout_ao_requests(monkeypatch, settings):
+    """Comportamental: exchange_code_for_tokens REALMENTE passa o timeout do setting ao requests.
+
+    Complementa o source-scan acima: prova que o valor CHEGA no requests (nao so que a
+    string aparece no fonte). Cobre os 2 call-sites de oauth_flow (token + userinfo).
+    """
+    settings.GCAL_OAUTH_TOKEN_TIMEOUT = 7  # distintivo do default 5
+    monkeypatch.setenv("GCAL_OAUTH_CLIENT_ID", "cid")
+    monkeypatch.setenv("GCAL_OAUTH_CLIENT_SECRET", "secret")
+    monkeypatch.setenv("GCAL_OAUTH_REDIRECT_URI", "https://x/callback")
+    seen: dict[str, object] = {}
+
+    class _Resp:
+        def raise_for_status(self) -> None: ...
+
+        def json(self) -> dict:
+            return {
+                "refresh_token": "r",
+                "access_token": "a",
+                "expires_in": 3600,
+                "token_type": "Bearer",
+                "scope": "https://www.googleapis.com/auth/calendar",
+                "email": "op@aprendereditora.com.br",
+                "id": "123",
+                "verified_email": True,
+                "name": "Operador",
+            }
+
+    monkeypatch.setattr(
+        "apps.core.services.oauth.oauth_flow.requests.post",
+        lambda url, data=None, timeout=None: seen.update(post=timeout) or _Resp(),
+    )
+    monkeypatch.setattr(
+        "apps.core.services.oauth.oauth_flow.requests.get",
+        lambda url, headers=None, timeout=None: seen.update(get=timeout) or _Resp(),
+    )
+
+    from apps.core.services.oauth.oauth_flow import exchange_code_for_tokens
+
+    exchange_code_for_tokens("authcode")
+
+    assert seen["post"] == 7  # troca code->token usa o setting
+    assert seen["get"] == 7  # userinfo usa o setting

--- a/v2/backend/apps/core/tests/test_gcal_request_resilience.py
+++ b/v2/backend/apps/core/tests/test_gcal_request_resilience.py
@@ -114,7 +114,7 @@ def test_exchange_code_passa_oauth_token_timeout_ao_requests(monkeypatch, settin
     class _Resp:
         def raise_for_status(self) -> None: ...
 
-        def json(self) -> dict:
+        def json(self) -> dict[str, object]:
             return {
                 "refresh_token": "r",
                 "access_token": "a",

--- a/v2/backend/config/settings.py
+++ b/v2/backend/config/settings.py
@@ -695,6 +695,18 @@ GCAL_AUTH_MODE = os.getenv("GCAL_AUTH_MODE", "service_account")
 # rapido); aplicado via AuthorizedHttp nos clients GCal.
 GCAL_HTTP_TIMEOUT = int(os.getenv("GCAL_HTTP_TIMEOUT", "10"))
 
+# Retries no request-path do GCal (list_calendars/list_events/health_check). O backoff de
+# 429/5xx (1+2+4s = ate 7s) empilha sobre GCAL_HTTP_TIMEOUT e segura o worker do gunicorn;
+# 1 retry (<=1s) cobre blip transitorio. insert/update/delete seguem em 3 (resiliencia no
+# Celery, fora do request-path). Incidente 2026-07-06.
+GCAL_REQUEST_MAX_RETRIES = max(0, int(os.getenv("GCAL_REQUEST_MAX_RETRIES", "1")))
+
+# Timeout (s) das chamadas `requests` ao endpoint de token OAuth do Google (troca de code,
+# refresh, revoke). O refresh roda no request-path SOB select_for_update (lock de linha) ->
+# um stall de 10s segura worker+lock; o endpoint de token e rapido (p99 << 2s), 5s e folga
+# (casa com Redis SOCKET_TIMEOUT=5).
+GCAL_OAUTH_TOKEN_TIMEOUT = int(os.getenv("GCAL_OAUTH_TOKEN_TIMEOUT", "5"))
+
 # Google Calendar sendUpdates parameter (RF05/RF06 - PR19)
 # Controls whether email notifications are sent to attendees:
 # - 'none': No emails (default, recommended for testing)


### PR DESCRIPTION
## Contexto (Onda 4a — hardening pós-incidente 2026-07-06)

Fecha os cortes de canto que eu mesmo admiti + achados da investigação profunda de área de influência.

## Correções

- **Retry cap no request-path** (`GCAL_REQUEST_MAX_RETRIES`, default 1, clamp `>=0`): as leituras `list_calendars`/`list_events`/`health_check` (request-path) passavam pelo `_retry_with_backoff` com o mesmo `max_retries=3` dos writes → o backoff de 429/5xx (1+2+4s = até 7s) **empilhava sobre `GCAL_HTTP_TIMEOUT` e segurava o worker do gunicorn** (mesmo vetor do #1504). Agora 1 retry (<=1s). `insert/update/delete/get` (Celery-path) **intocados** em 3.
- **Timeout OAuth 10→5s** (`GCAL_OAUTH_TOKEN_TIMEOUT`, default 5): os 4 `requests` ao endpoint de token (troca de code, userinfo, refresh, revoke). O **refresh roda sob `select_for_update`** → encurtar o timeout reduz a janela de lock num stall.
- **Backfill de testes** (cortes que eu havia pulado):
  - guard **LGPD**: o log DEBUG de INSERT não vaza e-mail de attendee nem descrição (handler direto no logger do módulo por causa do `propagate=False`; assert de não-vacuidade).
  - defaults dos 3 settings GCal via **subprocess env-limpo** (robusto vs estado do CI).
  - **comportamental** do timeout no `exchange_code_for_tokens` (prova que o valor chega no `requests`) + source-scan anti-re-hardcode.
  - retry-cap comportamental (sentinela distintivo do default).

## Verificação
- 10 testes novos/tocados verdes; regressão gcal/oauth/sync: **461 passed**.
- Investigação de área de influência (4 agentes) + review adversarial da implementação (5 achados, todos aplicados: clamp, sentinela distintivo, teste comportamental, subprocess dos 3 defaults, git-add explícito).

## Deploy
Sem migration. Precisa rebuild + `workflow_dispatch` para prod.
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `c191c3b5`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
