### PR TITLE
feat(throttle): rate-limit nos endpoints de import + liga export (Onda 4b)

### DIFF
--- a/v2/backend/apps/core/tests/test_throttle_import_export.py
+++ b/v2/backend/apps/core/tests/test_throttle_import_export.py
@@ -1,0 +1,103 @@
+"""Throttle dos endpoints de import (upload pesado) e export do dashboard.
+
+Contexto (Onda 4, pos-incidente 2026-07-06): os endpoints de upload/import e o export do
+dashboard NAO tinham rate-limit proprio — so o global `user: 1000/hour`. Cada import faz
+parse de arquivo + writes SINCRONOS segurando o worker do gunicorn; uma rajada podia
+saturar os workers (mesma familia de causa do incidente). PR-B adiciona os scopes
+`import` (30/min prod, 300/min dev) e liga o `export` (10/min prod) ja existente, ambos
+via `ScopedRateThrottle` (que ja esta em DEFAULT_THROTTLE_CLASSES) — basta `throttle_scope`.
+
+Estrategia de teste (mesma licao de test_login_throttle_simple.py): o 429 ponta-a-ponta
+pelo APIClient flaka no CI paralelo (pytest-xdist limpa o cache de throttle entre testes),
+entao validamos em DUAS camadas deterministas + validacao manual em staging do fluxo real:
+  1. WIRING (regressao): cada view de import declara `throttle_scope = "import"` e o export
+     declara `"export"` — um endpoint de import novo sem throttle REPROVA aqui.
+  2. COMPORTAMENTAL isolado: `ScopedRateThrottle` com rate forcado baixo bloqueia de fato
+     apos o limite para o scope `import` — prova que a mecanica atua em runtime, sem
+     depender do lifecycle de cache que flaka (cache dedicado + ident unico + clear).
+"""
+
+# pyright: reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportAttributeAccessIssue=false, reportMissingParameterType=false, reportUnknownParameterType=false, reportArgumentType=false
+
+from __future__ import annotations
+
+import importlib
+
+from django.conf import settings
+from django.contrib.auth.models import AnonymousUser
+from django.core.cache import cache
+from django.test import override_settings
+from rest_framework.test import APIRequestFactory
+from rest_framework.throttling import ScopedRateThrottle
+
+import pytest
+
+# (modulo, classe) de cada endpoint de import (POST). Ao criar um novo endpoint de
+# import, adicione-o aqui — o wiring test abaixo forca que ele carregue o throttle.
+IMPORT_VIEWS: list[tuple[str, str]] = [
+    ("apps.core.views_import_bloqueios", "ImportBloqueiosView"),
+    ("apps.core.views_import_eventos", "ImportEventosView"),
+    ("apps.core.views_import_produtos", "ImportProdutosView"),
+    ("apps.core.views_import_deslocamentos", "ImportDeslocamentosView"),
+    ("apps.core.views_import_usuarios", "ImportUsuariosView"),
+    ("apps.core.views_import_colecoes", "ImportColecoesView"),
+    ("apps.core.views_import_equipe_gerencia", "ImportEquipeGerenciaView"),
+    ("apps.core.views_import_municipios", "ImportMunicipiosView"),
+    ("apps.core.views_controle_imports", "ImportComprasView"),
+    ("apps.core.views_imports", "ControleImportAcoesView"),
+    ("apps.core.views_imports", "DATImportCadastrosView"),
+    ("apps.core.views.imports", "ImportJobBloqueiosUploadView"),
+]
+
+
+def _load(module: str, name: str) -> type:
+    return getattr(importlib.import_module(module), name)
+
+
+@pytest.mark.parametrize("module,name", IMPORT_VIEWS)
+def test_endpoint_de_import_declara_throttle_scope_import(module: str, name: str) -> None:
+    view = _load(module, name)
+    assert (
+        getattr(view, "throttle_scope", None) == "import"
+    ), f"{name} deve ter throttle_scope='import' — upload pesado nao pode ficar sem rate-limit proprio."
+
+
+def test_export_view_declara_throttle_scope_export() -> None:
+    view = _load("apps.core.views_gcal.detail", "DashboardEventsExportView")
+    assert getattr(view, "throttle_scope", None) == "export"
+
+
+def test_rates_import_e_export_definidos_com_formato_valido() -> None:
+    rates = settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]
+    assert "import" in rates and "/" in rates["import"], "scope 'import' precisa de rate em DEFAULT_THROTTLE_RATES"
+    assert "export" in rates and "/" in rates["export"], "scope 'export' precisa de rate em DEFAULT_THROTTLE_RATES"
+
+
+@override_settings(
+    CACHES={
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "throttle-import-behavioral",
+        }
+    }
+)
+def test_scoped_throttle_import_bloqueia_apos_o_limite() -> None:
+    """Comportamental isolado: apos o limite, o scope `import` bloqueia (base do 429).
+
+    Nao passa pelo APIClient (que flaka no xdist): dirige o proprio ScopedRateThrottle com
+    cache dedicado + ident unico. Rate forcado 2/min (distintivo do default 30/min).
+    """
+    cache.clear()  # cache locmem dedicado deste teste
+    factory = APIRequestFactory()
+    view = type("_ImportViewStub", (), {"throttle_scope": "import"})()
+    throttle = ScopedRateThrottle()
+    throttle.THROTTLE_RATES = {"import": "2/min"}  # rate baixo e distintivo do default
+
+    decisions: list[bool] = []
+    for _ in range(3):
+        request = factory.post("/api/import-stub/")
+        request.user = AnonymousUser()  # nao-autenticado -> ident = IP
+        request.META["REMOTE_ADDR"] = "203.0.113.201"
+        decisions.append(throttle.allow_request(request, view))
+
+    assert decisions == [True, True, False], f"esperava 2 permitidas + 1 bloqueada, veio {decisions}"

--- a/v2/backend/apps/core/views/imports.py
+++ b/v2/backend/apps/core/views/imports.py
@@ -65,6 +65,7 @@ class ImportJobBloqueiosUploadView(APIView):
 
     # Issue #1222 (Epic 1): import operacional aceita Controle (run_daily_operations) ou DAT (import_spreadsheet)
     permission_classes = [IsAuthenticated, CanImportGenericSpreadsheet]
+    throttle_scope = "import"
 
     @extend_schema(
         summary="Dispara import assincrono de bloqueios",

--- a/v2/backend/apps/core/views_controle_imports.py
+++ b/v2/backend/apps/core/views_controle_imports.py
@@ -76,6 +76,7 @@ class ImportComprasView(APIView):
     # passam a ser DAT-only via `HasPerm("import_spreadsheet")`. Controle
     # consome o dado mas não importa (D-1 do plano DAT-Imports).
     permission_classes = [IsAuthenticated, HasPerm("import_spreadsheet")]
+    throttle_scope = "import"
 
     @extend_schema(
         summary="Importar compras",

--- a/v2/backend/apps/core/views_gcal/detail.py
+++ b/v2/backend/apps/core/views_gcal/detail.py
@@ -83,10 +83,12 @@ class DashboardEventsExportView(APIView):
     - end (ISO date): Filtro início <= end (formato: YYYY-MM-DD)
     - format: csv|json (default: csv)
 
-    Permissions: HasPerm("import_spreadsheet")
+    Permissions: IsAuthenticated + CanUseGcal
+    Throttle: scope "export" (rate-limit de export pesado CSV/JSON)
     """
 
     permission_classes = [IsAuthenticated, CanUseGcal]
+    throttle_scope = "export"
 
     def get(self, request: Request, *args: Any, **kwargs: Any) -> Response | HttpResponse:
         # Usar helper unificado timezone-aware (Issue #96 follow-up #124)

--- a/v2/backend/apps/core/views_import_bloqueios.py
+++ b/v2/backend/apps/core/views_import_bloqueios.py
@@ -68,6 +68,7 @@ class ImportBloqueiosView(APIView):
     # AvailabilityBlockViewSet (formador declara o próprio); só o import
     # em massa é restrito (D-2 do plano).
     permission_classes = [IsAuthenticated, HasPerm("import_spreadsheet")]
+    throttle_scope = "import"
 
     @extend_schema(
         summary="Importar bloqueios de disponibilidade",

--- a/v2/backend/apps/core/views_import_colecoes.py
+++ b/v2/backend/apps/core/views_import_colecoes.py
@@ -52,6 +52,7 @@ class ImportColecoesView(APIView):
     """
 
     permission_classes = [IsAuthenticated, HasPerm("manage_admin_registries")]
+    throttle_scope = "import"
 
     @extend_schema(
         summary="Importar coleções",

--- a/v2/backend/apps/core/views_import_deslocamentos.py
+++ b/v2/backend/apps/core/views_import_deslocamentos.py
@@ -67,6 +67,7 @@ class ImportDeslocamentosView(APIView):
     # `HasPerm("import_spreadsheet")`. Lançamento individual de deslocamento
     # continua via UI dedicada; só o import em massa é restrito (D-3 do plano).
     permission_classes = [IsAuthenticated, HasPerm("import_spreadsheet")]
+    throttle_scope = "import"
 
     @extend_schema(
         summary="Importar deslocamentos",

--- a/v2/backend/apps/core/views_import_equipe_gerencia.py
+++ b/v2/backend/apps/core/views_import_equipe_gerencia.py
@@ -52,6 +52,7 @@ class ImportEquipeGerenciaView(APIView):
     """
 
     permission_classes = [IsAuthenticated, HasPerm("manage_admin_registries")]
+    throttle_scope = "import"
 
     @extend_schema(
         summary="Importar vínculos de equipe-gerência",

--- a/v2/backend/apps/core/views_import_eventos.py
+++ b/v2/backend/apps/core/views_import_eventos.py
@@ -75,6 +75,7 @@ class ImportEventosView(APIView):
     # `HasPerm("import_spreadsheet")`. Controle perde acesso ao import em
     # massa (D-1 do plano).
     permission_classes = [IsAuthenticated, HasPerm("import_spreadsheet")]
+    throttle_scope = "import"
 
     @extend_schema(
         summary="Importar solicitações/eventos",

--- a/v2/backend/apps/core/views_import_municipios.py
+++ b/v2/backend/apps/core/views_import_municipios.py
@@ -52,6 +52,7 @@ class ImportMunicipiosView(APIView):
     """
 
     permission_classes = [IsAuthenticated, HasPerm("manage_admin_registries")]
+    throttle_scope = "import"
 
     @extend_schema(
         summary="Importar municípios",

--- a/v2/backend/apps/core/views_import_produtos.py
+++ b/v2/backend/apps/core/views_import_produtos.py
@@ -67,6 +67,7 @@ class ImportProdutosView(APIView):
     # PR-A1 DAT-Imports (2026-04-29): centralização DAT-only via
     # `HasPerm("import_spreadsheet")`. Controle perde acesso (D-1).
     permission_classes = [IsAuthenticated, HasPerm("import_spreadsheet")]
+    throttle_scope = "import"
 
     @extend_schema(
         summary="Importar produtos",

--- a/v2/backend/apps/core/views_import_usuarios.py
+++ b/v2/backend/apps/core/views_import_usuarios.py
@@ -64,6 +64,7 @@ class ImportUsuariosView(APIView):
     """
 
     permission_classes = [IsAuthenticated, HasPerm("manage_admin_registries")]
+    throttle_scope = "import"
 
     @extend_schema(
         summary="Importar usuários",

--- a/v2/backend/apps/core/views_imports.py
+++ b/v2/backend/apps/core/views_imports.py
@@ -73,6 +73,7 @@ class ControleImportAcoesView(APIView):
     # PR-A1 DAT-Imports (2026-04-29): centralização DAT-only via
     # `HasPerm("import_spreadsheet")`. Controle perde acesso (D-1).
     permission_classes = [IsAuthenticated, HasPerm("import_spreadsheet")]
+    throttle_scope = "import"
 
     @extend_schema(
         summary="Importar ações de controle",
@@ -170,6 +171,7 @@ class DATImportCadastrosView(APIView):
     """
 
     permission_classes = [IsAuthenticated, HasPerm("manage_admin_registries")]
+    throttle_scope = "import"
 
     @extend_schema(
         summary="Importar cadastros DAT",

--- a/v2/backend/config/settings.py
+++ b/v2/backend/config/settings.py
@@ -465,9 +465,12 @@ REST_FRAMEWORK = {
         "availability_check": "60/min",  # 60 requests por minuto para availability check
         "metrics": "30/min",  # Geo queries + aggregations
         "reports": "30/min",  # Heavy aggregations
-        "gcal_read": "60/min",  # Google Calendar reads
         "gcal_write": "10/min",  # Google Calendar writes (publish)
         "export": "10/min",  # CSV/JSON exports
+        # Import: uploads pesados (parse de arquivo + writes SINCRONOS) seguram o worker do
+        # gunicorn — tier pesado como metrics/reports. Balde unico por usuario, compartilhado
+        # por todos os endpoints de import (Onda 4, pos-incidente 2026-07-06).
+        "import": "30/min",
         # Login: restrito em produção (brute-force protection — Issue #133),
         # relaxado fora dela para não atrapalhar dev / testes E2E multi-role.
         # Sobrescrito abaixo com valor ambiente-dependente.
@@ -539,9 +542,9 @@ if ENVIRONMENT == "development":
         "availability_check": "600/min",
         "metrics": "300/min",
         "reports": "300/min",
-        "gcal_read": "600/min",
         "gcal_write": "100/min",
         "export": "100/min",
+        "import": "300/min",  # 10x prod — uploads em dev/testes E2E nao devem bloquear
         # Login: 1000/min em dev para não bloquear testes E2E multi-role e
         # desenvolvimento manual (12+ logins em sequência). Em prod mantém
         # 10/min contra brute force (ver bloco DEFAULT_THROTTLE_RATES acima).


### PR DESCRIPTION
## Contexto (Onda 4b — hardening pos-incidente 2026-07-06)

Os endpoints de **upload/import** (parse de arquivo + writes SINCRONOS que seguram o worker do gunicorn) e o **export do dashboard** nao tinham rate-limit proprio — so o global `user: 1000/hour`. Uma rajada de imports podia saturar os workers (mesma familia de causa do incidente de logging).

## Mudancas
- **Novo scope `import`** (30/min prod, 300/min dev) via `throttle_scope` nos **12 endpoints POST de import**. O `ScopedRateThrottle` ja esta em `DEFAULT_THROTTLE_CLASSES` — basta o `throttle_scope` (nenhum `throttle_classes` por view).
- **Liga o scope `export`** (10/min prod) — ja existia em settings mas estava sem dono — no `DashboardEventsExportView`; corrige **docstring drift** (dizia `HasPerm("import_spreadsheet")`, usa `CanUseGcal`).
- **Remove o scope morto `gcal_read`** (definido nos 2 dicts, referenciado por nenhuma view/teste/frontend — confirmado por grep no repo).

## Testes (deterministas)
O 429 ponta-a-ponta pelo APIClient flaka no CI paralelo (pytest-xdist limpa o cache de throttle entre testes — ver `test_login_throttle_simple.py`). Validacao em duas camadas:
1. **Wiring (regressao):** cada import view declara `throttle_scope="import"`; export declara `"export"`. Um endpoint de import novo sem throttle reprova aqui.
2. **Comportamental isolado:** `ScopedRateThrottle` com rate forcado baixo bloqueia de fato apos o limite (cache dedicado + ident unico).

`test_throttle_scopes_sentinela` segue verde (parity base/dev + used-subset). Suite de import/export/throttle: **537 passed** (sem regressao de 429).

## Follow-up
Mensagem amigavel de **429** no `/dat/importacoes` sera tratada junto do **503** na Onda 4c (PR-C), num unico passo de error-handling no frontend.
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `e38e7672`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
