### PR TITLE
fix(gcal): timeout do Google vira 503 (nao 500) + UX de erro no frontend (Onda 4c)

### DIFF
--- a/v2/backend/apps/core/tests/test_gcal_timeout_503.py
+++ b/v2/backend/apps/core/tests/test_gcal_timeout_503.py
@@ -1,0 +1,102 @@
+"""GCal request-path: timeout do Google vira 503 (ServiceUnavailableError), nao 500.
+
+Onda 4c (pos-incidente 2026-07-06): `socket.timeout` IS `TimeoutError` no py3.12 e propaga
+cru (o retry client-level so pega `HttpError`). Antes, as 3 views de LEITURA do GCal
+(gcal_calendars, google_oauth_list_calendars, google_oauth_list_events) engoliam qualquer
+erro com `except Exception` -> 500 (erro do servidor, alarme falso). Agora um timeout do
+Google retorna 503 + code SERVICE_UNAVAILABLE — "servico externo indisponivel, tente de
+novo" — como o gcal_health ja fazia. Erros NAO-timeout continuam 500 (handler estreito).
+"""
+
+# pyright: reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportAttributeAccessIssue=false, reportMissingParameterType=false, reportUnknownParameterType=false, reportOptionalMemberAccess=false, reportArgumentType=false
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+import pytest
+
+from apps.core.models import GoogleOAuthCredential
+from apps.core.tests.factories import GroupFactory, UsuarioFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def _controle_client() -> tuple[APIClient, object]:
+    """APIClient autenticado com grupo Controle (satisfaz CanUseGcal)."""
+    user = UsuarioFactory()
+    user.groups.add(GroupFactory(name="Controle"))
+    api = APIClient()
+    api.force_authenticate(user=user)
+    return api, user
+
+
+class _TimeoutCalClient:
+    """Stub de client GCal cujas LEITURAS estouram timeout (socket.timeout == TimeoutError)."""
+
+    def __init__(self, *args: object, **kwargs: object) -> None: ...
+
+    def list_calendars(self) -> object:
+        raise TimeoutError("deadline exceeded")
+
+    def list_events(self, *args: object, **kwargs: object) -> object:
+        raise TimeoutError("deadline exceeded")
+
+
+def _make_credential(user: object) -> None:
+    GoogleOAuthCredential.objects.create(
+        user=user,
+        google_email="op@aprendereditora.com.br",
+        access_token_encrypted=b"enc-access",
+        refresh_token_encrypted=b"enc-refresh",
+        token_expiry=timezone.now() + timedelta(hours=1),
+        scope="https://www.googleapis.com/auth/calendar",
+        default_calendar_id="primary",
+    )
+
+
+def _assert_503(resp: object) -> None:
+    assert resp.status_code == 503, f"esperava 503, veio {resp.status_code}: {getattr(resp, 'data', None)}"
+    assert resp.data.get("code") == "SERVICE_UNAVAILABLE", f"code inesperado: {resp.data}"
+
+
+def test_gcal_calendars_timeout_vira_503(monkeypatch: pytest.MonkeyPatch) -> None:
+    api, _ = _controle_client()
+    monkeypatch.setattr(
+        "apps.core.views_gcal.gcal.get_gcal_client_and_calendar_id",
+        lambda: (_TimeoutCalClient(), "cal"),
+    )
+    _assert_503(api.get("/api/gcal/calendars/"))
+
+
+def test_oauth_list_calendars_timeout_vira_503(monkeypatch: pytest.MonkeyPatch) -> None:
+    api, user = _controle_client()
+    _make_credential(user)
+    monkeypatch.setattr("apps.core.services.gcal_oauth_client.OAuthCalendarClient", _TimeoutCalClient)
+    _assert_503(api.get("/api/integrations/google/calendars/"))
+
+
+def test_oauth_list_events_timeout_vira_503(monkeypatch: pytest.MonkeyPatch) -> None:
+    api, user = _controle_client()
+    _make_credential(user)
+    monkeypatch.setattr("apps.core.services.gcal_oauth_client.OAuthCalendarClient", _TimeoutCalClient)
+    _assert_503(api.get("/api/integrations/google/events/"))
+
+
+def test_gcal_calendars_erro_generico_continua_500(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Handler estreito: so TimeoutError vira 503; qualquer outro erro segue 500."""
+
+    class _BrokenClient:
+        def list_calendars(self) -> object:
+            raise ValueError("boom")
+
+    api, _ = _controle_client()
+    monkeypatch.setattr(
+        "apps.core.views_gcal.gcal.get_gcal_client_and_calendar_id",
+        lambda: (_BrokenClient(), "cal"),
+    )
+    resp = api.get("/api/gcal/calendars/")
+    assert resp.status_code == 500, f"erro generico deveria seguir 500, veio {resp.status_code}"

--- a/v2/backend/apps/core/views_gcal/gcal.py
+++ b/v2/backend/apps/core/views_gcal/gcal.py
@@ -49,6 +49,11 @@ def gcal_calendars(request: Request) -> Response:
 
         return Response(calendars, status=status.HTTP_200_OK)
 
+    except TimeoutError:
+        # socket.timeout IS TimeoutError (py3.12): o Google nao respondeu a tempo.
+        # 503 (servico externo indisponivel) em vez de 500 — nao e erro do nosso servidor.
+        logger.warning("Timeout ao listar calendarios do Google Calendar")
+        raise ServiceUnavailableError(service="Google Calendar", details="O Google demorou a responder")
     except Exception as e:
         logger.error(f"Error listing calendars: {e}", exc_info=True)
         return Response(

--- a/v2/backend/apps/core/views_oauth.py
+++ b/v2/backend/apps/core/views_oauth.py
@@ -30,6 +30,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.throttling import UserRateThrottle
 
+from apps.core.exceptions import ServiceUnavailableError
 from apps.core.models import AuditLog, GoogleOAuthCredential
 from apps.core.rbac.policies import CanUseGcal
 from apps.core.services.google_oauth import build_authorization_url, exchange_code_for_tokens, revoke_token
@@ -582,6 +583,10 @@ def google_oauth_list_events(request: Request) -> Response:
 
     except GoogleOAuthCredential.DoesNotExist:
         return Response({"error": "Nenhuma conexão Google encontrada"}, status=status.HTTP_404_NOT_FOUND)
+    except TimeoutError:
+        # socket.timeout IS TimeoutError (py3.12): 503 (Google indisponivel), nao 500.
+        logger.warning("⏱️ Timeout ao listar eventos do Google Calendar")
+        raise ServiceUnavailableError(service="Google Calendar", details="O Google demorou a responder")
     except Exception as e:
         logger.error(f"❌ Erro ao listar eventos: {e}")
         return Response({"error": "Erro ao listar eventos"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
@@ -639,6 +644,10 @@ def google_oauth_list_calendars(request: Request) -> Response:
 
     except GoogleOAuthCredential.DoesNotExist:
         return Response({"error": "Nenhuma conexão Google encontrada"}, status=status.HTTP_404_NOT_FOUND)
+    except TimeoutError:
+        # socket.timeout IS TimeoutError (py3.12): 503 (Google indisponivel), nao 500.
+        logger.warning("⏱️ Timeout ao listar calendários do Google Calendar")
+        raise ServiceUnavailableError(service="Google Calendar", details="O Google demorou a responder")
     except Exception as e:
         logger.error(f"❌ Erro ao listar calendários: {e}")
         return Response({"error": "Erro ao listar calendários"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)

--- a/v2/frontend/src/components/ImportUploader.tsx
+++ b/v2/frontend/src/components/ImportUploader.tsx
@@ -111,7 +111,12 @@ export default function ImportUploader({ label, onDryRun, onApply, description }
       const report = await onDryRun(file);
       setValidationResult(report);
     } catch (err) {
-      setError((err as Error).message || 'Erro ao validar arquivo');
+      const httpStatus = (err as { response?: { status?: number } }).response?.status;
+      if (httpStatus === 429) {
+        setError('Muitas importações em pouco tempo. Aguarde um instante e tente novamente.');
+      } else {
+        setError((err as Error).message || 'Erro ao validar arquivo');
+      }
     } finally {
       setLoading(false);
     }
@@ -131,7 +136,12 @@ export default function ImportUploader({ label, onDryRun, onApply, description }
       setApplyResult(report);
       setValidationResult(null); // Limpar validação após apply
     } catch (err) {
-      setError((err as Error).message || 'Erro ao importar arquivo');
+      const httpStatus = (err as { response?: { status?: number } }).response?.status;
+      if (httpStatus === 429) {
+        setError('Muitas importações em pouco tempo. Aguarde um instante e tente novamente.');
+      } else {
+        setError((err as Error).message || 'Erro ao importar arquivo');
+      }
     } finally {
       setLoadingApply(false);
     }

--- a/v2/frontend/src/components/google/GoogleIntegrationCard.tsx
+++ b/v2/frontend/src/components/google/GoogleIntegrationCard.tsx
@@ -99,7 +99,12 @@ const GoogleIntegrationCard = ({ status, onConnect, onDisconnect }: GoogleIntegr
       setCalendars(data.calendars || []);
     } catch (error) {
       logger.error('Erro ao carregar calendários:', error);
-      message.error('Não foi possível carregar seus calendários');
+      const httpStatus = (error as { response?: { status?: number } }).response?.status;
+      if (httpStatus === 503) {
+        message.error('O Google Calendar demorou a responder. Tente novamente em instantes.');
+      } else {
+        message.error('Não foi possível carregar seus calendários');
+      }
     } finally {
       setLoadingCalendars(false);
     }

--- a/v2/frontend/src/pages/PreAgenda/PreAgendaPage.tsx
+++ b/v2/frontend/src/pages/PreAgenda/PreAgendaPage.tsx
@@ -525,7 +525,12 @@ export default function PreAgendaPage(): JSX.Element {
       );
       setGcalEvents(data.events || []);
     } catch (error) {
-      message.error('Erro ao carregar eventos do Google Calendar');
+      const httpStatus = (error as { response?: { status?: number } }).response?.status;
+      if (httpStatus === 503) {
+        message.error('O Google Calendar demorou a responder. Tente novamente em instantes.');
+      } else {
+        message.error('Erro ao carregar eventos do Google Calendar');
+      }
       logger.error('Erro ao carregar eventos GCal:', error);
     } finally {
       setLoadingGcalEvents(false);


### PR DESCRIPTION
## Contexto (Onda 4c — hardening pos-incidente 2026-07-06)

`socket.timeout` **IS** `TimeoutError` no py3.12 e propaga cru — o retry client-level so captura `HttpError`. As **3 views de LEITURA** do GCal no request-path engoliam qualquer erro com `except Exception` → **500** (alarme falso de erro do NOSSO servidor, quando na verdade o Google que nao respondeu).

## Backend
As 3 views agora retornam **503 + `SERVICE_UNAVAILABLE`** num timeout do Google (espelhando o `gcal_health`, que ja fazia isso), com handler **estreito** (`except TimeoutError` antes do `except Exception`; erros nao-timeout seguem 500):
- `gcal_calendars` (`views_gcal/gcal.py`)
- `google_oauth_list_calendars` (`views_oauth.py`)
- `google_oauth_list_events` (`views_oauth.py`)

Confirmado por investigacao que essas 3 sao o conjunto **completo** de leituras GCal que 500am no request-path (as demais views nao chamam o client sincronamente; `gcal_health` ja e 503).

## Frontend (mensagens amigaveis por status, padrao `err.response.status` ja usado no codebase)
- **GoogleIntegrationCard** + **PreAgendaPage**: `503` → *"O Google Calendar demorou a responder. Tente novamente em instantes."* (antes: mensagem generica).
- **ImportUploader** (uploader **central** dos imports): `429` → *"Muitas importacoes em pouco tempo. Aguarde..."* — completa a UX do throttle da **Onda 4b** (antes mostrava o texto cru em ingles do DRF).

## Testes
- Backend: 3 testes de 503 (um por view, via DRF exception handler com client mockado levantando `TimeoutError`) + 1 de **narrowness** (erro generico continua 500). Regressao GCal/OAuth: 52 passed.
- Frontend: `tsc --noEmit` + `eslint .` verdes; branch presentacional com padrao de acesso ja provado no codebase — a substancia (503) esta coberta no backend. (Sem RTL de antd Upload: frageis em jsdom, valor negativo — lição do login-throttle.)
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `bb216cbb`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
