### PR TITLE
ci(deploy): retry no GET inicial do Portainer (band-aid do curl 28)

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -605,11 +605,33 @@ jobs:
           curl_opts+=(--config "$portainer_hdr_file")
 
           # --- Read current stack state ---
-          stack_json="$(curl "${curl_opts[@]}" \
-            "${portainer_url}/api/stacks/${PORTAINER_STACK_ID}")"
+          # Retry helper: um curl 28/000 transiente ao Portainer (blips de
+          # firewall/Kaspersky no caminho runner->:9443) NAO pode abortar o deploy
+          # inteiro logo no primeiro GET. Espelha o retry que o PUT ja tem (3
+          # tentativas, 10s de backoff). GET e idempotente -> retry simples e seguro.
+          get_response_file="$(mktemp)"
+          trap 'rm -f "$portainer_hdr_file" "$get_response_file"' EXIT
+          fetch_stack_json_with_retry() {
+            local url="$1" http_code attempt
+            local max_attempts=3 retry_sleep=10
+            for attempt in $(seq 1 "$max_attempts"); do
+              # --max-time 30: um GET de leitura e rapido; timeout curto detecta o
+              # blip cedo e re-tenta (os 300s de curl_opts sao p/ o PUT+redeploy).
+              http_code="$(curl "${curl_opts[@]}" --max-time 30 \
+                -o "$get_response_file" -w '%{http_code}' "$url" || true)"
+              if [[ "$http_code" =~ ^[0-9]+$ ]] && [ "$http_code" -ge 200 ] && [ "$http_code" -lt 300 ]; then
+                cat "$get_response_file"
+                return 0
+              fi
+              echo "Portainer GET falhou (HTTP ${http_code:-curl_error}) tentativa ${attempt}/${max_attempts}: ${url}" >&2
+              [ "$attempt" -lt "$max_attempts" ] && sleep "$retry_sleep"
+            done
+            echo "Portainer GET esgotou ${max_attempts} tentativas: ${url}" >&2
+            return 1
+          }
 
-          stack_file_json="$(curl "${curl_opts[@]}" \
-            "${portainer_url}/api/stacks/${PORTAINER_STACK_ID}/file")"
+          stack_json="$(fetch_stack_json_with_retry "${portainer_url}/api/stacks/${PORTAINER_STACK_ID}")"
+          stack_file_json="$(fetch_stack_json_with_retry "${portainer_url}/api/stacks/${PORTAINER_STACK_ID}/file")"
 
           stack_file_content="$(printf '%s' "$stack_file_json" | jq -r '.StackFileContent')"
           if [ -z "$stack_file_content" ] || [ "$stack_file_content" = "null" ]; then


### PR DESCRIPTION
## Problema
O step `Deploy via Portainer CE API (update IMAGE_TAG)` falhava logo no **primeiro GET** (fetch da stack) quando o runner não alcançava o Portainer `:9443` num blip transiente (firewall/Kaspersky) → `curl (28)` → `set -e` aborta o step inteiro. Os 3 últimos deploys da Onda 4 (#1507/#1508/#1509) morreram assim; `gh run rerun` resolvia (a conexão é **intermitente, não morta**).

## Fix
O **PUT** já tinha retry (3 tentativas + confirmação em timeout 000); os **2 GETs iniciais** ([deploy.yaml:607](.github/workflows/deploy.yaml)) não tinham. Esta PR espelha o retry nos GETs:
- Helper `fetch_stack_json_with_retry` — 3 tentativas, 10s de backoff.
- `--max-time 30` (GET de leitura é rápido; os 300s de `curl_opts` são só p/ o PUT+redeploy).
- GET é **idempotente** → retry simples e seguro (sem a lógica de confirmação que o PUT precisa).

Resultado: o deploy **auto-cura** o `curl 28` transiente em vez de exigir re-run manual.

## Validação
- `yaml.safe_load` OK; `bash -n` do run block OK.
- Mudança **isolada** ao caminho de erro do GET; não altera a imagem nem o comportamento em caminho feliz.

## Contexto
Paliativo enquanto o **design pull-based** (agente on-box + gate manual, ADR-018) — que remove o PUT inbound e fecha o `:9443` — não entra. Ver o ADR no mesmo lote de docs.
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `92b3ff6c`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
