### PR TITLE
chore(ci): CODEOWNERS na superficie de deploy (ADR-018 Fase 0)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,19 @@
+# CODEOWNERS — superfície crítica de deploy/CI
+#
+# ADR-018 Fase 0 (pré-requisitos de segurança, issue #1512).
+# Objetivo: exigir revisão do code owner nos caminhos que, se alterados por um
+# fork-PR malicioso ou por engano, comprometeriam o deploy de produção
+# (o repo é PÚBLICO). A enforcement depende de ligar em Branch protection de `main`
+# a opção "Require review from Code Owners" — ver #1512.
+#
+# GitHub usa o ÚLTIMO padrão que casa. Owner = mantenedor solo.
+
+# Pipeline de CI/CD (build, scan, deploy, provenance/cosign)
+/.github/workflows/   @matheusnorjosa
+
+# O próprio CODEOWNERS e configs de segurança do repo
+/.github/CODEOWNERS   @matheusnorjosa
+
+# Infra de deploy: compose de produção, Dockerfiles prod, scripts de infra
+# e (Fase 1) o código-fonte do agente pull on-box na VM01.
+/v2/infra/            @matheusnorjosa


### PR DESCRIPTION
## O quê
Adiciona `.github/CODEOWNERS` cobrindo a **superfície crítica de deploy/CI** — primeiro entregável da **Fase 0** do ADR-018 (pré-requisitos de segurança, #1512).

Caminhos protegidos (owner = mantenedor):
- `/.github/workflows/` — pipeline de build/scan/deploy/provenance
- `/.github/CODEOWNERS` — protege a própria proteção
- `/v2/infra/` — compose prod, Dockerfiles prod, scripts de infra e (Fase 1) o agente pull on-box

## Por quê
Repo é **público** → um fork-PR malicioso que altere o deploy pipeline é um vetor de RCE na VM01. CODEOWNERS + "Require review from Code Owners" na branch protection fecham esse caminho. Ref ADR-018 §Segurança.

## Enforcement (ação manual, fora deste PR)
O arquivo por si só não bloqueia nada. É preciso ligar em **Settings → Branches → main → Require review from Code Owners** (parte da Fase 0 / #1512).

## ⚠️ Merge = prod
`deploy.yaml` roda em **todo** push na `main` (sem filtro de `paths`), então **este merge reconstrói e redeploya o prod** — mesmo código-fonte, tag nova. O `.github/CODEOWNERS` **não entra na imagem Docker**, então o artefato é idêntico ao prod atual (`v2026.07.08-6b84bd0`, healthy) exceto pelo GIT_SHA. Consequências:
- Staging gate é **N/A funcionalmente** aqui (o arquivo não está na imagem; smoke seria idêntico ao prod atual).
- O redeploy pode exibir o **false-red do `:9443`** (job vermelho, prod correto — conferir a coluna Image no Portainer).
- Que um change de metadados de CI redeploye o prod é, ele mesmo, o *furo merge=prod* que a **Fase 2 (#1514)** corrige.

**Recomendação:** mergear intencionalmente quando você for ligar a branch protection (Fase 0), para o CODEOWNERS já entrar em vigor no mesmo passo.

Closes parte de #1512 · Ref #1518
