### PR TITLE
fix(ci): slsa-provenance subject-name qualifica registry (index.docker.io)

### DIFF
--- a/.github/workflows/slsa-provenance.yml
+++ b/.github/workflows/slsa-provenance.yml
@@ -101,14 +101,16 @@ jobs:
       - name: Generate SLSA provenance attestation (backend)
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
         with:
-          subject-name: ${{ env.BACKEND_IMAGE }}
+          # registry-qualified (index.docker.io/): sem o prefixo o attest interpreta
+          # 'norjosamatheus' como host de registry -> "No credentials found for registry".
+          subject-name: index.docker.io/${{ env.BACKEND_IMAGE }}
           subject-digest: ${{ steps.digests.outputs.backend_digest }}
           push-to-registry: true
 
       - name: Generate SLSA provenance attestation (frontend)
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
         with:
-          subject-name: ${{ env.FRONTEND_IMAGE }}
+          subject-name: index.docker.io/${{ env.FRONTEND_IMAGE }}
           subject-digest: ${{ steps.digests.outputs.frontend_digest }}
           push-to-registry: true
 


### PR DESCRIPTION
## O quê

Corrige o `subject-name` do `actions/attest-build-provenance` no `slsa-provenance.yml`: qualifica com `index.docker.io/` (backend e frontend). Sem o prefixo de registry, o attest interpretava `norjosamatheus` como **host de registry** e falhava com `No credentials found for registry norjosamatheus`.

## Como apareceu (bug latente)

O `slsa-provenance.yml` **nunca tinha rodado** — ele assina em `release: published`, mas as releases são criadas pelo `deploy.yaml` via `GITHUB_TOKEN`, e o GitHub **não deixa eventos de `GITHUB_TOKEN` dispararem outros workflows** (anti-loop). Ao disparar `slsa-provenance` **manualmente** pela 1ª vez (ADR-018 Fase 3, run [#28963423645](https://github.com/matheusnorjosa/aprender_sistema/actions/runs/28963423645)), o bug do subject-name apareceu.

## Por que precisa ir pra `main`

A identidade da assinatura keyless será `slsa-provenance.yml@refs/heads/<ref>`. O agente `aprender-deployer` só aceita `@refs/heads/main` (ou tags). Então o workflow tem de rodar **da main** — daí o merge.

## ⚠️ Follow-up separado (não neste PR)

O gap de **auto-trigger** (slsa nunca roda sozinho) é rastreado à parte — é **bloqueador do cutover** (a operação pull contínua exige toda imagem assinada). Ver a issue filha.

Ref #1513 · #1518
