### PR TITLE
ci(deploy): auto-assina toda release (slsa-provenance reusable, ADR-018 #1524)

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -155,6 +155,10 @@ jobs:
       # foram movidos p/ o job `tag_and_release` (desacopla contents:write de um
       # alvo classico de supply-chain: o job que builda/pusha imagem). #1397.
       contents: read
+    outputs:
+      # digests dos pushes -> consumidos pelo job `sign` (assinatura por digest, ADR-018 #1524)
+      backend_digest: ${{ steps.push_backend.outputs.digest }}
+      frontend_digest: ${{ steps.push_frontend.outputs.digest }}
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
@@ -243,6 +247,7 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
       - name: Build and push backend image
+        id: push_backend
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: ./v2
@@ -258,6 +263,7 @@ jobs:
             BUILD_DATE=${{ needs.prepare.outputs.build_date }}
 
       - name: Build and push frontend image
+        id: push_frontend
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: ./v2/frontend
@@ -269,6 +275,28 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             GIT_SHA=${{ github.sha }}
+
+  sign:
+    # ADR-018 #1524: auto-assina TODA imagem de prod (cosign keyless + attestation SLSA),
+    # reutilizando o slsa-provenance.yml. A identidade OIDC keyless de um reusable LOCAL
+    # e slsa-provenance.yml@refs/heads/main -> casa com o IMAGE_IDENTITY_RE do agente/promote
+    # (nenhuma mudanca no agente). Roda EM PARALELO ao PUT legado (nao e needs do `deploy`),
+    # entao um sign vermelho NAO bloqueia o deploy atual — seguro ate o cutover.
+    # Gate `ref == main`: dispatch de staging a partir de branch assinaria com identidade
+    # que o agente rejeita; entao so assina no caminho main.
+    name: Sign images (cosign keyless + SLSA)
+    needs: [prepare, build_and_push]
+    if: needs.prepare.outputs.should_build == 'true' && github.ref == 'refs/heads/main'
+    permissions:
+      id-token: write       # cosign keyless (Fulcio) — DEVE estar no caller
+      attestations: write   # actions/attest-build-provenance
+      contents: read
+    uses: ./.github/workflows/slsa-provenance.yml
+    with:
+      release_tag: ${{ needs.prepare.outputs.release_version }}
+      backend_digest: ${{ needs.build_and_push.outputs.backend_digest }}
+      frontend_digest: ${{ needs.build_and_push.outputs.frontend_digest }}
+    secrets: inherit
 
   tag_and_release:
     name: Tag and GitHub Release

--- a/.github/workflows/slsa-provenance.yml
+++ b/.github/workflows/slsa-provenance.yml
@@ -1,6 +1,25 @@
 name: SLSA Provenance and Signing
 
 on:
+  # Chamado pelo deploy.yaml (job `sign`) após o build+push — auto-assinatura de
+  # toda release de prod (ADR-018 #1524). Reusable LOCAL => identidade keyless
+  # continua slsa-provenance.yml@refs/heads/main (o agente/promote nao mudam).
+  workflow_call:
+    inputs:
+      release_tag:
+        description: "Tag imutável já buildada e pushada (vYYYY.MM.DD-<sha7>)"
+        required: true
+        type: string
+      backend_digest:
+        description: "Digest do backend (sha256:...) — evita TOCTOU de tag mutável"
+        required: false
+        type: string
+        default: ""
+      frontend_digest:
+        description: "Digest do frontend (sha256:...)"
+        required: false
+        type: string
+        default: ""
   workflow_dispatch:
     inputs:
       release_tag:
@@ -37,20 +56,16 @@ jobs:
       - name: Resolve release tag
         id: resolve
         env:
-          EVENT_NAME: ${{ github.event_name }}
-          RELEASE_TAG_INPUT: ${{ github.event.inputs.release_tag || '' }}
+          # inputs.* cobre workflow_call E workflow_dispatch; release usa o evento.
+          RELEASE_TAG_INPUT: ${{ inputs.release_tag || '' }}
           RELEASE_TAG_EVENT: ${{ github.event.release.tag_name || '' }}
         run: |
           set -euo pipefail
-          release_tag=""
-          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            release_tag="$(echo "${RELEASE_TAG_INPUT}" | xargs)"
-          elif [ "$EVENT_NAME" = "release" ]; then
-            release_tag="$(echo "${RELEASE_TAG_EVENT}" | xargs)"
-          fi
+          release_tag="$(echo "${RELEASE_TAG_INPUT}" | xargs)"
+          if [ -z "$release_tag" ]; then release_tag="$(echo "${RELEASE_TAG_EVENT}" | xargs)"; fi
 
           if [ -z "$release_tag" ]; then
-            echo "Unable to resolve release tag for event=${EVENT_NAME}." >&2
+            echo "Unable to resolve release tag." >&2
             exit 1
           fi
 
@@ -75,28 +90,31 @@ jobs:
           username: ${{ env.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
-      - name: Resolve image digests from immutable tag
+      - name: Resolve image digests
         id: digests
         env:
           RELEASE_TAG: ${{ steps.resolve.outputs.release_tag }}
+          # Digests passados pelo caller (deploy.yaml) evitam TOCTOU de tag mutavel.
+          # Fallback: resolve por tag (backfill via workflow_dispatch/release). Mesmo
+          # metodo (imagetools inspect) que o gate-duro do promote.yml usa.
+          BACKEND_DIGEST_IN: ${{ inputs.backend_digest || '' }}
+          FRONTEND_DIGEST_IN: ${{ inputs.frontend_digest || '' }}
         run: |
           set -euo pipefail
-
-          backend_ref="${BACKEND_IMAGE}:${RELEASE_TAG}"
-          frontend_ref="${FRONTEND_IMAGE}:${RELEASE_TAG}"
-
-          backend_digest="$(docker buildx imagetools inspect "${backend_ref}" | awk '/Digest:/ {print $2; exit}')"
-          frontend_digest="$(docker buildx imagetools inspect "${frontend_ref}" | awk '/Digest:/ {print $2; exit}')"
-
-          if [ -z "${backend_digest}" ] || [ -z "${frontend_digest}" ]; then
-            echo "Could not resolve backend/frontend digest for tag ${RELEASE_TAG}." >&2
-            exit 1
+          be="$BACKEND_DIGEST_IN"; fe="$FRONTEND_DIGEST_IN"
+          if [ -z "$be" ] || [ -z "$fe" ]; then
+            be="$(docker buildx imagetools inspect "${BACKEND_IMAGE}:${RELEASE_TAG}"  | awk '/Digest:/ {print $2; exit}')"
+            fe="$(docker buildx imagetools inspect "${FRONTEND_IMAGE}:${RELEASE_TAG}" | awk '/Digest:/ {print $2; exit}')"
           fi
-
-          echo "backend_ref=${backend_ref}" >> "$GITHUB_OUTPUT"
-          echo "frontend_ref=${frontend_ref}" >> "$GITHUB_OUTPUT"
-          echo "backend_digest=${backend_digest}" >> "$GITHUB_OUTPUT"
-          echo "frontend_digest=${frontend_digest}" >> "$GITHUB_OUTPUT"
+          for d in "$be" "$fe"; do
+            printf '%s' "$d" | grep -Eq '^sha256:[0-9a-f]{64}$' || { echo "digest invalido: $d" >&2; exit 1; }
+          done
+          {
+            echo "backend_ref=${BACKEND_IMAGE}:${RELEASE_TAG}"
+            echo "frontend_ref=${FRONTEND_IMAGE}:${RELEASE_TAG}"
+            echo "backend_digest=${be}"
+            echo "frontend_digest=${fe}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Generate SLSA provenance attestation (backend)
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
@@ -154,6 +172,7 @@ jobs:
           BACKEND_DIGEST: ${{ steps.digests.outputs.backend_digest }}
           FRONTEND_DIGEST: ${{ steps.digests.outputs.frontend_digest }}
           SIGNER_WORKFLOW: ${{ github.repository }}/.github/workflows/slsa-provenance.yml
+          GH_TOKEN: ${{ github.token }}   # gh attestation verify precisa de auth (self-check)
         run: |
           set -euo pipefail
           gh attestation verify "oci://${BACKEND_IMAGE}@${BACKEND_DIGEST}" \


### PR DESCRIPTION
## O quê

`deploy.yaml`, após o build+push, chama o `slsa-provenance.yml` (agora `workflow_call`) num job **`sign`** → **cosign keyless + attestation SLSA** de cada imagem, **por digest**. Fecha o gap #1524: o `slsa-provenance` nunca auto-disparava (release criada via `GITHUB_TOKEN` não cascateia eventos).

## Por que é seguro (identidade preservada + rollout paralelo)

- **Identidade NÃO muda:** um reusable **local** assina keyless com SAN `slsa-provenance.yml@refs/heads/main` — byte-a-byte igual ao `IMAGE_IDENTITY_RE` que o agente e o `promote.yml` já verificam. **Zero mudança no agente, sem re-deploy na VM.** (Pesquisa de OIDC + red-team no design.)
- **Rollout paralelo:** o `sign` roda ao lado do PUT legado (**não** é `needs` do job `deploy`) → um `sign` vermelho **não bloqueia** o deploy atual. Prod continua como hoje até o cutover.
- **Gate `ref == 'refs/heads/main'`:** evita que um dispatch de staging a partir de branch assine com identidade que o agente rejeitaria (red-team).
- Fix do `GH_TOKEN` no self-check do `slsa` (o `gh attestation verify` precisa de auth). `build_and_push` expõe os digests (assina por digest, sem TOCTOU).

## NÃO faz (é o cutover, fases seguintes)

Não toca o job `deploy` (o PUT no Portainer) — ele só sai no cutover (#1512+). Este PR só **adiciona** a assinatura automática.

## Validação (pós-merge, o agente é fail-closed)

1. Merge → o build do merge roda o `sign` (1ª imagem auto-assinada) em paralelo ao PUT.
2. `cosign verify <img>@<digest> --certificate-identity-regexp "<o mesmo de hoje>"` → verde = identidade correta.
3. `promote.yml` na tag nova (gate-duro verifica) + teste negativo numa tag antiga (não assinada → rejeita).

Validado local: yaml + **actionlint exit 0**.

Ref #1524 · #1518
