### PR TITLE
fix(infra): gate de backup rejeita dump vazio/truncado (check de tamanho)

### DIFF
--- a/v2/infra/deployer/config.env.example
+++ b/v2/infra/deployer/config.env.example
@@ -21,11 +21,13 @@ BACKEND_HOST_PORT="8000"                  # derivado do Env da stack quando pres
 
 # --- Precondicao de backup (issue #1455 / ADR-018 B2 — mecanismo ATIVO) ---
 # O worker grava dumps cifrados (.age) em /var/backups/aprender (bind-mount /backups
-# no docker-compose.prod.yml); o hook abaixo checa a idade do mais recente. Fail-closed.
+# no docker-compose.prod.yml); o hook abaixo valida o mais recente por IDADE + TAMANHO
+# (rejeita dump 0-byte/truncado). Fail-closed.
 BACKUP_REQUIRED="1"                       # 1 = fail-closed sem mecanismo
 BACKUP_FRESHNESS_CMD="/opt/aprender-deployer/current/hooks/check_backup.sh"
 BACKUP_DIR="/var/backups/aprender"        # host dir montado em /backups no worker
 BACKUP_MAX_AGE="100800"                   # 28h — margem sobre o backup diario das 02:00
+BACKUP_MIN_SIZE="1024"                    # bytes minimos (dump real ~300KB; corta 0-byte/truncado)
 # BACKUP_FRESHNESS_URL="https://.../backup/freshness"   # alternativa (forca https; nao usar p/ localhost http)
 
 # --- Notificacao (write-only; deixar vazio = no-op) ---

--- a/v2/infra/deployer/hooks/check_backup.sh
+++ b/v2/infra/deployer/hooks/check_backup.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env bash
 # hooks/check_backup.sh — BACKUP_FRESHNESS_CMD do applier (ADR-018 B2 / issue #1455).
 #
-# Sai 0 se existe um backup de DB FRESCO (idade <= BACKUP_MAX_AGE) em BACKUP_DIR;
+# Sai 0 se existe um backup de DB VALIDO (fresco E grande o suficiente) em BACKUP_DIR;
 # !=0 caso contrario. E o gate que o applier consulta em ensure_fresh_db_backup
 # (lib/backup.sh) ANTES de um PUT com migrate destrutivo verificado. Fail-closed:
-# ausencia/velho/erro => nao-zero => o applier REFUSE o deploy.
+# ausencia/velho/pequeno/erro => nao-zero => o applier REFUSE o deploy.
+#
+# "Valido" = idade <= BACKUP_MAX_AGE E tamanho >= BACKUP_MIN_SIZE. O check de tamanho
+# fecha o furo do backup 0-byte/truncado (um dump que falhou no meio deixa um arquivo
+# fresco mas vazio, que passaria so pela idade). Escolhe o mais NOVO entre os validos,
+# entao um backup falho recente nao bloqueia se houver um valido tambem recente.
 #
 # So faz stat (NUNCA le conteudo): os dumps sao .age (cifrados, SEC-017). Roda sob o
 # sandbox do applier (ProtectSystem=strict) — BACKUP_DIR precisa ser legivel (nao /home,
@@ -13,42 +18,48 @@
 # Env (via /etc/aprender-deployer/config.env, herdado pelo EnvironmentFile do applier):
 #   BACKUP_DIR      dir dos dumps no host (default /var/backups/aprender)
 #   BACKUP_MAX_AGE  idade maxima em segundos (default 100800 = 28h; margem sobre 02:00 diario)
+#   BACKUP_MIN_SIZE bytes minimos (default 1024; um dump real e ~300KB, um .age vazio <1KB)
 #
 # ADR-018 · issue #1455 (backup morto: worker/beat sem mount /backups) + #1513
 set -euo pipefail
 
 dir="${BACKUP_DIR:-/var/backups/aprender}"
 max_age="${BACKUP_MAX_AGE:-100800}"
+min_size="${BACKUP_MIN_SIZE:-1024}"
 
-# max_age precisa ser inteiro (fail-closed se lixo — nunca aceitar deploy por engano).
-case "$max_age" in
-  ''|*[!0-9]*) echo "check_backup: BACKUP_MAX_AGE invalido: '${max_age}'" >&2; exit 2 ;;
-esac
+# Parametros precisam ser inteiros (fail-closed se lixo — nunca aceitar deploy por engano).
+for _v in "$max_age" "$min_size"; do
+  case "$_v" in
+    ''|*[!0-9]*) echo "check_backup: parametro nao-inteiro: '${_v}'" >&2; exit 2 ;;
+  esac
+done
 
 [ -d "$dir" ] || { echo "check_backup: dir de backup ausente: ${dir}" >&2; exit 1; }
 
-# Backup mais recente (glob nao-expandido some via [ -e ]; sem depender de nullglob).
-newest=""
+# mtime/size via GNU (stat -c) com fallback BSD (stat -f) para portabilidade dos testes.
+_mtime() { stat -c %Y "$1" 2>/dev/null || stat -f %m "$1" 2>/dev/null || echo 0; }
+_size()  { stat -c %s "$1" 2>/dev/null || stat -f %z "$1" 2>/dev/null || echo 0; }
+
+now="$(date +%s)"
+newest=""; newest_mtime=0; newest_size=0
+seen=0; small=0; old=0
+# Glob nao-expandido some via [ -e ] (sem depender de nullglob). .gz e .gz.age nao colidem.
 for f in "$dir"/backup_full_*.sql.gz "$dir"/backup_full_*.sql.gz.age; do
   [ -e "$f" ] || continue
-  if [ -z "$newest" ] || [ "$f" -nt "$newest" ]; then newest="$f"; fi
+  seen=$((seen + 1))
+  mt="$(_mtime "$f")"; sz="$(_size "$f")"
+  case "$mt" in ''|*[!0-9]*) mt=0 ;; esac
+  case "$sz" in ''|*[!0-9]*) sz=0 ;; esac
+  if [ "$sz" -lt "$min_size" ]; then small=$((small + 1)); continue; fi
+  if [ "$(( now - mt ))" -gt "$max_age" ]; then old=$((old + 1)); continue; fi
+  # candidato valido (fresco + grande) — guarda o de mtime mais alto.
+  if [ "$mt" -gt "$newest_mtime" ]; then newest="$f"; newest_mtime="$mt"; newest_size="$sz"; fi
 done
-[ -n "$newest" ] || { echo "check_backup: nenhum backup_full_*.sql.gz[.age] em ${dir}" >&2; exit 1; }
 
-# mtime: GNU (stat -c %Y) com fallback BSD (stat -f %m) para portabilidade dos testes.
-now="$(date +%s)"
-mtime="$(stat -c %Y "$newest" 2>/dev/null || stat -f %m "$newest" 2>/dev/null || true)"
-case "$mtime" in
-  ''|*[!0-9]*) echo "check_backup: stat falhou em ${newest}" >&2; exit 2 ;;
-esac
-
-age=$(( now - mtime ))
-if [ "$age" -lt 0 ]; then
-  echo "check_backup: mtime no futuro (relogio?) file=$(basename "$newest")" >&2; exit 2
-fi
-if [ "$age" -le "$max_age" ]; then
-  echo "check_backup: fresco age=${age}s max=${max_age}s file=$(basename "$newest")"
+if [ -n "$newest" ]; then
+  echo "check_backup: OK age=$(( now - newest_mtime ))s size=${newest_size}B file=$(basename "$newest")"
   exit 0
 fi
-echo "check_backup: STALE age=${age}s max=${max_age}s file=$(basename "$newest")" >&2
+
+echo "check_backup: SEM backup valido em ${dir} (vistos=${seen} pequenos=${small} velhos=${old} min_size=${min_size} max_age=${max_age})" >&2
 exit 1

--- a/v2/infra/deployer/tests/hooks_check_backup.bats
+++ b/v2/infra/deployer/tests/hooks_check_backup.bats
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 # hooks_check_backup.bats — gate de frescor de backup (ADR-018 B2 / issue #1455).
 # Cobre o hook standalone (check_backup.sh) + a integracao com ensure_fresh_db_backup.
+# "Valido" = fresco (idade <= max_age) E grande (tamanho >= min_size).
 
 load helper
 
@@ -11,22 +12,22 @@ setup() {
 }
 teardown() { teardown_sandbox; }
 
-# _mkbackup <nome> <segundos-atras>
+# _mkbackup <nome> <segundos-atras> [bytes]   (default 2048 = acima do min_size 1024)
 _mkbackup() {
-  local f="$BKDIR/$1" ago="${2:-0}"
-  : > "$f"
+  local f="$BKDIR/$1" ago="${2:-0}" bytes="${3:-2048}"
+  head -c "$bytes" /dev/zero > "$f"
   touch -d "@$(( $(date +%s) - ago ))" "$f"
 }
 
-# ---------------- hook standalone ----------------
+# ---------------- hook standalone: frescor ----------------
 
-@test "check_backup: backup fresco (.sql.gz) -> 0" {
+@test "check_backup: backup valido (.sql.gz) -> 0" {
   _mkbackup "backup_full_20260709_020000.sql.gz" 3600
   BACKUP_DIR="$BKDIR" BACKUP_MAX_AGE=100800 run "$HOOK"
   [ "$status" -eq 0 ]
 }
 
-@test "check_backup: backup fresco cifrado (.sql.gz.age) -> 0" {
+@test "check_backup: backup valido cifrado (.sql.gz.age) -> 0" {
   _mkbackup "backup_full_20260709_020000.sql.gz.age" 3600
   BACKUP_DIR="$BKDIR" BACKUP_MAX_AGE=100800 run "$HOOK"
   [ "$status" -eq 0 ]
@@ -48,7 +49,7 @@ _mkbackup() {
   [ "$status" -eq 1 ]
 }
 
-@test "check_backup: escolhe o MAIS NOVO entre varios" {
+@test "check_backup: escolhe o MAIS NOVO entre validos" {
   _mkbackup "backup_full_20260701_020000.sql.gz"     200000   # velho
   _mkbackup "backup_full_20260709_020000.sql.gz.age" 1800     # novo (cifrado)
   BACKUP_DIR="$BKDIR" BACKUP_MAX_AGE=100800 run "$HOOK"
@@ -62,21 +63,54 @@ _mkbackup() {
   [ "$status" -eq 1 ]   # nenhum backup_full_* valido
 }
 
-@test "check_backup: BACKUP_MAX_AGE invalido -> 2 (fail-closed)" {
-  _mkbackup "backup_full_20260709_020000.sql.gz" 60
-  BACKUP_DIR="$BKDIR" BACKUP_MAX_AGE=abc run "$HOOK"
-  [ "$status" -eq 2 ]
-}
-
 @test "check_backup: defaults (sem BACKUP_MAX_AGE) usam 28h" {
   _mkbackup "backup_full_20260709_020000.sql.gz" 90000   # 25h < 28h default
   BACKUP_DIR="$BKDIR" run "$HOOK"
   [ "$status" -eq 0 ]
 }
 
+# ---------------- hook standalone: tamanho (furo do 0-byte) ----------------
+
+@test "check_backup: backup 0-byte fresco -> 1 (rejeita vazio)" {
+  _mkbackup "backup_full_20260709_020000.sql.gz.age" 60 0
+  BACKUP_DIR="$BKDIR" BACKUP_MAX_AGE=100800 run "$HOOK"
+  [ "$status" -eq 1 ]
+}
+
+@test "check_backup: backup pequeno (< min_size) fresco -> 1" {
+  _mkbackup "backup_full_20260709_020000.sql.gz.age" 60 200
+  BACKUP_DIR="$BKDIR" BACKUP_MAX_AGE=100800 run "$HOOK"
+  [ "$status" -eq 1 ]
+}
+
+@test "check_backup: 0-byte novo + valido velho-mas-fresco -> 0 (usa o valido)" {
+  _mkbackup "backup_full_20260709_020000.sql.gz.age" 3600 2048   # valido, fresco
+  _mkbackup "backup_full_20260709_030000.sql.gz.age" 60   0      # falho (0-byte), mais novo
+  BACKUP_DIR="$BKDIR" BACKUP_MAX_AGE=100800 run "$HOOK"
+  [ "$status" -eq 0 ]
+}
+
+@test "check_backup: BACKUP_MIN_SIZE customizado corta o borderline" {
+  _mkbackup "backup_full_20260709_020000.sql.gz.age" 60 1500
+  BACKUP_DIR="$BKDIR" BACKUP_MAX_AGE=100800 BACKUP_MIN_SIZE=4096 run "$HOOK"
+  [ "$status" -eq 1 ]   # 1500 < 4096
+}
+
+@test "check_backup: BACKUP_MAX_AGE invalido -> 2 (fail-closed)" {
+  _mkbackup "backup_full_20260709_020000.sql.gz" 60
+  BACKUP_DIR="$BKDIR" BACKUP_MAX_AGE=abc run "$HOOK"
+  [ "$status" -eq 2 ]
+}
+
+@test "check_backup: BACKUP_MIN_SIZE invalido -> 2 (fail-closed)" {
+  _mkbackup "backup_full_20260709_020000.sql.gz" 60
+  BACKUP_DIR="$BKDIR" BACKUP_MIN_SIZE=xyz run "$HOOK"
+  [ "$status" -eq 2 ]
+}
+
 # ---------------- integracao com ensure_fresh_db_backup (lib/backup.sh) ----------------
 
-@test "ensure_fresh_db_backup: hook + backup fresco -> 0 (deploy liberado)" {
+@test "ensure_fresh_db_backup: hook + backup valido -> 0 (deploy liberado)" {
   _mkbackup "backup_full_20260709_020000.sql.gz.age" 3600
   export BACKUP_FRESHNESS_CMD="env BACKUP_DIR=${BKDIR} BACKUP_MAX_AGE=100800 ${HOOK}"
   run ensure_fresh_db_backup
@@ -85,6 +119,13 @@ _mkbackup() {
 
 @test "ensure_fresh_db_backup: hook + backup velho -> !=0 (REFUSE)" {
   _mkbackup "backup_full_20260701_020000.sql.gz.age" 200000
+  export BACKUP_FRESHNESS_CMD="env BACKUP_DIR=${BKDIR} BACKUP_MAX_AGE=100800 ${HOOK}"
+  run ensure_fresh_db_backup
+  [ "$status" -ne 0 ]
+}
+
+@test "ensure_fresh_db_backup: hook + backup 0-byte -> !=0 (REFUSE)" {
+  _mkbackup "backup_full_20260709_020000.sql.gz.age" 60 0
   export BACKUP_FRESHNESS_CMD="env BACKUP_DIR=${BKDIR} BACKUP_MAX_AGE=100800 ${HOOK}"
   run ensure_fresh_db_backup
   [ "$status" -ne 0 ]


### PR DESCRIPTION
## Contexto

Follow-up de hardening do #1528 (B2 / #1455). Ao rodar o backup em prod, um recipient `age` corrompido fez o `backup_db.sh` deixar um **`.sql.gz.age` de 0 bytes**. O `check_backup.sh` original só checava **idade** → um dump 0-byte/truncado, fresco mas inútil, **passaria** no gate, deixando o applier liberar um deploy (com migrate destrutivo) sobre um backup ruim.

## Mudança

- **`check_backup.sh`**: além da idade, exige **tamanho >= `BACKUP_MIN_SIZE`** (default 1024B; um dump real é ~300KB). Escolhe o backup **mais novo que seja fresco E grande** — um dump falho recente não bloqueia se houver um válido também recente. Fail-closed (ausência/velho/pequeno/erro → REFUSE).
- **`tests/hooks_check_backup.bats`**: 12 → **18 casos** (novos: 0-byte, pequeno, borderline, `BACKUP_MIN_SIZE` inválido, fallback p/ válido mais velho, integração 0-byte → REFUSE).
- **`config.env.example`**: documenta `BACKUP_MIN_SIZE`.

## Fora de escopo (follow-up separado)
Sync do `BACKUP_AGE_RECIPIENT` (público) no `docker-compose.prod.yml` do repo — prod já tem vivo no Portainer; separei pra não disparar o staging gate neste PR de deployer.

## Test plan
- [x] `bash -n hooks/check_backup.sh`
- [x] `bats tests/hooks_check_backup.bats` — **18/18** (container Debian, bats real)
- [x] blobs LF, hook 100755 (executável)
- CI: `deployer bats` roda a suíte completa