### PR TITLE
chore(deploy): desliga o PUT legado do Portainer (ADR-018 cutover #1515)

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -407,11 +407,19 @@ jobs:
       - prepare
       - build_and_push
       - validate_existing_tag
-    if: |
-      always() &&
-      needs.prepare.result == 'success' &&
-      (needs.build_and_push.result == 'success' || needs.build_and_push.result == 'skipped') &&
-      (needs.validate_existing_tag.result == 'success' || needs.validate_existing_tag.result == 'skipped')
+    # ADR-018 cutover (#1515): PUT legado ao Portainer :9443 PUBLICO foi DESLIGADO.
+    # O deploy agora e PULL-BASED — o agente aprender-deployer (VM01) le o ponteiro
+    # assinado (promote.yml, gated) e deploya por DIGEST em 127.0.0.1:9443, imune ao
+    # false-red. build_and_push + sign CONTINUAM (o agente so deploya imagem que
+    # existe e esta assinada com cosign). Reverter em emergencia = restaurar a
+    # condicao original abaixo (git blame). Fase 4 (#1516): DELETAR este job inteiro
+    # + remover os secrets PRODUCTION_PORTAINER_* (estado final limpo).
+    #
+    # Condicao original (para revert de emergencia):
+    #   always() && needs.prepare.result == 'success' &&
+    #   (needs.build_and_push.result == 'success' || needs.build_and_push.result == 'skipped') &&
+    #   (needs.validate_existing_tag.result == 'success' || needs.validate_existing_tag.result == 'skipped')
+    if: false
     steps:
       - name: Resolve deploy endpoints and configuration
         id: resolve


### PR DESCRIPTION
## Contexto — cutover ADR-018 (#1515)

Este PR **desliga o PUT legado** ao Portainer `:9443` público no `deploy.yaml`. A partir daqui o deploy é **pull-based**: o agente `aprender-deployer` (VM01) lê o ponteiro assinado (`promote.yml`, gated) e deploya **por digest** em `127.0.0.1:9443` — imune ao false-red do `:9443` público.

## Mudança (mínima)
- Job `deploy` → `if: false` (desligado). Condição original preservada em comentário para revert de emergência.
- `build_and_push` + `sign` **continuam** — o agente só deploya imagem que existe e está assinada com cosign.

## ⚠️ ORDEM ATÔMICA (LANDMINE #13)
Mergear ISTO deve ser **atômico com o compose→@DIGEST** no Portainer. O PUT legado só seta `IMAGE_TAG`; com o compose já em `@DIGEST`, ele deployaria a imagem **errada**. Ordem segura da execução do cutover:
1. **Merge deste PR** (desliga o PUT — o próprio merge NÃO deploya: o `deploy.yaml` novo já tem `if: false`).
2. Portainer editor: compose→`@${DIGEST:?}` + Env `BACKEND_DIGEST`/`FRONTEND_DIGEST` → Update.
3. Capturar compose normalizado → `compose.pinned.yml` → re-install do agente.
4. `promote.yml` (gate Environment) → ponteiro assinado.
5. Semear selo → `systemctl start` agente → observar convergir no-op.

## Fora de escopo (Fase 4, #1516)
DELETAR o job inteiro + remover os secrets `PRODUCTION_PORTAINER_*` (estado final limpo, após as 2 promoções verdes da 3e provarem o agente).

## Notas
- actionlint local avisa `constant expression` no `if: false` — cosmético (o repo não roda actionlint em CI); `if: false` é inequivocamente seguro (sem footgun de variável que reative o landmine).
- Não mergear isoladamente — faz parte da sequência atômica do cutover 3d.