### PR TITLE
fix(deploy): remove comentario inline do template de config do agente (systemd EnvironmentFile)

### DIFF
--- a/v2/infra/deployer/config.env.example
+++ b/v2/infra/deployer/config.env.example
@@ -4,6 +4,11 @@
 # (0400 aprender-applier). Aqui so parametros de operacao. Nada de security-anchor:
 # emissor OIDC, regexes de identidade e trusted-root vivem em trust/ (imutavel).
 #
+# ATENCAO: este arquivo e lido pelo systemd via EnvironmentFile, que so reconhece
+# comentario NO INICIO da linha. Comentario inline (KEY="v"  # ...) GRUDA no valor
+# (ex.: PROD_HOST=aprendersistema.com.br# Host header... -> confirm_localhost quebra;
+# bug pego no cutover ADR-018 3d). Por isso todo comentario abaixo fica na propria linha.
+#
 # ADR-018 Fase 1 · issue #1513
 
 # --- Ponteiro de release (branch protegido deploy-pointer, tokenless) ---
@@ -11,31 +16,40 @@ POINTER_URL="https://raw.githubusercontent.com/matheusnorjosa/aprender_sistema/d
 POINTER_SIG_URL="https://raw.githubusercontent.com/matheusnorjosa/aprender_sistema/deploy-pointer/production.json.sigstore.json"
 
 # --- Portainer (localhost; TLS self-signed => insecure no curlrc) ---
-PORTAINER_BASE="https://127.0.0.1:9443"
-PORTAINER_STACK_ID="__PREENCHER__"       # id da stack aprender_prod no Portainer
-PORTAINER_ENDPOINT_ID="__PREENCHER__"    # endpoint id (docker local)
+# id da stack aprender_prod no Portainer
+PORTAINER_STACK_ID="__PREENCHER__"
+# endpoint id (docker local)
+PORTAINER_ENDPOINT_ID="__PREENCHER__"
 
 # --- Confirmacao on-box (imune ao false-red) ---
-PROD_HOST="aprendersistema.com.br"       # Host header p/ ALLOWED_HOSTS
-BACKEND_HOST_PORT="8000"                  # derivado do Env da stack quando presente
+# Host header p/ ALLOWED_HOSTS do Django
+PROD_HOST="aprendersistema.com.br"
+# porta do backend no host (fallback; derivado do Env da stack quando presente)
+BACKEND_HOST_PORT="8000"
 
 # --- Precondicao de backup (issue #1455 / ADR-018 B2 — mecanismo ATIVO) ---
 # O worker grava dumps cifrados (.age) em /var/backups/aprender (bind-mount /backups
 # no docker-compose.prod.yml); o hook abaixo valida o mais recente por IDADE + TAMANHO
 # (rejeita dump 0-byte/truncado). Fail-closed.
-BACKUP_REQUIRED="1"                       # 1 = fail-closed sem mecanismo
+# 1 = fail-closed sem mecanismo
+BACKUP_REQUIRED="1"
 BACKUP_FRESHNESS_CMD="/opt/aprender-deployer/current/hooks/check_backup.sh"
-BACKUP_DIR="/var/backups/aprender"        # host dir montado em /backups no worker
-BACKUP_MAX_AGE="100800"                   # 28h — margem sobre o backup diario das 02:00
-BACKUP_MIN_SIZE="1024"                    # bytes minimos (dump real ~300KB; corta 0-byte/truncado)
-# BACKUP_FRESHNESS_URL="https://.../backup/freshness"   # alternativa (forca https; nao usar p/ localhost http)
+# host dir montado em /backups no worker
+BACKUP_DIR="/var/backups/aprender"
+# 28h — margem sobre o backup diario das 02:00
+BACKUP_MAX_AGE="100800"
+# bytes minimos (dump real ~300KB; corta 0-byte/truncado)
+BACKUP_MIN_SIZE="1024"
+# Alternativa ao CMD (forca https; NAO usar p/ localhost http):
+# BACKUP_FRESHNESS_URL="https://.../backup/freshness"
 
 # --- Notificacao (write-only; deixar vazio = no-op) ---
 NOTIFY_URL=""
 
 # --- Ajustes finos (opcionais; defaults no codigo) ---
 # FETCH_MAX_TIME="30"
-# FETCH_PINNEDPUBKEY="sha256//..."        # pin TLS de raw.githubusercontent.com
+# pin TLS de raw.githubusercontent.com:
+# FETCH_PINNEDPUBKEY="sha256//..."
 # CONFIRM_TIMEOUT="300"
 # BREAKER_MAX="3"
 


### PR DESCRIPTION
## Contexto — ADR-018 cutover 3d + 3e

Durante o cutover, o `confirm_localhost` do applier travou porque o systemd `EnvironmentFile` **só reconhece comentário no início da linha**. Os comentários inline (`PROD_HOST="..."  # Host header`) grudaram no valor (`aprendersistema.com.br# Host header...`) -> Host/porta inválidos -> curl 000. Corrigido na VM via sed; este PR corrige o **template no repo** pra não recriar o bug no próximo install.

## Mudança
- Move todos os comentários inline dos **assignments ativos** para a própria linha (`# comentário` acima da `KEY="valor"`).
- Nota no header explicando a regra do systemd.
- Comentários de linhas já comentadas (`# KEY=...`) ficam como estão (systemd ignora a linha toda).

## Duplo papel
Serve também como a **versão nova da fase 3e** do ADR-018 — o merge gera um novo digest, que a promoção seguinte usa pra exercitar o caminho de **PUT real** do agente (idempotência-falha -> backup gate -> compose drift -> PUT -> confirm -> selo), até agora só testado no no-op.

## Test plan
- [x] grep: nenhum assignment ativo com comentário inline
- deployer-only: staging gate pula; deployer bats roda
