### PR TITLE
chore(deploy): limpeza pos-ADR-018 (RuntimeMaxSec morto, assercoes sem dentes, doc)

### DIFF
--- a/v2/infra/deployer/systemd/aprender-applier.service
+++ b/v2/infra/deployer/systemd/aprender-applier.service
@@ -12,7 +12,11 @@ UMask=0027
 ExecStart=/opt/aprender-deployer/current/apply.sh
 WorkingDirectory=/opt/aprender-deployer/current
 EnvironmentFile=/etc/aprender-deployer/config.env
-RuntimeMaxSec=900
+# Ver nota em aprender-deployer.service: RuntimeMaxSec nao vale em Type=oneshot.
+# Orcamento real do applier, dentro destes 900s:
+#   PUT (<=3 tentativas, PORTAINER_MAX_TIME=30 + backoff) ~120s
+# + poll do Env pos-PUT (PUT_CONFIRM_TIMEOUT)             ~180s
+# + confirm_localhost (CONFIRM_TIMEOUT)                   ~300s
 TimeoutStartSec=900
 
 # --- sandbox / hardening (idêntico ao deployer) ---

--- a/v2/infra/deployer/systemd/aprender-deployer.service
+++ b/v2/infra/deployer/systemd/aprender-deployer.service
@@ -12,7 +12,11 @@ UMask=0027
 ExecStart=/opt/aprender-deployer/current/reconcile.sh
 WorkingDirectory=/opt/aprender-deployer/current
 EnvironmentFile=/etc/aprender-deployer/config.env
-RuntimeMaxSec=600
+# Em Type=oneshot o systemd IGNORA RuntimeMaxSec e avisa no journal
+# ("RuntimeMaxSec= has no effect in combination with Type=oneshot").
+# Quem limita o tempo de vida aqui e o TimeoutStartSec — o oneshot vive
+# inteiro dentro do "start". Manter RuntimeMaxSec seria config que mente
+# sobre o que protege.
 TimeoutStartSec=600
 
 # --- sandbox / hardening ---

--- a/v2/infra/deployer/tests/systemd_units.bats
+++ b/v2/infra/deployer/tests/systemd_units.bats
@@ -24,9 +24,16 @@ D="${BATS_TEST_DIRNAME}/.."
   grep -q 'InaccessiblePaths=.*docker.sock' "$D/systemd/aprender-deployer.service"
 }
 
+# CUIDADO com `! comando` dentro de um @test: sob errexit o `!` ISENTA o comando de
+# abortar (POSIX), e o bats julga o teste pelo status FINAL do corpo. Uma negacao
+# seguida de qualquer assert positivo vira decoracao — passa sempre. Estas duas
+# assercoes ficaram sem dentes desde a Fase 1 (descoberto em 2026-07-10, testando o
+# proprio teste). Use `run` + `[ "$status" -ne 0 ]`, que reprova de verdade.
 @test "apply.sh nao grava lock/payload em RUN_DIR (usa APPLIER_STATE_DIR)" {
-  ! grep -q '\${RUN_DIR}/applier.lock' "$D/apply.sh"
-  ! grep -q '\${RUN_DIR}/payload' "$D/apply.sh"
+  run grep -q '\${RUN_DIR}/applier.lock' "$D/apply.sh"
+  [ "$status" -ne 0 ]
+  run grep -q '\${RUN_DIR}/payload' "$D/apply.sh"
+  [ "$status" -ne 0 ]
   grep -q '\${APPLIER_STATE_DIR}/applier.lock' "$D/apply.sh"
   grep -q '\${APPLIER_STATE_DIR}/payload' "$D/apply.sh"
 }
@@ -36,5 +43,18 @@ D="${BATS_TEST_DIRNAME}/.."
     grep -q '^NoNewPrivileges=yes'   "$D/systemd/$u.service"
     grep -q '^ProtectSystem=strict'  "$D/systemd/$u.service"
     grep -q '^CapabilityBoundingSet=$' "$D/systemd/$u.service"
+  done
+}
+
+# O systemd IGNORA RuntimeMaxSec em Type=oneshot e avisa no journal:
+#   "RuntimeMaxSec= has no effect in combination with Type=oneshot. Ignoring."
+# Quem limita o tempo de vida e o TimeoutStartSec. Manter RuntimeMaxSec seria
+# config que mente sobre o que protege (pego no journal ao reinstalar a 0.2.0).
+@test "units oneshot: TimeoutStartSec presente, RuntimeMaxSec ausente" {
+  for u in aprender-deployer aprender-applier; do
+    grep -q '^Type=oneshot'     "$D/systemd/$u.service"
+    grep -q '^TimeoutStartSec=' "$D/systemd/$u.service"
+    run grep -q '^RuntimeMaxSec=' "$D/systemd/$u.service"
+    [ "$status" -ne 0 ]
   done
 }

--- a/v2/infra/deployer/trust/README.md
+++ b/v2/infra/deployer/trust/README.md
@@ -29,3 +29,44 @@ Sem este arquivo, `cosign verify` (que usa `--trusted-root`) **falha-fechado**
 Capturado no bootstrap a partir do `GET /api/stacks/{id}/file` **depois** do PUT
 inicial na forma Opção-B (imagens por `@${DIGEST:?}`), garantindo byte-estabilidade
 com a normalização do Portainer. Ver `bootstrap/migrate-stack.sh`.
+
+## Re-gravar o `bin.sha256` quando um binário do host é atualizado
+
+O `install.sh` valida os 4 binários contra este arquivo **antes** de instalar e
+**recusa** se algum hash divergir. Isso é TOFU (*trust on first use*): um
+`unattended-upgrade` do `curl` ou do `jq` faz o próximo reinstall parar. É o
+mecanismo funcionando — mas exige uma decisão humana, não um `--record-bins` reflexo.
+
+`--record-bins` **pula a validação** e sobrescreve o arquivo com o que estiver no
+disco. Usá-lo sem provar a procedência lavaria um binário adulterado para dentro
+da raiz de confiança — logo o `curl`, que busca o ponteiro e fala com o Portainer.
+
+**Antes de re-gravar, prove que o binário é o do pacote assinado da distro:**
+
+```bash
+PKG=curl                                   # ou jq
+VER="$(dpkg-query -W -f='${Version}' "$PKG")"
+
+dpkg -V "$PKG" && echo "dpkg: sem adulteracao"     # md5sums do pacote instalado
+grep -i " ${PKG}:" /var/log/dpkg.log | tail -3     # quando mudou, e por quem
+
+# prova forte: baixa o .deb assinado do repo e compara o binario de dentro
+cd "$(mktemp -d)" && apt-get download "${PKG}=${VER}"
+dpkg-deb --fsys-tarfile ./*.deb | tar -xO "./usr/bin/${PKG}" | sha256sum
+sha256sum "/usr/bin/${PKG}"                         # tem de bater byte a byte
+```
+
+Se os dois `sha256` forem iguais e o `dpkg -V` estiver limpo, o binário veio de um
+pacote assinado pela distro (o `apt` verifica a assinatura do `Release`). Só então:
+
+```bash
+cp trust/bin.sha256 /root/adr018-cutover/bin.sha256.antes-$(date -u +%Y%m%dT%H%M%SZ)
+bash bootstrap/install.sh --src <arvore> --record-bins
+```
+
+Se os hashes **não** baterem, pare: `/usr/bin/curl` divergindo do pacote assinado,
+na máquina que verifica assinaturas de deploy, é incidente — não inconveniente.
+
+> Ocorrido real: 2026-07-10, `unattended-upgrade` subiu `curl` de `8.5.0-2ubuntu10.10`
+> para `10.11` às 06:28 UTC; o `install.sh` barrou o update do agente 7h depois.
+> A prova acima confirmou a procedência e o `--record-bins` foi feito conscientemente.

--- a/v2/infra/scripts/staging-gate.sh
+++ b/v2/infra/scripts/staging-gate.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# staging-gate.sh — roda o staging gate local (build imagens prod + up + migrate + smoke)
+# e, opcionalmente, atualiza um PR com os 3 marcadores + evidencia e marca Ready.
+#
+# Substitui o copia-e-cola manual do gate. Equivale a `make staging-full` (que quebra
+# no Windows GnuWin32 por causa do $(MAKE) recursivo) + a colagem dos marcadores.
+#
+# Uso:
+#   v2/infra/scripts/staging-gate.sh                  # so roda o gate; imprime resultado
+#   v2/infra/scripts/staging-gate.sh --pr 1494        # roda o gate; se 8/8, atualiza PR #1494 + marca Ready
+#   v2/infra/scripts/staging-gate.sh --pr 1494 --no-ready   # atualiza o body mas NAO marca Ready
+#   v2/infra/scripts/staging-gate.sh --keep           # nao derruba a stack no fim (debug)
+#
+# Pre-requisitos: Docker rodando; estar no commit/branch que vai virar a imagem
+# (GIT_SHA = HEAD); para --pr, `gh` autenticado.
+#
+# NUNCA faz merge. Desde o cutover do ADR-018 (#1530) o merge na main TAMBEM NAO
+# DEPLOYA: o job `deploy` do deploy.yaml esta `if: false`. O merge so faz build+sign.
+# Prod muda quando alguem roda `promote.yml` (gated no Environment `production`) e o
+# agente aprender-deployer, na VM01, pega o ponteiro assinado e aplica por digest.
+#
+# Exit codes: 0 ok | 2 precheck | 3 build backend | 4 build frontend | 5 up | 6 migrate
+#             | 7 smoke falhou | 8 sem gh | 9 PR nao encontrado | 10 gh edit falhou | 64 arg invalido
+set -uo pipefail
+
+PR=""
+DO_READY=1
+KEEP=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --pr)       PR="${2:-}"; shift 2;;
+    --pr=*)     PR="${1#*=}"; shift;;
+    --no-ready) DO_READY=0; shift;;
+    --keep)     KEEP=1; shift;;
+    -h|--help)  tail -n +2 "$0" | grep '^#' | sed 's/^#\{1,\} \{0,1\}//; s/^#//'; exit 0;;
+    *) echo "arg desconhecido: $1 (use --help)" >&2; exit 64;;
+  esac
+done
+
+# Resolve v2/infra a partir da localizacao do script (funciona de qualquer cwd).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INFRA_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"   # v2/infra
+cd "$INFRA_DIR" || { echo "nao consegui cd para $INFRA_DIR" >&2; exit 1; }
+
+TAG="staging-local"
+BACKEND_IMG="norjosamatheus/aprender-backend:$TAG"
+FRONTEND_IMG="norjosamatheus/aprender-frontend:$TAG"
+GATE() { IMAGE_TAG="$TAG" docker compose --env-file .env.staging -f docker-compose.yml -f docker-compose.staging-gate.yml "$@"; }
+
+teardown() {
+  if [ "$KEEP" -eq 1 ]; then echo "[gate] --keep: stack mantida (derrube depois com: make -C v2/infra staging-down)"; return; fi
+  echo "[gate] teardown (down -v)..."
+  GATE down -v >/dev/null 2>&1 || true
+}
+trap teardown EXIT
+
+LOG="$(mktemp)"
+fail() { echo "[gate] FALHOU: $1" >&2; exit "${2:-1}"; }
+
+echo "==> [1/5] precheck (compose valido / !reset suportado)"
+GATE config >/dev/null 2>&1 || fail "precheck (atualize Docker Compose >= 2.24.6 p/ !reset)" 2
+
+echo "==> [2/5] build backend prod ($BACKEND_IMG)"
+docker build -f Dockerfile.prod \
+  --build-arg GIT_SHA="$(git rev-parse --short HEAD)" \
+  --build-arg BUILD_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --build-arg APP_VERSION="$TAG" \
+  -t "$BACKEND_IMG" .. || fail "build backend" 3
+
+echo "==> [3/5] build frontend prod ($FRONTEND_IMG)"
+docker build -f ../frontend/Dockerfile.prod \
+  --build-arg GIT_SHA="$(git rev-parse --short HEAD)" \
+  -t "$FRONTEND_IMG" ../frontend || fail "build frontend" 4
+
+echo "==> [4/5] up + migrate"
+GATE up -d --no-build || fail "up" 5
+GATE run --rm web python manage.py migrate --noinput || fail "migrate" 6
+
+echo "==> [5/5] smoke (8 checks)"
+PYTHON=python bash scripts/smoke_test_staging.sh | tee "$LOG"
+SMOKE=${PIPESTATUS[0]}
+
+if [ "$SMOKE" -ne 0 ] || ! grep -q "ALL 8 CHECKS PASSED" "$LOG"; then
+  fail "smoke NAO passou (exit=$SMOKE) — PR nao sera tocado" 7
+fi
+echo "[gate] ✅ ALL 8 CHECKS PASSED"
+
+# ---------- atualizar PR (opcional) ----------
+if [ -z "$PR" ]; then
+  echo "[gate] sem --pr: gate verde, nada a atualizar."
+  exit 0
+fi
+
+command -v gh >/dev/null 2>&1 || fail "gh (GitHub CLI) nao encontrado / nao no PATH" 8
+
+# Evidencia = bloco de resultados do smoke, sem codigos ANSI.
+EVID="$(sed 's/\x1b\[[0-9;]*m//g' "$LOG" | awk '/STAGING GATE SMOKE TEST RESULTS/{c=1} c{print} /ALL 8 CHECKS PASSED/{exit}')"
+SHA="$(git rev-parse --short HEAD)"
+SENTINEL="<!-- staging-gate-auto -->"
+
+# Body atual SEM o bloco auto anterior (idempotente em re-runs).
+CUR="$(gh pr view "$PR" --json body -q .body 2>/dev/null)" || fail "PR #$PR nao encontrado (gh autenticado?)" 9
+BASE="$(printf '%s\n' "$CUR" | awk -v s="$SENTINEL" 'index($0,s){exit} {print}')"
+
+NEWBODY="$(mktemp)"
+{
+  printf '%s\n' "$BASE"
+  printf '%s\n' "$SENTINEL"
+  echo "## Staging gate"
+  echo
+  echo "- [x] make staging-full executado com sucesso (8/8 PASS)"
+  echo "- [x] Evidencia anexada no PR"
+  echo
+  echo "Evidencia (gate local, commit \`$SHA\`):"
+  echo
+  echo '```'
+  printf '%s\n' "$EVID"
+  echo '```'
+} > "$NEWBODY"
+
+gh pr edit "$PR" --body-file "$NEWBODY" >/dev/null || { rm -f "$NEWBODY"; fail "gh pr edit" 10; }
+rm -f "$NEWBODY"
+echo "[gate] ✅ body do PR #$PR atualizado (3 marcadores + evidencia)"
+
+if [ "$DO_READY" -eq 1 ]; then
+  if gh pr ready "$PR" >/dev/null 2>&1; then echo "[gate] ✅ PR #$PR marcado Ready"; else echo "[gate] PR #$PR ja estava Ready (ou nada a mudar)"; fi
+fi
+
+echo "[gate] pronto. Merge final (squash) e MANUAL. O merge NAO deploya (ADR-018): so build+sign."
+echo "[gate] para levar a prod: gh workflow run promote.yml -f release=<tag>  (gate 'production' pede aprovacao)."


### PR DESCRIPTION
Três achados da operação real de hoje — o primeiro deploy de produção conduzido pelo agente.

## 1. `RuntimeMaxSec` é no-op em `Type=oneshot`

Ao reinstalar o agente, o journal avisou:

```
aprender-deployer.service: RuntimeMaxSec= has no effect in combination with Type=oneshot. Ignoring.
```

Não abre buraco — quem limita o tempo de vida de um `oneshot` é o `TimeoutStartSec`, que está lá. Mas era **config que mentia sobre o que protegia**. Removida das duas units, com o orçamento real do applier documentado onde importa:

```
PUT (≤3 tentativas × 30s + backoff)  ~120s
poll do Env pós-PUT (#1532)          ~180s
confirm_localhost                    ~300s
                                     ----- < TimeoutStartSec=900
```

## 2. Três asserções dos bats nunca reprovaram nada

Sob `errexit`, um comando precedido de `!` é **isento de abortar** (POSIX). E o bats julga o teste pelo **status final** do corpo. Então:

```bash
! grep -q '${RUN_DIR}/applier.lock' "$D/apply.sh"   # falha aqui...
grep -q '${APPLIER_STATE_DIR}/applier.lock' ...     # ...e o status final é deste
```

A negação vira decoração. Passa sempre.

**Duas delas são da Fase 1 e guardavam o bug #1 do red-team**: o applier gravando lock/payload em `RUN_DIR`, que sob `ProtectSystem=strict` mata o processo antes de qualquer verificação. Ou seja, a guarda de regressão nunca guardou.

Descobri **testando o próprio teste**: injetei o defeito e a sentinela ficou verde. Convertidas para `run` + `[ "$status" -ne 0 ]`.

**Prova de que agora têm dentes** — com o defeito injetado nos dois sítios:

```
not ok 4 apply.sh nao grava lock/payload em RUN_DIR (usa APPLIER_STATE_DIR)
not ok 6 units oneshot: TimeoutStartSec presente, RuntimeMaxSec ausente
```

E limpo, `bats tests/` → **58/58**.

## 3. `trust/README.md`: como re-gravar o `bin.sha256`

Hoje às 06:28 UTC um `unattended-upgrade` subiu `curl` de `8.5.0-2ubuntu10.10` para `10.11`. Sete horas depois, o `install.sh` **recusou** atualizar o agente: hash divergente. TOFU funcionando.

O risco é a saída fácil: `--record-bins` **pula a validação inteira** e grava o que estiver no disco. Usá-lo sem provar procedência lavaria um binário adulterado para dentro da raiz de confiança — e logo o `curl`, que busca o ponteiro e fala com o Portainer.

Documentei a prova que usamos: `dpkg -V` + baixar o `.deb` **assinado** da exata versão instalada e comparar o `sha256` do binário lá dentro com o do disco. Bateram byte a byte.

## Bônus: `staging-gate.sh` versionado, e um aviso que virou mentira

O script estava **untracked** — some se a máquina sumir. Pior: o cabeçalho dizia que *"merge na main AUTO-DEPLOYA EM PROD"*. Desde o #1530 isso é **falso**: o job `deploy` está `if: false`, o merge só faz build+sign, e prod muda pelo `promote.yml` + gate + agente. Corrigido nos dois lugares (cabeçalho e mensagem final).

## Verificação

- `bats tests/` → **58/58** (Debian container)
- Ambas as sentinelas provadas: reprovam com o defeito injetado, passam sem ele
- `shellcheck -x v2/infra/scripts/staging-gate.sh` → exit 0
- Nenhuma diretiva `^RuntimeMaxSec=` restante; `^TimeoutStartSec=` presente nas duas units

Deployer-only + script: não dispara staging gate, não deploya.

Refs #1515, #1513