### PR TITLE
fix(backup): fecha as camadas silenciosas do DR (fail-closed, pipefail, .age)

### DIFF
--- a/v2/backend/apps/core/tasks_backup.py
+++ b/v2/backend/apps/core/tasks_backup.py
@@ -247,10 +247,15 @@ def verify_backup_health() -> dict[str, str | int | list[str]]:
 
     health_status = "healthy" if checks_passed == checks_total else "degraded"
 
-    logger.info(
-        f"Backup health check completed: {health_status} ({checks_passed}/{checks_total} passed)",
-        extra={"warnings": warnings},
-    )
+    _msg = f"Backup health check completed: {health_status} ({checks_passed}/{checks_total} passed)"
+    if health_status == "healthy":
+        logger.info(_msg, extra={"warnings": warnings})
+    else:
+        # #1541: 'degraded' e o sinal de backup morto — a razao de a task existir.
+        # SENTRY_DSN esta VAZIO em prod (o capture_message acima e no-op) e o INFO era
+        # engolido por alertas baseados em log (level>=WARNING). Logar em ERROR faz o
+        # alarme chegar a alguem, independente do Sentry.
+        logger.error(_msg, extra={"warnings": warnings})
 
     return {
         "status": health_status,

--- a/v2/backend/apps/core/tests/test_celery_backup.py
+++ b/v2/backend/apps/core/tests/test_celery_backup.py
@@ -31,6 +31,28 @@ class TestVerifyBackupHealth:
             assert result["status"] == "degraded"
             assert "No backups found" in str(result["warnings"])
 
+    def test_health_check_degraded_logs_error_for_alerting(self, tmp_path: Path) -> None:
+        """#1541: 'degraded' (backup morto) deve sair em logger.error — não info.
+
+        SENTRY_DSN está vazio em prod (o capture_message é no-op) e o INFO era
+        engolido por alertas de log (level>=WARNING). Se o resumo final voltar a INFO,
+        o detector de backup morto acha o problema e o alarme não chega a ninguém.
+        """
+        with (
+            patch("apps.core.tasks_backup.getattr") as mock_getattr,
+            patch("apps.core.tasks_backup.logger") as mock_logger,
+        ):
+            mock_getattr.return_value = str(tmp_path)  # dir vazio → "No backups found" → degraded
+            result = verify_backup_health()
+
+            assert result["status"] == "degraded"
+            assert mock_logger.error.called, "degraded deve logar em ERROR"
+            error_text = " ".join(str(c) for c in mock_logger.error.call_args_list)
+            assert "degraded" in error_text
+            # o resumo de conclusão NÃO pode sair em info quando degraded
+            info_text = " ".join(str(c) for c in mock_logger.info.call_args_list)
+            assert "completed: degraded" not in info_text
+
     def test_health_check_with_recent_backup_returns_healthy(self, tmp_path: Path) -> None:
         """Test that health check returns healthy when recent backup exists."""
         # Create a recent backup file

--- a/v2/infra/scripts/backup_db.sh
+++ b/v2/infra/scripts/backup_db.sh
@@ -15,13 +15,19 @@
 #
 # Refs: Issue #562 (C-05), MP5
 
-set -e
+# pipefail (audit #1541): sem ele, uma falha do pg_dump no MEIO do pipe
+# `pg_dump | gzip | age` era MASCARADA — gzip/age no fim saem 0 e o `set -e` nao
+# dispara, gravando um backup truncado que se disfarca de sucesso (a task Celery
+# via check=True enxergava returncode 0). Com pipefail a falha do pg_dump aborta e
+# propaga exit != 0 (retry + alerta), em vez de virar um dump silenciosamente ruim.
+set -euo pipefail
 
 # Configuration with environment variable support
 DB_HOST="${DB_HOST:-localhost}"
 DB_PORT="${DB_PORT:-5432}"
 DB_NAME="${DB_NAME:-aprender_db}"
 DB_USER="${DB_USER:-postgres}"
+DB_PASSWORD="${DB_PASSWORD:-}"
 BACKUP_DIR="${BACKUP_DIR:-/backups}"
 BACKUP_RETENTION_DAYS="${BACKUP_RETENTION_DAYS:-7}"
 DATE=$(date +%Y%m%d_%H%M%S)
@@ -29,8 +35,17 @@ S3_BUCKET="${S3_BUCKET:-}"
 # Normalize bucket name if provided with scheme
 S3_BUCKET="${S3_BUCKET#s3://}"
 
-# SEC-017: Optional encryption via age (when BACKUP_AGE_RECIPIENT is set)
+# SEC-017: encryption via age. Fail-CLOSED (audit #1541 / #1536): sem recipient o
+# script gravava o dump de PII em TEXTO CLARO, em silencio. Agora RECUSA, salvo
+# opt-out explicito BACKUP_ALLOW_PLAINTEXT=1 (dev / restore-test). Em prod o
+# recipient vem do environment do worker -> o caminho cifrado segue inalterado.
 BACKUP_AGE_RECIPIENT="${BACKUP_AGE_RECIPIENT:-}"
+BACKUP_ALLOW_PLAINTEXT="${BACKUP_ALLOW_PLAINTEXT:-0}"
+if [ -z "$BACKUP_AGE_RECIPIENT" ] && [ "$BACKUP_ALLOW_PLAINTEXT" != "1" ]; then
+    echo "[$(date)] ERROR: BACKUP_AGE_RECIPIENT ausente e BACKUP_ALLOW_PLAINTEXT!=1." >&2
+    echo "[$(date)] Recusando gerar backup de PII em texto claro (SEC-017, fail-closed)." >&2
+    exit 1
+fi
 
 # Naming convention: backup_full_YYYYMMDD_HHMMSS.sql.gz[.age]
 if [ -n "$BACKUP_AGE_RECIPIENT" ]; then
@@ -71,7 +86,12 @@ if [ -f "$BACKUP_FILE" ] && [ -s "$BACKUP_FILE" ]; then
     # Optional: Copy to S3 (if S3_BUCKET is configured)
     if [ -n "$S3_BUCKET" ]; then
         echo "[$(date)] Uploading to S3: s3://$S3_BUCKET/backups/"
-        aws s3 cp "$BACKUP_FILE" "s3://$S3_BUCKET/backups/" || echo "[$(date)] WARNING: S3 upload failed"
+        if ! aws s3 cp "$BACKUP_FILE" "s3://$S3_BUCKET/backups/"; then
+            # A copia offsite falhou, mas o backup LOCAL e valido — nao re-rodar
+            # pg_dump. Marcador distinto no STDERR (audit #1541) p/ um alerta de log
+            # (level>=WARNING) pegar, ja que o Sentry esta vazio em prod.
+            echo "[$(date)] WARNING: S3 upload FAILED (offsite copy missing) for $BACKUP_FILE" >&2
+        fi
     fi
 else
     echo "[$(date)] ERROR: Backup failed or file is empty!"

--- a/v2/infra/scripts/restore_db.sh
+++ b/v2/infra/scripts/restore_db.sh
@@ -32,7 +32,8 @@ echo ""
 
 # Determine backup file
 if [ "$1" == "--latest" ]; then
-    BACKUP_FILE=$(ls -t $BACKUP_DIR/*.sql.gz 2>/dev/null | head -1)
+    # inclui os cifrados .sql.gz.age (o que prod grava, SEC-017) — audit #1541.
+    BACKUP_FILE=$(ls -t $BACKUP_DIR/*.sql.gz $BACKUP_DIR/*.sql.gz.age 2>/dev/null | head -1)
     if [ -z "$BACKUP_FILE" ]; then
         echo -e "${RED}ERROR: No backup files found in $BACKUP_DIR${NC}"
         exit 1
@@ -51,12 +52,13 @@ else
     # Interactive mode - list available backups
     echo "Available backups:"
     echo ""
-    ls -lh $BACKUP_DIR/*.sql.gz 2>/dev/null | awk '{print NR". "$9" ("$5")"}'
+    # -t nos DOIS (lista e selecao) p/ numeracao consistente por tempo; inclui .age.
+    ls -lht $BACKUP_DIR/*.sql.gz $BACKUP_DIR/*.sql.gz.age 2>/dev/null | awk '{print NR". "$9" ("$5")"}'
     echo ""
     read -p "Enter backup number or full path: " SELECTION
-    
+
     if [[ "$SELECTION" =~ ^[0-9]+$ ]]; then
-        BACKUP_FILE=$(ls -t $BACKUP_DIR/*.sql.gz | sed -n "${SELECTION}p")
+        BACKUP_FILE=$(ls -t $BACKUP_DIR/*.sql.gz $BACKUP_DIR/*.sql.gz.age 2>/dev/null | sed -n "${SELECTION}p")
     else
         BACKUP_FILE="$SELECTION"
     fi

--- a/v2/infra/scripts/verify_backup.sh
+++ b/v2/infra/scripts/verify_backup.sh
@@ -6,14 +6,19 @@
 
 set -e
 
-BACKUP_DIR="/var/backups/aprender"
+BACKUP_DIR="${BACKUP_DIR:-/var/backups/aprender}"
 TEMP_DIR="/tmp/backup_verify_$$"
 DB_NAME="${DB_NAME:-aprender_db}"
+# Piso de bytes alinhado ao gate de deploy check_backup.sh (#1529).
+BACKUP_MIN_SIZE="${BACKUP_MIN_SIZE:-1024}"
 
 echo "[$(date)] Starting backup verification..."
 
-# Find the most recent backup
-LATEST_BACKUP=$(ls -t $BACKUP_DIR/*.sql.gz 2>/dev/null | head -1)
+# Backup mais recente — inclui os cifrados .sql.gz.age, que sao o que prod grava
+# (SEC-017). O glob antigo (`*.sql.gz`) ficava CEGO aos backups reais e validava um
+# .sql.gz legado, saindo "successfully" com falsa confianca (audit #1541 — mesma
+# familia do bug de glob corrigido no health-check em #1455).
+LATEST_BACKUP=$(ls -t "$BACKUP_DIR"/backup_full_*.sql.gz "$BACKUP_DIR"/backup_full_*.sql.gz.age 2>/dev/null | head -1)
 
 if [ -z "$LATEST_BACKUP" ]; then
     echo "[$(date)] ERROR: No backup files found in $BACKUP_DIR"
@@ -22,54 +27,57 @@ fi
 
 echo "[$(date)] Verifying: $LATEST_BACKUP"
 
-# Create temp directory
-mkdir -p $TEMP_DIR
-trap "rm -rf $TEMP_DIR" EXIT
-
-# Test gzip integrity
-echo "[$(date)] Testing gzip integrity..."
-if ! gzip -t "$LATEST_BACKUP"; then
-    echo "[$(date)] ERROR: Backup file is corrupted!"
+# Tamanho — piso HARD (exit != 0). Um dump truncado/vazio NAO pode sair "success":
+# era WARNING-only, entao um backup minusculo passava verde (audit #1541).
+SIZE=$(stat -c%s "$LATEST_BACKUP" 2>/dev/null || stat -f%z "$LATEST_BACKUP")
+if [ "$SIZE" -lt "$BACKUP_MIN_SIZE" ]; then
+    echo "[$(date)] ERROR: Backup too small (${SIZE}B < ${BACKUP_MIN_SIZE}B) — truncado/vazio?"
     exit 1
 fi
-
-# Decompress and check SQL structure
-echo "[$(date)] Checking SQL structure..."
-UNCOMPRESSED="$TEMP_DIR/backup.sql"
-gunzip -c "$LATEST_BACKUP" > "$UNCOMPRESSED"
-
-# Check for essential markers
-if ! grep -q "PostgreSQL database dump" "$UNCOMPRESSED"; then
-    echo "[$(date)] ERROR: Not a valid PostgreSQL dump!"
-    exit 1
-fi
-
-if ! grep -q "CREATE TABLE" "$UNCOMPRESSED"; then
-    echo "[$(date)] ERROR: No CREATE TABLE statements found!"
-    exit 1
-fi
-
-# Count tables
-TABLE_COUNT=$(grep -c "CREATE TABLE" "$UNCOMPRESSED" || echo "0")
-echo "[$(date)] Found $TABLE_COUNT tables in backup"
-
-# Check file size (should be reasonable)
-SIZE=$(stat -f%z "$LATEST_BACKUP" 2>/dev/null || stat -c%s "$LATEST_BACKUP")
 SIZE_MB=$((SIZE / 1024 / 1024))
-echo "[$(date)] Backup size: ${SIZE_MB}MB"
+echo "[$(date)] Backup size: ${SIZE}B (~${SIZE_MB}MB)"
 
-if [ "$SIZE_MB" -lt 1 ]; then
-    echo "[$(date)] WARNING: Backup seems too small (${SIZE_MB}MB)"
-fi
+# Integridade de CONTEUDO (gzip -t + marcadores SQL) so no PLAINTEXT. Um .age nao
+# pode ser inspecionado aqui: a chave PRIVADA nao vive na VM por design (fica no
+# gerenciador de senhas). Para .age, garantimos presenca + tamanho + frescor; a
+# verificacao de conteudo cifrado e exercitada no test_dr.sh (com a chave, fora de prod).
+case "$LATEST_BACKUP" in
+    *.age)
+        echo "[$(date)] Encrypted backup (.age): checagem de conteudo pulada (chave privada nao esta na VM, SEC-017)."
+        TABLE_COUNT="n/a (cifrado)"
+        ;;
+    *)
+        mkdir -p "$TEMP_DIR"
+        trap 'rm -rf "$TEMP_DIR"' EXIT
+        echo "[$(date)] Testing gzip integrity..."
+        if ! gzip -t "$LATEST_BACKUP"; then
+            echo "[$(date)] ERROR: Backup file is corrupted!"
+            exit 1
+        fi
+        echo "[$(date)] Checking SQL structure..."
+        UNCOMPRESSED="$TEMP_DIR/backup.sql"
+        gunzip -c "$LATEST_BACKUP" > "$UNCOMPRESSED"
+        if ! grep -q "PostgreSQL database dump" "$UNCOMPRESSED"; then
+            echo "[$(date)] ERROR: Not a valid PostgreSQL dump!"
+            exit 1
+        fi
+        if ! grep -q "CREATE TABLE" "$UNCOMPRESSED"; then
+            echo "[$(date)] ERROR: No CREATE TABLE statements found!"
+            exit 1
+        fi
+        TABLE_COUNT=$(grep -c "CREATE TABLE" "$UNCOMPRESSED" || echo "0")
+        echo "[$(date)] Found $TABLE_COUNT tables in backup"
+        ;;
+esac
 
-# Check backup age
-BACKUP_AGE=$(( ($(date +%s) - $(stat -f%m "$LATEST_BACKUP" 2>/dev/null || stat -c%Y "$LATEST_BACKUP")) / 86400 ))
+# Frescor — informativo. O gate de frescor que BLOQUEIA deploy e o check_backup.sh;
+# aqui e so um aviso ruidoso (age nao e corrupcao).
+BACKUP_AGE=$(( ($(date +%s) - $(stat -c%Y "$LATEST_BACKUP" 2>/dev/null || stat -f%m "$LATEST_BACKUP")) / 86400 ))
 echo "[$(date)] Backup age: ${BACKUP_AGE} days"
-
 if [ "$BACKUP_AGE" -gt 1 ]; then
     echo "[$(date)] WARNING: Latest backup is ${BACKUP_AGE} days old!"
 fi
 
 echo "[$(date)] Backup verification completed successfully!"
 echo "[$(date)] Latest backup: $LATEST_BACKUP"
-echo "[$(date)] Size: ${SIZE_MB}MB, Tables: $TABLE_COUNT, Age: ${BACKUP_AGE} days"
+echo "[$(date)] Size: ${SIZE}B, Tables: $TABLE_COUNT, Age: ${BACKUP_AGE} days"


### PR DESCRIPTION
Continuação da saga do **#1455**: a auditoria de falhas silenciosas (#1541) mostrou que o backup tinha **mais camadas quebradas** do que fechamos hoje — todas invisíveis, todas a jusante do gatilho que já consertamos.

## `backup_db.sh` — três defeitos

**`pipefail` (crítico).** Só tinha `set -e`. Numa falha do `pg_dump` no **meio** do pipe `pg_dump | gzip | age`, o gzip/age no fim saem 0 e o `set -e` **não dispara** — um backup truncado/vazio se disfarçava de sucesso (a task Celery via `check=True` enxergava returncode 0). Agora `set -euo pipefail` propaga a falha → `exit != 0` → retry + alerta. Foi por isso que o #1529 teve de pôr o check de tamanho no **gate**; o script em si não protegia a origem.

**Fail-CLOSED da cifragem (#1536).** Sem `BACKUP_AGE_RECIPIENT`, o script gravava PII em **texto claro** em silêncio. Agora **recusa** (`exit 1`), salvo opt-out explícito `BACKUP_ALLOW_PLAINTEXT=1` (dev/restore-test). Prod tem o recipient → **no-op lá** (caminho cifrado inalterado).

**S3 swallow.** `aws s3 cp ... || echo WARNING` engolia a falha da cópia offsite. Agora um marcador distinto no **stderr** (o backup local segue válido; não re-roda `pg_dump`).

## `verify_backup.sh` — o glob do #1455 ainda vivia aqui

Este script standalone tinha o **mesmo bug de glob** que consertamos no health-check (#1455): só olhava `*.sql.gz`, **cego** aos `.sql.gz.age` que prod grava → validava um `.sql.gz` legado e saía *"successfully"* com falsa confiança.

- glob passa a incluir `.sql.gz.age`;
- tamanho vira **piso HARD** (`exit != 0`), alinhado ao `check_backup.sh` (#1529), em vez de WARNING-only. **Não** usei o `<1MB` que o finder sugeriu — nossos dumps reais têm ~322KB e reprovariam; usei o piso de **bytes** (1024);
- conteúdo (`gzip -t` + marcadores SQL) só no plaintext; para `.age` pula (a chave **privada** não vive na VM por design) e verifica presença + tamanho + frescor.

## `restore_db.sh`

Os 3 globs de seleção (`--latest`, lista interativa, select) passam a incluir `.age`. O passo de restore **já** decifrava `.age`, mas a seleção do arquivo ficava cega. `-t` consistente entre lista e select.

## `tasks_backup.py` — o alarme que não alertava

`verify_backup_health` logava a conclusão em **INFO** mesmo quando `degraded` (backup morto). `SENTRY_DSN` está **vazio** em prod (o `capture_message` é no-op) e o INFO era engolido por alertas de log (`level>=WARNING`). Agora `degraded` sai em **ERROR** — o alarme chega a alguém, independente do Sentry.

## Verificação

- **Harness com stubs** (`pg_dump`/`age`): fail-closed (exit 1, sem arquivo), opt-out plaintext, caminho cifrado, e o **pipefail** (pg_dump falha → exit 1, não mascarado) → **7/7**.
- `pytest test_celery_backup + test_tasks_mp5` → **14 passed** (novo teste: `degraded` → ERROR, provado).
- `bash -n` nos 3 scripts; shellcheck limpo nas minhas linhas; `restore_db` mantém o estilo pré-existente. `pyright` 0 erros; `black`/`isort`/`flake8` limpos.

Refs #1455, #1536, #1541
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `6a4d5cc6`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
