### PR TITLE
fix(gcal): não engole falha de DELETE (evento órfão) + liga auto-retry do breaker

### DIFF
--- a/v2/backend/apps/core/services/gcal/sync.py
+++ b/v2/backend/apps/core/services/gcal/sync.py
@@ -208,9 +208,15 @@ def upsert_one(
                             operation_name=f"GCal DELETE #{s.id}",
                         )
                     except Exception as e:
-                        # Ignora se evento já foi deletado, mas registra outros erros
+                        # 404 = evento já deletado no Google (idempotência OK). Para
+                        # QUALQUER outro erro, RE-LEVANTA (#1541): limpar
+                        # external_event_id e retornar action="DELETE" aqui deixava o
+                        # evento VIVO no Google (participantes ainda o viam) e
+                        # descartava o único ponteiro para ele — evento órfão
+                        # permanente, reportado como sucesso. Espelha
+                        # cancel_solicitacao; o caller marca gcal_status=ERROR.
                         if "404" not in str(e):
-                            error_msg = f"Erro ao deletar: {str(e)}"
+                            raise
 
                     s.external_event_id = None
                     s.last_synced_at = timezone.now()

--- a/v2/backend/apps/core/tasks.py
+++ b/v2/backend/apps/core/tasks.py
@@ -11,7 +11,7 @@ Agendamento via CELERY_BEAT_SCHEDULE no settings.py:
   - Janela padrão: 90 dias atrás até 180 dias à frente
 """
 
-# pyright: reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportMissingParameterType=false, reportAttributeAccessIssue=false, reportReturnType=false, reportArgumentType=false, reportUntypedBaseClass=false, reportMissingTypeArgument=false, reportOptionalMemberAccess=false, reportCallIssue=false, reportUntypedFunctionDecorator=false, reportMissingTypeStubs=false, reportGeneralTypeIssues=false
+# pyright: reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportMissingParameterType=false, reportAttributeAccessIssue=false, reportReturnType=false, reportArgumentType=false, reportUntypedBaseClass=false, reportMissingTypeArgument=false, reportOptionalMemberAccess=false, reportCallIssue=false, reportUntypedFunctionDecorator=false, reportMissingTypeStubs=false, reportGeneralTypeIssues=false, reportFunctionMemberAccess=false
 
 from __future__ import annotations
 
@@ -187,6 +187,19 @@ def task_publish_solicitacao_to_gcal(
             "error": "DoesNotExist",
         }
     except Exception as e:
+        # #1541: se o publish caiu porque o circuit breaker do GCal está ABERTO,
+        # enfileira o auto-retry que espera o breaker fechar. A task
+        # queue_gcal_sync_retry existia (Gap 6) mas NUNCA era enfileirada — a sync
+        # derrubada pelo breaker ficava perdida até re-disparo MANUAL, em silêncio.
+        from apps.core.services.gcal.circuit_breaker import CircuitBreakerError
+
+        if isinstance(e, CircuitBreakerError) and not dry_run:
+            queue_gcal_sync_retry.apply_async(
+                (solicitation_id,),
+                kwargs={"dry_run": dry_run, "apply_blocked": apply_blocked},
+                countdown=60,
+            )
+
         # Tentar registrar erro e estado se a solicitação existir
         try:
             s = Solicitacao.objects.get(id=solicitation_id)

--- a/v2/backend/apps/core/tests/test_gcal_delete_swallow_1541.py
+++ b/v2/backend/apps/core/tests/test_gcal_delete_swallow_1541.py
@@ -1,0 +1,138 @@
+"""#1541 (lote C) — robustez do GCal: delete-swallow e auto-retry do breaker.
+
+Dois defeitos silenciosos achados pela auditoria adversarial:
+
+1. `upsert_one` (DELETE): uma falha não-404 ao deletar o evento no Google era
+   ENGOLIDA — o código zerava `external_event_id` e retornava `action="DELETE"`
+   como sucesso. O evento continuava vivo no Google (participantes ainda o viam) e
+   o único ponteiro para ele era descartado: órfão permanente, reportado como OK.
+
+2. `queue_gcal_sync_retry` existia (Gap 6) mas NUNCA era enfileirada. Uma sync
+   derrubada pelo circuit breaker aberto ficava perdida até re-disparo manual.
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportAttributeAccessIssue=false, reportOptionalMemberAccess=false, reportCallIssue=false, reportArgumentType=false
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from apps.core.services.gcal.sync import upsert_one
+from apps.core.tests.factories import SolicitacaoFactory
+
+pytestmark = pytest.mark.django_db
+
+# Bypassa o backoff/circuit-breaker real no teste: chama a fn uma vez e propaga.
+_PASSTHROUGH = "apps.core.services.gcal.sync._retry_with_circuit_breaker"
+
+
+def _passthrough(fn, **kwargs):
+    return fn()
+
+
+class _FakeClient:
+    """Cliente de Calendar mínimo cujo delete pode ser configurado para falhar."""
+
+    def __init__(self, delete_exc: Exception | None = None) -> None:
+        self._delete_exc = delete_exc
+
+    def get(self, calendar_id, event_id):  # noqa: ARG002
+        return {"id": event_id}
+
+    def insert(self, calendar_id, event_id, payload):  # noqa: ARG002
+        return {"id": event_id}
+
+    def update(self, calendar_id, event_id, payload):  # noqa: ARG002
+        return {"id": event_id}
+
+    def delete(self, calendar_id, event_id):  # noqa: ARG002
+        if self._delete_exc is not None:
+            raise self._delete_exc
+
+
+class TestUpsertDeleteSwallow:
+    def test_delete_failure_reraises_and_keeps_pointer(self):
+        """Falha não-404 ao deletar → RE-LEVANTA e NÃO zera external_event_id.
+
+        Antes do fix retornava action="DELETE" com o ponteiro descartado (órfão).
+        """
+        s = SolicitacaoFactory(status="reprovado", external_event_id="asv2-orphan-1")
+        client = _FakeClient(delete_exc=RuntimeError("500 Internal Server Error"))
+
+        with patch(_PASSTHROUGH, side_effect=_passthrough):
+            with pytest.raises(RuntimeError):
+                upsert_one(client=client, calendar_id="primary", s=s)
+
+        s.refresh_from_db()
+        assert s.external_event_id == "asv2-orphan-1", "ponteiro deve ser preservado na falha"
+
+    def test_delete_404_is_success_and_clears_pointer(self):
+        """404 = evento já removido no Google → sucesso idempotente, zera o ponteiro."""
+        s = SolicitacaoFactory(status="reprovado", external_event_id="asv2-gone-1")
+        client = _FakeClient(delete_exc=Exception("404 Not Found"))
+
+        with patch(_PASSTHROUGH, side_effect=_passthrough):
+            outcome = upsert_one(client=client, calendar_id="primary", s=s)
+
+        assert outcome.action == "DELETE"
+        s.refresh_from_db()
+        assert s.external_event_id is None
+
+    def test_delete_success_clears_pointer(self):
+        """DELETE bem-sucedido zera o ponteiro e reporta action=DELETE."""
+        s = SolicitacaoFactory(status="reprovado", external_event_id="asv2-ok-1")
+        client = _FakeClient(delete_exc=None)
+
+        with patch(_PASSTHROUGH, side_effect=_passthrough):
+            outcome = upsert_one(client=client, calendar_id="primary", s=s)
+
+        assert outcome.action == "DELETE"
+        s.refresh_from_db()
+        assert s.external_event_id is None
+
+
+class TestBreakerAutoRetryWired:
+    def test_publish_enqueues_retry_on_circuit_breaker_open(self):
+        """CircuitBreakerError no publish → enfileira queue_gcal_sync_retry.
+
+        Sem o wiring, a task de recuperação existia mas nunca era acionada: a sync
+        ficava perdida até re-disparo manual, em silêncio.
+        """
+        from apps.core.services.gcal.circuit_breaker import CircuitBreakerError, gcal_breaker
+        from apps.core.tasks import task_publish_solicitacao_to_gcal
+
+        s = SolicitacaoFactory(status="aprovado")
+
+        with (
+            patch(
+                "apps.core.services.gcal_sync_service.apply_one_solicitacao",
+                side_effect=CircuitBreakerError(gcal_breaker),
+            ),
+            patch("apps.core.tasks.queue_gcal_sync_retry.apply_async") as mock_enqueue,
+        ):
+            result = task_publish_solicitacao_to_gcal(s.id, dry_run=False, apply_blocked=True)
+
+        assert result["action"] == "ERROR"
+        assert mock_enqueue.called, "deve enfileirar o auto-retry quando o breaker abre"
+        args, _kwargs = mock_enqueue.call_args
+        assert args[0] == (s.id,)
+
+    def test_publish_does_not_enqueue_retry_for_other_errors(self):
+        """Erro comum (não breaker) NÃO enfileira retry — evita retry-storm à toa."""
+        from apps.core.tasks import task_publish_solicitacao_to_gcal
+
+        s = SolicitacaoFactory(status="aprovado")
+
+        with (
+            patch(
+                "apps.core.services.gcal_sync_service.apply_one_solicitacao",
+                side_effect=RuntimeError("erro qualquer"),
+            ),
+            patch("apps.core.tasks.queue_gcal_sync_retry.apply_async") as mock_enqueue,
+        ):
+            result = task_publish_solicitacao_to_gcal(s.id, dry_run=False, apply_blocked=True)
+
+        assert result["action"] == "ERROR"
+        assert not mock_enqueue.called


### PR DESCRIPTION
Dois defeitos silenciosos do GCal achados pela auditoria adversarial (#1541).

## 1. `upsert_one` engolia falha de DELETE → evento órfão reportado como sucesso

No `except` do delete ([sync.py:210](v2/backend/apps/core/services/gcal/sync.py#L210)), um erro **não-404** gravava `error_msg` mas em seguida:

```python
s.external_event_id = None          # ← INCONDICIONAL
...
return SyncOutcome(action="DELETE") # ← reportado como sucesso
```

Resultado: o evento continua **vivo no Google Calendar** (participantes ainda o veem), o único ponteiro para ele (`external_event_id`) é descartado, e a operação é reportada como `DELETE` bem-sucedido. Órfão permanente — só resta um `last_sync_error` numa coluna que ninguém monitora.

**Fix**: no não-404, **re-levanta** — exatamente o que a irmã `cancel_solicitacao` já fazia. O caller `task_publish` tem `except Exception` que marca `gcal_status=ERROR` + AuditLog `PUBLISH_GCAL_ERROR`. O ponteiro só é zerado e o `DELETE` só é reportado quando o delete **de fato** deu certo (ou 404 idempotente).

## 2. `queue_gcal_sync_retry` — a recuperação que nunca era acionada

A task de auto-retry do circuit breaker (Gap 6) estava **registrada mas nunca enfileirada**: `grep` em todo o backend não achava nenhum `.delay()`/`.apply_async()` para ela. Uma sync derrubada com o breaker **aberto** ficava perdida até re-disparo **manual**, em silêncio — e a `Action.GCAL_RETRY_SUCCESS` ainda sugeria que retries aconteciam.

**Fix**: `task_publish` detecta `CircuitBreakerError` e enfileira `queue_gcal_sync_retry` (`countdown=60s`). A task existente já espera o breaker fechar e re-tenta (`max_retries=10`). Guardado por `isinstance` + `not dry_run` — erro comum **não** enfileira (sem retry-storm).

## Testes (`test_gcal_delete_swallow_1541.py`)

| caso | esperado |
|---|---|
| delete não-404 | **raise** + `external_event_id` preservado |
| delete 404 | sucesso idempotente, zera ponteiro |
| delete ok | zera ponteiro, `action=DELETE` |
| `CircuitBreakerError` no publish | **enfileira** `queue_gcal_sync_retry` |
| erro comum no publish | **não** enfileira |

**Provado que pegam o bug**: sem os fixes, os 2 testes-alvo (re-raise + enqueue) falham.

- Suíte **core 2792 passed** (sem regressão no GCal/cancel/circuit-breaker)
- `pyright` 0 erros (`reportFunctionMemberAccess` adicionado ao header do `tasks.py` — é o `.apply_async` do `@shared_task`, que pyright vê como função não-tipada; o `sync.py` tem 1 erro **pré-existente**, não meu)
- `black`/`isort`/`flake8` limpos

Refs #1541
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `ed8db0f9`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
