### PR TITLE
test: religa 4 testes sem dentes (apply_blocked, grade mensal, cache, cookies)

### DIFF
--- a/v2/backend/apps/core/tests/test_availability_monthly_api.py
+++ b/v2/backend/apps/core/tests/test_availability_monthly_api.py
@@ -93,7 +93,9 @@ def setup_data():
 
     # Dependências
     municipio = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
-    projeto = ProjetoFactory(nome="Gestão Escolar", ativo=True)
+    # #1541: super=True (fluxo=SUPER) — sem isto as Solicitações não populam a grade
+    # e os testes de códigos/CH ficavam vazios (parte do motivo do skip 'TEMP').
+    projeto = ProjetoFactory(nome="Gestão Escolar", ativo=True, super=True)
     tipo_evento = TipoEventoFactory(nome="Formação")
 
     # Eventos aprovados
@@ -185,7 +187,6 @@ def setup_data():
     }
 
 
-@pytest.mark.skip(reason="TEMP: Conflito com PRs 17/18/19 - será corrigido após merge sequencial")
 def test_monthly_availability_codes(api_client, user_auth, setup_data):
     """
     Testa códigos E/2/P/X para grade mensal.
@@ -273,7 +274,6 @@ def test_monthly_availability_codes(api_client, user_auth, setup_data):
     assert detail["tipo"] == "Formação"
 
 
-@pytest.mark.skip(reason="TEMP: Conflito com PRs 17/18/19 - será corrigido após merge sequencial")
 def test_monthly_availability_ch_and_ranking(api_client, user_auth, setup_data):
     """
     Testa CH mês/ano e ranking denso.

--- a/v2/backend/apps/core/tests/test_features_apply_blocked.py
+++ b/v2/backend/apps/core/tests/test_features_apply_blocked.py
@@ -1,68 +1,74 @@
 """
 Testes para /api/features - apply_blocked.
 
-Valida que o campo apply_blocked é calculado corretamente
-com base no valor de GCAL_CLIENT.
+Valida que o campo apply_blocked é calculado corretamente com base no valor de
+GCAL_CLIENT (apply_blocked = GCAL_CLIENT != "google" — trava operações acidentais
+no Google Calendar).
+
+#1541: os 4 testes estavam 100% em @pytest.mark.skip 'TEMP' desde o PR16 (jan/2026)
+e nunca foram restaurados — o campo de segurança apply_blocked ficou sem cobertura
+ativa. Pior: se reativados falhariam por dois motivos (a) usavam APIClient SEM auth
+esperando 200, mas o endpoint exige autenticação (403); (b) usavam
+patch.dict(os.environ, ...) mas a view lê settings.GCAL_CLIENT, não os.environ. Ambos
+corrigidos aqui (force_authenticate + @override_settings).
 """
 
 # pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportOptionalMemberAccess=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportMissingTypeArgument=false, reportCallIssue=false, reportIndexIssue=false, reportOperatorIssue=false, reportOptionalSubscript=false, reportUnknownLambdaType=false
 
 from __future__ import annotations
 
-import os
-from unittest.mock import patch
-
+from django.test import override_settings
 from rest_framework.test import APIClient
 
 import pytest
 
+from apps.core.tests.factories import UsuarioFactory
+
 pytestmark = pytest.mark.django_db
 
 
-@pytest.mark.skip(reason="TEMP: De outro PR - será corrigido após merge sequencial")
-def test_features_apply_blocked_true():
-    """
-    Testa que apply_blocked=True quando GCAL_CLIENT="fake".
-
-    Garante que operações de apply são bloqueadas com client fake
-    para evitar operações acidentais.
-    """
-    with patch.dict(os.environ, {"GCAL_CLIENT": "fake"}):
-        client = APIClient()
-        response = client.get("/api/features/")
-
-        assert response.status_code == 200
-        data = response.json()
-        assert "apply_blocked" in data
-        assert data["apply_blocked"] is True
-        assert data["GCAL_CLIENT"] == "fake"
-
-
-@pytest.mark.skip(reason="TEMP: De outro PR - será corrigido após merge sequencial")
-def test_features_apply_blocked_false():
-    """
-    Testa que apply_blocked=False quando GCAL_CLIENT="google".
-
-    Com client real do Google, operações de apply são permitidas.
-    """
-    with patch.dict(os.environ, {"GCAL_CLIENT": "google"}):
-        client = APIClient()
-        response = client.get("/api/features/")
-
-        assert response.status_code == 200
-        data = response.json()
-        assert "apply_blocked" in data
-        assert data["apply_blocked"] is False
-        assert data["GCAL_CLIENT"] == "google"
-
-
-@pytest.mark.skip(reason="TEMP: De outro PR - será corrigido após merge sequencial")
-def test_features_returns_environment():
-    """
-    Testa que /api/features retorna informações de ambiente.
-    """
+def _auth_client() -> APIClient:
     client = APIClient()
-    response = client.get("/api/features/")
+    client.force_authenticate(user=UsuarioFactory())
+    return client
+
+
+@override_settings(GCAL_CLIENT="fake")
+def test_features_apply_blocked_true():
+    """apply_blocked=True quando GCAL_CLIENT='fake' (bloqueia apply acidental)."""
+    response = _auth_client().get("/api/features/")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["apply_blocked"] is True
+    assert data["GCAL_CLIENT"] == "fake"
+
+
+@override_settings(GCAL_CLIENT="google")
+def test_features_apply_blocked_false():
+    """apply_blocked=False quando GCAL_CLIENT='google' (client real permite apply)."""
+    response = _auth_client().get("/api/features/")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["apply_blocked"] is False
+    assert data["GCAL_CLIENT"] == "google"
+
+
+@override_settings(GCAL_CLIENT="test")
+def test_features_apply_blocked_with_unknown_client():
+    """Qualquer valor != 'google' bloqueia apply (fail-safe)."""
+    response = _auth_client().get("/api/features/")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["apply_blocked"] is True
+    assert data["GCAL_CLIENT"] == "test"
+
+
+def test_features_returns_environment():
+    """/api/features retorna ENVIRONMENT + GCAL_CLIENT."""
+    response = _auth_client().get("/api/features/")
 
     assert response.status_code == 200
     data = response.json()
@@ -70,18 +76,8 @@ def test_features_returns_environment():
     assert "GCAL_CLIENT" in data
 
 
-@pytest.mark.skip(reason="TEMP: De outro PR - será corrigido após merge sequencial")
-def test_features_apply_blocked_with_unknown_client():
-    """
-    Testa que apply_blocked=True com client desconhecido.
+def test_features_requires_authentication():
+    """Sem auth → 403: o endpoint expõe config de ambiente, não pode ser anônimo."""
+    response = APIClient().get("/api/features/")
 
-    Qualquer valor diferente de "google" deve bloquear apply.
-    """
-    with patch.dict(os.environ, {"GCAL_CLIENT": "test"}):
-        client = APIClient()
-        response = client.get("/api/features/")
-
-        assert response.status_code == 200
-        data = response.json()
-        assert data["apply_blocked"] is True
-        assert data["GCAL_CLIENT"] == "test"
+    assert response.status_code in (401, 403)

--- a/v2/frontend/e2e/checklist/performance.spec.ts
+++ b/v2/frontend/e2e/checklist/performance.spec.ts
@@ -232,6 +232,12 @@ test.describe('Checklist: Resource Loading', () => {
 
 test.describe('Checklist: Caching', () => {
   test('🔴 assets estáticos devem ter cache headers', async ({ page }) => {
+    // #1541: cache headers só existem no build de produção (CI); em dev o Vite serve
+    // sem cache-control. O skip ficava no FIM, depois de um mero console.log — então
+    // em CI o teste 🔴 passava mesmo com TODOS os assets sem cache-control (nenhum
+    // expect). Agora: skip no topo (SKIP honesto em dev) + asserção de verdade em CI.
+    test.skip(!process.env.CI, 'Cache headers verificados apenas em CI');
+
     const assetsWithoutCache: string[] = [];
 
     page.on('response', async (response) => {
@@ -246,10 +252,7 @@ test.describe('Checklist: Caching', () => {
         url.endsWith('.jpg') ||
         url.endsWith('.svg')
       ) {
-        const cacheControl = response.headers()['cache-control'];
-
-        // Em desenvolvimento, cache pode não estar configurado
-        if (process.env.CI && !cacheControl) {
+        if (!response.headers()['cache-control']) {
           assetsWithoutCache.push(url.split('/').pop() || url);
         }
       }
@@ -257,14 +260,10 @@ test.describe('Checklist: Caching', () => {
 
     await page.goto('/', { waitUntil: 'networkidle' });
 
-    if (assetsWithoutCache.length > 0) {
-      console.log('Assets sem cache headers:', assetsWithoutCache);
-    }
-
-    // Não falha em desenvolvimento
-    if (!process.env.CI) {
-      test.skip(true, 'Cache headers verificados apenas em CI');
-    }
+    expect(
+      assetsWithoutCache,
+      `Assets sem cache-control: ${assetsWithoutCache.join(', ')}`
+    ).toHaveLength(0);
   });
 
   test('🟡 deve usar preconnect para APIs externas', async ({ page }) => {

--- a/v2/frontend/e2e/checklist/security-headers.spec.ts
+++ b/v2/frontend/e2e/checklist/security-headers.spec.ts
@@ -169,6 +169,22 @@ test.describe('Checklist: Cookies Security', () => {
         c.name.toLowerCase().includes('token')
     );
 
+    // #1541: sem esta guarda, um sessionCookies VAZIO (o pior caso — auth mockada
+    // sem Set-Cookie real) fazia o for não executar nenhuma assertiva, e o teste 🔴
+    // passava vazio. Em STRICT_MODE exige que haja cookie para validar; em dev/mock
+    // registra SKIP em vez de PASS falso.
+    if (STRICT_MODE) {
+      expect(
+        sessionCookies.length,
+        'nenhum cookie de sessão encontrado para validar flags'
+      ).toBeGreaterThan(0);
+    } else {
+      test.skip(
+        sessionCookies.length === 0,
+        'sem cookies de sessão no ambiente mockado'
+      );
+    }
+
     for (const cookie of sessionCookies) {
       // HttpOnly para cookies de sessão
       if (cookie.name.toLowerCase().includes('session')) {


### PR DESCRIPTION
Auditoria de falhas silenciosas (#1541), **lote F**: testes que **nunca reprovavam** — passavam verdes mesmo com o defeito presente.

| teste | por que era sem dentes | fix |
|---|---|---|
| `test_features_apply_blocked.py` (4 testes) | 100% em `@pytest.mark.skip 'TEMP'` desde o PR16 (jan/2026) — cobertura **zero** do campo de segurança `apply_blocked`. E apodrecidos: `APIClient` sem auth esperando 200 (endpoint dá 403) + `patch.dict(os.environ)` (a view lê `settings.GCAL_CLIENT`) | un-skip + `force_authenticate` + `@override_settings` + teste novo de 403 sem auth |
| `test_availability_monthly_api.py` (2 testes) | skip `'TEMP: Conflito com PRs 17/18/19'` (PRs já mergeados); `setup_data` criava `ProjetoFactory` sem SUPER → grade vazia | un-skip + `super=True` |
| `performance.spec.ts` 🔴 cache headers | **nenhum `expect()`** — em CI só `console.log`; o `test.skip` de dev ficava no fim. Passava com todos os assets sem `cache-control` | `test.skip(!CI)` no topo + `expect(...).toHaveLength(0)` |
| `security-headers.spec.ts` 🔴 cookie flags | assertivas dentro de `for (cookie of sessionCookies)`; lista **vazia** (auth mockada) → loop não roda → passa sem assertiva | guarda: STRICT_MODE exige `length > 0`; dev/mock → SKIP |

## O que isto expõe

`apply_blocked` é o campo que impede escritas acidentais no Google Calendar. Ele tinha **cobertura ativa zero** há meses — e os testes, se alguém tentasse reativar, falhariam por terem apodrecido junto. Os dois 🔴 de frontend eram testes "obrigatórios" que passavam vazios.

## Verificação

- `pytest` backend → **9/9** (apply_blocked 5, monthly 4). O `super=True` populou a grade sem quebrar os 2 testes de monthly que já estavam ativos.
- `tsc --noEmit` e `eslint` limpos nas 2 specs
- `black`/`isort`/`flake8` limpos

Refs #1541
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `02ed5496`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
