### PR TITLE
docs: corrige drift pos-ADR-018 (RUNBOOK, checklist, ci/environments/pages specs) (#1541)

### DIFF
--- a/v2/docs/DEPLOY_CHECKLIST.md
+++ b/v2/docs/DEPLOY_CHECKLIST.md
@@ -1,68 +1,59 @@
 # Deploy Checklist
 
-Checklist de configuração para o pipeline canônico de deploy:
-- `.github/workflows/deploy.yaml`
+> **Modelo atual: pull-based (ADR-018).** A SSOT do mecanismo de deploy é
+> [`specs/infra/deploy.spec.md`](specs/infra/deploy.spec.md) — este checklist só resume os passos operacionais.
+> O modelo antigo (o CI fazia `PUT` no Portainer `:9443` **público**) foi desligado no cutover (#1515) e o job
+> `deploy` removido na Fase 4 (#1516). **Não** há mais secrets `PORTAINER_*` / `STAGING_*` / `PRODUCTION_*`.
+
+Workflows canônicos:
+
+- `.github/workflows/deploy.yaml` — **"Build, sign and release (main)"**
+- `.github/workflows/promote.yml` — promoção/rollback (gated)
 
 ## 1. Pré-requisitos gerais
 
-- [ ] Environments GitHub criados: `staging` e `production`
-- [ ] `production` com reviewers obrigatórios
-- [ ] Docker Hub token válido (`DOCKER_HUB_TOKEN`)
-- [ ] Portainer acessível pelo runner do GitHub Actions
+- [ ] GitHub Environment `production` criado com **required reviewer** (1 aprovação)
+- [ ] Branch protegido `deploy-pointer` (o ponteiro de release assinado é publicado nele)
+- [ ] Docker Hub token válido (`DOCKER_HUB_TOKEN`) para push das imagens
+- [ ] Agente `aprender-deployer` ativo na VM01 (systemd) com o trusted-root do cosign pinado offline
+- [ ] `cosign` disponível no pipeline (assinatura keyless + provenance SLSA)
 
-## 2. Variáveis/secrets de Portainer
+## 2. Secrets/vars removidos (NÃO reconfigurar)
 
-Defina por ambiente (ou fallback global):
+Após o cutover ADR-018 (#1515/#1516), estes secrets/vars foram **removidos do GitHub** e não têm mais uso:
 
-| Nome | Escopo | Obrigatório |
-|---|---|---|
-| `STAGING_PORTAINER_URL` / `PRODUCTION_PORTAINER_URL` | per-env | Sim (ou `PORTAINER_URL`) |
-| `STAGING_PORTAINER_STACK_ID` / `PRODUCTION_PORTAINER_STACK_ID` | per-env | Sim (ou `PORTAINER_STACK_ID`) |
-| `STAGING_PORTAINER_ENDPOINT_ID` / `PRODUCTION_PORTAINER_ENDPOINT_ID` | per-env | Sim (ou `PORTAINER_ENDPOINT_ID`) |
-| `STAGING_PORTAINER_ACCESS_TOKEN` / `PRODUCTION_PORTAINER_ACCESS_TOKEN` | per-env | Sim (ou `PORTAINER_ACCESS_TOKEN`) |
-| `STAGING_PORTAINER_SKIP_TLS_VERIFY` / `PRODUCTION_PORTAINER_SKIP_TLS_VERIFY` | per-env | Não (default `true`) |
+- `PORTAINER_*` (URL / STACK_ID / ENDPOINT_ID / ACCESS_TOKEN / SKIP_TLS_VERIFY) e as variantes `STAGING_*` / `PRODUCTION_*`
+- `STAGING_HEALTHCHECK_URL` / `PRODUCTION_HEALTHCHECK_URL`, `STAGING_VERSIONCHECK_URL` / `PRODUCTION_VERSIONCHECK_URL`
+- `STAGING_DEPLOY_COMMAND` / `PRODUCTION_DEPLOY_COMMAND`
 
-## 3. Verificação pós-deploy
+O único token de Portainer que ainda existe fica **dentro da VM01** (o `aprender-applier` o detém), nunca no GitHub.
 
-| Nome | Escopo | Obrigatório |
-|---|---|---|
-| `STAGING_HEALTHCHECK_URL` / `PRODUCTION_HEALTHCHECK_URL` | per-env | Sim |
-| `STAGING_VERSIONCHECK_URL` / `PRODUCTION_VERSIONCHECK_URL` | per-env | Sim |
-| `POST_DEPLOY_SKIP_TLS_VERIFY` | global | Não (default `false`) |
+## 3. Merge na `main` (build + sign + release)
+
+- [ ] Merge na `main` dispara `deploy.yaml`: build → scan (Trivy) → push no Docker Hub → **assina** as imagens
+      (cosign keyless + provenance SLSA) → cria a **tag imutável** `vYYYY.MM.DD-<sha7>` + GitHub Release
+- [ ] **Merge NÃO deploya** — nenhum ambiente é atualizado neste passo
+- [ ] Gate Trivy verde (bloqueia HIGH/CRITICAL); imagens assinadas verificáveis por digest
+
+## 4. Promoção para produção (`promote.yml`)
+
+Produção muda em **dois passos deliberados**:
+
+```bash
+# 1) Promoção — gated no GitHub Environment `production` (required reviewer)
+gh workflow run promote.yml -f release=vYYYY.MM.DD-<sha7>
+```
+
+- [ ] `promote.yml` resolve tag→digest, exige imagens assinadas e publica o ponteiro **assinado** (`cosign sign-blob`) no branch `deploy-pointer`
+- [ ] O agente `aprender-deployer` (VM01) lê o ponteiro, verifica com cosign contra o trusted-root pinado, aplica **por digest** em `127.0.0.1:9443` e confirma de dentro da VM (`/api/readyz/` + `/api/version/`)
+- [ ] **Rollback** = promover a tag anterior pelo mesmo caminho gated: `gh workflow run promote.yml -f release=<tag-anterior>`
 
 Observação:
-- em promoção para produção, `STAGING_VERSIONCHECK_URL` precisa existir para o gate de homologação da tag.
 
-## 4. Comandos canônicos
+- O pipeline rejeita `latest`; use apenas tag imutável `vYYYY.MM.DD-<sha7>`. Sem retag `latest`.
+- Alterar o compose exige edição **manual** no Editor do Portainer + re-captura do pinado (senão o agente recusa por `compose_drift`).
 
-### 4.1 Staging automático
-
-- Trigger: `push` em `main`.
-- Esperado: build + scan + push + deploy em `staging`.
-
-### 4.2 Staging manual
-
-```bash
-gh workflow run deploy.yaml -f target_environment=staging
-```
-
-### 4.3 Promoção para produção
-
-```bash
-gh workflow run deploy.yaml -f target_environment=production -f promotion_tag=vYYYY.MM.DD-<sha>
-```
-
-### 4.4 Rollback de produção
-
-```bash
-gh workflow run deploy.yaml -f target_environment=production -f rollback_tag=vYYYY.MM.DD-<sha-anterior>
-```
-
-Observação:
-- O workflow rejeita `latest` em produção. Use apenas tag imutável no formato `vYYYY.MM.DD-<sha-or-id>`.
-- O build/publish do pipeline usa somente a tag imutável da release (sem retag `latest`).
-
-### 4.5 Go-live local (v2)
+## 5. Go-live local (v2)
 
 Sequência mínima de validação pré-go-live (rodar em `v2/`):
 
@@ -71,31 +62,19 @@ Sequência mínima de validação pré-go-live (rodar em `v2/`):
 - [ ] `make healthz` — checa `/healthz/` (saúde da app)
 - [ ] `make ban-v1` — roda `scripts/ban_v1.sh`: remove à força containers, redes e volumes legados do projeto v1 (`com.docker.compose.project=aprendersistema`), garantindo que nenhum resíduo v1 sobreviva ao corte (CP-05).
 
-## 5. Evidências obrigatórias
+## 6. Gate de PR (staging local)
 
-- [ ] Artifact `deploy-evidence-<run_id>` disponível
-- [ ] `deploy-evidence.txt` presente
-- [ ] `post-deploy-health-response.txt` presente
-- [ ] `post-deploy-version-response.txt` presente
-- [ ] Em caso de falha de update: `portainer-stack-update-attempts.txt`
-
-## 6. Gate de PR (staging)
+Não há staging remoto: a barreira prod-like é o `make staging-full` **local** do autor, evidenciado no corpo do PR.
 
 - [ ] Check `[required] staging gate evidence` verde no PR
 - [ ] PR contém `ALL 8 CHECKS PASSED` no corpo (evidência auditável)
 - [ ] Checklist `make staging-full` marcado no PR
 - [ ] PR com impacto em runtime (`v2/backend/**`, `v2/frontend/**`, `v2/infra/**`); se não houver impacto, o check pode ficar `skipped`
 
-## 7. Variáveis obsoletas (remover)
+## 7. Critérios de aceite do deploy
 
-As variáveis abaixo não são mais usadas após a depreciação do `release.yaml`:
-
-- `STAGING_DEPLOY_COMMAND`
-- `PRODUCTION_DEPLOY_COMMAND`
-
-## 8. Critérios de aceite do deploy
-
-- [ ] Deploy de `staging` conclui sem erro opaco
-- [ ] Deploy de `production` exige aprovação do environment
-- [ ] `version` endpoint contém a tag esperada
-- [ ] Rollback por tag imutável executa com sucesso
+- [ ] `deploy.yaml` conclui build+scan+push+sign+release sem erro
+- [ ] Tag imutável `vYYYY.MM.DD-<sha7>` + Release publicados
+- [ ] Promoção exige aprovação do Environment `production`
+- [ ] Agente na VM01 aplica por digest e confirma `/api/version/` = release promovida
+- [ ] Rollback por promoção de tag anterior executa pelo mesmo caminho gated

--- a/v2/docs/RUNBOOK.md
+++ b/v2/docs/RUNBOOK.md
@@ -2,7 +2,7 @@
 
 **Versão:** 1.0
 **Projeto Docker:** `aprender_v2`
-**Última atualização:** 2026-02-24
+**Última atualização:** 2026-07-10
 
 ---
 
@@ -20,76 +20,48 @@
 
 ## 🚀 Deploy Workflow (Canônico)
 
-Workflow oficial:
-- `.github/workflows/deploy.yaml`
+> **Modelo atual: pull-based (ADR-018).** SSOT: [`specs/infra/deploy.spec.md`](specs/infra/deploy.spec.md).
+> O modelo antigo (o CI fazia `PUT` no Portainer `:9443` **público**) foi desligado no cutover (#1515) e o job
+> `deploy` foi **removido** na Fase 4 (#1516).
 
-Comportamento:
-- `push` na `main` -> deploy automático em `staging`.
-- `workflow_dispatch`:
-  - `target_environment=staging` (build e deploy de staging),
-  - `target_environment=production` + `promotion_tag`,
-  - `target_environment=production` + `rollback_tag`.
+Workflows oficiais:
+- `.github/workflows/deploy.yaml` (hoje **"Build, sign and release (main)"**)
+- `.github/workflows/promote.yml` (promoção/rollback, gated)
 
-Regra de produção:
-- usar somente tag imutável `vYYYY.MM.DD-<sha-or-id>`;
-- `latest` é bloqueada para promoção/rollback.
-- o pipeline publica apenas a tag imutável da release (sem retag `latest`).
-- promoção deve partir de PR com check `[required] staging gate evidence` aprovado.
+### Merge na `main` NÃO deploya
 
-### Variáveis obrigatórias por ambiente
+`push`/merge na `main` dispara apenas `deploy.yaml`, que faz **build → scan (Trivy) → push no Docker Hub →
+assina** as imagens (cosign keyless + provenance SLSA) → cria a **tag imutável** `vYYYY.MM.DD-<sha7>` + GitHub
+Release. Nenhum ambiente é atualizado nesse passo.
 
-Portainer:
-- `STAGING_PORTAINER_URL` / `PRODUCTION_PORTAINER_URL` ou `PORTAINER_URL`
-- `STAGING_PORTAINER_STACK_ID` / `PRODUCTION_PORTAINER_STACK_ID` ou `PORTAINER_STACK_ID`
-- `STAGING_PORTAINER_ENDPOINT_ID` / `PRODUCTION_PORTAINER_ENDPOINT_ID` ou `PORTAINER_ENDPOINT_ID`
-- `STAGING_PORTAINER_ACCESS_TOKEN` / `PRODUCTION_PORTAINER_ACCESS_TOKEN` ou `PORTAINER_ACCESS_TOKEN`
+### Produção muda em dois passos deliberados
 
-Verificação:
-- `STAGING_HEALTHCHECK_URL` / `PRODUCTION_HEALTHCHECK_URL`
-- `STAGING_VERSIONCHECK_URL` / `PRODUCTION_VERSIONCHECK_URL`
+1. **Promoção (`promote.yml`)** — `workflow_dispatch` atrás do GitHub Environment `production` (*required
+   reviewer*, 1 aprovação). Resolve tag→digest, exige imagens assinadas, monta e **assina** o ponteiro de
+   release (`cosign sign-blob`, identidade OIDC do workflow) e publica no branch protegido **`deploy-pointer`**.
 
-### Evidências geradas
+   ```bash
+   gh workflow run promote.yml -f release=vYYYY.MM.DD-<sha7>
+   ```
 
-Artifacts relevantes:
-- `deploy-evidence.txt`
-- `post-deploy-health-response.txt`
-- `post-deploy-version-response.txt`
-- `post-deploy-debug.txt`
-- `portainer-stack-update-attempts.txt` (quando houver retries/falhas no update da stack)
+2. **Aplicação (agente `aprender-deployer` na VM01)** — systemd na própria VM lê o ponteiro assinado,
+   verifica com **cosign** contra um trusted-root pinado offline, verifica as imagens **por digest**, checa
+   anti-rollback (selo monotônico) + drift do compose + backup de DB fresco, faz o `PUT` em
+   **`127.0.0.1:9443`** com o compose pinado que ele mesmo detém e confirma de dentro da VM
+   (`/api/readyz/` + `/api/version/`). Por confirmar em `localhost`, é imune ao *false-red* do `:9443` público.
 
-### Troubleshooting do post-deploy
+### Regras de produção
 
-Quando falhar a verificação de versão/health no `deploy.yaml`, usar:
+- Só tag imutável `vYYYY.MM.DD-<sha7>`; `latest` é bloqueada para promoção. O pipeline não faz retag `latest`.
+- **Rollback = promover a tag anterior** pelo mesmo caminho gated: `gh workflow run promote.yml -f release=<tag-anterior>`.
+- Alterar o compose exige edição **manual** no Editor do Portainer + re-captura do pinado (senão o agente recusa por `compose_drift`).
 
-1. `deploy-evidence.txt` para contexto do run.
-2. `post-deploy-debug.txt` para causa classificada (`failure_cause`):
-   - `network_unavailable`
-   - `endpoint_not_ready`
-   - `version_mismatch`
-3. `post-deploy-*.txt` para última resposta dos endpoints.
+### Depreciado / removido
 
-### Comandos canônicos
-
-```bash
-# Staging manual
-gh workflow run deploy.yaml -f target_environment=staging
-
-# Produção (promoção)
-gh workflow run deploy.yaml -f target_environment=production -f promotion_tag=vYYYY.MM.DD-<sha>
-
-# Produção (rollback)
-gh workflow run deploy.yaml -f target_environment=production -f rollback_tag=vYYYY.MM.DD-<sha-anterior>
-```
-
-### Deprecação aplicada
-
-Workflows removidos:
-- `.github/workflows/release.yaml`
-- `.github/workflows/dockerhub-rebuild.yml`
-
-Variáveis obsoletas:
-- `STAGING_DEPLOY_COMMAND`
-- `PRODUCTION_DEPLOY_COMMAND`
+- Job `deploy` (PUT ao Portainer `:9443` público) e `validate_existing_tag` — **removidos** (#1516).
+- `workflow_dispatch` do `deploy.yaml` **não** tem mais os inputs `target_environment` / `promotion_tag` / `rollback_tag`.
+- Secrets/vars `PORTAINER_*`, `STAGING_*`, `PRODUCTION_*` e `*_DEPLOY_COMMAND` — **removidos do GitHub** (não configurar mais).
+- Workflows `release.yaml` e `dockerhub-rebuild.yml` — removidos (issue #814).
 
 ## 🔄 Recarregar Variáveis de Ambiente (.env)
 

--- a/v2/docs/specs/frontend/pages.spec.md
+++ b/v2/docs/specs/frontend/pages.spec.md
@@ -1,7 +1,7 @@
 ---
 title: Páginas (React)
 status: canonical
-last_verified: 2026-06-19
+last_verified: 2026-07-10
 sources_of_truth:
   - v2/frontend/src/App.tsx
   - v2/frontend/src/components/AppRoutes.tsx
@@ -33,13 +33,13 @@ Esta spec é o **índice canônico do inventário de páginas**: domínio, rota 
 ## Fonte de verdade no código
 
 - [`v2/frontend/src/App.tsx`](../../../frontend/src/App.tsx) — shell: carrega `getMe()` + `getMyPolicies()`, decide login vs app, monta sidebar/header/`<AppRoutes>`. `LoginPage` é a única página lazy fora de `AppRoutes`.
-- [`v2/frontend/src/components/AppRoutes.tsx`](../../../frontend/src/components/AppRoutes.tsx) — **registro único de rotas**. 39 páginas lazy + 50 `<Route>` (inclui 7 redirects de URLs legadas). Cada rota guardada usa o padrão `element={guard ? <Page /> : <Forbidden />}`.
+- [`v2/frontend/src/components/AppRoutes.tsx`](../../../frontend/src/components/AppRoutes.tsx) — **registro único de rotas**. 40 páginas lazy + 52 `<Route>` (inclui 6 redirects de URLs legadas). Cada rota guardada usa o padrão `element={guard ? <Page /> : <Forbidden />}`.
 - [`v2/frontend/src/hooks/usePermissions.ts`](../../../frontend/src/hooks/usePermissions.ts) — deriva flags `canControle`/`canDAT`/`canDashboard*`/`canDisponibilidade`/… de `setores`+`funcoes`+`is_superuser` do payload de `/api/me/`.
 - [`v2/frontend/src/hooks/useCanAccess.ts`](../../../frontend/src/hooks/useCanAccess.ts) — camada de tradução semântica: converte `policies` públicas (de `GET /api/me/policies/`) em flags como `canAccessApprovals`, `canCreateSolicitation`, `canViewComprasDashboard`.
 - [`v2/frontend/src/components/AppSidebar.tsx`](../../../frontend/src/components/AppSidebar.tsx) — menu lateral; usa as mesmas flags para esconder itens (UX, não é o gate autoritativo).
-- Diretório [`v2/frontend/src/pages/`](../../../frontend/src/pages) — **14 diretórios de domínio** (AdminDAT, Aprovacoes, Auth, Controle, DAT, DATModule, Dashboards, Deslocamentos, Disponibilidade, Home, MapaBrasil, MeusEventos, PreAgenda, Solicitacoes) + `__tests__`.
+- Diretório [`v2/frontend/src/pages/`](../../../frontend/src/pages) — **15 diretórios de domínio** (AdminDAT, Aprovacoes, Auth, Controle, DAT, DATModule, Dashboards, Deslocamentos, Disponibilidade, Home, MapaBrasil, MeusEventos, Perfil, PreAgenda, Solicitacoes) + `__tests__`.
 
-> **Correção de mito:** o número real é **40 páginas lazy-loaded** (39 em `AppRoutes` + `LoginPage` em `App.tsx`), não "45+". `Solicitacoes.tsx` e `Disponibilidade.tsx` na raiz de `pages/` ainda existem; `pages/Disponibilidade` (dir) é o que está roteado em `/solicitacoes/bloqueios`.
+> **Correção de mito:** o número real é **41 páginas lazy-loaded** (40 em `AppRoutes` + `LoginPage` em `App.tsx`), não "45+". `Solicitacoes.tsx` e `Disponibilidade.tsx` na raiz de `pages/` ainda existem; `pages/Disponibilidade` (dir) é o que está roteado em `/solicitacoes/bloqueios`.
 
 ## Contratos e invariantes
 
@@ -66,6 +66,12 @@ Inventário por domínio (rota → componente → guard). Detalhe da capability 
 | Rota | Página | Guard |
 |---|---|---|
 | (sem rota — render condicional em `App.tsx`) | `Auth/LoginPage` | anônimo |
+
+### Perfil
+
+| Rota | Página | Guard |
+|---|---|---|
+| `/perfil` | `Perfil/PerfilPage` | autenticado |
 
 ### Solicitações (agrupadas sob `/solicitacoes/*`)
 
@@ -152,4 +158,4 @@ Inventário por domínio (rota → componente → guard). Detalhe da capability 
 - **`DATPage` (`pages/DAT/DATPage.tsx`) órfã.** Não está mais roteada (substituída por `ImportacoesPage`); remoção definitiva ficou para "PR-D" (ver comentário no `AppRoutes`).
 - **Páginas raiz legadas.** `pages/Solicitacoes.tsx` e `pages/Disponibilidade.tsx` (arquivos soltos na raiz de `pages/`) coexistem com os diretórios homônimos roteados — risco de confusão; conferir o import do `AppRoutes` antes de editar.
 - **Logout via `window.location.reload()`.** Tech-debt assumido (#927) — sem auth store centralizado, logout força reload em vez de limpeza de estado.
-- **README de specs frontend desatualizado.** [`./README.md`](./README.md) ainda diz "6/14 documentadas" e "45+ pages"; esta spec corrige a contagem para 14 dirs / 40 páginas lazy.
+- **README de specs frontend desatualizado.** [`./README.md`](./README.md) ainda diz "6/14 documentadas" e "45+ pages"; esta spec corrige a contagem para 15 dirs / 41 páginas lazy.

--- a/v2/docs/specs/infra/ci.spec.md
+++ b/v2/docs/specs/infra/ci.spec.md
@@ -1,7 +1,7 @@
 ---
 title: CI/CD (GitHub Actions)
 status: canonical
-last_verified: 2026-06-22
+last_verified: 2026-07-10
 sources_of_truth:
   - .github/workflows/ci.yaml
   - codecov.yml
@@ -30,7 +30,7 @@ related:
 
 ## Propósito
 
-Pipeline de integração e entrega contínua do AS v2 sobre GitHub Actions. A CI valida cada PR para `main` (lint, RBAC lint, type-check, testes backend paralelos, paridade Docker, frontend) e bloqueia merge enquanto os gates `[required]` não passarem; o deploy publica imagens no Docker Hub e atualiza a stack via **Portainer CE API**. Como **não existe staging remoto** (merge na `main` = deploy direto em produção, ADR-010), os gates de PR são a única rede de proteção antes da produção.
+Pipeline de integração e entrega contínua do AS v2 sobre GitHub Actions. A CI valida cada PR para `main` (lint, RBAC lint, type-check, testes backend paralelos, paridade Docker, frontend) e bloqueia merge enquanto os gates `[required]` não passarem. **Merge na `main` NÃO deploya** (modelo pull-based, ADR-018): dispara `deploy.yaml` ("Build, sign and release"), que faz build+scan+push das imagens no Docker Hub, **assina** (cosign keyless + provenance SLSA) e cria a tag imutável `vYYYY.MM.DD-<sha7>` + Release. Produção só muda por **promoção deliberada** (`promote.yml`, gated no Environment `production`) aplicada pelo agente `aprender-deployer` na VM01 (ver [`deploy.spec.md`](./deploy.spec.md)). Como **não existe staging remoto**, os gates de PR + o staging-gate local são a única rede de proteção antes da produção.
 
 A nomenclatura dos checks é o contrato de governança: `[required]` bloqueia merge, `[info]` é informativo, `[ops]` é rotina manual/agendada fora do gate de PR. A SSOT desta convenção e da lista de checks obrigatórios é [`docs/operations/ci-check-policy.md`](../../../../docs/operations/ci-check-policy.md).
 
@@ -48,14 +48,14 @@ A nomenclatura dos checks é o contrato de governança: `[required]` bloqueia me
 ## Contratos e invariantes
 
 - **Checks `[required]` (gate de merge em `main`)** — devem ficar obrigatórios no ruleset `Protect main`: `[required] tests`, `[required] lint`, `[required] backend rbac-lint`, `[required] build/lint do frontend`, `[required] checklist tests (meta, a11y, security)`, `[required] dependency review`, `[required] architecture dependency guardrails`, `[required] Python Dependencies`, `[required] Frontend Dependencies`, `[required] Container Scan`, `[required] Secret Detection`, `[required] staging gate evidence`. SSOT: [`ci-check-policy.md`](../../../../docs/operations/ci-check-policy.md).
-- **Least-privilege do `GITHUB_TOKEN`** — workflow-level default = `contents: read`; cada job que precisa de mais declara o seu (#1397). Em `deploy.yaml`, `contents: write` existe **apenas** no job `tag_and_release` (git tag + `gh release`); o job que builda/pusha imagem fica em `contents: read` (desacopla `contents:write` de alvo de supply-chain). No canary, `issues: write` vive só no job `canary-report` que comenta na issue #677.
+- **Least-privilege do `GITHUB_TOKEN`** — workflow-level default = `contents: read`; cada job que precisa de mais declara o seu (#1397). Em `deploy.yaml`, `contents: write` existe **apenas** no job de tag/release (git tag + `gh release`); o job que builda/pusha imagem fica em `contents: read` (desacopla `contents:write` de alvo de supply-chain). A assinatura das imagens usa `id-token: write` (cosign keyless OIDC). No canary, `issues: write` vive só no job `canary-report` que comenta na issue #677.
 - **Cobertura backend ≥ 85%** — `coverage combine` dos dois jobs (core + dev_tools) com `coverage report --fail-under=85`. Falha abaixo do limiar bloqueia o gate.
 - **Paralelização xdist no gate (M3, #1402/#1403)** — gate usa `pytest -n auto --dist loadscope` (~15min→~5min). `loadscope` mantém testes da mesma classe/módulo no mesmo worker. Habilitado **só** após a suíte estabilizar (causa raiz: `transaction=True` truncava o seed RBAC; fix de re-seed pós-truncate). O canary cobre a matriz `workers×dist` mas **nunca** bloqueia (`fail_on_test_error=false`).
 - **Backend impact detector (fail-safe)** — eventos não-PR (push/dispatch) forçam `backend_changed=true` (modo full seguro); PR sem base/head SHA também. O agregador `[required] tests` exige que os jobs backend ou tenham passado (impacto) ou tenham `skipped` (sem impacto) — nunca silenciosamente verde por engano.
 - **Docker parity (#1401 carve-out)** — `docker-parity-backend` NÃO consome o reusable: usa topologia de container (`host.docker.internal`, `REQUIRE_DOCKER=1`, migrate in-container, build via buildx). Versões de postgres/redis aqui devem ser sincronizadas manualmente com o `services` do reusable (SSOT das versões: `postgres:15.13`, `redis:7.4`).
 - **Gate de staging (evidência)** — para PRs com impacto em runtime (`v2/backend/apps|config|requirements.txt`, `v2/frontend/src|public|Dockerfile.prod`, `v2/infra/...`), o corpo do PR precisa de 3 marcadores literais (sem acento, crase normalizada): checkbox `make staging-full ... (8/8 PASS)`, checkbox `Evidencia anexada no PR`, e o texto `ALL 8 CHECKS PASSED`. PRs em draft ou sem impacto em runtime são pulados.
 - **Guard rails de lint** — Black/isort/Flake8 + ban de `/api/v1/` fora da allowlist (#796); RBAC lint AST bane `user.groups.filter(name=...)` e classes `Is<Role>` fora da whitelist (idioma canônico: `permission_classes=[HasPerm("codename")]`).
-- **Deploy/security gate** — invariantes de imutabilidade de tag, fire-and-forget com confirmação (#1396) e gate Trivy (bloqueia HIGH/CRITICAL) são contrato do deploy: ver [`deploy.spec.md`](./deploy.spec.md).
+- **Deploy/security gate** — imutabilidade de tag, assinatura das imagens (cosign keyless + provenance SLSA) e gate Trivy (bloqueia HIGH/CRITICAL) são contrato do deploy; a aplicação em prod é **por digest**, verificada pelo agente na VM01 (`promote.yml` → `deploy-pointer` → `aprender-deployer`): ver [`deploy.spec.md`](./deploy.spec.md).
 - **Não usar `paths` no gatilho `pull_request` de workflow que publica check `[required]`** (senão o check fica pendente para sempre e trava o ruleset). `frontend-ci.yml` removeu path filters de PR exatamente por isso.
 
 ## API / Interface
@@ -63,7 +63,7 @@ A nomenclatura dos checks é o contrato de governança: `[required]` bloqueia me
 - **CI (`ci.yaml`)** — dispara em `push`/`pull_request` para `main`. Jobs: `backend-impact`, `lint`, `rbac-lint`, `backend-tests-core`, `backend-tests-devtools`, `backend-tests` (combine+threshold), `backend-typecheck`, `docker-parity-backend`, `tests` (agregador `[required]`).
 - **Reusable (`_backend-test.yml`)** — `workflow_call` com inputs: `pytest_paths`, `pytest_extra_args`, `coverage_file`, `validate_test_paths`, `fail_on_test_error`, `emit_canary_metadata`, `artifact_name`/`artifact_paths` (obrigatórios), entre outros. Roda em Python 3.12 com `COVERAGE_CORE=sysmon` (sys.monitoring do 3.12, #1399).
 - **Canary (`backend-xdist-canary.yml`)** — `schedule` (cron `20 10 * * *`), `workflow_dispatch` e `push` em paths do próprio canary. Matriz `workers=[2,auto] × dist=[loadscope,loadfile]`; publica snapshot na issue #677.
-- **Deploy (`deploy.yaml`)** — `push` em `main` → staging-auto; `workflow_dispatch` com `target_environment` (staging|production), `promotion_tag`, `rollback_tag`. Interface detalhada (modos, gate de promoção, polling): [`deploy.spec.md`](./deploy.spec.md).
+- **Deploy (`deploy.yaml`)** — `push` em `main` → build+scan+push+**sign**+tag/release (não deploya). Promoção/rollback e mudança de prod ficam no `promote.yml` (gated no Environment `production`) + agente `aprender-deployer` na VM01. O `workflow_dispatch` do `deploy.yaml` **não** tem mais `target_environment`/`promotion_tag`/`rollback_tag`. Interface detalhada: [`deploy.spec.md`](./deploy.spec.md).
 
 ## Fluxos principais
 
@@ -76,25 +76,25 @@ A nomenclatura dos checks é o contrato de governança: `[required]` bloqueia me
 5. `backend-typecheck` (pyright em `apps/core config`) e `docker-parity-backend` (smoke em imagem `Dockerfile.prod`) rodam em paralelo.
 6. `tests` agrega: verde só se todos passaram (ou todos `skipped` quando sem impacto).
 7. `frontend-ci` (react doctor + build/lint + checklist) e `staging-gate-audit` (evidência no corpo) completam o gate.
-8. Merge em `main` dispara `deploy.yaml`.
+8. Merge em `main` dispara `deploy.yaml` (build+sign+release; **não** deploya — prod só muda por `promote.yml` gated).
 
-**Deploy (resumo — detalhe em `deploy.spec.md`):** build+scan(Trivy)+push das imagens → `validate_existing_tag` (promotion/rollback) → `deploy` chama Portainer CE API atualizando só o `IMAGE_TAG` → post-deploy verification (polling de versão + fallback via Portainer API quando o health externo está inacessível por rede).
+**Deploy (resumo — detalhe em `deploy.spec.md`):** merge na `main` → build+scan(Trivy)+push das imagens → **assina** (cosign keyless + provenance SLSA) → cria tag imutável `vYYYY.MM.DD-<sha7>` + Release. Prod muda depois em dois passos deliberados: `promote.yml` (gated no Environment `production`) resolve tag→digest e assina o ponteiro no branch `deploy-pointer`; o agente `aprender-deployer` na VM01 verifica com cosign e aplica **por digest** em `127.0.0.1:9443`, confirmando de dentro da VM.
 
 **Erros relevantes:**
 
 - Cobertura < 85% → `backend-tests` falha → `tests` vermelho.
 - xdist instável → fica **isolado** no canary (não bloqueia); recorrências viram issues de estabilização antes de promover ao gate.
 - Corpo de PR sem os 3 marcadores → `staging gate evidence` falha (exceto draft / sem runtime impact).
-- Deploy timeout (HTTP 000 por firewall) → confirmação fail-fast via GET do `IMAGE_TAG` e fallback Portainer (não assume sucesso cego).
+- Aplicação em prod (agente na VM01) é **fail-closed** por degrau (assinatura, digest, anti-rollback, drift do compose, backup fresco) e confirma em `localhost` — imune ao *false-red* do `:9443` público.
 
 ## Decisões relacionadas (ADRs)
 
-- **ADR-010** — Deploy Portainer→prod, sem staging remoto (referenciado em [`deploy.spec.md`](./deploy.spec.md) e no índice de infra).
+- **ADR-018** — deploy **pull-based**: `promote.yml` (gated) → ponteiro assinado no branch `deploy-pointer` → agente `aprender-deployer` aplica por digest na VM01. **Supersede** o ADR-010 (PUT do CI ao Portainer `:9443` público), desligado no cutover #1515 e removido na Fase 4 #1516. Detalhe em [`deploy.spec.md`](./deploy.spec.md).
 - **#1397** — least-privilege do `GITHUB_TOKEN` (M2).
 - **#1401** — reusable `_backend-test.yml` (SSOT de setup de teste).
 - **#1402 / #1403** — estabilização xdist + promoção de `-n auto --dist loadscope` no gate (M3).
 - **#1399** — `COVERAGE_CORE=sysmon` (sys.monitoring do Python 3.12).
-- **#1396 / #1394** — fail-fast pós-timeout do Portainer + token via `curl --config` (fora do argv).
+- **#1396 / #1394** (histórico, modelo antigo) — fail-fast pós-timeout do Portainer + token via `curl --config` (fora do argv); superados pelo modelo pull-based (ADR-018).
 
 ## Testes que cobrem
 
@@ -114,4 +114,4 @@ A CI é infra-as-code; sua "prova" são os próprios checks de gate e o canary, 
 - **Canary só mostra top-5** — o report da issue #677 lista os 5 piores; a magnitude total de falhas pode ficar subdimensionada no comentário (vide M3: a issue citava 6 testes, eram 537).
 - **`pull_request` sem path filters em checks `[required]`** — necessário para o ruleset, mas faz `frontend-ci` rodar mesmo em PRs sem mudança de frontend (custo aceito por governança).
 - **react-doctor exige `--offline`** — o score depende de telemetria remota; sem `--offline` o gate é não-determinístico (memória `react-doctor-offline-determinism`).
-- **Deploy é Portainer→prod sem staging remoto** — o gate de evidência de staging depende de `make staging-full` **local** do autor; não há ambiente staging que a CI valide. Detalhe e gaps de deploy em [`deploy.spec.md`](./deploy.spec.md).
+- **Sem staging remoto; prod só muda por promoção gated (pull-based)** — merge na `main` não deploya; o gate de evidência de staging depende de `make staging-full` **local** do autor; não há ambiente staging que a CI valide. Detalhe e gaps de deploy em [`deploy.spec.md`](./deploy.spec.md).

--- a/v2/docs/specs/infra/environments.spec.md
+++ b/v2/docs/specs/infra/environments.spec.md
@@ -1,7 +1,7 @@
 ---
 title: Ambientes (dev / staging / prod-like)
 status: canonical
-last_verified: 2026-06-19
+last_verified: 2026-07-10
 sources_of_truth:
   - v2/Makefile
   - v2/infra/Makefile
@@ -158,6 +158,9 @@ PostgreSQL externo da VM02; Redis é local na stack. Backend em `:28000`, fronte
   spec passa a ser a SSOT do tópico; quando o doc longo existir, deve ser linkado aqui (não duplicado).
 - **`make health-*` usa health externo via curl,** que em algumas redes (Kaspersky/Golden) retorna HTTP 000
   para `:443` mesmo com containers `healthy` — não confundir falha de rede com falha de app (ver deploy.spec).
-- **Prod sem staging remoto:** não há ambiente de staging em VM; merge na `main` = deploy direto pra prod
-  (ver [deploy.spec](./deploy.spec.md)). O `staging-gate`/`prod-like` **locais** são a única barreira prod-like
+- **Prod sem staging remoto; deploy pull-based (ADR-018):** não há ambiente de staging em VM. Merge na `main`
+  **não** deploya — só faz build+scan+push+sign+tag/release. Produção muda em dois passos deliberados:
+  `promote.yml` (gated no Environment `production`) assina um ponteiro de release no branch `deploy-pointer`, e
+  o agente `aprender-deployer` na VM01 verifica e aplica **por digest** em `127.0.0.1:9443` (ver
+  [deploy.spec](./deploy.spec.md)). O `staging-gate`/`prod-like` **locais** são a única barreira prod-like
   antes do merge.


### PR DESCRIPTION
## Contexto

Lote E da auditoria #1541: correção de **drift de documentação** — docs que ainda
descreviam o modelo ANTIGO de deploy (o CI fazia `PUT` no Portainer `:9443` público),
removido pelo **ADR-018** (pull-based). As SSOTs `v2/docs/specs/infra/deploy.spec.md` e
`docs/architecture/infrastructure.md` já estavam corretas (#1540) e serviram de referência.

Docs-only: não dispara staging gate.

## Modelo correto (ADR-018) refletido nas docs

- Merge na `main` **NÃO deploya**. Dispara `deploy.yaml` ("Build, sign and release"):
  build + scan + push no Docker Hub + **assina** (cosign keyless + provenance SLSA) +
  tag imutável `vYYYY.MM.DD-<sha7>` + Release. Fim.
- Prod muda em dois passos deliberados: (1) `gh workflow run promote.yml -f release=<tag>`
  (gated no Environment `production`, required reviewer); (2) o agente `aprender-deployer`
  na VM01 lê o ponteiro assinado em `deploy-pointer`, verifica com cosign e aplica **por
  digest** em `127.0.0.1:9443`, confirmando de dentro da VM (imune ao *false-red*).
- Job `deploy` (PUT ao `:9443` público) e `validate_existing_tag` **removidos** (#1516);
  `workflow_dispatch` sem `target_environment`/`promotion_tag`/`rollback_tag`.
- Secrets `PORTAINER_*`/`STAGING_*`/`PRODUCTION_*` removidos do GitHub.

## O que cada doc dizia de errado -> verdade

- **`v2/docs/RUNBOOK.md`** — §7 descrevia deploy Portainer com `gh workflow run deploy.yaml
  -f target_environment=... / promotion_tag / rollback_tag` (comandos que hoje FALHAM) e
  listava secrets `PORTAINER_*`. -> Reescrita para o fluxo pull-based (merge = só
  build+sign; promoção/rollback = `promote.yml` gated + agente na VM01). "Última
  atualização" -> 2026-07-10.
- **`v2/docs/DEPLOY_CHECKLIST.md`** — mandava configurar `PORTAINER_*` como obrigatórios e
  usar `-f target_environment=...`. -> Reescrita para ADR-018 com redirect à SSOT
  `deploy.spec.md`; seção de secrets vira "removidos (não reconfigurar)"; go-live local e
  gate de staging preservados.
- **`v2/docs/specs/infra/ci.spec.md`** — afirmava "atualiza a stack via Portainer CE API",
  "staging-auto", inputs `target_environment/promotion_tag/rollback_tag`,
  `validate_existing_tag` e "merge na main = deploy direto em produção". -> Substituído pelo
  resumo build+scan+push+sign+tag/release; promoção/rollback apontam para `promote.yml` +
  agente; ADR-010 alinhado a ADR-018 (supersede). `last_verified` -> 2026-07-10.
- **`v2/docs/specs/infra/environments.spec.md`** — "merge na main = deploy direto pra prod".
  -> Corrigido para ADR-018. `last_verified` -> 2026-07-10.
- **`v2/docs/specs/frontend/pages.spec.md`** — contagens defasadas. Contado no fonte
  (`AppRoutes.tsx` + `App.tsx`): `lazy(` = 40 (era 39), `<Route` = 52 (era 50), 6 redirects
  (era 7), 15 dirs de domínio com `Perfil` (era 14), total 41 páginas lazy (40 em AppRoutes
  + LoginPage). -> Números corrigidos + linha de inventário para `/perfil` -> `Perfil/PerfilPage`.
  `last_verified` -> 2026-07-10.

## Validação (gates de CI)

- `python scripts/check_doc_links.py` -> **OK** (0 links relativos quebrados)
- `python scripts/check_doc_frontmatter.py` -> **OK** (frontmatter válido)

Refs #1541
