### PR TITLE
feat(deploy): GC de imagens pos-deploy no agente pull-based (#1548)

### DIFF
--- a/v2/infra/deployer/apply.sh
+++ b/v2/infra/deployer/apply.sh
@@ -118,6 +118,7 @@ main() {
   # Liveness em localhost (readyz 200 + version == release).
   if confirm_localhost "$P_RELEASE" "$port"; then
     seal_bump "$P_SEQUENCE"; _breaker_reset "$P_SEQUENCE"
+    gc_run || log_warn "gc_failed"   # retencao de imagens best-effort; NUNCA aborta (pos-selo)
     notify "OK" "deployed" "$P_RELEASE"; log_info "deploy_ok" "release=${P_RELEASE}"; exit 0
   fi
 

--- a/v2/infra/deployer/config.env.example
+++ b/v2/infra/deployer/config.env.example
@@ -62,6 +62,18 @@ NOTIFY_URL=""
 # PUT_CONFIRM_TIMEOUT="180"
 # PUT_CONFIRM_INTERVAL="5"
 
+# --- Retencao de imagens (GC pos-deploy; via API Portainer, best-effort/NAO-fatal) ---
+# Apos cada deploy CONFIRMADO, remove imagens antigas dos repos aprender-* mantendo as
+# N mais novas por repo (prod + rollback local). force=false => fail-safe se em uso; a
+# imagem em producao nunca sai. As imagens sao cache (o registry guarda todo digest e o
+# deploy repulla) => remover local NAO quebra rollback. Requer que o token do Portainer
+# tenha permissao de imagem no endpoint; sem ela apenas no-opa. Minimo efetivo = 1.
+# Deleta por REFERENCIA (repo:tag e repo@digest), nao por Id (o pin repo:tag@digest da
+# duas refs; por Id o Docker recusaria 409). BUDGET = teto de parede (s) do GC no deploy.
+# IMAGE_GC_ENABLED="1"
+# IMAGE_GC_KEEP="3"
+# IMAGE_GC_BUDGET="120"
+
 # --- Binarios (se fora dos defaults) ---
 # COSIGN_BIN="/usr/local/bin/cosign"
 # GH_BIN="/usr/local/bin/gh"

--- a/v2/infra/deployer/lib/common.sh
+++ b/v2/infra/deployer/lib/common.sh
@@ -54,7 +54,7 @@ common_write_atomic() {
 }
 
 # Source das demais libs (log primeiro — todas dependem dele).
-for _lib in log notify state seal fetch pointer verify_image portainer compose confirm backup; do
+for _lib in log notify state seal fetch pointer verify_image portainer compose confirm backup gc; do
   # shellcheck source=/dev/null
   . "${DEPLOYER_HOME}/lib/${_lib}.sh"
 done

--- a/v2/infra/deployer/lib/gc.sh
+++ b/v2/infra/deployer/lib/gc.sh
@@ -1,0 +1,120 @@
+# shellcheck shell=bash
+# lib/gc.sh — retencao de imagens pos-deploy (ADR-018).
+#
+# Depois de um deploy CONFIRMADO (selo avancado), remove imagens ANTIGAS dos repos
+# aprender-* via a API do Portainer (o MESMO token do applier; SEM socket docker),
+# mantendo as IMAGE_GC_KEEP mais novas por repo. Motivo: cada release baixa uma
+# imagem nova por digest e a anterior fica no store para sempre -> o disco da VM01
+# (60GB) enche. O fluxo pull-based nunca teve GC (issue #1548).
+#
+# Por REFERENCIA, nao por Id: o compose pina `repo:${IMAGE_TAG}@${DIGEST}` (Opcao B),
+# entao cada imagem carrega DUAS referencias (um RepoTag e um RepoDigest). `docker rmi`
+# por Id com force=false RECUSA (409) uma imagem com >1 referencia — o GC nao limparia
+# nada. Removemos cada referencia (RepoTag/RepoDigest do repo); a imagem e recuperada
+# quando a ULTIMA referencia sai. force=false continua fail-safe (o delete final de uma
+# imagem em uso por container devolve 409).
+#
+# Invariantes de seguranca (todas exercitadas em tests/lib_gc.bats):
+#   - best-effort: NUNCA aborta um deploy (toda falha -> log + return 0). E chamado
+#     DEPOIS do selo; um erro aqui nao pode reverter um deploy ja confirmado.
+#   - NUNCA toca a imagem EM USO: exclusao explicita do running digest (nunca emitimos
+#     nenhuma referencia dela) + force=false. Duas travas independentes.
+#   - keep >= 1 SEMPRE: 0 nao protegeria nada; a versao em producao sempre fica.
+#   - deadline de parede (IMAGE_GC_BUDGET): o GC nunca gasta mais que isso, bem abaixo
+#     do TimeoutStartSec do systemd. Para cedo e LOGA (sem corte silencioso).
+#   - anti-injecao em DUAS camadas: a referencia (a) tem de comecar com o repo esperado
+#     (allowlist) e (b) casar um charset seguro (sem metacaractere de shell/URL) antes
+#     de entrar na URL do DELETE.
+#   - as imagens locais sao CACHE: o registry guarda todo digest e o deploy repulla
+#     (RepullImageAndRedeploy:true), entao remover local NAO quebra rollback.
+
+: "${IMAGE_GC_ENABLED:=1}"
+: "${IMAGE_GC_KEEP:=3}"
+: "${IMAGE_GC_BUDGET:=120}"
+
+# gc_candidates <images_json> <repo> <keep> <running_digest> -> referencias a remover
+# (uma por linha). Seleciona as imagens do <repo>, ordena por Created (desc), MANTEM as
+# <keep> mais novas, EXCLUI a que carrega o <running_digest>, e emite cada RepoTag/
+# RepoDigest do <repo> das restantes.
+gc_candidates() {
+  local images="$1" repo="$2" keep="$3" running="$4"
+  "$JQ_BIN" -r --arg repo "$repo" --argjson keep "$keep" --arg running "$running" '
+    [ .[]
+      | select(
+          ((.RepoTags    // []) | any(startswith($repo + ":")))
+          or ((.RepoDigests // []) | any(startswith($repo + "@")))
+        )
+    ]
+    | sort_by(.Created) | reverse
+    | .[$keep:]
+    | .[]
+    | select(((.RepoDigests // []) | any(. == ($repo + "@" + $running))) | not)
+    | ((.RepoTags // []) + (.RepoDigests // []))[]
+    | select(startswith($repo + ":") or startswith($repo + "@"))
+  ' <<<"$images" 2>/dev/null || true
+}
+
+# gc_delete_one <repo> <ref> -> 0 se removeu; !=0 caso contrario. Sempre NAO-fatal.
+gc_delete_one() {
+  local repo="$1" ref="$2" http
+  # 0a trava: rejeita ref vazia / multi-linha / com controle. A 2a trava (grep -Eq) casa
+  # POR LINHA, entao sem isto uma ref forjada tipo `repo:tag\n?force=true` passaria (linha 1
+  # valida) e o resto entraria na URL. Um daemon legitimo nunca emite isso (a gramatica de
+  # referencia do Docker proibe \n), mas a validacao nao deve depender do formato do caller.
+  case "$ref" in
+    ''|*[$'\n\r']*) log_warn "gc_ref_invalid"; return 1 ;;
+  esac
+  # 1a trava: a referencia pertence ao repo esperado (allowlist da identity.env).
+  case "$ref" in
+    "${repo}:"*|"${repo}@"*) : ;;
+    *) log_warn "gc_ref_foreign" "ref=${ref}"; return 1 ;;
+  esac
+  # 2a trava: charset seguro (sem metacaractere de shell/URL) -> anti-injecao na URL.
+  printf '%s' "$ref" \
+    | grep -Eq '^[A-Za-z0-9][A-Za-z0-9._/-]*(:[A-Za-z0-9][A-Za-z0-9._-]*|@sha256:[0-9a-f]{64})$' \
+    || { log_warn "gc_bad_ref" "ref=${ref}"; return 1; }
+  http="$(portainer_delete_image "$ref")" \
+    || { log_warn "gc_delete_err" "ref=${ref}"; return 1; }
+  case "$http" in
+    2*)  log_audit "gc_removed"     "ref=${ref}" "http=${http}"; return 0 ;;
+    409) log_info  "gc_in_use"      "ref=${ref}"; return 1 ;;   # em uso por container: seguro
+    404) log_info  "gc_absent"      "ref=${ref}"; return 1 ;;   # ja removida
+    *)   log_warn  "gc_delete_http" "ref=${ref}" "http=${http}"; return 1 ;;
+  esac
+}
+
+# gc_run -> executa a retencao. Best-effort; retorna 0 SEMPRE (chamado apos o selo).
+gc_run() {
+  [ "${IMAGE_GC_ENABLED:-1}" = "1" ] || { log_info "gc_disabled"; return 0; }
+
+  local keep="${IMAGE_GC_KEEP:-3}"
+  case "$keep" in ''|*[!0-9]*) log_warn "gc_keep_bad" "keep=${keep}"; return 0 ;; esac
+  [ "$keep" -ge 1 ] || { log_warn "gc_keep_lt1" "keep=${keep}"; return 0; }  # min 1: prod nunca sai
+
+  local budget="${IMAGE_GC_BUDGET:-120}"
+  case "$budget" in ''|*[!0-9]*) budget=120 ;; esac
+  local deadline; deadline=$(( $(date +%s 2>/dev/null || echo 0) + budget ))
+
+  local images
+  images="$(portainer_list_images)" || { log_warn "gc_list_failed"; return 0; }
+  "$JQ_BIN" -e 'type=="array"' >/dev/null 2>&1 <<<"$images" \
+    || { log_warn "gc_list_not_array"; return 0; }
+
+  local pair repo digest ref total=0 removed=0 stopped=0
+  for pair in "${P_BACKEND_REPO:-}|${P_BACKEND_DIGEST:-}" \
+              "${P_FRONTEND_REPO:-}|${P_FRONTEND_DIGEST:-}"; do
+    repo="${pair%%|*}"; digest="${pair##*|}"
+    [ -n "$repo" ] && [ -n "$digest" ] || { log_warn "gc_repo_skip" "repo=${repo}"; continue; }
+    while IFS= read -r ref; do
+      [ -n "$ref" ] || continue
+      if [ "$(date +%s 2>/dev/null || echo 0)" -ge "$deadline" ]; then stopped=1; break; fi
+      total=$((total + 1))
+      gc_delete_one "$repo" "$ref" && removed=$((removed + 1)) || true
+    done < <(gc_candidates "$images" "$repo" "$keep" "$digest")
+    [ "$stopped" -eq 1 ] && break
+  done
+
+  [ "$stopped" -eq 1 ] && log_warn "gc_budget_exhausted" "budget=${budget}" "refs_deleted=${removed}"
+  log_info "gc_done" "keep=${keep}" "refs_seen=${total}" "refs_deleted=${removed}" "stopped=${stopped}"
+  return 0
+}

--- a/v2/infra/deployer/lib/portainer.sh
+++ b/v2/infra/deployer/lib/portainer.sh
@@ -6,6 +6,8 @@
 #   GET  /api/stacks/{id}          -> .Env
 #   GET  /api/stacks/{id}/file     -> .StackFileContent
 #   PUT  /api/stacks/{id}?endpointId={n}  {StackFileContent,Env,Prune,RepullImageAndRedeploy}
+#   GET    /api/endpoints/{n}/docker/images/json   -> lista de imagens (GC, lib/gc.sh)
+#   DELETE /api/endpoints/{n}/docker/images/{id}   -> remove imagem (GC, force=false)
 
 : "${PORTAINER_CURLRC:=/etc/aprender-deployer/portainer.curlrc}"
 
@@ -88,4 +90,26 @@ portainer_wait_env_digest() {
       "want_backend=${want_be}"   "last_backend=${be}" \
       "want_frontend=${want_fe}"  "last_frontend=${fe}"
   return 1
+}
+
+# --- GC de imagens (Docker Engine API via proxy do Portainer; usado por lib/gc.sh) ---
+# O mesmo token do applier proxya a Docker API sob /api/endpoints/{id}/docker/*. Requer
+# que a chave tenha permissao de imagem no endpoint; sem ela o list/delete devolve 4xx
+# e o GC apenas no-opa (best-effort, nao afeta o deploy).
+
+# portainer_list_images -> imprime o JSON array das imagens do endpoint.
+portainer_list_images() {
+  _portainer_curl "${PORTAINER_BASE}/api/endpoints/${PORTAINER_ENDPOINT_ID}/docker/images/json"
+}
+
+# portainer_delete_image <ref> -> imprime o http_code do DELETE.
+# <ref> = uma REFERENCIA (repo:tag ou repo@sha256:...), nunca o Id nu: por Id o Docker
+# recusa (409) imagens com >1 referencia (o pin repo:tag@digest gera duas). Por referencia
+# ele desreferencia; a imagem sai quando a ultima referencia sai.
+# force=false: fail-safe — o Docker recusa (409) o delete final de uma imagem em uso.
+# noprune=false: remove tambem as camadas-pai orfas (recupera mais espaco).
+portainer_delete_image() {
+  local ref="$1"
+  _portainer_curl -o /dev/null -w '%{http_code}' -X DELETE \
+    "${PORTAINER_BASE}/api/endpoints/${PORTAINER_ENDPOINT_ID}/docker/images/${ref}?force=false&noprune=false"
 }

--- a/v2/infra/deployer/tests/lib_gc.bats
+++ b/v2/infra/deployer/tests/lib_gc.bats
@@ -1,0 +1,207 @@
+#!/usr/bin/env bats
+# lib_gc.bats — retencao de imagens pos-deploy (lib/gc.sh). Deterministico, sem rede.
+#
+# Deleta por REFERENCIA (repo:tag e repo@digest), nao por Id: o pin repo:tag@digest da
+# duas refs por imagem e um `docker rmi` por Id recusaria 409. Estes testes provam que
+# ambas as refs saem, que a imagem EM USO nunca e tocada, o anti-injecao/scoping, e que
+# nada aborta (best-effort, ate sob set -e).
+#
+# Fixture:
+#   backend  K=0..4: RepoTags=[BE:bK], RepoDigests=[BE@sha256:h64(K)],     Created=100+K, em uso=h64(4)
+#   frontend K=0..3: RepoTags=[FE:fK], RepoDigests=[FE@sha256:h64(100+K)], Created=100+K, em uso=h64(103)
+
+load helper
+
+setup()    { setup_sandbox; _gc_setup; }
+teardown() { teardown_sandbox; }
+
+# -- fixtures ---------------------------------------------------------------------
+
+_h64() { printf '%064x' "$1"; }
+
+_gc_setup() {
+  export P_BACKEND_REPO="norjosamatheus/aprender-backend"
+  export P_FRONTEND_REPO="norjosamatheus/aprender-frontend"
+  export P_BACKEND_DIGEST="sha256:$(_h64 4)"     # backend em uso (o mais novo)
+  export P_FRONTEND_DIGEST="sha256:$(_h64 103)"  # frontend em uso (o mais novo)
+
+  export PORTAINER_BASE="https://127.0.0.1:9443" PORTAINER_ENDPOINT_ID="3"
+  export PORTAINER_CURLRC="$SANDBOX/curlrc"; printf 'header = "X-API-KEY: ptr_test"\n' > "$PORTAINER_CURLRC"
+
+  export MOCK_IMAGES_FILE="$SANDBOX/images.json"
+  export MOCK_DELETED_FILE="$SANDBOX/deleted.txt"; : > "$MOCK_DELETED_FILE"
+  export MOCK_DELETE_CODE="${MOCK_DELETE_CODE:-200}"
+
+  _mk "$SANDBOX/mock_curl" '#!/usr/bin/env bash
+url=""; method=GET; want_code=0; prev=""
+for a in "$@"; do
+  case "$prev" in -X) method="$a";; esac
+  case "$a" in http://*|https://*) url="$a";; -w) want_code=1;; esac
+  prev="$a"
+done
+case "$url" in
+  */docker/images/json)
+     cat "$MOCK_IMAGES_FILE"; exit $? ;;
+  */docker/images/*)
+     if [ "$method" = DELETE ]; then
+       ref="${url##*/docker/images/}"; ref="${ref%%\?*}"
+       printf "%s\n" "$ref" >> "$MOCK_DELETED_FILE"
+       [ "$want_code" = 1 ] && printf "%s" "${MOCK_DELETE_CODE:-200}"
+       exit 0
+     fi ;;
+esac
+exit 1'
+  export CURL_BIN="$SANDBOX/mock_curl"
+}
+
+# _img <repo> <tag> <created> <n>  -> RepoTags=[repo:tag], RepoDigests=[repo@sha256:h64(n)]
+_img() {
+  printf '{"Id":"sha256:%s","Created":%s,"RepoTags":["%s:%s"],"RepoDigests":["%s@sha256:%s"]}' \
+    "$(_h64 "$4")" "$3" "$1" "$2" "$1" "$(_h64 "$4")"
+}
+
+_write_default() {
+  local b f
+  b="$(_img "$P_BACKEND_REPO" b0 100 0)"
+  b="$b,$(_img "$P_BACKEND_REPO" b1 101 1)"
+  b="$b,$(_img "$P_BACKEND_REPO" b2 102 2)"
+  b="$b,$(_img "$P_BACKEND_REPO" b3 103 3)"
+  b="$b,$(_img "$P_BACKEND_REPO" b4 104 4)"
+  f="$(_img "$P_FRONTEND_REPO" f0 100 100)"
+  f="$f,$(_img "$P_FRONTEND_REPO" f1 101 101)"
+  f="$f,$(_img "$P_FRONTEND_REPO" f2 102 102)"
+  f="$f,$(_img "$P_FRONTEND_REPO" f3 103 103)"
+  printf '[%s,%s]' "$b" "$f" > "$MOCK_IMAGES_FILE"
+}
+
+_has()   { grep -qF "$1" "$MOCK_DELETED_FILE"; }
+_count() { if [ -s "$MOCK_DELETED_FILE" ]; then grep -c . "$MOCK_DELETED_FILE"; else printf 0; fi; }
+
+# -- testes -----------------------------------------------------------------------
+
+@test "keep=3: deleta AMBAS as refs (tag+digest) das antigas; preserva running/kept" {
+  export IMAGE_GC_KEEP=3
+  _write_default
+  run gc_run
+  [ "$status" -eq 0 ]
+  _has "$P_BACKEND_REPO:b0"; _has "$P_BACKEND_REPO@sha256:$(_h64 0)"   # backend Created 100
+  _has "$P_BACKEND_REPO:b1"; _has "$P_BACKEND_REPO@sha256:$(_h64 1)"   # backend Created 101
+  _has "$P_FRONTEND_REPO:f0"; _has "$P_FRONTEND_REPO@sha256:$(_h64 100)"  # frontend Created 100
+  ! _has "$P_BACKEND_REPO:b4"; ! _has "$P_BACKEND_REPO@sha256:$(_h64 4)"  # running/kept: intacto
+  ! _has "$P_FRONTEND_REPO:f3"
+  [ "$(_count)" -eq 6 ]
+}
+
+@test "NUNCA toca a imagem em uso, mesmo sendo a mais antiga (nenhuma ref)" {
+  export P_BACKEND_DIGEST="sha256:$(_h64 0)"   # backend em uso = o MAIS ANTIGO (Created 100)
+  export IMAGE_GC_KEEP=3
+  _write_default
+  run gc_run
+  [ "$status" -eq 0 ]
+  ! _has "$P_BACKEND_REPO:b0"; ! _has "$P_BACKEND_REPO@sha256:$(_h64 0)"  # em uso: nenhuma ref sai
+  _has "$P_BACKEND_REPO:b1";  _has "$P_BACKEND_REPO@sha256:$(_h64 1)"     # o outro antigo: removido
+}
+
+@test "DELETE 409 (em uso) nao aborta: gc_run retorna 0" {
+  export IMAGE_GC_KEEP=3 MOCK_DELETE_CODE=409
+  _write_default
+  run gc_run
+  [ "$status" -eq 0 ]
+}
+
+@test "best-effort sob set -e: 409 nao derruba o shell" {
+  export IMAGE_GC_KEEP=3 MOCK_DELETE_CODE=409
+  _write_default
+  run bash -c 'set -euo pipefail; . "$DEPLOYER_HOME/lib/common.sh"; gc_run; echo "RC=$?"'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"RC=0"* ]]
+}
+
+@test "falha ao listar nao aborta: rc=0 e nada removido" {
+  export IMAGE_GC_KEEP=3
+  rm -f "$MOCK_IMAGES_FILE"
+  run gc_run
+  [ "$status" -eq 0 ]
+  [ "$(_count)" -eq 0 ]
+}
+
+@test "resposta nao-array nao aborta e nada e removido" {
+  export IMAGE_GC_KEEP=3
+  printf 'not-an-array' > "$MOCK_IMAGES_FILE"
+  run gc_run
+  [ "$status" -eq 0 ]
+  [ "$(_count)" -eq 0 ]
+}
+
+@test "referencia com injecao no tag e recusada: nenhum DELETE emitido" {
+  export IMAGE_GC_KEEP=1
+  export P_BACKEND_DIGEST="sha256:$(_h64 999)"
+  local good bad
+  good="$(_img "$P_BACKEND_REPO" good 200 50)"
+  bad='{"Id":"sha256:'"$(_h64 100)"'","Created":100,"RepoTags":["'"$P_BACKEND_REPO"':v1; rm -rf /"],"RepoDigests":[]}'
+  printf '[%s,%s]' "$good" "$bad" > "$MOCK_IMAGES_FILE"
+  run gc_run
+  [ "$status" -eq 0 ]
+  [ "$(_count)" -eq 0 ]
+}
+
+@test "ref de repo estranho na mesma imagem e ignorada (scoping)" {
+  export IMAGE_GC_KEEP=1
+  export P_BACKEND_DIGEST="sha256:$(_h64 999)"
+  local new old
+  new="$(_img "$P_BACKEND_REPO" bnew 300 60)"
+  old='{"Id":"sha256:'"$(_h64 61)"'","Created":100,"RepoTags":["'"$P_BACKEND_REPO"':bold","evilcorp/x:latest"],"RepoDigests":["'"$P_BACKEND_REPO"'@sha256:'"$(_h64 61)"'"]}'
+  printf '[%s,%s]' "$new" "$old" > "$MOCK_IMAGES_FILE"
+  run gc_run
+  [ "$status" -eq 0 ]
+  _has "$P_BACKEND_REPO:bold"; _has "$P_BACKEND_REPO@sha256:$(_h64 61)"
+  ! _has "evilcorp/x:latest"
+}
+
+@test "IMAGE_GC_ENABLED=0 desliga: nada removido" {
+  export IMAGE_GC_ENABLED=0 IMAGE_GC_KEEP=3
+  _write_default
+  run gc_run
+  [ "$status" -eq 0 ]
+  [ "$(_count)" -eq 0 ]
+}
+
+@test "IMAGE_GC_KEEP=0 e invalido (min 1): protege prod, nada removido" {
+  export IMAGE_GC_KEEP=0
+  _write_default
+  run gc_run
+  [ "$status" -eq 0 ]
+  [ "$(_count)" -eq 0 ]
+}
+
+@test "keep >= total: nada a remover" {
+  export IMAGE_GC_KEEP=50
+  _write_default
+  run gc_run
+  [ "$status" -eq 0 ]
+  [ "$(_count)" -eq 0 ]
+}
+
+@test "IMAGE_GC_BUDGET=0: para antes de qualquer delete (deadline no passado)" {
+  export IMAGE_GC_KEEP=3 IMAGE_GC_BUDGET=0
+  _write_default
+  run gc_run
+  [ "$status" -eq 0 ]
+  [ "$(_count)" -eq 0 ]
+}
+
+@test "gc_delete_one recusa ref multi-linha (grep casa por-linha; defense-in-depth)" {
+  local mlref
+  mlref="$P_BACKEND_REPO:v1
+?force=true&x=y"
+  run gc_delete_one "$P_BACKEND_REPO" "$mlref"
+  [ "$status" -ne 0 ]
+  [ "$(_count)" -eq 0 ]
+}
+
+@test "gc_delete_one aceita ref valida por referencia e emite 1 DELETE" {
+  run gc_delete_one "$P_BACKEND_REPO" "$P_BACKEND_REPO:vok"
+  [ "$status" -eq 0 ]
+  _has "$P_BACKEND_REPO:vok"
+  [ "$(_count)" -eq 1 ]
+}


### PR DESCRIPTION
## Contexto (#1548)

O agente pull-based (ADR-018) **nunca fez GC de imagens**: cada deploy baixa uma imagem
nova por digest (`repo:${IMAGE_TAG}@${DIGEST}`) e a anterior fica no store da VM01 para
sempre. Observado no Portainer: **32 imagens, 24.4 GB** (a maioria `aprender-backend`
~1.5 GB, `Unused`) numa VM de **60 GB**. Sem política de retenção, enche.

## O que este PR faz

GC pós-deploy **confirmado** (após `seal_bump`), via **API do Portainer** (mesmo token do
applier; **sem** socket docker — respeita o least-privilege do ADR-018). Mantém as
`IMAGE_GC_KEEP` (default **3**) mais novas por repo aprender-* e remove as antigas.

- `lib/gc.sh` (novo) — `gc_candidates` / `gc_delete_one` / `gc_run`.
- `lib/portainer.sh` — `portainer_list_images` + `portainer_delete_image` (Docker API proxy).
- `apply.sh:121` — hook `gc_run || log_warn` após o selo.
- `common.sh` — `gc` no source list · `config.env.example` — knobs.

## Decisões de segurança

- **Deleta por REFERÊNCIA** (`repo:tag` e `repo@digest`), não por `.Id`: o pin
  `repo:tag@digest` gera duas refs por imagem e `docker rmi` por Id com `force=false`
  recusaria (**409** "multiple repositories") — o GC ficaria **inerte**. Por referência,
  a imagem sai quando a última referência sai. *(achado da revisão adversarial #1)*
- **Nunca toca a imagem em uso**: exclusão explícita do running digest **+** `force=false`
  (o Docker recusa 409 o delete final de imagem em uso). Duas travas.
- **Best-effort**: chamado após o selo; retorna 0 sempre; toda falha interna é guardada
  (não dispara o `set -euo pipefail`). **Nunca aborta um deploy.**
- **Deadline de parede** (`IMAGE_GC_BUDGET=120s`): bem abaixo do `TimeoutStartSec=900`;
  para cedo e loga (sem corte silencioso). *(hardening da revisão de fail-safety)*
- **Anti-injeção em 2 camadas** antes da ref entrar na URL: prefixo do repo (allowlist da
  `identity.env`) + charset seguro + rejeição de multi-linha. *(achado da re-revisão #2)*
- As imagens são **cache**: o registry guarda todo digest e o deploy repulla
  (`RepullImageAndRedeploy`), então remover local **não quebra rollback**.

## Testes

- `tests/lib_gc.bats` (novo, **14 casos**) — roda no CI via `deployer-bats.yml` (`bats tests/`).
  Cobre: mantém N por repo; **nunca** remove a imagem em uso (mesmo a mais antiga); deleta
  ambas as refs (tag+digest); recusa injeção no tag e ref multi-linha; ignora ref de repo
  estranho (scoping); não-fatal sob `set -e`/409/list-fail/não-array; `ENABLED=0`/`keep=0`/
  `keep≥total`/`budget=0`.
- Provado local com harness bash (14/14) e **2 revisões adversariais** multi-agente
  (o achado 409-by-Id e o gate multi-linha foram corrigidos neste PR).

## Alívio imediato (backlog atual)

No Portainer → Images: remover as `Unused` de `aprender-backend`/`aprender-frontend`. O GC
passa a capar automaticamente a partir do próximo deploy.
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `710dffdf`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
