### PR TITLE
chore(deploy): bump VERSION do agente para 0.3.0-imagegc (#1548)

### DIFF
--- a/v2/infra/deployer/VERSION
+++ b/v2/infra/deployer/VERSION
@@ -1,1 +1,1 @@
-0.2.0-robustez
+0.3.0-imagegc


### PR DESCRIPTION
Sincroniza o `VERSION` do agente pull-based com o que **já está instalado e rodando na VM01** desde 2026-07-11: `0.3.0-imagegc` (a release que trouxe o GC de imagens do #1548/#1549).

O #1549 adicionou `lib/gc.sh` mas esqueceu de bumpar o `VERSION` (seguia `0.2.0-robustez`). Isso importava porque o `install.sh` usa `cat VERSION` para nomear o dir imutável em `/opt/aprender-deployer/<versao>/` — sem o bump, um novo install faria `rm -rf` do dir da versão rodando (não-atômico + perde rollback). Na sessão de VM eu editei o `VERSION` da árvore para fazer o install atômico; este PR só alinha o repo.

Sem mudança de comportamento. Só o texto do `VERSION`.
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `ac714f0f`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
