### PR TITLE
fix(deps): bump Pillow 12.3.0 + httplib2 0.32.0 (9 CVEs)

### DIFF
--- a/v2/backend/requirements-prod.txt
+++ b/v2/backend/requirements-prod.txt
@@ -49,7 +49,7 @@ google-api-python-client==2.197.0
 google-auth==2.55.0
 google-auth-httplib2==0.4.0
 google-auth-oauthlib==1.4.0
-httplib2==0.31.2  # import direto nos clients GCal (transporte http com timeout)
+httplib2==0.32.0  # import direto nos clients GCal (transporte http com timeout)
 
 # Production Server
 gunicorn==23.0.0
@@ -57,7 +57,7 @@ gunicorn==23.0.0
 # Excel/CSV Processing (ETL runtime)
 openpyxl==3.1.5
 pandas==2.3.3
-Pillow==12.2.0
+Pillow==12.3.0
 xlsxwriter==3.2.0
 
 # Utilities

--- a/v2/backend/requirements.txt
+++ b/v2/backend/requirements.txt
@@ -58,7 +58,7 @@ google-api-python-client==2.197.0
 google-auth==2.55.0
 google-auth-httplib2==0.4.0
 google-auth-oauthlib==1.4.0
-httplib2==0.31.2  # import direto nos clients GCal (transporte http com timeout)
+httplib2==0.32.0  # import direto nos clients GCal (transporte http com timeout)
 
 # ================================================================
 # Production Server
@@ -78,7 +78,7 @@ mypy==1.11.2
 # ================================================================
 openpyxl==3.1.5
 pandas==2.3.3
-Pillow==12.2.0
+Pillow==12.3.0
 
 # ================================================================
 # Database


### PR DESCRIPTION
## Resumo

O gate `[required] Python Dependencies` passou a **bloquear todos os PRs** (pip-audit exit 1). CVEs publicados na PyPI Advisory Database em **2026-07-16**; o Dependabot ainda não abriu PR (só tinha um bump de `ws` no frontend).

Detectado no PR #1552 (frontend-only) — o gate falhou lá sem relação com aquele diff.

## CVEs

| Pacote | Atual | Fix | CVEs |
|---|---|---|---|
| **Pillow** | 12.2.0 | **12.3.0** | **8** — PYSEC-2026-2253, 2254, 2255, 2256, 2257, 3451, 3452, 3453 |
| **httplib2** | 0.31.2 | **0.32.0** | 1 — PYSEC-2026-3444 |

Diferente do caso `flask-cors`/`PyJWT` (sem fix upstream → tratados com `--ignore-vuln` + TTL no PR #1364), **estes têm fix publicado**. Bump é o caminho correto — nada de ignore.

Versões confirmadas direto no PyPI (não só no output do pip-audit):
- Pillow **12.3.0** — latest, não-yanked
- httplib2 **0.32.0** — latest, publicado 2026-06-26

## Risco avaliado: httplib2

`httplib2` está pinado com comentário explícito (*"import direto nos clients GCal (transporte http com timeout)"*) porque a **Onda 1 de hardening (#1504)** passou a construir o transporte com timeout:

```python
# gcal_google_client.py:87 e gcal_oauth_client.py:109
authorized_http = AuthorizedHttp(self.credentials, http=httplib2.Http(timeout=settings.GCAL_HTTP_TIMEOUT))
```

A superfície usada é mínima e **sobreviveu ao bump** (verificado em runtime):
- `httplib2.Http(timeout=30)` → OK, atributo `.timeout` preservado
- `google_auth_httplib2.AuthorizedHttp` → importável

## Validação

Deps novas instaladas no container e testadas:

- [x] `pytest apps/core/tests/ -k gcal` → **317 passed**, 1 skipped
- [x] `pytest apps/core/tests/` (suíte completa) → **2811 passed**, 37 skipped
- [x] Imagem prod construída e inspecionada: `httplib2 0.32.0 | Pillow 12.3.0`

> **Nota:** ambos os runs usam `--ignore=apps/core/tests/test_pr_security_url_substring.py`. Esse arquivo **aborta a coleta** no Docker dev com `ModuleNotFoundError: No module named 'validate_oauth_config'`. É bug **pré-existente**, já rastreado na **issue #1460** — não introduzido por este bump.

## Staging Gate

- [x] `make staging-full` executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR (trecho de log contendo "ALL 8 CHECKS PASSED")

### Evidencia Staging Gate

```text
==============================================
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
==============================================
```

Pipeline: precheck → build (backend 1.67GB com as deps novas) → up → migrate → smoke (8 checks) → teardown (`down -v`).

## Sem migration

Só `requirements.txt` + `requirements-prod.txt`. Nenhuma mudança de schema, capability ou policy.

## Desbloqueia

PR #1552 e qualquer outro PR aberto — o gate `[required] Python Dependencies` volta a passar.