### PR TITLE
fix(availability): checa RD-01..08 de todos os participantes, nao so de quem cria (#1452)

### DIFF
--- a/v2/backend/apps/core/services/availability_service.py
+++ b/v2/backend/apps/core/services/availability_service.py
@@ -112,14 +112,21 @@ def _fmt_interval_local(start: datetime, end: datetime) -> str:
     return f"{s:%H:%M %d/%m}–{e:%H:%M %d/%m}"
 
 
-@cache_availability_check(timeout=300)  # CP3: Cache 5 min (TTL curto, dados mudam frequentemente)
-def check_conflicts(
-    *, usuario: Usuario, inicio: datetime, fim: datetime, municipio: Municipio | None = None
+def _check_conflicts_impl(
+    *,
+    usuario: Usuario,
+    inicio: datetime,
+    fim: datetime,
+    municipio: Municipio | None = None,
+    exclude_solicitacao_id: int | None = None,
 ) -> CheckResult:
     """
-    Verifica conflitos para um novo intervalo (inicio, fim) de um usuário.
+    Implementação pura da checagem RD-01..RD-08. Não usar diretamente.
 
-    NÃO grava nada. NÃO aprova nada. Checagem consultiva apenas.
+    Público: `check_conflicts` (cacheado, consultivo) e `check_conflicts_uncached`
+    (sem cache, para enforcement transacional).
+
+    NÃO grava nada. NÃO aprova nada.
 
     Considera:
     - Solicitações aprovadas (eventos confirmados) → RD-01 (X)
@@ -132,6 +139,11 @@ def check_conflicts(
         inicio: datetime início do intervalo (timezone-aware UTC)
         fim: datetime fim do intervalo (timezone-aware UTC)
         municipio: Município opcional (necessário para checagem RD-04)
+        exclude_solicitacao_id: Ignora esta solicitação em TODOS os checks. Usado ao
+            revalidar um evento já gravado (update/aprovação), para que ele não
+            conflite consigo mesmo. Precisa ser aplicado na origem (`events_qs`) e não
+            filtrado depois por `ref_id`: o conflito M (RD-05) não tem `ref_id` e
+            somaria as horas do próprio evento em dobro.
 
     Returns:
         CheckResult com ok=True/False e lista de conflitos
@@ -154,6 +166,8 @@ def check_conflicts(
     events_qs = Solicitacao.objects.filter(status=Solicitacao.Status.APROVADO).filter(
         Q(usuario=usuario) | Q(participations__usuario=usuario)
     )
+    if exclude_solicitacao_id is not None:
+        events_qs = events_qs.exclude(pk=exclude_solicitacao_id)
 
     # ================================================================
     # RD-02, RD-03: BLOQUEIOS aprovados
@@ -307,3 +321,64 @@ def check_conflicts(
     # RD-07: Retornar todos os conflitos encontrados
     # ================================================================
     return CheckResult(ok=(len(conflicts) == 0), conflicts=conflicts)
+
+
+@cache_availability_check(timeout=300)  # CP3: Cache 5 min (TTL curto, dados mudam frequentemente)
+def check_conflicts(
+    *, usuario: Usuario, inicio: datetime, fim: datetime, municipio: Municipio | None = None
+) -> CheckResult:
+    """
+    Checagem consultiva de disponibilidade (RD-01..RD-08), com cache de 5 min.
+
+    Para leitura/preview: telas de disponibilidade, feedback antecipado no wizard.
+    NÃO usar para enforcement — o resultado pode ter até 5 min de atraso.
+    Enforcement usa `check_conflicts_uncached` dentro da transação.
+
+    A assinatura não expõe `exclude_solicitacao_id` de propósito: a chave de cache
+    (`cache_utils.py`) é montada a partir de uma whitelist fixa de campos, então um
+    argumento extra alteraria o resultado sem alterar a chave — envenenando o cache.
+
+    Args:
+        usuario: Usuário para verificar disponibilidade
+        inicio: datetime início do intervalo (timezone-aware UTC)
+        fim: datetime fim do intervalo (timezone-aware UTC)
+        municipio: Município opcional (necessário para checagem RD-04)
+
+    Returns:
+        CheckResult com ok=True/False e lista de conflitos
+    """
+    return _check_conflicts_impl(usuario=usuario, inicio=inicio, fim=fim, municipio=municipio)
+
+
+def check_conflicts_uncached(
+    *,
+    usuario: Usuario,
+    inicio: datetime,
+    fim: datetime,
+    municipio: Municipio | None = None,
+    exclude_solicitacao_id: int | None = None,
+) -> CheckResult:
+    """
+    Mesma checagem de `check_conflicts`, sempre lendo do banco.
+
+    Usar em enforcement (criação, edição, aprovação, publicação): dentro da transação,
+    depois de travar os participantes, um resultado cacheado deixaria passar o
+    double-booking que o lock existe para impedir.
+
+    Args:
+        usuario: Usuário para verificar disponibilidade
+        inicio: datetime início do intervalo (timezone-aware UTC)
+        fim: datetime fim do intervalo (timezone-aware UTC)
+        municipio: Município opcional (necessário para checagem RD-04)
+        exclude_solicitacao_id: Ignora esta solicitação (revalidar evento já gravado)
+
+    Returns:
+        CheckResult com ok=True/False e lista de conflitos
+    """
+    return _check_conflicts_impl(
+        usuario=usuario,
+        inicio=inicio,
+        fim=fim,
+        municipio=municipio,
+        exclude_solicitacao_id=exclude_solicitacao_id,
+    )

--- a/v2/backend/apps/core/services/solicitacao_approval.py
+++ b/v2/backend/apps/core/services/solicitacao_approval.py
@@ -19,6 +19,7 @@ from django.utils import timezone
 from apps.core.exceptions import ValidationAPIError
 from apps.core.models import AuditLog, Solicitacao, Usuario
 from apps.core.services.db_retry import retry_on_deadlock
+from apps.core.services.solicitacao_availability import enforce_solicitacao_availability
 
 logger = logging.getLogger(__name__)
 
@@ -119,13 +120,20 @@ def approve_solicitacao(
         ApprovalResult with operation details
 
     Raises:
-        ValidationAPIError: If solicitacao is not pending
+        ValidationAPIError: If solicitacao is not pending, or if any participant has a
+            conflict (#1452)
     """
     client_ip = _get_client_ip(request)
     with transaction.atomic():
         solicitacao = Solicitacao.objects.select_for_update().get(pk=solicitacao.pk)
         if solicitacao.status != "pendente":
             _raise_invalid_status_error(solicitacao)
+
+        # #1452: aprovar é o momento em que o evento passa a ocupar a agenda, e pode ter
+        # ficado pendente por dias. Revalidar aqui — o `select_for_update` acima tranca só
+        # esta linha, então quem garante exclusão entre solicitações distintas do mesmo
+        # formador é o advisory lock por participante dentro do guard.
+        enforce_solicitacao_availability(solicitacao, action="approve")
 
         prev_status = solicitacao.status
         solicitacao.status = "aprovado"
@@ -288,6 +296,17 @@ def batch_approve_solicitacoes(
 
         # Approve in batch
         for sol in solicitacoes:
+            # #1452: cada solicitação é revalidada imediatamente antes de ser aprovada.
+            # Como aprovamos em sequência dentro da mesma transação, a checagem da
+            # próxima já enxerga as anteriores como aprovadas — é isso que impede um
+            # lote de aprovar dois eventos conflitantes do mesmo formador de uma vez.
+            # Conflito reprova só aquele item; o resto do lote segue.
+            try:
+                enforce_solicitacao_availability(sol, action="batch_approve")
+            except ValidationAPIError as exc:
+                errors.append({"id": sol.id, "detail": exc.message})
+                continue
+
             prev_status = sol.status
             sol.status = "aprovado"
             sol.save()

--- a/v2/backend/apps/core/services/solicitacao_availability.py
+++ b/v2/backend/apps/core/services/solicitacao_availability.py
@@ -1,0 +1,271 @@
+"""
+Solicitacao Availability Guard — enforcement de RD-01..RD-08 por participante (#1452).
+
+SSOT dos call-sites que gravam/aprovam/publicam evento. O cálculo dos conflitos continua
+em `availability_service.check_conflicts_uncached` (RD-01..RD-08); aqui decidimos QUEM é
+checado, garantimos exclusão mútua entre transações e traduzimos o resultado em bloqueio.
+
+Motivo: `check_conflicts` era chamado apenas para o criador da solicitação. Como o
+coordenador que cria tipicamente não é o formador que atende, as regras rodavam na pessoa
+errada e o formador podia ser alocado em dois eventos simultâneos.
+"""
+
+# pyright: reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportAttributeAccessIssue=false, reportArgumentType=false
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from django.db import connection
+
+from apps.core.exceptions import ValidationAPIError
+from apps.core.models import Participation, Solicitacao, Usuario
+from apps.core.services.availability_service import Conflict, check_conflicts_uncached
+
+logger = logging.getLogger(__name__)
+
+# Papéis que ocupam a agenda da pessoa e por isso entram na checagem.
+#
+# CONVIDADO fica de fora de propósito: é audiência, não recurso alocado. Checá-lo
+# estouraria a capacidade diária (RD-05) de quem é convidado a vários eventos no mesmo
+# dia — um diretor convidado a 5 eventos bloquearia os 5.
+ENFORCED_ROLES: tuple[str, ...] = (
+    Participation.Role.COORDENADOR,
+    Participation.Role.FORMADOR,
+    Participation.Role.COORD_ACOMPANHA,
+)
+
+# Namespace do advisory lock (classid), para não colidir com outros locks da aplicação.
+_LOCK_NAMESPACE = 1452
+
+
+@dataclass
+class ParticipantConflicts:
+    """Conflitos encontrados para um participante específico."""
+
+    usuario_id: int
+    usuario_nome: str
+    conflicts: list[Conflict]
+
+
+@dataclass
+class GuardResult:
+    """
+    Resultado da checagem de todos os participantes de uma solicitação.
+
+    ok: True se nenhum participante tem conflito
+    blocked: participantes com conflito (vazio se ok)
+    skipped_guests: e-mails de convidados externos que não puderam ser checados
+    checked_usuario_ids: ids efetivamente checados (já deduplicados)
+    """
+
+    ok: bool
+    blocked: list[ParticipantConflicts]
+    skipped_guests: list[str]
+    checked_usuario_ids: list[int]
+
+
+def _display_name(usuario: Usuario) -> str:
+    """Nome legível do participante para as mensagens de conflito (RD-08)."""
+    return str(usuario.get_full_name() or usuario.username)
+
+
+def collect_participants(solicitacao: Solicitacao) -> tuple[list[Usuario], list[str]]:
+    """
+    Lê do banco quem deve ser checado nesta solicitação.
+
+    A fonte é a tabela `Participation` já gravada — não o payload da requisição. Resolver
+    o payload de novo aqui abriria espaço para checar pessoas diferentes das que foram
+    salvas, que é exatamente a falha que este guard existe para fechar.
+
+    O criador (`solicitacao.usuario`) entra sempre, mesmo sem `Participation`: preserva a
+    checagem que já existia antes do #1452 e cobre eventos sem participantes extras.
+
+    Convidado externo sem cadastro (`usuario=NULL` + `guest_email`) é fisicamente
+    não-checável: não tem `AvailabilityBlock` nem casa com `Q(participations__usuario=)`.
+    Volta em `skipped_guests` para ser reportado — nunca ignorado em silêncio.
+
+    Returns:
+        (usuarios a checar, deduplicados por id; e-mails de convidados pulados)
+    """
+    participations = Participation.objects.filter(solicitacao=solicitacao, role__in=ENFORCED_ROLES).select_related(
+        "usuario"
+    )
+
+    # Dedup por id é obrigatório: o coordenador é sempre gravado como COORDENADOR e pode
+    # também estar em formador_ids. Sem dedup as horas dele contariam 2x no RD-05.
+    usuarios_by_id: dict[int, Usuario] = {}
+    skipped_guests: list[str] = []
+
+    if solicitacao.usuario_id:
+        usuarios_by_id[solicitacao.usuario_id] = solicitacao.usuario
+
+    for p in participations:
+        if p.usuario_id:
+            usuarios_by_id.setdefault(p.usuario_id, p.usuario)
+        elif p.guest_email and p.guest_email not in skipped_guests:
+            skipped_guests.append(p.guest_email)
+
+    usuarios = [usuarios_by_id[uid] for uid in sorted(usuarios_by_id)]
+    return usuarios, skipped_guests
+
+
+def lock_participants(usuario_ids: list[int]) -> None:
+    """
+    Trava os participantes até o fim da transação (`pg_advisory_xact_lock`).
+
+    Sem isto o fix é apenas metade: `select_for_update` nas rotinas de aprovação tranca a
+    própria linha da solicitação. Duas solicitações distintas do mesmo formador trancam
+    linhas disjuntas, e como `pendente` é invisível para a checagem (que só olha eventos
+    aprovados), cada transação lê a outra como inexistente e ambas commitam — o formador
+    acaba com dois eventos no mesmo horário.
+
+    Travando por `usuario_id`, a segunda transação espera a primeira e enxerga o evento
+    recém-aprovado. A ordem ASC fixa evita deadlock quando duas solicitações compartilham
+    mais de um participante.
+
+    Requer transação aberta: `pg_advisory_xact_lock` libera no commit/rollback.
+    """
+    if not usuario_ids:
+        return
+
+    with connection.cursor() as cursor:
+        for usuario_id in sorted(usuario_ids):
+            cursor.execute("SELECT pg_advisory_xact_lock(%s, %s)", [_LOCK_NAMESPACE, usuario_id])
+
+
+def check_solicitacao_availability(solicitacao: Solicitacao, *, lock: bool = True) -> GuardResult:
+    """
+    Checa RD-01..RD-08 para cada participante da solicitação.
+
+    Deve rodar dentro de `transaction.atomic()`: o lock é por transação e o resultado só
+    vale enquanto ele estiver mantido.
+
+    A própria solicitação é excluída da checagem (`exclude_solicitacao_id`) — senão um
+    evento já gravado conflitaria consigo mesmo. A exclusão acontece na origem da query e
+    não como filtro por `ref_id` depois: o conflito de capacidade diária (M, RD-05) não
+    tem `ref_id` e somaria as horas do próprio evento em dobro.
+
+    Args:
+        solicitacao: evento já gravado (precisa de pk, inicio, fim)
+        lock: trava os participantes antes de ler. False só para leitura consultiva.
+
+    Returns:
+        GuardResult com ok/blocked/skipped_guests
+    """
+    usuarios, skipped_guests = collect_participants(solicitacao)
+
+    if lock:
+        lock_participants([u.id for u in usuarios])
+
+    blocked: list[ParticipantConflicts] = []
+    for usuario in usuarios:
+        result = check_conflicts_uncached(
+            usuario=usuario,
+            inicio=solicitacao.inicio,
+            fim=solicitacao.fim,
+            municipio=solicitacao.municipio,
+            exclude_solicitacao_id=solicitacao.pk,
+        )
+        if not result.ok:
+            blocked.append(
+                ParticipantConflicts(
+                    usuario_id=usuario.id,
+                    usuario_nome=_display_name(usuario),
+                    conflicts=result.conflicts,
+                )
+            )
+
+    return GuardResult(
+        ok=not blocked,
+        blocked=blocked,
+        skipped_guests=skipped_guests,
+        checked_usuario_ids=[u.id for u in usuarios],
+    )
+
+
+def _build_message(guard: GuardResult) -> str:
+    """Mensagem de bloqueio nomeando quem está alocado (RD-08)."""
+    nomes = ", ".join(p.usuario_nome for p in guard.blocked)
+    if len(guard.blocked) == 1:
+        return f"{nomes} já está alocado neste horário. Não é possível criar o evento."
+    return f"{nomes} já estão alocados neste horário. Não é possível criar o evento."
+
+
+def raise_if_blocked(guard: GuardResult) -> None:
+    """
+    Converte um GuardResult bloqueado em 400 `availability_conflict`.
+
+    Conflito é bloqueio duro, sem override: vale para todos os fluxos, inclusive
+    NAO_SUPER (decisão de negócio, 2026-07-16).
+
+    O payload mantém `conflicts` achatado como antes do #1452 (clientes existentes leem
+    essa chave) e acrescenta `blocked_participants` com a atribuição por pessoa.
+    """
+    if guard.ok:
+        return
+
+    todos: list[Conflict] = [c for p in guard.blocked for c in p.conflicts]
+    raise ValidationAPIError(
+        message=_build_message(guard),
+        code="availability_conflict",
+        extra={
+            "conflicts": [c.__dict__ for c in todos],
+            "blocked_participants": [
+                {
+                    "usuario_id": p.usuario_id,
+                    "usuario_nome": p.usuario_nome,
+                    "conflicts": [c.__dict__ for c in p.conflicts],
+                }
+                for p in guard.blocked
+            ],
+            "skipped_guests": guard.skipped_guests,
+        },
+    )
+
+
+def enforce_solicitacao_availability(solicitacao: Solicitacao, *, action: str) -> GuardResult:
+    """
+    Checa e bloqueia. Ponto de entrada dos call-sites (create, update, approve, publish).
+
+    Requer transação aberta.
+
+    Args:
+        solicitacao: evento já gravado
+        action: rótulo do call-site, só para log/auditoria
+
+    Returns:
+        GuardResult (ok=True) quando passa
+
+    Raises:
+        ValidationAPIError: `availability_conflict` quando algum participante tem conflito
+    """
+    guard = check_solicitacao_availability(solicitacao)
+
+    if guard.skipped_guests:
+        # PA-05: convidado externo não é checável. Registrar sempre — a ausência de
+        # checagem precisa ser visível, não presumida.
+        logger.warning(
+            "availability_guest_check_skipped",
+            extra={
+                "event": "availability_guest_check_skipped",
+                "action": action,
+                "solicitacao_id": solicitacao.pk,
+                "skipped_guests": guard.skipped_guests,
+            },
+        )
+
+    if not guard.ok:
+        logger.info(
+            "availability_blocked",
+            extra={
+                "event": "availability_blocked",
+                "action": action,
+                "solicitacao_id": solicitacao.pk,
+                "blocked_usuario_ids": [p.usuario_id for p in guard.blocked],
+            },
+        )
+        raise_if_blocked(guard)
+
+    return guard

--- a/v2/backend/apps/core/services/solicitacao_publish.py
+++ b/v2/backend/apps/core/services/solicitacao_publish.py
@@ -143,6 +143,28 @@ def preview_gcal(
     )
 
 
+def _warn_if_participants_unavailable(solicitacao: Solicitacao) -> None:
+    """
+    Registra (sem bloquear) participantes com conflito num evento já aprovado (#1452).
+
+    Sinaliza double-booking legado, anterior ao enforcement na criação/aprovação.
+    """
+    from apps.core.services.solicitacao_availability import check_solicitacao_availability
+
+    guard = check_solicitacao_availability(solicitacao, lock=False)
+    if guard.ok:
+        return
+
+    logger.warning(
+        "publish_availability_conflict_detected",
+        extra={
+            "event": "publish_availability_conflict_detected",
+            "solicitacao_id": solicitacao.id,
+            "blocked_usuario_ids": [p.usuario_id for p in guard.blocked],
+        },
+    )
+
+
 def publish_to_gcal(
     solicitacao: Solicitacao,
     user: Usuario,
@@ -177,6 +199,15 @@ def publish_to_gcal(
             message="Apenas solicitações aprovadas podem ser publicadas no Google Calendar.",
             code="not_approved",
         )
+
+    # #1452: revalidação NÃO bloqueante, de propósito.
+    #
+    # Publicar não aloca nada — o evento já está aprovado e ocupa a agenda desde então.
+    # Com o enforcement na criação e na aprovação, dois eventos aprovados conflitantes só
+    # existem em dados anteriores a esta correção; bloquear a publicação deles puniria o
+    # operador por um evento que a instituição já assumiu. Então aqui só registramos, para
+    # que o double-booking legado apareça em vez de passar despercebido.
+    _warn_if_participants_unavailable(solicitacao)
 
     # Check if apply is blocked
     gcal_client = getattr(settings, "GCAL_CLIENT", None)

--- a/v2/backend/apps/core/tests/test_availability_per_formador_1452.py
+++ b/v2/backend/apps/core/tests/test_availability_per_formador_1452.py
@@ -1,0 +1,573 @@
+"""
+Testes: disponibilidade validada por participante, não só por quem cria (#1452).
+
+O bug: `check_conflicts` só rodava para `request.user`. Como o coordenador que cria
+tipicamente não é o formador que atende, as regras RD-01..RD-08 eram avaliadas na pessoa
+errada e o formador podia ser alocado em dois eventos simultâneos.
+
+Cobre os 4 boundaries que gravam/aprovam/publicam evento, mais as decisões de negócio
+(2026-07-16): bloqueio duro, CONVIDADO fora da checagem, gerente coberto via COORDENADOR/
+COORD_ACOMPANHA.
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportOptionalMemberAccess=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportMissingTypeArgument=false, reportCallIssue=false, reportIndexIssue=false, reportOperatorIssue=false, reportOptionalSubscript=false, reportUnknownLambdaType=false
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+from django.utils import timezone
+from rest_framework import status as http_status
+from rest_framework.test import APIClient
+
+import pytest
+
+from apps.core.models import Compra, Participation, Solicitacao
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture
+def municipio():
+    return MunicipioFactory(nome="Fortaleza 1452", uf="CE")
+
+
+@pytest.fixture
+def tipo_evento():
+    return TipoEventoFactory(nome="Formação 1452")
+
+
+@pytest.fixture
+def projeto_super(municipio):
+    """
+    Fluxo SUPER: fica pendente na criação (PA-04), permitindo testar a aprovação.
+
+    A Compra é obrigatória: o serializer recusa solicitação para (município, projeto) sem
+    compra registrada. Os testes de criação usam `projeto=None` e não precisam dela.
+    """
+    projeto = ProjetoFactory(nome="Projeto SUPER 1452", fluxo="SUPER")
+    Compra.objects.create(
+        codigo="COMP-1452",
+        projeto=projeto,
+        municipio=municipio,
+        quantidade=10,
+        data=date(2026, 1, 10),
+        uso="Fixture #1452",
+        external_hash="compra-1452-hash",
+    )
+    return projeto
+
+
+@pytest.fixture
+def coordenador():
+    """Quem cria o evento. Não é o formador — é justamente esse o ponto do #1452."""
+    user = UsuarioFactory(username="coord_1452", first_name="Ana", last_name="Coordenadora")
+    user.groups.add(GroupFactory(name="Coordenador"))
+    return user
+
+
+@pytest.fixture
+def formador():
+    return UsuarioFactory(username="formador_1452", first_name="Bruno", last_name="Formador")
+
+
+@pytest.fixture
+def aprovador():
+    """Gerente da Superintendência — único perfil que aprova além do superuser (PA-02)."""
+    user = UsuarioFactory(username="gerente_1452", first_name="Carla", last_name="Gerente")
+    user.groups.add(GroupFactory(name="Superintendência"), GroupFactory(name="Gerente"))
+    return user
+
+
+@pytest.fixture
+def horario():
+    """Janela base: amanhã, 09:00–11:00 (UTC)."""
+    inicio = (timezone.now() + timedelta(days=1)).replace(hour=9, minute=0, second=0, microsecond=0)
+    return inicio, inicio + timedelta(hours=2)
+
+
+def _evento_aprovado_para(usuario, municipio, tipo_evento, inicio, fim, projeto=None):
+    """Evento já aprovado ocupando a agenda do usuário (participa como FORMADOR)."""
+    solicitacao = SolicitacaoFactory(
+        usuario=usuario,
+        municipio=municipio,
+        tipo_evento=tipo_evento,
+        projeto=projeto,
+        inicio=inicio,
+        fim=fim,
+        status=Solicitacao.Status.APROVADO,
+    )
+    Participation.objects.create(solicitacao=solicitacao, usuario=usuario, role=Participation.Role.FORMADOR)
+    return solicitacao
+
+
+def _payload(municipio, tipo_evento, inicio, fim, projeto=None, **extra):
+    payload = {
+        "municipio": municipio.pk,
+        "tipo_evento": tipo_evento.pk,
+        "inicio": inicio.isoformat(),
+        "fim": fim.isoformat(),
+    }
+    if projeto is not None:
+        payload["projeto"] = projeto.pk
+    payload.update(extra)
+    return payload
+
+
+# ============================================================================
+# O bug do #1452: a regra rodava na pessoa errada
+# ============================================================================
+
+
+class TestCreateChecaFormador:
+    def test_bloqueia_quando_formador_ja_alocado_mesmo_com_coordenador_livre(
+        self, coordenador, formador, municipio, tipo_evento, horario
+    ):
+        """
+        O coração do #1452: coordenador com agenda livre, formador já alocado.
+
+        Antes da correção retornava 201 — a checagem rodava no coordenador, que estava
+        livre, e o formador era gravado depois, sem passar por regra nenhuma.
+        """
+        inicio, fim = horario
+        _evento_aprovado_para(formador, municipio, tipo_evento, inicio, fim)
+
+        client = APIClient()
+        client.force_authenticate(user=coordenador)
+        response = client.post(
+            "/api/solicitacoes/",
+            _payload(
+                municipio,
+                tipo_evento,
+                inicio + timedelta(minutes=30),
+                fim + timedelta(minutes=30),
+                extra_participants={"formador_ids": [formador.pk]},
+            ),
+            format="json",
+        )
+
+        assert response.status_code == http_status.HTTP_400_BAD_REQUEST
+        assert response.data["code"] == "availability_conflict"
+        assert "Bruno Formador" in response.data["detail"]
+
+        bloqueados = response.data["errors"]["blocked_participants"]
+        assert [p["usuario_id"] for p in bloqueados] == [formador.pk]
+
+    def test_conflito_desfaz_o_evento_inteiro(self, coordenador, formador, municipio, tipo_evento, horario):
+        """Bloqueio precisa reverter a solicitação e as participações já gravadas."""
+        inicio, fim = horario
+        _evento_aprovado_para(formador, municipio, tipo_evento, inicio, fim)
+        solicitacoes_antes = Solicitacao.objects.count()
+        participations_antes = Participation.objects.count()
+
+        client = APIClient()
+        client.force_authenticate(user=coordenador)
+        client.post(
+            "/api/solicitacoes/",
+            _payload(
+                municipio,
+                tipo_evento,
+                inicio,
+                fim,
+                extra_participants={"formador_ids": [formador.pk]},
+            ),
+            format="json",
+        )
+
+        assert Solicitacao.objects.count() == solicitacoes_antes
+        assert Participation.objects.count() == participations_antes
+
+    def test_permite_quando_formador_esta_livre(self, coordenador, formador, municipio, tipo_evento, horario):
+        """Guarda contra o oposto: bloquear tudo também seria bug."""
+        inicio, fim = horario
+
+        client = APIClient()
+        client.force_authenticate(user=coordenador)
+        response = client.post(
+            "/api/solicitacoes/",
+            _payload(
+                municipio,
+                tipo_evento,
+                inicio,
+                fim,
+                extra_participants={"formador_ids": [formador.pk]},
+            ),
+            format="json",
+        )
+
+        assert response.status_code == http_status.HTTP_201_CREATED
+        assert Participation.objects.filter(
+            solicitacao_id=response.data["id"], usuario=formador, role=Participation.Role.FORMADOR
+        ).exists()
+
+    def test_evento_adjacente_nao_conflita(self, coordenador, formador, municipio, tipo_evento, horario):
+        """RD-01: `fim == inicio` é encosto, não sobreposição."""
+        inicio, fim = horario
+        _evento_aprovado_para(formador, municipio, tipo_evento, inicio, fim)
+
+        client = APIClient()
+        client.force_authenticate(user=coordenador)
+        response = client.post(
+            "/api/solicitacoes/",
+            _payload(
+                municipio,
+                tipo_evento,
+                fim,  # começa exatamente quando o outro termina
+                fim + timedelta(hours=1),
+                extra_participants={"formador_ids": [formador.pk]},
+            ),
+            format="json",
+        )
+
+        assert response.status_code == http_status.HTTP_201_CREATED
+
+    def test_coord_acompanha_tambem_e_checado(self, coordenador, municipio, tipo_evento, horario):
+        """
+        COORD_ACOMPANHA ocupa a agenda como qualquer outro recurso.
+
+        Também é por aqui que o gerente entra: "Gerente" é função RBAC, não papel de
+        Participation — um gerente que participa é gravado como COORDENADOR ou
+        COORD_ACOMPANHA, então já está coberto.
+        """
+        inicio, fim = horario
+        acompanhante = UsuarioFactory(username="acompanha_1452", first_name="Dora", last_name="Acompanha")
+        _evento_aprovado_para(acompanhante, municipio, tipo_evento, inicio, fim)
+
+        client = APIClient()
+        client.force_authenticate(user=coordenador)
+        response = client.post(
+            "/api/solicitacoes/",
+            _payload(
+                municipio,
+                tipo_evento,
+                inicio,
+                fim,
+                extra_participants={"coord_acompanha_ids": [acompanhante.pk]},
+            ),
+            format="json",
+        )
+
+        assert response.status_code == http_status.HTTP_400_BAD_REQUEST
+        assert response.data["code"] == "availability_conflict"
+
+    def test_convidado_nao_e_checado(self, coordenador, municipio, tipo_evento, horario):
+        """
+        CONVIDADO é audiência, não recurso alocado (decisão de negócio 2026-07-16).
+
+        Checá-lo estouraria a capacidade diária (RD-05) de quem é convidado a vários
+        eventos no mesmo dia, bloqueando todos.
+        """
+        inicio, fim = horario
+        convidado = UsuarioFactory(username="convidado_1452")
+        _evento_aprovado_para(convidado, municipio, tipo_evento, inicio, fim)
+
+        client = APIClient()
+        client.force_authenticate(user=coordenador)
+        response = client.post(
+            "/api/solicitacoes/",
+            _payload(municipio, tipo_evento, inicio, fim),
+            format="json",
+        )
+        assert response.status_code == http_status.HTTP_201_CREATED
+
+        Participation.objects.create(
+            solicitacao_id=response.data["id"], usuario=convidado, role=Participation.Role.CONVIDADO
+        )
+
+        from apps.core.services.solicitacao_availability import check_solicitacao_availability
+
+        guard = check_solicitacao_availability(Solicitacao.objects.get(pk=response.data["id"]), lock=False)
+        assert guard.ok
+        assert convidado.pk not in guard.checked_usuario_ids
+
+    def test_coordenador_que_tambem_e_formador_conta_uma_vez(self, coordenador, municipio, tipo_evento):
+        """
+        Dedup por usuario_id: o coordenador é sempre gravado como COORDENADOR e pode
+        também vir em formador_ids. Sem dedup, as horas dele contariam 2x no RD-05 e um
+        evento de 5h estouraria sozinho o limite diário de 8h.
+        """
+        inicio = (timezone.now() + timedelta(days=1)).replace(hour=8, minute=0, second=0, microsecond=0)
+        fim = inicio + timedelta(hours=5)
+
+        client = APIClient()
+        client.force_authenticate(user=coordenador)
+        response = client.post(
+            "/api/solicitacoes/",
+            _payload(
+                municipio,
+                tipo_evento,
+                inicio,
+                fim,
+                extra_participants={"formador_ids": [coordenador.pk]},
+            ),
+            format="json",
+        )
+
+        assert response.status_code == http_status.HTTP_201_CREATED
+
+        from apps.core.services.solicitacao_availability import check_solicitacao_availability
+
+        guard = check_solicitacao_availability(Solicitacao.objects.get(pk=response.data["id"]), lock=False)
+        assert guard.checked_usuario_ids == [coordenador.pk]
+
+    def test_convidado_externo_sem_cadastro_e_reportado_nao_ignorado(
+        self, coordenador, municipio, tipo_evento, horario
+    ):
+        """
+        Guest sem Usuario não tem agenda para checar. O que não pode é o pulo ser
+        silencioso — precisa aparecer em `skipped_guests` (PA-05).
+        """
+        inicio, fim = horario
+
+        client = APIClient()
+        client.force_authenticate(user=coordenador)
+        response = client.post(
+            "/api/solicitacoes/",
+            _payload(
+                municipio,
+                tipo_evento,
+                inicio,
+                fim,
+                extra_participants={"formador_emails": ["externo@fora.com"]},
+            ),
+            format="json",
+        )
+        assert response.status_code == http_status.HTTP_201_CREATED
+
+        from apps.core.services.solicitacao_availability import check_solicitacao_availability
+
+        guard = check_solicitacao_availability(Solicitacao.objects.get(pk=response.data["id"]), lock=False)
+        assert guard.skipped_guests == ["externo@fora.com"]
+
+
+# ============================================================================
+# Boundary 2: edição
+# ============================================================================
+
+
+class TestUpdateChecaFormador:
+    def test_mover_evento_para_horario_ocupado_do_formador_bloqueia(
+        self, coordenador, formador, municipio, tipo_evento, horario
+    ):
+        """`perform_update` não tinha checagem nenhuma: dava para editar até o conflito."""
+        inicio, fim = horario
+        _evento_aprovado_para(formador, municipio, tipo_evento, inicio, fim)
+
+        client = APIClient()
+        client.force_authenticate(user=coordenador)
+        criado = client.post(
+            "/api/solicitacoes/",
+            _payload(
+                municipio,
+                tipo_evento,
+                fim + timedelta(days=2),
+                fim + timedelta(days=2, hours=2),
+                extra_participants={"formador_ids": [formador.pk]},
+            ),
+            format="json",
+        )
+        assert criado.status_code == http_status.HTTP_201_CREATED
+        solicitacao_id = criado.data["id"]
+
+        response = client.patch(
+            f"/api/solicitacoes/{solicitacao_id}/",
+            {"inicio": inicio.isoformat(), "fim": fim.isoformat()},
+            format="json",
+        )
+
+        assert response.status_code == http_status.HTTP_400_BAD_REQUEST
+        assert response.data["code"] == "availability_conflict"
+
+        solicitacao = Solicitacao.objects.get(pk=solicitacao_id)
+        assert solicitacao.inicio != inicio, "edição bloqueada não pode ter sido persistida"
+
+    def test_editar_sem_mover_nao_conflita_consigo_mesmo(self, coordenador, formador, municipio, tipo_evento, horario):
+        """
+        `exclude_solicitacao_id`: o evento sendo editado não pode entrar na própria
+        checagem — senão qualquer edição de evento aprovado seria bloqueada por ele mesmo.
+        """
+        inicio, fim = horario
+
+        client = APIClient()
+        client.force_authenticate(user=coordenador)
+        criado = client.post(
+            "/api/solicitacoes/",
+            _payload(
+                municipio,
+                tipo_evento,
+                inicio,
+                fim,
+                extra_participants={"formador_ids": [formador.pk]},
+            ),
+            format="json",
+        )
+        assert criado.status_code == http_status.HTTP_201_CREATED
+
+        response = client.patch(
+            f"/api/solicitacoes/{criado.data['id']}/",
+            {"observacoes": "ajuste de texto"},
+            format="json",
+        )
+
+        assert response.status_code == http_status.HTTP_200_OK
+
+
+# ============================================================================
+# Boundary 3: aprovação (TOCTOU)
+# ============================================================================
+
+
+class TestApproveRevalida:
+    def test_aprovar_revalida_conflito_surgido_depois(
+        self, coordenador, formador, aprovador, municipio, tipo_evento, projeto_super, horario
+    ):
+        """
+        SUPER fica pendente e pode ficar dias na fila. Se a agenda do formador foi
+        ocupada nesse meio-tempo, aprovar sem revalidar cria o double-booking.
+        """
+        inicio, fim = horario
+
+        client = APIClient()
+        client.force_authenticate(user=coordenador)
+        criado = client.post(
+            "/api/solicitacoes/",
+            _payload(
+                municipio,
+                tipo_evento,
+                inicio,
+                fim,
+                projeto=projeto_super,
+                extra_participants={"formador_ids": [formador.pk]},
+            ),
+            format="json",
+        )
+        assert criado.status_code == http_status.HTTP_201_CREATED, criado.data
+        assert criado.data["status"] == "pendente"
+
+        # Agenda do formador é ocupada depois da criação
+        _evento_aprovado_para(formador, municipio, tipo_evento, inicio, fim)
+
+        approver_client = APIClient()
+        approver_client.force_authenticate(user=aprovador)
+        response = approver_client.patch(f"/api/solicitacoes/{criado.data['id']}/approve/", {}, format="json")
+
+        assert response.status_code == http_status.HTTP_400_BAD_REQUEST
+        assert response.data["code"] == "availability_conflict"
+        assert Solicitacao.objects.get(pk=criado.data["id"]).status == "pendente"
+
+    def test_batch_aprova_a_primeira_e_barra_a_conflitante(
+        self, coordenador, formador, aprovador, municipio, tipo_evento, projeto_super, horario
+    ):
+        """
+        Duas pendentes do mesmo formador no mesmo horário, aprovadas no mesmo lote.
+
+        `select_for_update` não resolve: cada uma tranca a própria linha, e `pendente` é
+        invisível para a checagem (que só olha aprovados). Como revalidamos item a item
+        dentro da transação, a segunda já enxerga a primeira como aprovada.
+        """
+        inicio, fim = horario
+
+        client = APIClient()
+        client.force_authenticate(user=coordenador)
+        ids = []
+        for _ in range(2):
+            criado = client.post(
+                "/api/solicitacoes/",
+                _payload(
+                    municipio,
+                    tipo_evento,
+                    inicio,
+                    fim,
+                    projeto=projeto_super,
+                    extra_participants={"formador_ids": [formador.pk]},
+                ),
+                format="json",
+            )
+            assert criado.status_code == http_status.HTTP_201_CREATED
+            ids.append(criado.data["id"])
+
+        approver_client = APIClient()
+        approver_client.force_authenticate(user=aprovador)
+        response = approver_client.post("/api/solicitacoes/batch-approve/", {"ids": ids}, format="json")
+
+        assert response.status_code == http_status.HTTP_200_OK
+        aprovadas = Solicitacao.objects.filter(id__in=ids, status="aprovado").count()
+        assert aprovadas == 1, "o lote não pode aprovar dois eventos conflitantes do mesmo formador"
+        assert Solicitacao.objects.filter(id__in=ids, status="pendente").count() == 1
+
+
+# ============================================================================
+# Cache: enforcement não pode ler resultado velho nem envenenar a chave
+# ============================================================================
+
+
+class TestCacheSplit:
+    def test_check_conflicts_nao_aceita_exclude_solicitacao_id(self, formador, municipio, horario):
+        """
+        A chave de cache é montada a partir de uma whitelist fixa. Um kwarg extra mudaria
+        o resultado sem mudar a chave — a próxima chamada com a mesma chave receberia a
+        resposta errada. Quem precisa excluir usa a versão sem cache.
+        """
+        from apps.core.services.availability_service import check_conflicts
+
+        inicio, fim = horario
+        with pytest.raises(TypeError):
+            check_conflicts(  # type: ignore[call-arg]
+                usuario=formador,
+                inicio=inicio,
+                fim=fim,
+                municipio=municipio,
+                exclude_solicitacao_id=1,
+            )
+
+    def test_check_conflicts_uncached_enxerga_evento_recem_criado(self, formador, municipio, tipo_evento, horario):
+        """
+        Enforcement lê sempre do banco: um resultado com até 5 min de atraso deixaria
+        passar exatamente o double-booking que o lock existe para impedir.
+        """
+        from apps.core.services.availability_service import check_conflicts, check_conflicts_uncached
+
+        inicio, fim = horario
+
+        assert check_conflicts(usuario=formador, inicio=inicio, fim=fim, municipio=municipio).ok
+        _evento_aprovado_para(formador, municipio, tipo_evento, inicio, fim)
+
+        assert not check_conflicts_uncached(usuario=formador, inicio=inicio, fim=fim, municipio=municipio).ok
+
+    def test_exclude_solicitacao_id_tambem_tira_do_limite_diario(self, formador, municipio, tipo_evento):
+        """
+        A exclusão precisa valer na origem da query, não como filtro por `ref_id` depois:
+        o conflito de capacidade diária (M, RD-05) não tem `ref_id` e somaria as horas do
+        próprio evento em dobro.
+        """
+        from apps.core.services.availability_service import check_conflicts_uncached
+
+        inicio = (timezone.now() + timedelta(days=1)).replace(hour=8, minute=0, second=0, microsecond=0)
+        fim = inicio + timedelta(hours=5)
+        solicitacao = _evento_aprovado_para(formador, municipio, tipo_evento, inicio, fim)
+
+        # 5h já gravadas + 5h do mesmo evento = 10h > limite de 8h/dia
+        sem_exclusao = check_conflicts_uncached(usuario=formador, inicio=inicio, fim=fim, municipio=municipio)
+        assert [c.code for c in sem_exclusao.conflicts].count("M") == 1
+
+        com_exclusao = check_conflicts_uncached(
+            usuario=formador,
+            inicio=inicio,
+            fim=fim,
+            municipio=municipio,
+            exclude_solicitacao_id=solicitacao.pk,
+        )
+        assert com_exclusao.ok

--- a/v2/backend/apps/core/utils/cache_utils.py
+++ b/v2/backend/apps/core/utils/cache_utils.py
@@ -40,13 +40,18 @@ def cache_availability_check(timeout: int | None = None) -> Callable[[F], F]:
     Cache key includes a per-user version counter. When user's data changes,
     the version increments and all old entries become cache misses naturally.
 
+    A chave é montada a partir destes 4 argumentos e mais nada. Por isso o wrapper
+    aceita SÓ eles: um kwarg extra mudaria o resultado sem mudar a chave, e a próxima
+    chamada com a chave antiga receberia a resposta errada. Quem precisa de argumentos
+    extras (ex.: `exclude_solicitacao_id`) chama a versão sem cache.
+
     Args:
         timeout: TTL in seconds (default: 300 + jitter)
     """
 
     def decorator(func: F) -> F:
         @wraps(func)
-        def wrapper(*, usuario: Any, inicio: Any, fim: Any, municipio: Any = None, **kwargs: Any) -> Any:
+        def wrapper(*, usuario: Any, inicio: Any, fim: Any, municipio: Any = None) -> Any:
             usuario_id = usuario.id
             version = _get_cache_version(usuario_id)
 
@@ -65,7 +70,7 @@ def cache_availability_check(timeout: int | None = None) -> Callable[[F], F]:
             if cached_result is not None:
                 return cached_result
 
-            result = func(usuario=usuario, inicio=inicio, fim=fim, municipio=municipio, **kwargs)
+            result = func(usuario=usuario, inicio=inicio, fim=fim, municipio=municipio)
 
             ttl = timeout if timeout is not None else _ttl_with_jitter()
             cache.set(cache_key, result, timeout=ttl)

--- a/v2/backend/apps/core/views_solicitacao.py
+++ b/v2/backend/apps/core/views_solicitacao.py
@@ -278,28 +278,28 @@ class SolicitacaoViewSet(viewsets.ModelViewSet):
         - NAO_SUPER: status='aprovado' (auto-aprovado)
 
         PR15: Suporta extra_participants para criar Participation automaticamente.
+
+        #1452: a disponibilidade é checada para TODOS os participantes, não só para quem
+        cria. Por isso a checagem roda depois de gravar as Participation, dentro da mesma
+        transação: o guard lê a tabela, e um conflito desfaz o evento inteiro.
         """
-        from .exceptions import ValidationAPIError
-        from .services.availability_service import check_conflicts
+        from django.db import transaction
 
-        inicio = serializer.validated_data.get("inicio")
-        fim = serializer.validated_data.get("fim")
-        municipio = serializer.validated_data.get("municipio")
-
-        if inicio is not None and fim is not None:
-            result = check_conflicts(usuario=self.request.user, inicio=inicio, fim=fim, municipio=municipio)
-            if not result.ok:
-                raise ValidationAPIError(
-                    message="Conflito de disponibilidade detectado.",
-                    code="availability_conflict",
-                    extra={"conflicts": [c.__dict__ for c in result.conflicts]},
-                )
+        from .services.solicitacao_availability import enforce_solicitacao_availability
 
         projeto = serializer.validated_data.get("projeto")
         initial_status = resolve_initial_status(projeto=projeto)
 
-        # ASQ-002: status inicial decidido em camada de serviço (não no model.save()).
-        instance = serializer.save(usuario=self.request.user, status=initial_status.status)
+        with transaction.atomic():
+            # ASQ-002: status inicial decidido em camada de serviço (não no model.save()).
+            instance = serializer.save(usuario=self.request.user, status=initial_status.status)
+
+            # PR15: Processar extra_participants
+            extra_participants = self.request.data.get("extra_participants", {})
+            if extra_participants:
+                self._create_participants(instance, extra_participants)
+
+            enforce_solicitacao_availability(instance, action="create")
 
         logger.info(
             "solicitacao_initial_status_decided",
@@ -314,11 +314,6 @@ class SolicitacaoViewSet(viewsets.ModelViewSet):
                 "reason": initial_status.reason,
             },
         )
-
-        # PR15: Processar extra_participants
-        extra_participants = self.request.data.get("extra_participants", {})
-        if extra_participants:
-            self._create_participants(instance, extra_participants)
 
     def _create_participants(self, solicitacao, extra):
         """
@@ -406,8 +401,14 @@ class SolicitacaoViewSet(viewsets.ModelViewSet):
         - Formadores alterados (adicionados/removidos)
         - Usuário que editou
         - IP e User-Agent
+
+        #1452: editar data, município ou formadores realoca gente — a checagem roda depois
+        das alterações, sobre o estado final, e um conflito desfaz a edição inteira.
         """
+        from django.db import transaction
+
         from .models import Participation, Usuario
+        from .services.solicitacao_availability import enforce_solicitacao_availability
 
         instance = serializer.instance
 
@@ -433,13 +434,16 @@ class SolicitacaoViewSet(viewsets.ModelViewSet):
             "formador_ids": list(old_formador_ids),
         }
 
-        # Salva as alterações
-        serializer.save()
+        with transaction.atomic():
+            # Salva as alterações
+            serializer.save()
 
-        # Processa extra_participants se presente
-        extra_participants = self.request.data.get("extra_participants", {})
-        if extra_participants and "formador_ids" in extra_participants:
-            self._update_formadores(instance, extra_participants)
+            # Processa extra_participants se presente
+            extra_participants = self.request.data.get("extra_participants", {})
+            if extra_participants and "formador_ids" in extra_participants:
+                self._update_formadores(instance, extra_participants)
+
+            enforce_solicitacao_availability(instance, action="update")
 
         # Coleta dados novos após save
         instance.refresh_from_db()


### PR DESCRIPTION
## Resumo

`check_conflicts` era chamado **uma vez, para `request.user`** — o coordenador que cria. Os formadores chegavam em `extra_participants.formador_ids` e eram gravados **depois**, sem passar por regra nenhuma.

Como o coordenador que cria tipicamente **não** é o formador que atende, as regras RD-01..RD-08 rodavam na pessoa errada. Coordenador com agenda livre + formador já alocado = **201 Created**. Double-booking real.

O service de disponibilidade está correto (fix #550). A lacuna era nos **call-sites**.

## Os 4 boundaries

| Boundary | Antes | Agora |
|---|---|---|
| `perform_create` | checava só o criador | checa todos os participantes |
| `perform_update` | **checagem nenhuma** — dava para editar até o conflito | checa o estado final |
| `approve` / `batch_approve` | zero revalidação (TOCTOU) | revalida + advisory lock |
| `publish_to_gcal` | zero revalidação | registra, **não bloqueia** (ver abaixo) |

## Fix

**NEW** `apps/core/services/solicitacao_availability.py` como SSOT — os call-sites viraram burros.

**Quem é checado**: `COORDENADOR` + `FORMADOR` + `COORD_ACOMPANHA`, deduplicados por `usuario_id`.

- **`CONVIDADO` fica fora** — é audiência, não recurso alocado. Checá-lo estouraria a capacidade diária (RD-05) de quem é convidado a vários eventos no mesmo dia, bloqueando todos.
- **Gerente**: `Participation.Role` tem exatamente 4 valores e nenhum é `GERENTE` — "Gerente" é **função RBAC**, não papel de participação. Um gerente que participa é gravado como `COORDENADOR` ou `COORD_ACOMPANHA`, então já está coberto. Teste explícito.
- **Dedup é obrigatório**: o coordenador é sempre gravado como `COORDENADOR` e pode também vir em `formador_ids`. Sem dedup, as horas contariam 2x no RD-05 e um evento de 5h estouraria sozinho o limite de 8h/dia.

**A checagem roda depois de gravar as Participation**, dentro da mesma transação. O guard lê a **tabela**, não o payload — resolver o payload de novo no guard abriria espaço para checar pessoas diferentes das que foram salvas, que é exatamente a falha sendo fechada. Conflito desfaz o evento inteiro.

## Advisory lock — sem ele o fix é metade

`select_for_update` na aprovação tranca **a própria linha**. Duas solicitações distintas do mesmo formador trancam linhas **disjuntas**; cada uma lê a outra como `pendente`; e `pendente` é **invisível** para a checagem (que filtra `status=APROVADO`). **Ambas commitam.**

Fix: `pg_advisory_xact_lock(1452, usuario_id)`, ordem ASC fixa (evita deadlock quando duas solicitações compartilham participantes). A segunda transação espera a primeira e enxerga o evento recém-aprovado.

No `batch_approve`, revalidar item a item dentro da transação resolve o caso intra-lote de graça: a checagem da segunda já vê a primeira como aprovada.

## Cache era armadilha no enforcement

`check_conflicts` é `@cache_availability_check(timeout=300)`. A chave é montada de uma **whitelist fixa** (`v, usuario_id, inicio, fim, municipio_id`), mas o decorator repassava `**kwargs` à função **sem incluí-los na chave** — um `exclude_solicitacao_id` pelo caminho cacheado seria **poisoning silencioso**.

Split:

| Função | Uso |
|---|---|
| `check_conflicts` | consultivo/leitura, cacheado. **Assinatura pública inalterada** — não mexe em `views_availability.py:328,451` nem nos 6 testes de cache. |
| `check_conflicts_uncached` | enforcement, sempre do banco, aceita `exclude_solicitacao_id` |

O decorator agora **recusa** kwargs desconhecidos (`TypeError`) em vez de repassá-los silenciosamente.

`exclude_solicitacao_id` é aplicado **na origem da query**, não como filtro por `ref_id` depois: o conflito de capacidade diária (M) **não tem `ref_id`** e somaria as horas do próprio evento em dobro.

## Por que publish só registra

Publicar **não aloca nada** — o evento já está aprovado e ocupa a agenda desde então. Com o enforcement na criação e na aprovação, dois eventos aprovados conflitantes só existem em **dados anteriores a esta correção**. Bloquear a publicação deles puniria o operador por um evento que a instituição já assumiu. Então: `logger.warning` para o double-booking legado **aparecer** em vez de passar despercebido.

## Guest sem cadastro

`Participation` com `usuario=NULL` + `guest_email` é **fisicamente não-checável** (não tem `AvailabilityBlock`, não casa `Q(participations__usuario=)`). É pulado — mas **nunca em silêncio**: volta em `skipped_guests` + `logger.warning` (PA-05). E-mail que **resolve** para um Usuario é checado normalmente.

## Decisões de negócio (stakeholder, 2026-07-16)

- Conflito é **bloqueio duro**, sem override auditado. Vale para todos os fluxos, inclusive NAO_SUPER.
- Mensagem nomeia quem está alocado (RD-08): `"Bruno Formador ja esta alocado neste horario. Nao e possivel criar o evento."`

## Compatibilidade do payload de erro

`code: "availability_conflict"` e a chave `conflicts` (achatada) preservados. **Acrescenta** `blocked_participants` (atribuição por pessoa) e `skipped_guests`.

## Validação local

- [x] **Testes RED provados**: com o wiring removido via `git stash`, **6 dos 15 falham**; com o fix, **15/15 PASS**. Teste que nunca falhou não prova nada.
- [x] Suite completa: **2826 passed, 37 skipped, 0 failed** (`--ignore` do #1460, que aborta a coleta por bug pre-existente)
- [x] `pyright apps/core config`: **483 erros vs 487 na main** — nenhum erro novo
- [x] `black --check` / `isort --check-only` / `flake8`: limpos

### Cobertura dos testes (15)

Bug central (coordenador livre + formador ocupado) · rollback total · caso feliz · **adjacencia `fim == inicio`** (RD-01: encosto nao e sobreposicao) · COORD_ACOMPANHA checado · CONVIDADO fora · dedup coordenador-formador · guest reportado · update movendo para horario ocupado · update sem conflitar consigo mesmo · aprovacao revalidando conflito surgido depois · batch aprovando 1 de 2 conflitantes · cache recusando kwarg · uncached lendo do banco · exclusao no limite diario

## Staging Gate

- [x] `make staging-full` executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR (trecho de log contendo "ALL 8 CHECKS PASSED")

### Evidencia Staging Gate

```text
==============================================
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
==============================================
```

## Escopo

Este PR e a **regra** (backend). O feedback antecipado no wizard — conflito aparecer quando o coordenador seleciona formador + data — vem no **PR B (frontend)**. Nesta ordem de proposito: a UX sem a regra e decorativa (da para burlar chamando a API direto), e `checkAvailability()` ja existe em `api/availability.ts:112` sem nenhum call-site.

Closes #1452
