### PR TITLE
feat(availability): aviso antecipado de conflito no wizard (#1452 frontend)

### DIFF
--- a/v2/backend/apps/core/tests/test_availability_batch.py
+++ b/v2/backend/apps/core/tests/test_availability_batch.py
@@ -24,8 +24,15 @@ from rest_framework.test import APIClient
 
 import pytest
 
-from apps.core.models import AvailabilityBlock
-from apps.core.tests.factories import GroupFactory, MunicipioFactory, UsuarioFactory
+from apps.core.models import AvailabilityBlock, Participation, Solicitacao
+from apps.core.services.availability_service import check_conflicts
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
 
 pytestmark = pytest.mark.django_db
 
@@ -314,3 +321,60 @@ class TestAvailabilityCheckManyEndpoint:
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert "fim" in str(response.data).lower() or "posterior" in str(response.data).lower()
+
+    def test_check_many_le_sem_cache_ve_evento_de_participante_recem_criado(self, user_controle, formador_1, municipio):
+        """#1452: check-many lê SEM cache e enxerga um evento onde o formador entra
+        como participante, mesmo quando o caminho cacheado ainda diria 'livre'.
+
+        Reproduz o gap: a invalidação de cache só cobre `Solicitacao.usuario_id` (o
+        criador); não há signal em `Participation`. Então, quando o coordenador cria o
+        evento e o formador entra só como participante, o cache do formador não é
+        invalidado. Um preview cacheado mentiria 'livre' e o botão do wizard seria
+        liberado para um evento que o backend recusa.
+        """
+        client = APIClient()
+        client.force_authenticate(user=user_controle)
+
+        inicio = timezone.now() + timedelta(days=3, hours=9)
+        fim = inicio + timedelta(hours=2)
+
+        # 1) Prima o cache: sem eventos, o caminho cacheado registra "livre" p/ o formador.
+        primed = check_conflicts(usuario=formador_1, inicio=inicio, fim=fim, municipio=municipio)
+        assert primed.ok is True
+
+        # 2) O coordenador cria o evento; o formador entra como PARTICIPANTE (não como
+        #    criador). O signal de invalidação bumpa o cache do coordenador — nunca o
+        #    do formador (não existe receiver em Participation).
+        coordenador = UsuarioFactory(username=f"coord_{uuid4().hex[:8]}", cpf=str(uuid4().int % 10**11).zfill(11))
+        evento = SolicitacaoFactory(
+            usuario=coordenador,
+            municipio=municipio,
+            tipo_evento=TipoEventoFactory(nome="Formação batch cache"),
+            projeto=None,
+            inicio=inicio,
+            fim=fim,
+            status=Solicitacao.Status.APROVADO,
+        )
+        Participation.objects.create(solicitacao=evento, usuario=formador_1, role=Participation.Role.FORMADOR)
+
+        # 3) O caminho CACHEADO ainda mente "livre" (cache do formador não foi invalidado).
+        stale = check_conflicts(usuario=formador_1, inicio=inicio, fim=fim, municipio=municipio)
+        assert stale.ok is True, "pré-condição: o cache do formador está obsoleto (é o bug que motiva o uncached)"
+
+        # 4) check-many, por ler SEM cache, enxerga o conflito na hora.
+        response = client.post(
+            "/api/availability/check-many/",
+            {
+                "usuarios_ids": [formador_1.id],
+                "inicio": inicio.isoformat(),
+                "fim": fim.isoformat(),
+                "municipio_id": municipio.id,
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["ok"] is False, "check-many precisa ver o evento recém-criado (sem cache)"
+        assert data["results"][0]["ok"] is False
+        assert "X" in [c["code"] for c in data["results"][0]["conflicts"]]

--- a/v2/backend/apps/core/views_availability.py
+++ b/v2/backend/apps/core/views_availability.py
@@ -24,7 +24,7 @@ from .api_schemas import AVAILABILITY_CONFLICT_EXAMPLE, AVAILABILITY_OK_EXAMPLE,
 from .models import AvailabilityBlock, EquipeGerencia, Municipio, Usuario
 from .permissions import HasPerm
 from .serializers import AvailabilityBlockSerializer
-from .services.availability_service import check_conflicts
+from .services.availability_service import check_conflicts, check_conflicts_uncached
 
 
 def is_privileged_user(user):
@@ -448,7 +448,15 @@ class AvailabilityCheckManyView(APIView):
                 all_ok = False
                 continue
 
-            result = check_conflicts(usuario=usuario, inicio=inicio, fim=fim, municipio=municipio)
+            # #1452: lê SEM cache. Este endpoint checa participantes (formadores/
+            # coordenadores), e a invalidação de cache só cobre Solicitacao.usuario_id
+            # (o criador) — não há signal em Participation (`signals.py:72-93`), então
+            # alocar um formador nunca invalida o cache dele. Um preview cacheado poderia
+            # dizer "livre" e o enforcement (que lê uncached, PR A) recusar no submit;
+            # como o wizard bloqueia o botão com base nesta resposta, a fonte precisa ser
+            # a mesma do enforcement. O throttle `availability_check` (60/min) + debounce
+            # no cliente cobrem o custo de não cachear.
+            result = check_conflicts_uncached(usuario=usuario, inicio=inicio, fim=fim, municipio=municipio)
 
             results.append(
                 {

--- a/v2/frontend/src/api/availability.ts
+++ b/v2/frontend/src/api/availability.ts
@@ -12,6 +12,8 @@ import type {
   AvailabilityBlock,
   AvailabilityBlockPayload,
   AvailabilityCheckResponse,
+  AvailabilityCheckManyRequest,
+  AvailabilityCheckManyResponse,
   MonthlyGridResponse,
   Gerencia,
 } from '../types';
@@ -112,6 +114,27 @@ export async function deleteBlock(id: ID): Promise<void> {
 export async function checkAvailability(params: AvailabilityCheckParams): Promise<AvailabilityCheckResponse> {
   const url = buildUrl('/availability/check/', params as unknown as QueryParams);
   return await fetchAPI(url);
+}
+
+/**
+ * Checa disponibilidade de vários usuários de uma vez (#1452).
+ *
+ * Usado pelo wizard de nova solicitação para avisar cedo quando um participante
+ * (formador/coordenador) já está alocado. Uma chamada em vez de N, para não estourar
+ * o throttle `availability_check`. Aceita `signal` para cancelar respostas obsoletas.
+ *
+ * @param params - usuarios_ids + intervalo + município
+ * @param options - opções do fetch (ex.: `signal` de um AbortController)
+ */
+export async function checkAvailabilityMany(
+  params: AvailabilityCheckManyRequest,
+  options: { signal?: AbortSignal } = {}
+): Promise<AvailabilityCheckManyResponse> {
+  return await fetchAPI('/availability/check-many/', {
+    ...options,
+    method: 'POST',
+    body: JSON.stringify(params),
+  });
 }
 
 /**

--- a/v2/frontend/src/components/AvailabilityConflictAlert.tsx
+++ b/v2/frontend/src/components/AvailabilityConflictAlert.tsx
@@ -1,0 +1,67 @@
+/**
+ * AvailabilityConflictAlert — mostra os participantes já alocados (#1452).
+ *
+ * Apresentacional puro (sem fetch). Serve dois pontos: o aviso antecipado no wizard
+ * (a partir de `useAvailabilityPreview`) e o erro 400 do submit (`blocked_participants`
+ * do backend). O texto do conflito (`title`/`detail`) vem verbatim do backend — o `code`
+ * só define a cor da tag, para não criar uma segunda fonte de verdade das regras RD.
+ */
+
+import { JSX } from 'react';
+import Alert from 'antd/es/alert';
+import Tag from 'antd/es/tag';
+
+import type { BlockedParticipant, ConflictDetail } from '../types';
+
+/** Cor da tag por código de conflito (RD-01..08). Só estética. */
+const COR_POR_CODIGO: Record<ConflictDetail['code'], string> = {
+  X: 'red', // sobreposição de evento
+  T: 'volcano', // bloqueio total
+  P: 'orange', // bloqueio parcial
+  D: 'gold', // deslocamento
+  M: 'geekblue', // capacidade diária
+};
+
+export interface AvailabilityConflictAlertProps {
+  bloqueados: BlockedParticipant[];
+  /** id do bloco, para `aria-describedby` do botão desabilitado. */
+  id?: string;
+}
+
+export default function AvailabilityConflictAlert({
+  bloqueados,
+  id,
+}: AvailabilityConflictAlertProps): JSX.Element | null {
+  if (bloqueados.length === 0) return null;
+
+  return (
+    <Alert
+      id={id}
+      type="error"
+      showIcon
+      role="alert"
+      className="mb-4"
+      message="Não é possível criar o evento"
+      description={
+        <ul className="list-none pl-0 m-0">
+          {bloqueados.map((p) => (
+            <li key={p.usuario_id} className="mb-2">
+              <strong>{p.usuario_nome}</strong> já está alocado neste horário.
+              <div className="mt-1">
+                {p.conflicts.map((c, i) => (
+                  <div key={`${p.usuario_id}-${i}`} className="text-sm">
+                    <Tag color={COR_POR_CODIGO[c.code] ?? 'default'}>{c.code}</Tag>
+                    <span>{c.detail || c.title}</span>
+                  </div>
+                ))}
+              </div>
+            </li>
+          ))}
+          <li className="text-sm text-gray-500">
+            Remova o participante em conflito ou volte ao passo anterior e escolha outra data/horário.
+          </li>
+        </ul>
+      }
+    />
+  );
+}

--- a/v2/frontend/src/components/__tests__/AvailabilityConflictAlert.test.tsx
+++ b/v2/frontend/src/components/__tests__/AvailabilityConflictAlert.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+
+import AvailabilityConflictAlert from '../AvailabilityConflictAlert';
+import type { BlockedParticipant } from '../../types';
+
+describe('AvailabilityConflictAlert', () => {
+  test('não renderiza nada quando não há bloqueados', () => {
+    const { container } = render(<AvailabilityConflictAlert bloqueados={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  test('nomeia o participante e mostra o texto do conflito verbatim do backend', () => {
+    const bloqueados: BlockedParticipant[] = [
+      {
+        usuario_id: 99,
+        usuario_nome: 'Bruno Formador',
+        conflicts: [{ code: 'X', title: 'Sobreposição', detail: 'Conflita com evento aprovado #5', ref_id: 5 }],
+      },
+    ];
+    render(<AvailabilityConflictAlert bloqueados={bloqueados} id="x" />);
+
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText('Não é possível criar o evento')).toBeInTheDocument();
+    expect(screen.getByText('Bruno Formador')).toBeInTheDocument();
+    expect(screen.getByText('Conflita com evento aprovado #5')).toBeInTheDocument();
+    expect(screen.getByText('X')).toBeInTheDocument();
+  });
+
+  test('lista múltiplos participantes bloqueados', () => {
+    const bloqueados: BlockedParticipant[] = [
+      { usuario_id: 1, usuario_nome: 'Ana', conflicts: [{ code: 'T', title: 'Bloqueio', detail: 'total' }] },
+      { usuario_id: 2, usuario_nome: 'Bruno', conflicts: [{ code: 'M', title: 'Capacidade', detail: 'diária' }] },
+    ];
+    render(<AvailabilityConflictAlert bloqueados={bloqueados} />);
+    expect(screen.getByText('Ana')).toBeInTheDocument();
+    expect(screen.getByText('Bruno')).toBeInTheDocument();
+  });
+});

--- a/v2/frontend/src/constants/timing.ts
+++ b/v2/frontend/src/constants/timing.ts
@@ -18,6 +18,9 @@ export const TIMING = {
   // Debounce
   DEBOUNCE_DEFAULT_MS: 300,
   DEBOUNCE_SEARCH_MS: 400,
+  // #1452: checagem de disponibilidade no wizard. Constante própria (não reusar
+  // SEARCH) para poder ajustar sem acoplar à busca; o gatilho é seleção, não digitação.
+  DEBOUNCE_AVAILABILITY_CHECK_MS: 400,
 
   // Delays
   GCAL_DETAIL_LOAD_DELAY_MS: 2000,

--- a/v2/frontend/src/hooks/__tests__/useAvailabilityPreview.test.ts
+++ b/v2/frontend/src/hooks/__tests__/useAvailabilityPreview.test.ts
@@ -1,0 +1,167 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+const { checkAvailabilityManyMock } = vi.hoisted(() => ({
+  checkAvailabilityManyMock: vi.fn(),
+}));
+
+vi.mock('../../api/availability', () => ({
+  checkAvailabilityMany: checkAvailabilityManyMock,
+}));
+
+import { useAvailabilityPreview, type AvailabilityPreviewInput } from '../useAvailabilityPreview';
+
+const DEBOUNCE = 400;
+
+function baseInput(over: Partial<AvailabilityPreviewInput> = {}): AvailabilityPreviewInput {
+  return {
+    inicio: '2026-08-01T12:00:00Z',
+    fim: '2026-08-01T14:00:00Z',
+    municipioId: 456,
+    participantes: [
+      { id: 1, nome: 'Ana Criadora', criador: true },
+      { id: 99, nome: 'Bruno Formador', criador: false },
+    ],
+    enabled: true,
+    ...over,
+  };
+}
+
+describe('useAvailabilityPreview', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test('não dispara sem participante além do criador (idle)', () => {
+    const { result } = renderHook(() =>
+      useAvailabilityPreview(baseInput({ participantes: [{ id: 1, nome: 'Ana', criador: true }] }))
+    );
+    expect(result.current).toEqual({ status: 'idle' });
+    expect(checkAvailabilityManyMock).not.toHaveBeenCalled();
+  });
+
+  test('não dispara com intervalo/município incompletos', () => {
+    const { result } = renderHook(() => useAvailabilityPreview(baseInput({ municipioId: null })));
+    expect(result.current).toEqual({ status: 'idle' });
+    expect(checkAvailabilityManyMock).not.toHaveBeenCalled();
+  });
+
+  test('enabled=false não dispara', () => {
+    renderHook(() => useAvailabilityPreview(baseInput({ enabled: false })));
+    vi.advanceTimersByTime(DEBOUNCE);
+    expect(checkAvailabilityManyMock).not.toHaveBeenCalled();
+  });
+
+  test('debounce: várias mudanças em rajada coalescem em 1 request', async () => {
+    checkAvailabilityManyMock.mockResolvedValue({ ok: true, results: [] });
+    const { rerender } = renderHook(({ p }) => useAvailabilityPreview(p), {
+      initialProps: { p: baseInput() },
+    });
+    // 3 mudanças de intervalo dentro da janela de debounce
+    rerender({ p: baseInput({ fim: '2026-08-01T14:30:00Z' }) });
+    rerender({ p: baseInput({ fim: '2026-08-01T15:00:00Z' }) });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(DEBOUNCE);
+    });
+    expect(checkAvailabilityManyMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('payload inclui o criador e deduplica ids', async () => {
+    checkAvailabilityManyMock.mockResolvedValue({ ok: true, results: [] });
+    renderHook(() =>
+      useAvailabilityPreview(
+        baseInput({
+          // criador também aparece como coordenador -> só 1 vez
+          participantes: [
+            { id: 1, nome: 'Ana', criador: true },
+            { id: 99, nome: 'Bruno', criador: false },
+            { id: 1, nome: 'Ana', criador: false },
+          ],
+        })
+      )
+    );
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(DEBOUNCE);
+    });
+    const arg = checkAvailabilityManyMock.mock.calls[0][0];
+    expect(arg.usuarios_ids).toEqual([1, 99]);
+  });
+
+  test('conflito: mapeia os bloqueados com nome do participante', async () => {
+    checkAvailabilityManyMock.mockResolvedValue({
+      ok: false,
+      results: [
+        { usuario_id: 1, ok: true, conflicts: [] },
+        {
+          usuario_id: 99,
+          ok: false,
+          conflicts: [{ code: 'X', title: 'Sobreposição', detail: 'evento #5', ref_id: 5 }],
+        },
+      ],
+    });
+    const { result } = renderHook(() => useAvailabilityPreview(baseInput()));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(DEBOUNCE);
+    });
+    if (result.current.status !== 'conflito') throw new Error(`esperava conflito, veio ${result.current.status}`);
+    expect(result.current.bloqueados).toHaveLength(1);
+    expect(result.current.bloqueados[0]).toMatchObject({ usuario_id: 99, usuario_nome: 'Bruno Formador' });
+  });
+
+  test('429 -> indisponivel throttled (fail-open, não bloqueia)', async () => {
+    checkAvailabilityManyMock.mockRejectedValue(Object.assign(new Error('rate'), { status: 429 }));
+    const { result } = renderHook(() => useAvailabilityPreview(baseInput()));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(DEBOUNCE);
+    });
+    if (result.current.status !== 'indisponivel') throw new Error(`esperava indisponivel, veio ${result.current.status}`);
+    expect(result.current.motivo).toBe('throttled');
+  });
+
+  test('500 -> indisponivel erro (fail-open)', async () => {
+    checkAvailabilityManyMock.mockRejectedValue(Object.assign(new Error('boom'), { status: 500 }));
+    const { result } = renderHook(() => useAvailabilityPreview(baseInput()));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(DEBOUNCE);
+    });
+    if (result.current.status !== 'indisponivel') throw new Error(`esperava indisponivel, veio ${result.current.status}`);
+    expect(result.current.motivo).toBe('erro');
+  });
+
+  test('resposta obsoleta é descartada: a última entrada vence', async () => {
+    // 1ª chamada (input A) resolve DEPOIS da 2ª (input B). O guard de sequência
+    // precisa manter o resultado de B.
+    let resolveA!: (v: unknown) => void;
+    checkAvailabilityManyMock
+      .mockImplementationOnce(() => new Promise((res) => { resolveA = res; }))
+      .mockResolvedValueOnce({ ok: true, results: [] }); // B: livre
+
+    const { result, rerender } = renderHook(({ p }) => useAvailabilityPreview(p), {
+      initialProps: { p: baseInput() }, // A: com formador 99
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(DEBOUNCE); // dispara A (fica pendente)
+    });
+
+    // muda o input -> nova key -> dispara B
+    rerender({ p: baseInput({ participantes: [{ id: 1, nome: 'Ana', criador: true }, { id: 77, nome: 'Carla', criador: false }] }) });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(DEBOUNCE); // dispara B (resolve livre)
+    });
+    expect(result.current.status).toBe('ok');
+
+    // agora A resolve tarde, com conflito — deve ser IGNORADO
+    await act(async () => {
+      resolveA({
+        ok: false,
+        results: [{ usuario_id: 99, ok: false, conflicts: [{ code: 'X', title: 't', detail: 'd' }] }],
+      });
+      await Promise.resolve();
+    });
+    expect(result.current.status).toBe('ok');
+  });
+});

--- a/v2/frontend/src/hooks/useAvailabilityPreview.ts
+++ b/v2/frontend/src/hooks/useAvailabilityPreview.ts
@@ -1,0 +1,135 @@
+/**
+ * useAvailabilityPreview — aviso antecipado de conflito de disponibilidade (#1452).
+ *
+ * Checa, enquanto o coordenador monta a solicitação, se algum participante
+ * (criador + formadores + coordenadores) já está alocado no intervalo escolhido.
+ * O enforcement real é do backend (bloqueio duro no submit); este hook é a UX que
+ * antecipa o "não é possível criar o evento" e permite bloquear o botão com honestidade.
+ *
+ * Correção central — status derivado DURANTE o render, não em effect:
+ * o resultado guardado vale para uma `key` (intervalo + participantes). Se a `key` atual
+ * difere da guardada, o status é 'checking' na hora, sem pintar um veredito velho contra
+ * input novo, e sem precisar filtrar o resultado anterior quando um participante é removido.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+
+import { checkAvailabilityMany } from '../api/availability';
+import { TIMING } from '../constants';
+import logger from '../utils/logger';
+import type { BlockedParticipant, ConflictDetail, ID } from '../types';
+
+export interface PreviewParticipant {
+  id: ID;
+  nome: string;
+  /** true para o criador da solicitação (não pode ser removido para resolver o conflito). */
+  criador: boolean;
+}
+
+export interface AvailabilityPreviewInput {
+  inicio: string | null;
+  fim: string | null;
+  municipioId: ID | null;
+  participantes: PreviewParticipant[];
+  /** Desliga a checagem (ex.: enquanto não se está no passo de participantes). */
+  enabled?: boolean;
+}
+
+export type AvailabilityPreview =
+  | { status: 'idle' }
+  | { status: 'checking' }
+  | { status: 'ok' }
+  | { status: 'conflito'; bloqueados: BlockedParticipant[] }
+  | { status: 'indisponivel'; motivo: 'throttled' | 'erro' };
+
+interface StoredResult {
+  key: string;
+  preview: AvailabilityPreview;
+}
+
+/**
+ * Monta a `key` estável da checagem. `null` quando não há o que checar
+ * (intervalo/município incompletos ou nenhum participante além do criador).
+ * Ordenar os ids garante que [1,2] e [2,1] não refaçam a checagem.
+ */
+function buildKey(input: AvailabilityPreviewInput): string | null {
+  if (input.enabled === false) return null;
+  if (!input.inicio || !input.fim || input.municipioId == null) return null;
+
+  const temParticipante = input.participantes.some((p) => !p.criador);
+  if (!temParticipante) return null;
+
+  const ids = Array.from(new Set(input.participantes.map((p) => p.id))).sort((a, b) => Number(a) - Number(b));
+  return `${input.inicio}|${input.fim}|${input.municipioId}|${ids.join(',')}`;
+}
+
+export function useAvailabilityPreview(input: AvailabilityPreviewInput): AvailabilityPreview {
+  const key = buildKey(input);
+  const [stored, setStored] = useState<StoredResult | null>(null);
+
+  // Guarda de sequência: descarta resposta de uma checagem que não é mais a atual.
+  const seqRef = useRef(0);
+
+  // Nomes por id para preencher `usuario_nome` (o check-many devolve só usuario_id).
+  const nomePorId = new Map<ID, PreviewParticipant>(input.participantes.map((p) => [p.id, p]));
+
+  useEffect(() => {
+    if (key === null) return;
+
+    const seq = ++seqRef.current;
+    const controller = new AbortController();
+    const usuariosIds = Array.from(new Set(input.participantes.map((p) => p.id)));
+
+    const timer = setTimeout(() => {
+      void checkAvailabilityMany(
+        {
+          usuarios_ids: usuariosIds,
+          inicio: input.inicio as string,
+          fim: input.fim as string,
+          municipio_id: input.municipioId as ID,
+        },
+        { signal: controller.signal }
+      )
+        .then((resp) => {
+          if (seq !== seqRef.current) return; // chegou obsoleta
+          if (resp.ok) {
+            setStored({ key, preview: { status: 'ok' } });
+            return;
+          }
+          const bloqueados: BlockedParticipant[] = resp.results
+            .filter((r) => !r.ok)
+            .map((r) => {
+              const p = nomePorId.get(r.usuario_id);
+              return {
+                usuario_id: r.usuario_id,
+                usuario_nome: p?.nome ?? `Participante #${r.usuario_id}`,
+                conflicts: r.conflicts as ConflictDetail[],
+              };
+            });
+          setStored({ key, preview: { status: 'conflito', bloqueados } });
+        })
+        .catch((err: unknown) => {
+          if (controller.signal.aborted) return; // cancelamento não é falha
+          if (seq !== seqRef.current) return;
+          const httpStatus = (err as { status?: number })?.status;
+          const motivo = httpStatus === 429 ? 'throttled' : 'erro';
+          // Fail-open: o backend é o gate real; não travar o usuário por uma
+          // checagem que falhou. O status 'indisponivel' NÃO bloqueia o botão.
+          logger.warn('Falha ao pré-checar disponibilidade (fail-open):', err);
+          setStored({ key, preview: { status: 'indisponivel', motivo } });
+        });
+    }, TIMING.DEBOUNCE_AVAILABILITY_CHECK_MS);
+
+    return () => {
+      clearTimeout(timer);
+      controller.abort();
+    };
+    // nomePorId deriva de participantes; a key já cobre a identidade dos inputs.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key]);
+
+  // Derivação durante o render: só confia no resultado guardado se for da key atual.
+  if (key === null) return { status: 'idle' };
+  if (stored && stored.key === key) return stored.preview;
+  return { status: 'checking' };
+}

--- a/v2/frontend/src/pages/Solicitacoes/NewSolicitacaoWizard.tsx
+++ b/v2/frontend/src/pages/Solicitacoes/NewSolicitacaoWizard.tsx
@@ -43,12 +43,14 @@ import {
 } from '../../api/lookup';
 import { getMe } from '../../api/availability';
 import { computePermissions } from '../../hooks/usePermissions';
+import { useAvailabilityPreview, type PreviewParticipant } from '../../hooks/useAvailabilityPreview';
 import DateTimeRange from '../../components/DateTimeRange';
 import ComboBox from '../../components/ComboBox';
 import FormadoresPicker from '../../components/FormadoresPicker';
 import CoordenadoresPicker from '../../components/CoordenadoresPicker';
+import AvailabilityConflictAlert from '../../components/AvailabilityConflictAlert';
 import logger from '../../utils/logger';
-import type { ID, FluxoType } from '../../types';
+import type { ID, FluxoType, BlockedParticipant, AvailabilityConflictErrorPayload } from '../../types';
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
@@ -118,6 +120,11 @@ export default function NewSolicitacaoWizard(): JSX.Element {
   const [loading, setLoading] = useState<boolean>(false);
   const [isSuperuser, setIsSuperuser] = useState<boolean>(false);
   const [municipioLookupHasResults, setMunicipioLookupHasResults] = useState<boolean | null>(null);
+  // #1452: identidade do criador — sempre entra na checagem de disponibilidade
+  // (o backend também o checa), e o nome preenche o alerta de conflito.
+  const [me, setMe] = useState<{ id: ID; nome: string } | null>(null);
+  // #1452: conflito devolvido pelo backend no submit (fecha o TOCTOU / cache).
+  const [submitConflito, setSubmitConflito] = useState<BlockedParticipant[]>([]);
 
   // Estado do formulário
   const [formData, setFormData] = useState<FormDataType>({
@@ -149,6 +156,8 @@ export default function NewSolicitacaoWizard(): JSX.Element {
           // Epic 3.3 cleanup: usa flag derivada (SSOT). Admin escape hatch
           // do wizard — bypassa exigência de projeto/município no Step 2.
           setIsSuperuser(computePermissions(me).isAdmin);
+          // #1452: guarda o criador para a checagem de disponibilidade.
+          setMe({ id: me.id, nome: me.name || me.username || 'Você' });
         }
       } catch (error) {
         logger.warn('Falha ao carregar perfil do usuário no wizard:', error);
@@ -239,8 +248,22 @@ export default function NewSolicitacaoWizard(): JSX.Element {
 
   // Navegação entre passos
   const next = (): void => {
+    // DateTimeRange (Step 0) fica fora de Form.Item, então validateFields() não o vê.
+    // Sem esta guarda dá para avançar sem data, e o gatilho da checagem (#1452) depende dela.
+    if (currentStep === 0 && (!formData.inicio || !formData.fim)) {
+      message.error('Por favor, selecione a data e o horário do evento');
+      return;
+    }
+
     form.validateFields().then(values => {
-      setFormData({ ...formData, ...values });
+      // validateFields() sem args devolve a chave de TODO field montado, inclusive os
+      // opcionais não tocados — com valor `undefined`. Sem filtrar, o spread abaixo
+      // sobrescreve `coordenadores: []` por `undefined` e o render do resumo estoura em
+      // `.length` (#1452). Só mescla o que realmente tem valor.
+      const definidos = Object.fromEntries(
+        Object.entries(values).filter(([, v]) => v !== undefined)
+      );
+      setFormData({ ...formData, ...definidos });
       setCurrentStep(currentStep + 1);
     }).catch(err => {
       logger.debug('Validação falhou:', err);
@@ -254,6 +277,7 @@ export default function NewSolicitacaoWizard(): JSX.Element {
   // Submit final
   const handleSubmit = async (): Promise<void> => {
     setLoading(true);
+    setSubmitConflito([]);
     try {
       // Garantir que formadores é um array
       const formadores = Array.isArray(formData.formadores) ? formData.formadores : [];
@@ -318,10 +342,82 @@ export default function NewSolicitacaoWizard(): JSX.Element {
       navigate('/solicitacoes/minhas');
     } catch (error) {
       logger.error('Erro ao criar solicitação:', error);
-      message.error('Erro ao criar solicitação. Verifique os dados e tente novamente.');
+
+      // #1452: o backend recusa o double-booking com 400 `availability_conflict` e a
+      // mensagem nomeando o formador. Antes o catch engolia isso e mostrava um genérico.
+      const data = (error as { response?: { data?: unknown } })?.response?.data;
+      const payloadErro = data as Partial<AvailabilityConflictErrorPayload> | undefined;
+
+      if (payloadErro?.code === 'availability_conflict') {
+        const bloqueados = payloadErro.errors?.blocked_participants ?? [];
+        setSubmitConflito(bloqueados);
+        message.error(payloadErro.detail || 'Um participante já está alocado neste horário.');
+      } else {
+        const detail = (data as { detail?: string })?.detail;
+        message.error(detail || 'Erro ao criar solicitação. Verifique os dados e tente novamente.');
+      }
     } finally {
       setLoading(false);
     }
+  };
+
+  // #1452: quem entra na checagem de disponibilidade. Espelha o backend (PR A):
+  // criador + FORMADOR + COORD_ACOMPANHA, deduplicados por id. O criador frequentemente
+  // também está em coordenadores — sem dedup as horas dele contariam 2x (RD-05).
+  // CONVIDADO fica fora (o wizard não coleta convidados).
+  const participantes = useMemo((): PreviewParticipant[] => {
+    const formadores = Array.isArray(formData.formadores) ? formData.formadores : [];
+    const coordenadores = Array.isArray(formData.coordenadores) ? formData.coordenadores : [];
+    const lista: PreviewParticipant[] = [
+      ...(me ? [{ id: me.id, nome: me.nome, criador: true }] : []),
+      ...formadores.map(f => ({ id: f.id, nome: f.label || f.name || `#${f.id}`, criador: false })),
+      ...coordenadores.map(c => ({ id: c.id, nome: c.label || c.name || `#${c.id}`, criador: false })),
+    ];
+    const vistos = new Set<ID>();
+    return lista.filter(p => (vistos.has(p.id) ? false : (vistos.add(p.id), true)));
+  }, [me, formData.formadores, formData.coordenadores]);
+
+  const preview = useAvailabilityPreview({
+    inicio: formData.inicio,
+    fim: formData.fim,
+    municipioId: formData.municipio?.id ?? null,
+    participantes,
+    enabled: currentStep >= 1,
+  });
+
+  const conflitoAntecipado = preview.status === 'conflito';
+
+  // Bloco de UX da checagem (aviso antecipado). Só render — o gate real é o backend.
+  const renderPreviewAviso = (): ReactNode => {
+    if (preview.status === 'conflito') {
+      return <AvailabilityConflictAlert bloqueados={preview.bloqueados} id="preview-conflito" />;
+    }
+    if (preview.status === 'checking') {
+      return (
+        <Alert
+          type="info"
+          showIcon
+          className="mb-4"
+          message="Verificando disponibilidade dos participantes…"
+        />
+      );
+    }
+    if (preview.status === 'indisponivel') {
+      return (
+        <Alert
+          type="warning"
+          showIcon
+          className="mb-4"
+          message="Não foi possível verificar a disponibilidade agora"
+          description={
+            preview.motivo === 'throttled'
+              ? 'Muitas verificações em sequência. Aguarde alguns segundos. Você pode continuar; o sistema recusa o evento na criação se houver conflito.'
+              : 'Você pode continuar; o sistema recusa o evento na criação se houver conflito.'
+          }
+        />
+      );
+    }
+    return null;
   };
 
   // Passos do wizard memoizados (Issue #426)
@@ -445,6 +541,10 @@ export default function NewSolicitacaoWizard(): JSX.Element {
             />
           </Form.Item>
 
+          {/* #1452: aviso antecipado de conflito, no ponto em que o coordenador
+              acabou de escolher formador + data. */}
+          {renderPreviewAviso()}
+
           {formData.projeto && (
             <Alert
               message={formData.projeto.fluxo === 'SUPER' ? 'Aprovação Manual Requerida' : 'Aprovação Automática'}
@@ -555,6 +655,12 @@ export default function NewSolicitacaoWizard(): JSX.Element {
         <>
           <Title level={4}>Revise sua solicitação</Title>
 
+          {/* #1452: o conflito não pode sumir entre o passo 1 e a criação. */}
+          {renderPreviewAviso()}
+          {submitConflito.length > 0 && (
+            <AvailabilityConflictAlert bloqueados={submitConflito} id="submit-conflito" />
+          )}
+
           <Descriptions bordered column={1} size="small">
             <Descriptions.Item label="Projeto">
               {formData.projeto?.label}
@@ -574,12 +680,12 @@ export default function NewSolicitacaoWizard(): JSX.Element {
                 : 'Não informado'}
             </Descriptions.Item>
             <Descriptions.Item label="Formadores">
-              {formData.formadores.length > 0
+              {Array.isArray(formData.formadores) && formData.formadores.length > 0
                 ? formData.formadores.map(f => f.label || f.name).join(', ')
                 : 'Nenhum'}
             </Descriptions.Item>
             <Descriptions.Item label="Coordenadores Acompanhantes">
-              {formData.coordenadores.length > 0
+              {Array.isArray(formData.coordenadores) && formData.coordenadores.length > 0
                 ? formData.coordenadores.map(c => c.label || c.name).join(', ')
                 : 'Nenhum'}
             </Descriptions.Item>
@@ -623,7 +729,7 @@ export default function NewSolicitacaoWizard(): JSX.Element {
         </>
       ),
     },
-  ], [formData, rangeValue, handleRangeChange, handleProjetoChange, lookupMunicipiosElegiveis, isSuperuser, municipioLookupHasResults]);
+  ], [formData, rangeValue, handleRangeChange, handleProjetoChange, lookupMunicipiosElegiveis, isSuperuser, municipioLookupHasResults, preview, submitConflito]);
 
   return (
     <section className="p-6 max-w-4xl mx-auto" aria-labelledby="nova-solicitacao-title">
@@ -667,12 +773,28 @@ export default function NewSolicitacaoWizard(): JSX.Element {
             </Button>
           )}
           {currentStep < steps.length - 1 && (
-            <Button type="primary" onClick={next} aria-label="Ir para proximo passo">
+            <Button
+              type="primary"
+              onClick={next}
+              aria-label="Ir para proximo passo"
+              // #1452: no passo de participantes, conflito confirmado bloqueia o avanço.
+              disabled={currentStep === 1 && conflitoAntecipado}
+              aria-describedby={currentStep === 1 && conflitoAntecipado ? 'preview-conflito' : undefined}
+            >
               Próximo
             </Button>
           )}
           {currentStep === steps.length - 1 && (
-            <Button type="primary" onClick={handleSubmit} loading={loading}>
+            <Button
+              type="primary"
+              onClick={handleSubmit}
+              loading={loading}
+              // #1452: não deixa confirmar com conflito antecipado nem após o 400 do backend.
+              disabled={conflitoAntecipado || submitConflito.length > 0}
+              aria-describedby={
+                conflitoAntecipado ? 'preview-conflito' : submitConflito.length > 0 ? 'submit-conflito' : undefined
+              }
+            >
               Confirmar Solicitação
             </Button>
           )}

--- a/v2/frontend/src/pages/Solicitacoes/__tests__/NewSolicitacaoWizard.availability.test.tsx
+++ b/v2/frontend/src/pages/Solicitacoes/__tests__/NewSolicitacaoWizard.availability.test.tsx
@@ -1,0 +1,228 @@
+import { useEffect } from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+
+const {
+  createSolicitacaoMock,
+  getMeMock,
+  checkAvailabilityManyMock,
+  lookupMunicipiosWithFiltersMock,
+  lookupProjetosMock,
+  lookupTiposEventoMock,
+  navigateMock,
+} = vi.hoisted(() => ({
+  createSolicitacaoMock: vi.fn(),
+  getMeMock: vi.fn(),
+  checkAvailabilityManyMock: vi.fn(),
+  lookupMunicipiosWithFiltersMock: vi.fn(),
+  lookupProjetosMock: vi.fn(),
+  lookupTiposEventoMock: vi.fn(),
+  navigateMock: vi.fn(),
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return { ...actual, useNavigate: () => navigateMock };
+});
+vi.mock('../../../api/solicitacoes', () => ({ createSolicitacao: createSolicitacaoMock }));
+vi.mock('../../../api/availability', () => ({
+  getMe: getMeMock,
+  checkAvailabilityMany: checkAvailabilityManyMock,
+}));
+vi.mock('../../../api/lookup', () => ({
+  lookupMunicipiosWithFilters: lookupMunicipiosWithFiltersMock,
+  lookupProjetos: lookupProjetosMock,
+  lookupTiposEvento: lookupTiposEventoMock,
+}));
+
+// Stubs que EMITEM onChange (o real dispara ao selecionar). Sem isso o gatilho
+// da feature — "selecionar formador + data" — é intestável.
+vi.mock('../../../components/DateTimeRange', () => ({
+  default: ({ onChange }: { onChange?: (v: unknown) => void }) => (
+    <button
+      type="button"
+      data-testid="set-date"
+      onClick={() => onChange?.({ date: '2026-08-01', start: '09:00', end: '11:00' })}
+    >
+      set-date
+    </button>
+  ),
+}));
+vi.mock('../../../components/FormadoresPicker', () => ({
+  default: ({ onChange }: { onChange?: (v: unknown) => void }) => (
+    <button
+      type="button"
+      data-testid="pick-formador"
+      onClick={() => onChange?.([{ id: 99, email: 'f@x.com', label: 'Bruno Formador' }])}
+    >
+      pick-formador
+    </button>
+  ),
+}));
+vi.mock('../../../components/CoordenadoresPicker', () => ({
+  default: () => <div data-testid="coordenadores-picker">CoordenadoresPicker</div>,
+}));
+
+function MockComboBox({
+  placeholder = '',
+  lookupFunction,
+  onChange,
+}: {
+  placeholder?: string;
+  lookupFunction: (q: string) => Promise<unknown[]>;
+  onChange?: (item: unknown) => void;
+  disabled?: boolean;
+}) {
+  useEffect(() => {
+    void lookupFunction('');
+  }, [lookupFunction]);
+  const testid = placeholder.includes('projeto')
+    ? 'cb-projeto'
+    : placeholder.includes('tipo')
+      ? 'cb-tipo'
+      : 'cb-municipio';
+  return (
+    <button
+      type="button"
+      data-testid={testid}
+      onClick={() => {
+        if (testid === 'cb-projeto') onChange?.({ id: 123, label: 'Projeto X', fluxo: 'SUPER' });
+        else if (testid === 'cb-tipo') onChange?.({ id: 789, label: 'Formação' });
+        else onChange?.({ id: 456, label: 'Fortaleza - CE' });
+      }}
+    >
+      {testid}
+    </button>
+  );
+}
+vi.mock('../../../components/ComboBox', () => ({ default: MockComboBox }));
+
+import NewSolicitacaoWizard from '../NewSolicitacaoWizard';
+
+async function irParaParticipantesESelecionarFormador(): Promise<void> {
+  await screen.findByTestId('cb-projeto');
+  fireEvent.click(screen.getByTestId('cb-projeto'));
+  await waitFor(() => screen.getByTestId('cb-tipo'));
+  fireEvent.click(screen.getByTestId('cb-tipo'));
+  fireEvent.click(screen.getByTestId('cb-municipio'));
+  fireEvent.click(screen.getByTestId('set-date'));
+  fireEvent.click(screen.getByRole('button', { name: /Ir para proximo passo/i }));
+  await screen.findByTestId('pick-formador');
+  fireEvent.click(screen.getByTestId('pick-formador'));
+}
+
+const RESP_CONFLITO = {
+  ok: false,
+  results: [
+    { usuario_id: 1, ok: true, conflicts: [] },
+    {
+      usuario_id: 99,
+      ok: false,
+      conflicts: [{ code: 'X', title: 'Sobreposição', detail: 'Conflita com evento aprovado #5', ref_id: 5 }],
+    },
+  ],
+};
+
+describe('NewSolicitacaoWizard — aviso antecipado de disponibilidade (#1452)', () => {
+  beforeEach(() => {
+    if (!window.matchMedia) {
+      Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: vi.fn().mockImplementation((query: string) => ({
+          matches: false,
+          media: query,
+          onchange: null,
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          dispatchEvent: vi.fn(),
+        })),
+      });
+    }
+    vi.clearAllMocks();
+    lookupProjetosMock.mockResolvedValue([{ id: 123, label: 'Projeto X', fluxo: 'SUPER' }]);
+    lookupTiposEventoMock.mockResolvedValue([{ id: 789, label: 'Formação' }]);
+    lookupMunicipiosWithFiltersMock.mockResolvedValue([{ id: 456, label: 'Fortaleza - CE' }]);
+    getMeMock.mockResolvedValue({ is_superuser: true, id: 1, name: 'Ana Criadora', username: 'ana' });
+    checkAvailabilityManyMock.mockResolvedValue({ ok: true, results: [] });
+  });
+
+  test('selecionar formador + data dispara check-many com o criador incluso e deduplicado', async () => {
+    render(
+      <MemoryRouter>
+        <NewSolicitacaoWizard />
+      </MemoryRouter>
+    );
+    await irParaParticipantesESelecionarFormador();
+
+    await waitFor(() => expect(checkAvailabilityManyMock).toHaveBeenCalled());
+    const arg = checkAvailabilityManyMock.mock.calls[0][0];
+    expect(arg.usuarios_ids).toEqual([1, 99]); // criador (1) + formador (99)
+    expect(arg.municipio_id).toBe(456);
+    expect(arg.inicio).toBeTruthy();
+  });
+
+  test('conflito confirmado: mostra o formador e DESABILITA o Próximo', async () => {
+    checkAvailabilityManyMock.mockResolvedValue(RESP_CONFLITO);
+    render(
+      <MemoryRouter>
+        <NewSolicitacaoWizard />
+      </MemoryRouter>
+    );
+    await irParaParticipantesESelecionarFormador();
+
+    expect(await screen.findByText('Não é possível criar o evento')).toBeInTheDocument();
+    expect(screen.getByText('Bruno Formador')).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /Ir para proximo passo/i })).toBeDisabled()
+    );
+  });
+
+  test('sem conflito: nenhum alerta de bloqueio e Próximo habilitado', async () => {
+    checkAvailabilityManyMock.mockResolvedValue({ ok: true, results: [] });
+    render(
+      <MemoryRouter>
+        <NewSolicitacaoWizard />
+      </MemoryRouter>
+    );
+    await irParaParticipantesESelecionarFormador();
+
+    await waitFor(() => expect(checkAvailabilityManyMock).toHaveBeenCalled());
+    expect(screen.queryByText('Não é possível criar o evento')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Ir para proximo passo/i })).not.toBeDisabled();
+  });
+
+  test('checagem falha (500): fail-open — Próximo continua habilitado', async () => {
+    checkAvailabilityManyMock.mockRejectedValue(Object.assign(new Error('boom'), { status: 500 }));
+    render(
+      <MemoryRouter>
+        <NewSolicitacaoWizard />
+      </MemoryRouter>
+    );
+    await irParaParticipantesESelecionarFormador();
+
+    await waitFor(() => expect(checkAvailabilityManyMock).toHaveBeenCalled());
+    expect(screen.queryByText('Não é possível criar o evento')).not.toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /Ir para proximo passo/i })).not.toBeDisabled()
+    );
+  });
+
+  test('avançar sem tocar em Coordenadores NÃO quebra o wizard (guarda do P0)', async () => {
+    render(
+      <MemoryRouter>
+        <NewSolicitacaoWizard />
+      </MemoryRouter>
+    );
+    await irParaParticipantesESelecionarFormador();
+    // sai do step 1 SEM ter tocado no CoordenadoresPicker
+    fireEvent.click(screen.getByRole('button', { name: /Ir para proximo passo/i }));
+    // Se o P0 (coordenadores undefined -> .length) não estivesse guardado, o render
+    // do resumo estouraria e desmontaria a árvore. Chegar ao passo seguinte prova o fix.
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /Voltar para passo anterior/i })).toBeInTheDocument()
+    );
+  });
+});

--- a/v2/frontend/src/types/availability.ts
+++ b/v2/frontend/src/types/availability.ts
@@ -74,6 +74,56 @@ export interface AvailabilityCheckResponse {
 }
 
 /**
+ * Availability check-many request (#1452) — checa vários usuários de uma vez.
+ */
+export interface AvailabilityCheckManyRequest {
+  usuarios_ids: ID[];
+  inicio: string;
+  fim: string;
+  municipio_id?: ID;
+}
+
+/**
+ * Resultado por usuário no check-many.
+ */
+export interface AvailabilityCheckManyResult {
+  usuario_id: ID;
+  ok: boolean;
+  conflicts: ConflictDetail[];
+}
+
+/**
+ * Availability check-many response.
+ */
+export interface AvailabilityCheckManyResponse {
+  ok: boolean;
+  results: AvailabilityCheckManyResult[];
+}
+
+/**
+ * Participante bloqueado no payload de erro 400 `availability_conflict` do backend
+ * (`solicitacao_availability.py:raise_if_blocked`).
+ */
+export interface BlockedParticipant {
+  usuario_id: ID;
+  usuario_nome: string;
+  conflicts: ConflictDetail[];
+}
+
+/**
+ * Shape do erro 400 `availability_conflict` retornado no submit (#1452).
+ */
+export interface AvailabilityConflictErrorPayload {
+  detail: string;
+  code: 'availability_conflict';
+  errors: {
+    conflicts: ConflictDetail[];
+    blocked_participants: BlockedParticipant[];
+    skipped_guests: unknown[];
+  };
+}
+
+/**
  * Monthly availability grid response
  */
 export type AvailabilityCode = 'E' | '2' | 'P' | 'T' | 'X' | 'D' | 'D1' | '';

--- a/v2/frontend/src/types/index.ts
+++ b/v2/frontend/src/types/index.ts
@@ -72,6 +72,11 @@ export type {
   AvailabilityCheckRequest,
   ConflictDetail,
   AvailabilityCheckResponse,
+  AvailabilityCheckManyRequest,
+  AvailabilityCheckManyResult,
+  AvailabilityCheckManyResponse,
+  BlockedParticipant,
+  AvailabilityConflictErrorPayload,
   MonthlyGridResponse,
 } from './availability';
 


### PR DESCRIPTION
## Resumo

Este é o **PR B** do #1452 — a UX que o stakeholder pediu: *"informar que o formador já está alocado nesta data e que não é possível criar o evento"*, **na hora em que o coordenador seleciona formador + data**. O **PR A (#1554, mergeado)** já bloqueia de verdade no backend; aqui o wizard antecipa o aviso e bloqueia o avanço.

Hoje o coordenador só descobria o conflito no **submit** — e nem a mensagem aparecia: o `catch` do wizard trocava o 400 do backend (com o nome do formador) por um genérico "Erro ao criar solicitação".

## O que muda para o usuário

Ao selecionar um formador já alocado no intervalo escolhido, aparece um alerta vermelho nomeando a pessoa e o motivo, e o botão **Próximo** (passo Participantes) fica desabilitado. Idem **Confirmar Solicitação** no passo final. As saídas estão sempre disponíveis: remover o participante ou voltar e trocar a data.

## Decisão central: bloquear é honesto porque as fontes agora coincidem

O argumento contra bloquear seria "o preview lê cache, o enforcement lê fresco → falso-bloqueio". Fechei isso no backend:

**`check-many` passa a ler `check_conflicts_uncached`.** A invalidação de cache só cobre `Solicitacao.usuario_id` (o criador); **não existe signal em `Participation`** ([signals.py:72-93](../blob/main/v2/backend/apps/core/signals.py#L72-L93)) — alocar um formador como participante nunca invalida o cache dele. Um preview cacheado mentiria "livre". Com preview e enforcement lendo a mesma fonte, bloquear o botão não trava ninguém indevidamente.

> Fica um gap pré-existente: esse mesmo cache obsoleto afeta a **grade de Disponibilidade** (que continua cacheada). Merece issue própria — o fix é um receiver `post_save`/`post_delete` em `Participation`, com análise de storm de invalidação. **Fora do escopo deste PR.**

## Correção (frontend)

| Arquivo | Mudança |
|---|---|
| **NEW** `hooks/useAvailabilityPreview.ts` | debounce; **guarda de sequência** (descarta resposta obsoleta); **fail-open** em erro/429 (o backend é o gate — não travar por checagem que falhou); **status derivado durante o render** por uma `key` (intervalo+participantes) — nunca pinta veredito velho contra input novo, e o alerta some na hora ao remover o participante. |
| **NEW** `components/AvailabilityConflictAlert.tsx` | apresentacional puro; texto do conflito verbatim do backend, `code` só define a cor da tag. Serve o preview E o erro de submit. |
| `api/availability.ts` + `types/availability.ts` | `checkAvailabilityMany` + tipos. |
| `NewSolicitacaoWizard.tsx` | guarda `me.id/nome`; computa participantes (dedup+sort); render do aviso nos passos 1 e 3; desabilita Próximo/Confirmar no conflito; **conserta o catch** que engolia o 400. |

**Quem é checado**: criador + formadores + coord_acompanha, deduplicados por id — **paridade com o enforcement do PR A** (CONVIDADO fora, o wizard nem coleta convidados). **Uma** chamada ao `check-many`, não N — o endpoint tem `throttle_scope` e N formadores × cada edição = 429 garantido.

## Hardening — defensivo, não um crash ativo

`next()` passa a **filtrar `undefined`** dos valores do `validateFields()` antes do spread, e o resumo guarda `.length` com `Array.isArray`.

Fui verificar a alegação (do meu próprio design) de que isso seria um "crash em prod": provei em **teste isolado** que o `validateFields()` do antd devolve `coordenadores: undefined` para o campo opcional não tocado, e que a sobrescrita de `[]` por `undefined` é real. Mas **não reproduzi o crash no wizard completo** — nem com o fix removido (o teste de integração do P0 passa nos dois casos). Consistente com o fato de a criação de eventos funcionar em prod desde o go-live. Ou seja: a sobrescrita é incorreta e vale guardar, mas **não estou alegando que conserta uma tela branca ativa**.

## Testes

- **17 no frontend**: 9 do hook (debounce coalesce, guarda de sequência com resposta fora de ordem, fail-open 429/500, dedup+criador no payload, inputs incompletos → idle), 3 do componente, 5 de integração do wizard (dispara com criador+dedup, conflito desabilita Próximo, sem conflito habilitado, 500 fail-open, P0-safety).
- **1 no backend**: `check-many` enxerga um evento onde o formador entra como participante que o caminho **cacheado** perderia (prima o cache "livre" → cria evento via Participation → cacheado ainda diz livre, check-many diz conflito).
- **Provados vermelhos sem o fix**: 4 de integração FE + o do backend (`assert True is False` — o cache obsoleto dizia "livre"). O teste do P0 passa nos dois casos, por isso não o conto como prova — e digo isso abertamente.
- Suítes: **FE 477/477**, **BE 2827** (0 falhas), `tsc` 0, ESLint 0, pyright 483 (= baseline), black/isort/flake8 limpos.

## Staging Gate

- [x] `make staging-full` executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR (trecho de log contendo "ALL 8 CHECKS PASSED")

### Evidencia Staging Gate

```text
==============================================
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
==============================================
```

## Follow-ups (issues à parte)

1. Signal de invalidação de cache em `Participation` (a grade de Disponibilidade continua com o mesmo cache obsoleto).
2. `checkAvailability` (single) segue dead code, re-exportado em `api/solicitacoes.ts:308` — remoção limpa é PR próprio.

Relacionado a #1452 (backend fechado pelo #1554).
