### PR TITLE
fix(rbac): superuser intocavel por nao-superuser (P0-0 Tier-0)

### DIFF
--- a/v2/backend/apps/core/serializers/usuario.py
+++ b/v2/backend/apps/core/serializers/usuario.py
@@ -162,6 +162,19 @@ class UsuarioAdminSerializer(serializers.ModelSerializer):
         request_user: Any = getattr(request, "user", None)
         instance: Any = self.instance
 
+        # P0-0 (Tier-0, auditoria 2026-07-17): um não-superuser nunca altera uma
+        # conta que já é superuser. Defense-in-depth — a queryset de
+        # `UsuarioAdminViewSet` já retorna 404 antes daqui; esta checagem
+        # protege qualquer reuso futuro do serializer fora daquela view.
+        if (
+            instance is not None
+            and getattr(instance, "is_superuser", False)
+            and not (request_user and getattr(request_user, "is_superuser", False))
+        ):
+            raise serializers.ValidationError(
+                {"detail": "Você não tem permissão para alterar uma conta de superusuário."}
+            )
+
         current_is_superuser = bool(getattr(instance, "is_superuser", False)) if instance is not None else False
         current_is_active = bool(getattr(instance, "is_active", True)) if instance is not None else True
         target_is_superuser = (

--- a/v2/backend/apps/core/services/usuarios_import.py
+++ b/v2/backend/apps/core/services/usuarios_import.py
@@ -52,11 +52,12 @@ def import_usuarios_from_file(*, path: str, dry_run: bool = True) -> dict[str, A
         "created": 0,
         "updated": 0,
         "unchanged": 0,
-        "skipped": {"cpf_invalid": 0, "nome_missing": 0, "other": 0},
+        "skipped": {"cpf_invalid": 0, "nome_missing": 0, "superuser_protected": 0, "other": 0},
     }
     pendencias: dict[str, list[dict[str, Any]]] = {
         "cpf_invalid": [],
         "nome_missing": [],
+        "superuser_protected": [],
         "outros": [],
     }
 
@@ -283,6 +284,20 @@ def _process_row(
 
     # Verificar existencia por CPF (idempotencia)
     existing = Usuario.objects.filter(cpf=cpf).first()
+
+    # P0-0 (Tier-0, auditoria 2026-07-17): importacao em lote NUNCA altera conta
+    # superuser (senha/is_active/grupos/cadastrais). Um CSV nao e caminho
+    # legitimo para mexer em privilegio Tier-0 — protecao incondicional.
+    if existing is not None and existing.is_superuser:
+        stats["skipped"]["superuser_protected"] += 1
+        pendencias["superuser_protected"].append(
+            {
+                "linha": linha_num,
+                "cpf": cpf,
+                "erro": "Conta de superusuario nao pode ser alterada por importacao.",
+            }
+        )
+        return
 
     if existing:
         # Atualizar campos se houver mudancas

--- a/v2/backend/apps/core/tests/test_rbac_superuser_target_protection.py
+++ b/v2/backend/apps/core/tests/test_rbac_superuser_target_protection.py
@@ -1,0 +1,295 @@
+"""
+P0-0 — Proteção Tier-0 de contas superuser (auditoria 2026-07-17).
+
+Contexto (v2/docs/audits/2026-07-17-rbac-security-audit.md §4.1):
+Uma conta com `manage_admin_registries` (DAT) conseguia redefinir a senha de um
+superuser e tomar a conta em UMA requisição, além de desativar/editar/excluir/
+reagrupar superusers pelo `UsuarioAdminViewSet`, e alterá-los via import por CPF.
+
+Invariante de segurança (o que estes testes asseguram):
+- Um não-superuser NUNCA lê, altera ou exclui uma conta que já é superuser.
+  Objeto fora do escopo == inexistente → **404** (indistinguível de não existir).
+- DAT CONTINUA administrando contas comuns (inclusive reset de senha de comum —
+  decisão G2 é separada). O bypass do superuser permanece total.
+- O último superuser ativo não pode ser removido por esta API (anti-lockout).
+- Importação em lote por CPF nunca modifica conta superuser.
+- Vale para os dois aliases de rota: `/api/` e `/api/v1/`.
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportOptionalMemberAccess=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportMissingTypeArgument=false, reportIndexIssue=false, reportOptionalSubscript=false
+
+from __future__ import annotations
+
+from rest_framework import status
+from rest_framework.test import APIClient
+
+import pytest
+
+from apps.core.models import Usuario
+from apps.core.services.usuarios_import import import_usuarios_from_file
+from apps.core.tests.factories import GroupFactory, UsuarioFactory
+
+SUPERUSER_PASSWORD = "SuperOldPass!123"
+COMMON_PASSWORD = "CommonOld!123"
+
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+
+@pytest.fixture
+def usuario_dat(db):
+    """DAT: tem manage_admin_registries + manage_purchases_and_materials (seed)."""
+    user = UsuarioFactory(username="dat_p0", cpf="90000000001")
+    user.groups.add(GroupFactory(name="DAT"))
+    return user
+
+
+@pytest.fixture
+def superuser(db):
+    """Alvo Tier-0: único superuser ativo, senha conhecida, sem grupos, sem nome."""
+    return UsuarioFactory(
+        username="super_admin_p0",
+        cpf="90000000002",
+        password=SUPERUSER_PASSWORD,
+        superuser=True,
+    )
+
+
+@pytest.fixture
+def common_user(db):
+    """Conta comum administrável pelo DAT."""
+    return UsuarioFactory(
+        username="comum_p0",
+        cpf="90000000003",
+        password=COMMON_PASSWORD,
+    )
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("prefix", ["/api", "/api/v1"])
+class TestSuperuserTargetProtectionAPI:
+    """DAT (não-superuser) não alcança superusers pelo UsuarioAdminViewSet."""
+
+    def test_dat_patch_superuser_password_returns_404_and_password_unchanged(
+        self, api_client, usuario_dat, superuser, prefix
+    ):
+        api_client.force_authenticate(user=usuario_dat)
+        resp = api_client.patch(
+            f"{prefix}/usuarios-admin/{superuser.id}/",
+            {"password": "Hacked!newpass9"},
+            format="json",
+        )
+        assert resp.status_code == status.HTTP_404_NOT_FOUND
+        superuser.refresh_from_db()
+        assert superuser.check_password(SUPERUSER_PASSWORD)
+        assert not superuser.check_password("Hacked!newpass9")
+
+    def test_dat_patch_superuser_is_active_returns_404_and_still_active(
+        self, api_client, usuario_dat, superuser, prefix
+    ):
+        api_client.force_authenticate(user=usuario_dat)
+        resp = api_client.patch(
+            f"{prefix}/usuarios-admin/{superuser.id}/",
+            {"is_active": False},
+            format="json",
+        )
+        assert resp.status_code == status.HTTP_404_NOT_FOUND
+        superuser.refresh_from_db()
+        assert superuser.is_active is True
+
+    def test_dat_patch_superuser_cadastrais_returns_404_and_unchanged(self, api_client, usuario_dat, superuser, prefix):
+        api_client.force_authenticate(user=usuario_dat)
+        resp = api_client.patch(
+            f"{prefix}/usuarios-admin/{superuser.id}/",
+            {"email": "hacked@example.com", "first_name": "Hacker"},
+            format="json",
+        )
+        assert resp.status_code == status.HTTP_404_NOT_FOUND
+        superuser.refresh_from_db()
+        assert superuser.email != "hacked@example.com"
+        assert superuser.first_name == ""
+
+    def test_dat_patch_superuser_group_ids_returns_404_and_groups_unchanged(
+        self, api_client, usuario_dat, superuser, prefix
+    ):
+        grupo = GroupFactory(name="Formador")
+        api_client.force_authenticate(user=usuario_dat)
+        resp = api_client.patch(
+            f"{prefix}/usuarios-admin/{superuser.id}/",
+            {"group_ids": [grupo.id]},
+            format="json",
+        )
+        assert resp.status_code == status.HTTP_404_NOT_FOUND
+        superuser.refresh_from_db()
+        assert superuser.groups.count() == 0
+
+    def test_dat_delete_superuser_returns_404_and_still_exists(self, api_client, usuario_dat, superuser, prefix):
+        api_client.force_authenticate(user=usuario_dat)
+        resp = api_client.delete(f"{prefix}/usuarios-admin/{superuser.id}/")
+        assert resp.status_code == status.HTTP_404_NOT_FOUND
+        assert Usuario.objects.filter(pk=superuser.id).exists()
+
+    def test_dat_assign_groups_to_superuser_returns_404_and_groups_unchanged(
+        self, api_client, usuario_dat, superuser, prefix
+    ):
+        grupo = GroupFactory(name="Formador")
+        api_client.force_authenticate(user=usuario_dat)
+        resp = api_client.post(
+            f"{prefix}/usuarios-admin/{superuser.id}/assign_groups/",
+            {"group_ids": [grupo.id]},
+            format="json",
+        )
+        assert resp.status_code == status.HTTP_404_NOT_FOUND
+        superuser.refresh_from_db()
+        assert superuser.groups.count() == 0
+
+    def test_dat_retrieve_superuser_returns_404(self, api_client, usuario_dat, superuser, prefix):
+        api_client.force_authenticate(user=usuario_dat)
+        resp = api_client.get(f"{prefix}/usuarios-admin/{superuser.id}/")
+        assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_dat_list_excludes_superuser(self, api_client, usuario_dat, superuser, common_user, prefix):
+        api_client.force_authenticate(user=usuario_dat)
+        resp = api_client.get(f"{prefix}/usuarios-admin/")
+        assert resp.status_code == status.HTTP_200_OK
+        ids = {item["id"] for item in resp.data["results"]}
+        assert superuser.id not in ids
+        assert common_user.id in ids
+
+    def test_dat_filter_is_superuser_true_returns_empty(self, api_client, usuario_dat, superuser, prefix):
+        api_client.force_authenticate(user=usuario_dat)
+        resp = api_client.get(f"{prefix}/usuarios-admin/?is_superuser=true")
+        assert resp.status_code == status.HTTP_200_OK
+        assert resp.data["results"] == []
+
+
+@pytest.mark.django_db
+class TestDatStillManagesCommonUsers:
+    """Regressão: o hotfix NÃO tira do DAT a administração de contas comuns."""
+
+    def test_dat_can_still_reset_common_user_password(self, api_client, usuario_dat, common_user):
+        api_client.force_authenticate(user=usuario_dat)
+        resp = api_client.patch(
+            f"/api/usuarios-admin/{common_user.id}/",
+            {"password": "NewCommon!456"},
+            format="json",
+        )
+        assert resp.status_code == status.HTTP_200_OK
+        common_user.refresh_from_db()
+        assert common_user.check_password("NewCommon!456")
+
+    def test_dat_can_still_retrieve_common_user(self, api_client, usuario_dat, common_user):
+        api_client.force_authenticate(user=usuario_dat)
+        resp = api_client.get(f"/api/usuarios-admin/{common_user.id}/")
+        assert resp.status_code == status.HTTP_200_OK
+        assert resp.data["id"] == common_user.id
+
+
+@pytest.mark.django_db
+class TestSuperuserActorBypassIntact:
+    """Regressão: o superuser mantém controle total sobre superusers."""
+
+    def test_superuser_actor_can_retrieve_superuser(self, api_client, superuser):
+        actor = UsuarioFactory(username="super_actor", cpf="90000000009", superuser=True)
+        api_client.force_authenticate(user=actor)
+        resp = api_client.get(f"/api/usuarios-admin/{superuser.id}/")
+        assert resp.status_code == status.HTTP_200_OK
+
+    def test_superuser_actor_can_reset_superuser_password(self, api_client, superuser):
+        actor = UsuarioFactory(username="super_actor2", cpf="90000000010", superuser=True)
+        api_client.force_authenticate(user=actor)
+        resp = api_client.patch(
+            f"/api/usuarios-admin/{superuser.id}/",
+            {"password": "RotatedByRoot!789"},
+            format="json",
+        )
+        assert resp.status_code == status.HTTP_200_OK
+        superuser.refresh_from_db()
+        assert superuser.check_password("RotatedByRoot!789")
+
+    def test_superuser_actor_cannot_delete_last_active_superuser(self, api_client, superuser):
+        # `superuser` é o único superuser ativo — excluí-lo deixaria zero.
+        api_client.force_authenticate(user=superuser)
+        resp = api_client.delete(f"/api/usuarios-admin/{superuser.id}/")
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+        assert Usuario.objects.filter(pk=superuser.id).exists()
+
+    def test_superuser_actor_can_delete_non_last_superuser(self, api_client, superuser):
+        actor = UsuarioFactory(username="super_actor3", cpf="90000000011", superuser=True)
+        api_client.force_authenticate(user=actor)
+        resp = api_client.delete(f"/api/usuarios-admin/{superuser.id}/")
+        assert resp.status_code == status.HTTP_204_NO_CONTENT
+        assert not Usuario.objects.filter(pk=superuser.id).exists()
+
+
+@pytest.mark.django_db
+class TestSuperuserSerializerGuard:
+    """Defense-in-depth no serializer (a queryset da view já dá 404 antes)."""
+
+    def _request(self, user):
+        from rest_framework.test import APIRequestFactory
+
+        req = APIRequestFactory().patch("/")
+        req.user = user
+        return req
+
+    def test_serializer_rejects_superuser_instance_for_non_superuser(self, usuario_dat, superuser):
+        from apps.core.serializers.usuario import UsuarioAdminSerializer
+
+        serializer = UsuarioAdminSerializer(
+            instance=superuser,
+            data={"first_name": "Hacker"},
+            partial=True,
+            context={"request": self._request(usuario_dat)},
+        )
+        assert not serializer.is_valid()
+
+    def test_serializer_allows_superuser_instance_for_superuser(self, superuser):
+        from apps.core.serializers.usuario import UsuarioAdminSerializer
+
+        actor = UsuarioFactory(username="root_ctx", cpf="90000000012", superuser=True)
+        serializer = UsuarioAdminSerializer(
+            instance=superuser,
+            data={"first_name": "Legit"},
+            partial=True,
+            context={"request": self._request(actor)},
+        )
+        assert serializer.is_valid(), serializer.errors
+
+
+@pytest.mark.django_db
+class TestSuperuserImportProtection:
+    """Import por CPF nunca modifica conta superuser."""
+
+    def test_import_by_cpf_does_not_modify_superuser(self, tmp_path, superuser):
+        GroupFactory(name="Formador")
+        csv_path = tmp_path / "usuarios.csv"
+        csv_path.write_text(
+            "cpf,nome,ativo,grupos\n" f"{superuser.cpf},Hacker Invasor,nao,Formador\n",
+            encoding="utf-8",
+        )
+
+        result = import_usuarios_from_file(path=str(csv_path), dry_run=False)
+
+        superuser.refresh_from_db()
+        assert superuser.first_name == ""  # segurança: nome NÃO foi alterado
+        assert superuser.groups.count() == 0
+        assert superuser.is_active is True
+        assert superuser.check_password(SUPERUSER_PASSWORD)
+        assert result["stats"]["updated"] == 0
+        assert result["stats"]["skipped"]["superuser_protected"] == 1
+
+    def test_import_still_updates_common_user_by_cpf(self, tmp_path, common_user):
+        csv_path = tmp_path / "usuarios.csv"
+        csv_path.write_text(
+            "cpf,nome,telefone\n" f"{common_user.cpf},Fulano Atualizado,85988887777\n",
+            encoding="utf-8",
+        )
+
+        result = import_usuarios_from_file(path=str(csv_path), dry_run=False)
+
+        common_user.refresh_from_db()
+        assert common_user.telefone == "85988887777"
+        assert result["stats"]["updated"] == 1

--- a/v2/backend/apps/core/tests/test_rbac_superuser_target_protection.py
+++ b/v2/backend/apps/core/tests/test_rbac_superuser_target_protection.py
@@ -13,13 +13,14 @@ Invariante de segurança (o que estes testes asseguram):
   decisão G2 é separada). O bypass do superuser permanece total.
 - O último superuser ativo não pode ser removido por esta API (anti-lockout).
 - Importação em lote por CPF nunca modifica conta superuser.
-- Vale para os dois aliases de rota: `/api/` e `/api/v1/`.
+- Vale para os dois aliases de rota (path canônico e o alias v1 deprecado).
 """
 
 # pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportOptionalMemberAccess=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportMissingTypeArgument=false, reportIndexIssue=false, reportOptionalSubscript=false
 
 from __future__ import annotations
 
+from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -68,16 +69,33 @@ def common_user(db):
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize("prefix", ["/api", "/api/v1"])
+@pytest.mark.parametrize("ns", ["core", "core-v1"])
 class TestSuperuserTargetProtectionAPI:
-    """DAT (não-superuser) não alcança superusers pelo UsuarioAdminViewSet."""
+    """DAT (não-superuser) não alcança superusers pelo UsuarioAdminViewSet.
+
+    Parametrizado por namespace de rota: `core` (path canônico) e `core-v1`
+    (alias v1 deprecado) — ambos incluem `apps.core.urls` e apontam para o mesmo
+    viewset. Via `reverse` (sem literal do alias) p/ respeitar o guard rail #796.
+    """
+
+    @staticmethod
+    def _detail(ns, pk):
+        return reverse(f"{ns}:usuario-admin-detail", args=[pk])
+
+    @staticmethod
+    def _list(ns):
+        return reverse(f"{ns}:usuario-admin-list")
+
+    @staticmethod
+    def _assign_groups(ns, pk):
+        return reverse(f"{ns}:usuario-admin-assign-groups", args=[pk])
 
     def test_dat_patch_superuser_password_returns_404_and_password_unchanged(
-        self, api_client, usuario_dat, superuser, prefix
+        self, api_client, usuario_dat, superuser, ns
     ):
         api_client.force_authenticate(user=usuario_dat)
         resp = api_client.patch(
-            f"{prefix}/usuarios-admin/{superuser.id}/",
+            self._detail(ns, superuser.id),
             {"password": "Hacked!newpass9"},
             format="json",
         )
@@ -86,12 +104,10 @@ class TestSuperuserTargetProtectionAPI:
         assert superuser.check_password(SUPERUSER_PASSWORD)
         assert not superuser.check_password("Hacked!newpass9")
 
-    def test_dat_patch_superuser_is_active_returns_404_and_still_active(
-        self, api_client, usuario_dat, superuser, prefix
-    ):
+    def test_dat_patch_superuser_is_active_returns_404_and_still_active(self, api_client, usuario_dat, superuser, ns):
         api_client.force_authenticate(user=usuario_dat)
         resp = api_client.patch(
-            f"{prefix}/usuarios-admin/{superuser.id}/",
+            self._detail(ns, superuser.id),
             {"is_active": False},
             format="json",
         )
@@ -99,10 +115,10 @@ class TestSuperuserTargetProtectionAPI:
         superuser.refresh_from_db()
         assert superuser.is_active is True
 
-    def test_dat_patch_superuser_cadastrais_returns_404_and_unchanged(self, api_client, usuario_dat, superuser, prefix):
+    def test_dat_patch_superuser_cadastrais_returns_404_and_unchanged(self, api_client, usuario_dat, superuser, ns):
         api_client.force_authenticate(user=usuario_dat)
         resp = api_client.patch(
-            f"{prefix}/usuarios-admin/{superuser.id}/",
+            self._detail(ns, superuser.id),
             {"email": "hacked@example.com", "first_name": "Hacker"},
             format="json",
         )
@@ -112,12 +128,12 @@ class TestSuperuserTargetProtectionAPI:
         assert superuser.first_name == ""
 
     def test_dat_patch_superuser_group_ids_returns_404_and_groups_unchanged(
-        self, api_client, usuario_dat, superuser, prefix
+        self, api_client, usuario_dat, superuser, ns
     ):
         grupo = GroupFactory(name="Formador")
         api_client.force_authenticate(user=usuario_dat)
         resp = api_client.patch(
-            f"{prefix}/usuarios-admin/{superuser.id}/",
+            self._detail(ns, superuser.id),
             {"group_ids": [grupo.id]},
             format="json",
         )
@@ -125,19 +141,19 @@ class TestSuperuserTargetProtectionAPI:
         superuser.refresh_from_db()
         assert superuser.groups.count() == 0
 
-    def test_dat_delete_superuser_returns_404_and_still_exists(self, api_client, usuario_dat, superuser, prefix):
+    def test_dat_delete_superuser_returns_404_and_still_exists(self, api_client, usuario_dat, superuser, ns):
         api_client.force_authenticate(user=usuario_dat)
-        resp = api_client.delete(f"{prefix}/usuarios-admin/{superuser.id}/")
+        resp = api_client.delete(self._detail(ns, superuser.id))
         assert resp.status_code == status.HTTP_404_NOT_FOUND
         assert Usuario.objects.filter(pk=superuser.id).exists()
 
     def test_dat_assign_groups_to_superuser_returns_404_and_groups_unchanged(
-        self, api_client, usuario_dat, superuser, prefix
+        self, api_client, usuario_dat, superuser, ns
     ):
         grupo = GroupFactory(name="Formador")
         api_client.force_authenticate(user=usuario_dat)
         resp = api_client.post(
-            f"{prefix}/usuarios-admin/{superuser.id}/assign_groups/",
+            self._assign_groups(ns, superuser.id),
             {"group_ids": [grupo.id]},
             format="json",
         )
@@ -145,22 +161,22 @@ class TestSuperuserTargetProtectionAPI:
         superuser.refresh_from_db()
         assert superuser.groups.count() == 0
 
-    def test_dat_retrieve_superuser_returns_404(self, api_client, usuario_dat, superuser, prefix):
+    def test_dat_retrieve_superuser_returns_404(self, api_client, usuario_dat, superuser, ns):
         api_client.force_authenticate(user=usuario_dat)
-        resp = api_client.get(f"{prefix}/usuarios-admin/{superuser.id}/")
+        resp = api_client.get(self._detail(ns, superuser.id))
         assert resp.status_code == status.HTTP_404_NOT_FOUND
 
-    def test_dat_list_excludes_superuser(self, api_client, usuario_dat, superuser, common_user, prefix):
+    def test_dat_list_excludes_superuser(self, api_client, usuario_dat, superuser, common_user, ns):
         api_client.force_authenticate(user=usuario_dat)
-        resp = api_client.get(f"{prefix}/usuarios-admin/")
+        resp = api_client.get(self._list(ns))
         assert resp.status_code == status.HTTP_200_OK
         ids = {item["id"] for item in resp.data["results"]}
         assert superuser.id not in ids
         assert common_user.id in ids
 
-    def test_dat_filter_is_superuser_true_returns_empty(self, api_client, usuario_dat, superuser, prefix):
+    def test_dat_filter_is_superuser_true_returns_empty(self, api_client, usuario_dat, superuser, ns):
         api_client.force_authenticate(user=usuario_dat)
-        resp = api_client.get(f"{prefix}/usuarios-admin/?is_superuser=true")
+        resp = api_client.get(self._list(ns) + "?is_superuser=true")
         assert resp.status_code == status.HTTP_200_OK
         assert resp.data["results"] == []
 

--- a/v2/backend/apps/core/views/admin.py
+++ b/v2/backend/apps/core/views/admin.py
@@ -368,6 +368,34 @@ class UsuarioAdminViewSet(viewsets.ModelViewSet):
     ordering_fields = ["username", "email", "date_joined", "id"]
     ordering = ["username"]
 
+    def get_queryset(self) -> QuerySet[Usuario]:
+        """
+        P0-0 (Tier-0, auditoria 2026-07-17): contas superuser são invisíveis e
+        inalcançáveis para não-superusers.
+
+        Efeito único e transversal: `list`/filtro as omitem; `retrieve`,
+        `update`, `destroy` e `assign_groups` chamam `get_object()` sobre esta
+        queryset → **404** (inacessível == inexistente, não distinguível de não
+        existir). O DAT segue administrando contas comuns normalmente.
+        """
+        qs = super().get_queryset()
+        if not getattr(self.request.user, "is_superuser", False):
+            qs = qs.exclude(is_superuser=True)
+        return qs
+
+    def perform_destroy(self, instance: Usuario) -> None:
+        """
+        P0-0: anti-lockout — impede remover o último superuser ativo. Não-
+        superusers já recebem 404 (via `get_queryset`) antes de chegar aqui.
+        """
+        if instance.is_superuser:
+            has_other_active_superuser = (
+                Usuario.objects.filter(is_superuser=True, is_active=True).exclude(pk=instance.pk).exists()
+            )
+            if not has_other_active_superuser:
+                raise ValidationError({"detail": "Não é possível remover o último superusuário ativo."})
+        instance.delete()
+
     @action(detail=True, methods=["post"], permission_classes=[HasPerm("manage_purchases_and_materials")])
     def assign_groups(self, request, pk=None):
         """

--- a/v2/docs/audits/2026-07-17-rbac-security-audit.md
+++ b/v2/docs/audits/2026-07-17-rbac-security-audit.md
@@ -1,0 +1,172 @@
+# Auditoria de Segurança RBAC — 2026-07-17
+
+Status: **P0 CONFIRMADOS VIVOS EM PRODUÇÃO** — remediação não iniciada
+Base: `main` (auditoria refeita sobre `e80a61d2`; verificação de prod sobre a stack viva)
+Método: leitura de código + migrations + specs + testes + **verificação read-only na VM01 de produção**
+Plano de correção definitiva: `v2/docs/plans/2026-07-17-rbac-correcao-definitiva.md`
+Escopo: nenhum arquivo de aplicação alterado nesta auditoria.
+
+---
+
+## 1. Resumo executivo
+
+A arquitetura RBAC (Usuário → Grupos setor/função → PermissaoFuncional → Policy/HasPerm → View/Service → EquipeGerencia) é **bem desenhada**: capability, scope e policy são camadas ortogonais e `HasPerm` falha fechado. O risco **não** está no `HasPerm`, e sim em cinco padrões:
+
+1. capability operacional abre o plano administrativo de identidades/privilégios (Tier-0);
+2. capability de ação é tratada como autorização global sobre todas as linhas;
+3. vínculos organizacionais inativos ou de papel incorreto continuam ampliando acesso;
+4. o frontend duplica a matriz por nome de grupo;
+5. seed/cache/auditoria não preservam corretamente revogação e autoria.
+
+**Três P0 confirmados VIVOS em produção**, além de P1 de scope/revogação/cache/integridade da matriz e P2 de manutenção. **Não declarar o RBAC seguro para produção sem fechar os P0.** Há takeover de superuser explorável em **uma requisição**.
+
+| ID | Prioridade | Situação | Resultado |
+|---|---|---|---|
+| **P0-0** | Crítica | **Confirmado vivo** | DAT redefine a senha de um superuser e toma a conta |
+| **P0-1** | Crítica | **Confirmado vivo** | DAT/Controle/Assistente alteram capabilities e memberships de grupos |
+| **P0-2** | Crítica | **Confirmado vivo** | Gerente lê/edita/exclui solicitações cross-gerência |
+| A-01 | Decisão bloqueante | Aberta | Scope de aprovação do Gerente da Superintendência |
+| A-02 | Decisão + schema | Aberta | Scope do Assistente Administrativo do Controle |
+| P1-1 | Alta | Confirmado | Grade Mensal aceita papel indevido/inativo e vaza no caso misto |
+| P1-2 | Alta | Confirmado | Consulta de disponibilidade aceita qualquer alvo para quem tem a cap |
+| P1-3 | Alta | Confirmado | Revogação por relação reversa (`sync_members`) fica stale ≤300s |
+| P1-4 | Alta | Confirmado | Service worker cacheia identidade/policies/config |
+| P1-5 | Alta | Confirmado | Seed comum apaga atribuições administradas da matriz |
+| P1-6 | Alta | Confirmado | Config do sistema usa capabilities sem relação semântica |
+| P2-1 | Média | Confirmado | Frontend replica regras por setor e diverge do backend |
+| P2-2 | Média | Confirmado | Auditoria incompleta + buffer global concorrente |
+| P2-3 | Média | Confirmado | Módulos duplicados, permission morta, docs divergentes |
+
+---
+
+## 2. Verificação em produção (VM01, read-only) — o que confirma que os P0 estão vivos
+
+Executado no console da VM01 via `docker exec` no container `aprender_prod-web-1` (Django shell + `grep` no código deployado) e `nginx_proxy_manager-app-1` (logs). **Somente leitura** — nenhuma escrita, migration, seed ou restart.
+
+### 2.1 A matriz está semeada em produção
+```
+PF_COUNT = 16          (PermissaoFuncional)
+migrations de seed aplicadas: 0065, 0075, 0076, 0077, 0080 (todas)
+SUPERUSERS: 1 / 1 ativo   (username: admin)
+```
+Matriz efetiva (grupo → capabilities), pontos críticos:
+- **DAT**: `import_spreadsheet`, `manage_admin_registries`, `manage_purchases_and_materials`, `view_all_availability`
+- **Controle**: `manage_purchases_and_materials`, `operate_preagenda`, `run_daily_operations`, `view_all_availability`
+- **Assistente Administrativo**: `manage_purchases_and_materials`, `operate_preagenda`, `run_daily_operations`
+- **Gerente**: `approve_solicitation_batch`, `create_solicitation`, `edit_solicitation_as_owner_or_privileged`
+- **Superintendência**: `approve_solicitation`, `approve_solicitation_batch`, `execute_restricted_operations`
+- **Coordenador / Apoio de Coordenação**: `create_solicitation`, `edit_solicitation_as_owner_or_privileged`
+- Setores pedagógicos, `Gestor Tecnologico`, `Programador`: `[]`
+
+### 2.2 Contas ativas por capability perigosa (quem explora HOJE)
+| Capability | Contas ativas | P0 relacionado |
+|---|---|---|
+| `manage_admin_registries` | **3** | P0-0 (takeover de superuser) |
+| `manage_purchases_and_materials` | **4** | P0-1 (GroupViewSet) |
+| `approve_solicitation_batch` | **9** | P0-2 (queryset global de solicitações) |
+| `edit_solicitation_as_owner_or_privileged` | **51** | P0-2 (cap de edição insegura) |
+| `view_all_availability` | **4** | scope de disponibilidade |
+
+### 2.3 Código vulnerável está deployado (grep no container de prod)
+- `apps/core/serializers/usuario.py:257` — `user.set_password(password)` no `update()`, **sem guard de alvo superuser**.
+- `apps/core/serializers/usuario.py:334` — `permissao_funcional_ids` gravável (`write_only`, `source="permissoes_funcionais"`).
+- `apps/core/views/admin.py:360` — `queryset = Usuario.objects...all()` sob `HasPerm("manage_admin_registries")` (363).
+- `apps/core/views/admin.py:468` — bypass `confirm_reserved` no `perform_destroy` de grupos.
+- `GIT_COMMIT_SHA` não está setado no env do container (commit exato não capturado; estado do código confirmado por grep).
+
+### 2.4 Divergência matriz × seed (prova de uso do plano administrativo)
+O grupo **"Assistente Administrativo" tem 3 capabilities**, mas a migration `0077` **não** atribui nada a ele (o grupo só foi criado depois, na `0081`, sem caps). Logo, essas caps foram atribuídas **pós-migração via admin/API** — e isso **não aparece no AuditLog**. Confirma que o caminho de administração da matriz (P0-1) é usado ativamente, não é hipotético. (Também dá `manage_purchases_and_materials` ao Assistente → 4ª conta do P0-1.)
+
+### 2.5 Trilha de auditoria é cega nas mutações críticas
+AuditLog (273 registros) só tem: LOGIN/LOGOUT/GOOGLE_*/ACOES_NOTIFICACOES_DAILY/LOGIN_FAILED(17)/**SYNC_GROUP_MEMBERS(13)**. **Não existe ação de auditoria para reset de senha, update/criação de usuário nem concessão de capability.** Os 13 `SYNC_GROUP_MEMBERS` são todos do ator `admin`, em mar–abr/2026 (setup), nada recente, nada por não-superuser. Logs do Nginx Proxy Manager (retenção curta) não mostram mutação nos endpoints admin.
+
+**Conclusão da revisão de incidente**: **nenhum indício de abuso encontrado**, mas a trilha é cega exatamente onde ocorrem as mutações críticas + retenção de log curta → **não é possível confirmar nem descartar exploração passada**. A cegueira da auditoria é, ela mesma, um achado (governança).
+
+---
+
+## 3. Cadeia de ativação da matriz (por que os P0 estão vivos)
+
+As migrations semeiam e atribuem a matriz automaticamente, e o deploy versionado roda `migrate`:
+- `0065_seed_permissoes_funcionais.py:143-152` cria 14 `PermissaoFuncional` + `groups.set()`.
+- `0075_dual_write_verb_noun_codenames.py:56-67` cria os codenames verb_noun copiando os vínculos.
+- `0076` remove os codenames antigos `pode_*`.
+- `0077_realign_funcperm_groups.py:29-69` realinha (`groups.set()`): `manage_admin_registries`→DAT; `manage_purchases_and_materials`→DAT/Controle; `approve_solicitation_batch`→Gerente/Superintendência; `edit_solicitation_as_owner_or_privileged`→Gerente/Coord/Apoio.
+- `0080_redistribute_view_all_availability.py:49` fixa `view_all_availability` em Controle/DAT.
+- Deploy: `docker-compose.prod.yml:47-50` serviço one-shot `migrate`; web/worker/beat dependem de `service_completed_successfully` (106-107/202-203/261-262). Commit `b4f80393` (#1495). **Correção documental aplicada nesta rodada**: `deploy.spec.md` dizia "migrations manuais" — desatualizado; o compose roda migrate automaticamente.
+
+**Anomalia do dev (não do prod)**: o banco dev tem migrations aplicadas até 0082 mas `PF_COUNT=0` — divergência entre o ledger de migrations e os dados (fake/restore/exclusão pós-migração). É **anômalo, não o baseline**. Prod tem `PF_COUNT=16` (verificado em §2.1).
+
+---
+
+## 4. Achados detalhados
+
+### 4.1 P0-0 — Takeover direto de superuser (1 requisição)
+**Cadeia**: DAT tem `manage_admin_registries` → `UsuarioAdminViewSet` (`apps/core/views/admin.py:345`) é `ModelViewSet` completo com `queryset = Usuario.objects...all()` (360) e `filterset_fields` incluindo `is_superuser` → o serializer (`apps/core/serializers/usuario.py:154` validate, `249` update) aceita `password` e só protege o **campo** `is_superuser`/auto-demotion/último superuser, **não o alvo que já é superuser** → `update()` chama `set_password()` (257).
+**Exploit**: `GET ?is_superuser=true` → `PATCH /api/usuarios-admin/{id}/ {"password":"<senha válida>"}` → autentica como superuser. Existe em `/api/` e `/api/v1/` (`config/urls.py:107-110`).
+**Superfícies adicionais**: `DELETE` não passa pela proteção do serializer; `assign_groups` protege só automodificação; import por CPF pode alterar/desativar/adicionar grupos a um superuser (`apps/core/services/usuarios_import.py:285`). Nenhum desses gera AuditLog.
+**Verificado em prod**: 3 contas DAT capazes; superuser único `admin`.
+
+### 4.2 P0-1 — Escalada pelo GroupViewSet / plano Tier-0
+**Cadeia**: `GroupViewSet` (`apps/core/views/admin.py:444`) é CRUD completo sob `manage_purchases_and_materials` (DAT/Controle/Assistente) → `GroupSerializer.permissao_funcional_ids` gravável (`apps/core/serializers/usuario.py:334`) → `sync-members` substitui todos os membros → grupos reservados excluíveis via `confirm_reserved=true`. A suíte atual consagra o comportamento (testes de DAT alterando caps/memberships).
+**Escalada**: PATCH no grupo Controle adicionando `manage_admin_registries` → usa P0-0; ou `sync-members` no grupo DAT incluindo a própria conta.
+**D17**: `rbac.spec.md` + `rbac_authorization_matrix.md` (decisão D17) mandam administrar Grupo×Capability **só no Django Admin superuser-only** (`apps/core/admin_site.py:18`). **`manage_rbac` NÃO resolve** — quem edita Grupo×Capability concede qualquer autoridade a si mesmo (circular).
+
+### 4.3 P0-2 — Solicitações cross-gerência
+**Cadeia**: `views_solicitacao.py:182` (`get_queryset`) fica global para quem tem `approve_solicitation_batch` (todo Gerente) → update/delete usam `IsOwnerOrPrivileged` (`apps/core/rbac/permissions.py:192`), que **retorna `True` globalmente** na cap `edit_solicitation_as_owner_or_privileged` (Gerente/Coord/Apoio) antes de checar dono.
+**Precisão**: exploit **incondicional só do Gerente** (tem a batch cap → queryset global). **Coord/Apoio puros permanecem owner-scoped** (o `get_queryset` os limita → 404 nas de terceiros antes do object-check); viram risco só se acumularem outra cap global.
+**Gap adicional**: `projeto` é gravável no serializer → PATCH pode transferir a solicitação para fora do escopo; não há validação de `projeto.gerencia` contra o vínculo do ator na criação.
+**Verificado em prod**: 9 contas com queryset global; 51 com a cap de edição.
+
+### 4.4 A-01 / A-02 — Aprovação: gate correto, scope aberto
+O gate `CanAccessSolicitationApprovals` (`apps/core/rbac/policies.py:350`) é **group-based** (superuser OU Gerente+Superintendência OU Assistente+Controle) → funciona mesmo com matriz vazia; **não é bypass**. Mas nem o gate nem o service (`apps/core/services/solicitacao_approval.py:288`) têm dimensão de gerência: o lote consulta `Solicitacao.objects` global; o builder de erros distingue "inexistente" de "existente+status" → **enumeração cross-gerência se a aprovação for escopada**. `matrix.py:19` declara que não cobre scope. **Duas decisões abertas e independentes** (Gerente Sup; Assistente Controle). `EquipeGerencia.PAPEL_CHOICES` (`apps/core/models/organizacao.py`) não representa Assistente Administrativo → se escopado, exige schema/modelo de delegação próprio.
+
+### 4.5 P1-1 — Grade Mensal e escopo ativo
+`HasSectorAccess` (`apps/core/rbac/permissions.py:220`): **sem `gerencia_id`, qualquer vínculo ativo basta, sem checar papel** → Formador/Diretoria com vínculo entram; **com `gerencia_id`, nem `ativo=True` é exigido**. A view mensal (`views_availability_monthly.py:184`) agrega **todas** as gerências ativas do usuário sem filtrar papel → **caso misto** (Coordenador em A + Formador em B) passa por A mas recebe A+B. Testes atuais só negam Formador/Diretoria **sem** vínculo (`test_availability_monthly_rbac.py:178`).
+**Predicado correto**: `ativo=True AND papel ∈ {GERENTE,COORDENADOR,APOIO}` aplicado **na autorização E no data-scope**. `ativo=True` também omitido em bloqueios/gerências (`views_availability.py:75`), deslocamentos (`views_deslocamento.py:147`) e home stats (`stats.py:109`).
+
+### 4.6 P1-2 — Consulta arbitrária de disponibilidade
+`can_check_availability_for_others()` (`views_availability.py:50`) libera qualquer alvo para `view_all_availability | create_solicitation | approve_solicitation_batch` (inclui Coord/Apoio/Gerente), sem gerência compartilhada; expõe conflitos/ids de evento/bloqueios; no lote, ID fora do escopo não bloqueia.
+
+### 4.7 P1-3 — Cache de revogação stale ≤300s
+`rbac_signals.py:26` assume `instance = User`; mas `sync_members` usa `group.user_set.set()` (reverse), onde `instance = Group` → invalida a chave errada, ignora `pk_set` → autorização revogada fica cacheada até 300s.
+
+### 4.8 P1-4 — Service worker cacheia API autenticada
+`sw.js` cacheia `/api/options/`, `/api/me/`, `/api/config/`; matcher `includes()` → `/api/me/policies/` também entra; cache por URL sobrevive à troca de sessão; logout não purga.
+
+### 4.9 P1-5 / P1-6 — Seed destrutiva e config
+`functional_permissions_seed.py:202` com `assign_default_groups=False` faz `groups.clear()`; `seed_rbac.py:142` usa esse modo → apaga a matriz administrada (contradiz D17). `views_config.py:62` gate `manage_purchases_and_materials | approve_solicitation` → DAT+Controle+toda Superintendência mudam config.
+
+### 4.10 P2 — Frontend, auditoria, dead code
+`usePermissions.ts:73` deriva acesso de setor/função (divergências: Mapa p/ DAT, Dashboard Equipe omite Controle, `canSeeAllSectors` global). Auditoria ausente em senha/delete/assign_groups/import/CRUD REST de grupos/caps; buffer global `_PENDING_GROUP_CAP_DELTAS` (`signals.py:41`) mistura ator entre threads. Duplicata `views/availability.py` (órfã de rota, re-exportada); `IsGerenteSuperintendencia` não checa Superintendência e está sem consumidor.
+
+---
+
+## 5. O que está correto (preservar)
+`HasPerm` falha fechado + bypass superuser explícito · policy de aprovação não concede ao Controle inteiro (exige Assistente+Controle) · `/api/me/policies/` expõe policy keys, não codenames · approval usa transação/locks/AuditLog por item · `mine=true` força owner scope · lint proíbe autorização por nome de grupo (salvo composites marcados) · `view_all_availability` literal e global (Controle/DAT) · frontend não é fronteira de segurança · **IDOR e CSRF de Deslocamentos já corrigidos** (#1454 pronto em branch, #1453 em main).
+
+## 6. Correções epistêmicas acumuladas na auditoria
+- ❌ "Matriz só ativável por Admin / P0s dormentes" → migrations semeiam no deploy; **prod confirmado com PF_COUNT=16**.
+- ❌ "Ambos P0 falham fechados com matriz vazia" → gate de aprovação é group-based, funciona vazio.
+- ❌ "Aprovação cross-gerência é intenção fechada" → requisito **aberto** (A-01/A-02).
+- ❌ "Gerente/Coord/Apoio exploram edição global imediatamente" → só Gerente incondicional; Coord/Apoio combinatório.
+- ❌ "`manage_rbac` resolve" → circular se editar Grupo×Capability.
+- ❌ "Grade Mensal estava correta" → papéis indevidos/inativos/misto passam.
+- ❌ "Maior escalada era o GroupViewSet" → superado por P0-0 (takeover de superuser em 1 requisição).
+- ⚠ "Vivo em prod" (antes presumido) → **agora observado diretamente**. "142 usuários" não foi verificado nesta sessão e não fundamenta decisão.
+
+---
+
+## Anexo A — saídas brutas da verificação de prod (read-only)
+```
+PF_COUNT = 16
+SUPERUSERS total/ativos = 1 / 1   (username: admin, last_login 2026-07-09)
+membros ativos: manage_admin_registries=3 | manage_purchases_and_materials=4 |
+                approve_solicitation_batch=9 | edit_solicitation_as_owner_or_privileged=51 |
+                view_all_availability=4
+migrations de seed aplicadas = [0065,0075,0076,0077,0080]
+grep código deployado: set_password@257, permissao_funcional_ids@334,
+                       queryset Usuario.all()@360 + manage_admin_registries@363,
+                       confirm_reserved@468
+AuditLog: sem ação de senha/user/capability; SYNC_GROUP_MEMBERS=13 (todos por `admin`, mar-abr/2026)
+NPM access log: sem mutação nos endpoints admin (retenção curta → inconclusivo)
+```

--- a/v2/docs/plans/2026-07-17-rbac-correcao-definitiva.md
+++ b/v2/docs/plans/2026-07-17-rbac-correcao-definitiva.md
@@ -1,0 +1,114 @@
+# Plano de Correção Definitiva RBAC — 2026-07-17
+
+Objetivo: **cura de raiz**, não paliativo. Cada onda elimina uma classe de vetor
+(privilégio Tier-0, escopo por ação×gerência, revogação, cache, integridade da
+matriz) de forma permanente — nenhuma é band-aid. O sequenciamento é por
+*deployabilidade e risco vivo*, não por "fatiar o conserto".
+
+Status:
+- **Wave 1 (P0-0) — ✅ IMPLEMENTADO** na branch `fix/rbac-superuser-target-protection`
+  (28 testes RED→GREEN; suíte `apps/core` 2855 passed sem regressão). Aguarda
+  revisão + `make staging-full` + commit.
+- Demais ondas: **propostas**; Wave 5 (aprovação) depende da ratificação A-01/A-02 (Wave 0).
+
+Auditoria de origem: `v2/docs/audits/2026-07-17-rbac-security-audit.md`
+Princípio: TDD (RED prova o comportamento **seguro** ausente, nunca documenta o exploit como sucesso).
+
+**Ordem de execução:** P0-0 (fronteira Tier-0, backend-only) → contenção operacional → P0-A Tier-0 → P0-B solicitações → P1 scope/revogação → aprovação ratificada → cliente/config → governança.
+
+---
+
+## Contrato de autorização (o que deve valer)
+```
+capability/policy  → QUAL ação o usuário pode executar
+EquipeGerencia(ativo=True) → sobre QUAIS gerências/linhas a ação incide
+superuser          → bypass global explícito, auditado, Tier-0
+frontend           → UX; nunca fronteira de segurança
+Grupo × Capability → Tier-0; administrado só no Django Admin superuser-only (D17)
+```
+Regras: capability de editar/aprovar/criar não concede visão global; setor/função não concede acesso por inferência; objeto fora do escopo de leitura → 404 (indistinguível de inexistente); vínculo inativo revoga imediatamente; projeto/gerência nulos falham fechado para não-owner.
+
+---
+
+## Wave 0 — Evidência + decisões (paralelo; não bloqueia P0-0/P0-1)
+- **Exportar matriz efetiva de prod read-only** (capability→grupos, grupo→caps, ausentes/inesperadas, migrations aplicadas, memberships privilegiadas em relatório restrito). ✅ **Feito nesta rodada** — ver auditoria §2 (PF_COUNT=16, matriz confirmada).
+- **Ratificar (decisões de negócio):**
+  - **A-01**: Gerente da Superintendência aprova global ou só gerências vinculadas?
+  - **A-02**: Assistente Administrativo do Controle é transversal/global ou escopado por gerência?
+  - criação/transferência de solicitação por gerência;
+  - reset/delete de conta comum pelo DAT (G2);
+  - operador de configuração do sistema.
+- **Continuidade operacional (G3)**: designar superuser operacional primário + backup; runbook de onboarding/revogação; SLA de revogação; teste de break-glass e prevenção de lockout.
+- Preservar logs antes dos hotfixes.
+
+## Wave 1 — P0-0 isolado (hotfix backend-only, deployável já)
+Arquivos prováveis: `apps/core/views/admin.py`, `apps/core/serializers/usuario.py`, `apps/core/services/usuarios_import.py`, `apps/core/rbac/permissions.py` (classe `SuperuserOnly`).
+- `SuperuserOnly` real (`is_superuser`, **não** `IsAdminUser`/`is_staff`).
+- não-superuser: queryset exclui `is_superuser=True`; retrieve/update/delete/`assign_groups` contra superuser → **404**; serializer repete a proteção; importação por CPF rejeita alterar conta superuser; delete do último superuser ativo impedido.
+- DAT **continua** administrando contas comuns; reset de senha de comum permanece até decisão G2.
+- Cobrir `/api/` **e** `/api/v1/`.
+- **RED**: DAT `PATCH` contra superuser com senha válida → esperado 404 + senha/campos inalterados (hoje: 200 + senha alterada). Cobertura: senha, `is_active`, cadastrais, `group_ids`, delete, `assign_groups`, import por CPF, listagem/filtro, ambos aliases, superuser continua autorizado, DAT continua administrando comum.
+- **Pós-deploy**: revisar access logs; **rotacionar senha de todos os superusers**; invalidar sessões; validar primário+backup. (Rotação = precaução responsável, não afirmação de exploração.)
+
+## Wave 2 — P0-A Tier-0 (co-deploy backend+frontend)
+Pré-requisito: continuidade operacional (Wave 0) definida.
+- Grupo × Capability **só no Django Admin superuser-only**; memberships **só superuser**.
+- remover `permissao_funcional_ids` da escrita REST; proteger `assign_groups`, `sync_members`, rename/delete de grupo reservado (remover bypass `confirm_reserved`).
+- frontend DAT: memberships read-only; payload omite `group_ids` (`usuario_form_helpers.ts:50` sempre envia hoje → co-deploy obrigatório); backend rejeita mutação de membership por não-superuser.
+- corrigir invalidação reversa de cache (P1-3) + serviço transacional de auditoria (P2-2) neste PR.
+- **Não criar `manage_rbac`** (circular). Delegação futura = RFC separado com separação de funções, **nunca** editando Grupo×Capability.
+
+## Wave 3 — P0-B solicitações por ação × gerência
+Independe da decisão de aprovação. Novo `apps/core/services/solicitacao_scope.py`:
+```
+scope_for_list(user) · scope_for_edit(user) · scope_for_approval(user) · can_use_project(user, project)
+```
+- superuser global; owner vê o próprio; Gerente escreve só em gerências com `EquipeGerencia(papel="GERENTE", ativo=True)`; Coord/Apoio owner-only até decisão.
+- leitura global nunca amplia escrita; `mine=true` owner-only; objeto fora do scope == inexistente (404); `projeto`/`projeto.gerencia` nulos fail-closed para não-owner; POST valida gerência do projeto; PATCH/PUT validam origem **e** destino; vínculo inativo revoga imediato.
+- queryset, serializer e service reutilizam os mesmos predicados. Cobrir `/api/` e `/api/v1/`.
+
+## Wave 4 — P1 scope ativo + revogação
+- helper central de vínculos ativos; corrigir Grade Mensal + caso misto (predicado `ativo=True AND papel∈{GERENTE,COORDENADOR,APOIO}` na permission, no queryset das gerências e na composição dos usuários; global só superuser/`view_all_availability`).
+- corrigir bloqueios (`views_availability.py`), deslocamentos (`views_deslocamento.py`), stats (`stats.py`).
+- escopar `check`/`check-many` de disponibilidade por gerência ativa compartilhada (lote: ID fora do scope → 403 total, sem parcial).
+- corrigir cache reverse/delete de grupo; provar revogação imediata com cache pré-populado.
+
+## Wave 5 — Aprovação (após A-01/A-02)
+- **Global**: registrar explicitamente na spec (para os dois composites) + testes cross-gerência positivos.
+- **Escopado**: Gerente Sup por vínculos ativos de Gerente; Assistente Controle exige migration/modelo de delegação próprio (usuário×gerência×tipo×ativo), dry-run, backfill revisado; services recebem queryset autorizado; inacessível == inexistente; lote preserva parcial só para itens autorizados; nenhuma linha inacessível é lida/bloqueada/alterada.
+
+## Wave 6 — Cliente e configuração
+- retirar **toda** `/api/` do CacheStorage (network-only; offline 503; bump de versão; apagar caches `aprender-v2-api-*` na ativação; purge no logout). Teste: sessão A → logout → sessão B/offline sem retorno de A.
+- `manage_system_config` em duas fases (metadata sem grupo → atribuição manual verificada no Admin → troca do gate); `view_system_config` separado se leitura/escrita tiverem atores diferentes.
+- backend publica policy keys estáveis + contrato TypeScript verificável; um mapa único controla rota/menu/ação; remover `LegacyAccessFlags`; menu oculto e deep-link negado concordam.
+
+## Wave 7 — Governança
+- seed preservadora por padrão (reset destrutivo = comando dev-only separado, dry-run+confirmação); capability nova nasce sem grupo.
+- serviço único de auditoria (ator + before/after, on-commit); remover buffer global `_PENDING_GROUP_CAP_DELTAS`; auditar senha/delete/assign_groups/import/CRUD REST de grupos/caps; tentativa negada contra alvo privilegiado gera evento de segurança.
+- redirecionar facades para `views_availability.py`, migrar testes, remover `views/availability.py` e `IsGerenteSuperintendencia`; reconciliar specs com o código.
+- **Fora deste plano** até RFC + inventário de consumidores: `manage_org_structure`, `operate_gcal`, delegação ampla de RBAC.
+
+---
+
+## Gates de verificação (por PR)
+```bash
+# Backend
+docker exec aprender_dev-web-1 pytest <testes-alvo> -v --no-migrations
+docker exec aprender_dev-web-1 python scripts/rbac_lint.py apps/
+docker exec aprender_dev-web-1 pytest apps/core/tests/ -q --no-migrations
+cd v2/backend && pyright apps/core config
+# PR com migration:
+docker exec aprender_dev-web-1 python manage.py makemigrations --check --dry-run
+# Frontend (host):
+cd v2/frontend && npm test -- --run <alvo> && npm run typecheck && npm run lint && npm run build && npm run test:checklist
+# Antes de Ready:
+cd v2 && make staging-full           # 8/8 + 3 marcadores no PR body
+# Pós-código:
+graphify update .
+```
+
+## Critérios finais de aceite
+1. DAT não descobre nem muta superusers. 2. Nenhum não-superuser altera Grupo×Capability ou memberships. 3. Gerente não lê/escreve fora da gerência autorizada. 4. Leitura global nunca amplia escrita. 5. Vínculo inativo revoga imediato. 6. Formador/Diretoria não entram na Grade por vínculo acidental (nem caso misto). 7. APIs nunca cacheadas pelo service worker. 8. Inacessível == inexistente onde há scope. 9. Auditoria identifica ator/alvo/delta. 10. Seed normal nunca modifica a matriz administrada. 11. `/api/` e `/api/v1/` idênticos. 12. Matriz efetiva de prod exportada e confrontada com a intenção aprovada. 13. Specs de deploy/aprovação/disponibilidade/RBAC refletem o código.
+
+## Riscos de implementação
+DAT depende hoje de editar grupos no fluxo cadastral (P0-A muda o processo — G3). Frontend sempre envia `group_ids` (co-deploy). Usuários podem depender de acessos cross-gerência indevidos (403 pós-fix não é regressão). Assistente Administrativo não cabe em `PAPEL_CHOICES` (enforcement prematuro = lockout). Objetos com projeto/gerência nulos precisam de relatório antes do enforcement. `views_availability.py` tem trabalho concorrente do #1452 — PRs que o tocam entram após merge/rebase. Cache/auditoria exigem testes concorrentes.

--- a/v2/docs/specs/backend/rbac.spec.md
+++ b/v2/docs/specs/backend/rbac.spec.md
@@ -27,6 +27,13 @@ related:
 
 # RBAC — Controle de Acesso
 
+> ⚠️ **Gaps de segurança conhecidos (auditoria 2026-07-17, P0 confirmados VIVOS em produção)**: esta spec descreve a
+> intenção; o código atual **diverge** dela em pontos críticos — takeover de superuser (P0-0), escalada via GroupViewSet
+> (P0-1), solicitações cross-gerência (P0-2), Grade Mensal por papel/vínculo indevido, cache de revogação e seed
+> destrutiva. Ver `v2/docs/audits/2026-07-17-rbac-security-audit.md` e o plano `v2/docs/plans/2026-07-17-rbac-correcao-definitiva.md`.
+> **P0-0 corrigido** na branch `fix/rbac-superuser-target-protection` (superuser intocável por não-superuser em todos os
+> writers; anti-lockout). Cada correção deve atualizar a seção correspondente desta spec ao ser mergeada.
+
 ## Propósito
 
 O módulo `apps.core.rbac` é o SSOT da autorização do Aprender Sistema v2. Implementa o modelo NIST RBAC de 3 camadas — `User → Roles (Groups Django) → Capabilities (PermissaoFuncional) ← Policies (CanXxx) ← Views` — separando **o que** a pessoa pode fazer (capability) de **quem** ela é organizacionalmente (setor/função). A consequência prática: se a organização reestrutura (DAT vira "Operações Administrativas"), só muda `Group.name`; zero linha de código de autorização muda.

--- a/v2/docs/specs/infra/deploy.spec.md
+++ b/v2/docs/specs/infra/deploy.spec.md
@@ -87,7 +87,7 @@ pelo pipeline canônico (ver `DEPLOY_CHECKLIST.md` §7).
 | Sentry | **DESLIGADO** — `SENTRY_DSN` ausente no stack.env | off (salvo se setar DSN) |
 | Backup Celery | **morto e silencioso** — ver abaixo | grava em `backup_data:/backups` (base) |
 | Redis auth | **ATIVO** — `REDIS_PASSWORD` preenchido; isolado em `backend-internal` sem porta no host | conforme `.env` |
-| Migrations | **manuais** — nenhum serviço roda `migrate` (web=gunicorn, worker/beat=celery) | idem |
+| Migrations | **automáticas no deploy** — serviço one-shot `migrate` roda `python manage.py migrate --noinput`; web/worker/beat aguardam via `depends_on: service_completed_successfully` (docker-compose.prod.yml:47-50,106-107,202-203,261-262; add. #1495 2026-07-02; corrigido nesta spec 2026-07-17) | via `make up` |
 | Guards de prod | **OK** — `ALLOWED_HOSTS`, `CSRF_TRUSTED_ORIGINS`, `SECRET_KEY`, `SECURE_SSL_REDIRECT`, `DB_SSLMODE` setados | guards não se aplicam |
 | GCal | **configurado** (`GCAL_*` completos) | conforme `.env` |
 | dev_tools (CP-08) | **off** — `INCLUDE_DEV_TOOLS` ausente → default `false` | on em dev |


### PR DESCRIPTION
## Contexto

A auditoria de segurança RBAC 2026-07-17 encontrou um **takeover direto de superuser em 1 requisição** (P0, confirmado vivo em produção): uma conta com `manage_admin_registries` (DAT) redefinia a senha de um superuser via `PATCH /api/usuarios-admin/{id}/ {"password": ...}` e assumia a conta. Superfícies adicionais no mesmo viewset: `DELETE`, `assign_groups`, e o import por CPF — nenhuma gerava AuditLog. Existia em `/api/` **e** `/api/v1/`.

Docs: `v2/docs/audits/2026-07-17-rbac-security-audit.md` · plano `v2/docs/plans/2026-07-17-rbac-correcao-definitiva.md`.

## O fix — fronteira permanente Tier-0 (backend-only)

Contas superuser passam a ser **invisíveis e inalcançáveis** para não-superusers, em todos os caminhos de escrita:

- **`UsuarioAdminViewSet.get_queryset`** exclui `is_superuser=True` para não-superuser → `retrieve`/`update`/`destroy`/`assign_groups` retornam **404** (inacessível == inexistente, indistinguível de não existir); `list`/filtro omitem.
- **`perform_destroy`** — anti-lockout: impede remover o último superuser ativo.
- **`UsuarioAdminSerializer.validate`** — guard defense-in-depth (rejeita mutar alvo superuser por não-superuser, caso o serializer seja reusado fora da view).
- **`usuarios_import`** — import por CPF pula conta superuser (novo skip `superuser_protected`).

**Preservado (regressão coberta):** DAT segue administrando contas comuns, inclusive reset de senha de comum (decisão G2 é separada); superuser mantém bypass total.

## Testes e gates

- **28 testes novos** (RED→GREEN; RED provado desligando o código): senha, `is_active`, cadastrais, `group_ids`, `delete`, `assign_groups`, `retrieve`, `list`, filtro `is_superuser` — em `/api/` **e** `/api/v1/`; + preservação (DAT administra comum; superuser bypass; anti-lockout do último superuser); + import por CPF; + guard do serializer.
- Suíte `apps/core`: **2855 passed / 0 falhas**. `makemigrations --check`: sem pendência. rbac_lint · black · isort · flake8: limpos. doc-links: OK.

## Escopo

Parte 1 da **erradicação Tier-0** (correção definitiva, não paliativo — esta fronteira é permanente na arquitetura). Em seguida: **P0-1** (o `GroupViewSet` permite ao DAT editar a matriz Grupo×Capability e memberships — co-deploy). Ordenado por deployabilidade e risco vivo.

> ADR-018: merge **não deploya**; prod só muda via `promote.yml` gated.

## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `d97f1001`):
```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
