### PR TITLE
ci(infra): destrava coleta pytest no dev + fecha false-greens do gate backend (#1460 #1459 #1458)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -541,6 +541,10 @@ jobs:
     - name: docker compose config -q (contrato de prod via template prod-like)
       run: |
         set -euo pipefail
+        # O compose usa `env_file: APP_ENV_FILE` e o template aponta para
+        # .env.prodlike.local (gitignored, ausente na CI). Materializa o .local a
+        # partir do .example — o mesmo fluxo do dev (`cp .example .local`).
+        cp v2/infra/.env.prodlike.example v2/infra/.env.prodlike.local
         docker compose \
           --env-file v2/infra/.env.prodlike.example \
           -f v2/infra/docker-compose.prod.yml \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -512,6 +512,41 @@ jobs:
               apps/core/tests/test_auth_backends.py
           '
 
+    - name: Validate prod-like env template boots under production guards (#1458)
+      # Reusa a imagem prod recem-buildada: roda `manage.py check` com o
+      # .env.prodlike.example. Se o template regredir e violar um guard de
+      # settings.py:64-95 (ENVIRONMENT=production), o boot aborta (exit 1) e
+      # este job [required] fica vermelho — pega o drift template<->guards (#2).
+      run: |
+        set -euo pipefail
+        # --entrypoint python pula o entrypoint.sh (que espera DB): o check so
+        # precisa importar settings (onde rodam os guards de producao), nao conectar.
+        docker run --rm --entrypoint python \
+          --env-file v2/infra/.env.prodlike.example \
+          aprender-backend:ci-parity-${{ github.sha }} \
+          manage.py check
+
+  # ----------------------------------------------------------------
+  # Job 4b: Prod compose contract lint (#1458 achado #5)
+  # Valida que docker-compose.prod.yml continua um contrato coerente
+  # (interpolacao, sintaxe, volumes, redes) usando o template prod-like.
+  # Barato (~segundos, sem build). Complementa o guard-smoke do template acima.
+  # ----------------------------------------------------------------
+  prod-compose-contract:
+    name: "prod compose contract"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
+    - name: docker compose config -q (contrato de prod via template prod-like)
+      run: |
+        set -euo pipefail
+        docker compose \
+          --env-file v2/infra/.env.prodlike.example \
+          -f v2/infra/docker-compose.prod.yml \
+          config -q
+        echo "OK docker-compose.prod.yml: contrato valido com o template prod-like"
+
   # ----------------------------------------------------------------
   # Job 5: Required backend gate
   # Keeps the required "tests" check in ruleset while aggregating

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,8 +75,11 @@ jobs:
         CHANGED_COUNT="$(printf '%s\n' "$CHANGED_FILES" | sed '/^$/d' | wc -l | tr -d ' ')"
 
         # Conservative impact patterns to prevent false green:
-        # includes backend app, backend runtime infra, backend tests and this CI workflow itself.
-        BACKEND_IMPACT_REGEX='^(v2/backend/|v2/infra/|v2/tests/|v2/.dockerignore$|\.github/workflows/ci\.yaml$|\.github/workflows/_backend-test\.yml$)'
+        # includes backend app, backend runtime infra, backend tests, this CI workflow itself,
+        # the reusable backend-test workflow and the setup-python-deps composite action that the
+        # backend jobs consume (a change there — e.g. bump de actions/setup-python, pip install ou
+        # cache — precisa exercitar a suite backend, senao o PR fica verde-falso; ver #1459).
+        BACKEND_IMPACT_REGEX='^(v2/backend/|v2/infra/|v2/tests/|v2/.dockerignore$|\.github/workflows/ci\.yaml$|\.github/workflows/_backend-test\.yml$|\.github/actions/setup-python-deps/)'
         BACKEND_MATCHED_FILES="$(printf '%s\n' "$CHANGED_FILES" | grep -E "$BACKEND_IMPACT_REGEX" || true)"
         BACKEND_MATCHED_COUNT="$(printf '%s\n' "$BACKEND_MATCHED_FILES" | sed '/^$/d' | wc -l | tr -d ' ')"
 

--- a/v2/backend/apps/core/tests/test_pr_security_url_substring.py
+++ b/v2/backend/apps/core/tests/test_pr_security_url_substring.py
@@ -11,18 +11,46 @@ teste, trocando ``"meet.google.com" in url`` por ``urlparse(url).hostname == "me
 
 from __future__ import annotations
 
-import sys
+import importlib.util
 from pathlib import Path
 
 import pytest
 
-# ``validate_oauth_config.py`` vive em ``v2/infra/`` (script standalone fora do
-# pacote Django). Adiciona ao sys.path para conseguir importar nos testes.
-_INFRA_DIR = Path(__file__).resolve().parents[4] / "infra"
-if str(_INFRA_DIR) not in sys.path:
-    sys.path.insert(0, str(_INFRA_DIR))
+# ``validate_oauth_config.py`` é um script standalone que vive em ``v2/infra/``
+# (fora do pacote Django). No checkout completo (host/CI) ele fica ao lado de
+# ``v2/backend``; no container de dev o backend é montado como raiz ``/app`` e
+# ``infra`` não é montado. Localizamos o arquivo varrendo os ancestrais (robusto
+# a qualquer layout) e o carregamos via ``importlib`` sem poluir ``sys.path``.
+# Se ausente, pulamos o módulo inteiro em vez de abortar a coleta do pytest
+# (o ``ModuleNotFoundError`` no topo interrompia a run inteira no Docker dev).
 
-from validate_oauth_config import validate_client_id, validate_redirect_uri  # noqa: E402
+
+def _load_validate_oauth_config():
+    here = Path(__file__).resolve()
+    candidates = [
+        *(parent / "infra" / "validate_oauth_config.py" for parent in here.parents),
+        *(parent / "validate_oauth_config.py" for parent in here.parents),
+    ]
+    for path in candidates:
+        if path.is_file():
+            spec = importlib.util.spec_from_file_location("validate_oauth_config", path)
+            assert spec and spec.loader
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+            return module
+    return None
+
+
+_module = _load_validate_oauth_config()
+if _module is None:
+    pytest.skip(
+        "validate_oauth_config.py indisponível (v2/infra não montado neste ambiente)",
+        allow_module_level=True,
+    )
+
+assert _module is not None  # pytest.skip(allow_module_level=True) acima aborta o módulo
+validate_client_id = _module.validate_client_id
+validate_redirect_uri = _module.validate_redirect_uri
 
 
 class TestValidateClientId:

--- a/v2/infra/.env.prodlike.example
+++ b/v2/infra/.env.prodlike.example
@@ -3,11 +3,19 @@
 # -----------------------------------------------------------------------------
 # Uso recomendado:
 #   cp .env.prodlike.example .env.prodlike.local
+#   docker network create shared_proxy   # rede externa do compose de prod (idempotente)
 #   docker compose --env-file .env.prodlike.local -f docker-compose.prod.yml up -d
+#   # ou, pelo Makefile: make up-prod-like  (cria a rede shared_proxy automaticamente)
 #
 # Objetivo:
 # - Reproduzir comportamento de producao com compose de producao
 # - Sem colidir com dev/staging locais
+#
+# IMPORTANTE: ENVIRONMENT=production ativa os guards em settings.py:64-95. Este
+# template JA passa nos guards sem edicao (ALLOWED_HOSTS com host de fachada
+# nao-dev; SECRET_KEY >= 50 chars). NAO relaxar os guards para "subir mais facil"
+# — o CI valida que este arquivo continua bootavel (#1458: job docker-parity-backend
+# roda `manage.py check` com --env-file deste template).
 
 COMPOSE_PROJECT_NAME=aprender_prod_like
 APP_ENV_FILE=.env.prodlike.local
@@ -15,15 +23,18 @@ IMAGE_TAG=v2026.01.28-a58c1b2
 
 ENVIRONMENT=production
 DEBUG=0
-SECRET_KEY=CHANGE_ME_PRODLIKE_SECRET_KEY_LONG
+# Placeholder >= 50 chars (guard settings.py:93). Gere a chave real com:
+#   python -c "from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())"
+SECRET_KEY=CHANGE_ME_prodlike_only_replace_with_50plus_char_random_secret
 REQUIRE_DOCKER=1
 
 # Portas publicadas no host (isoladas)
 BACKEND_HOST_PORT=28000
 FRONTEND_PORT=18081
 
-# Backend publico local
-ALLOWED_HOSTS=localhost,127.0.0.1,web
+# Backend publico local. Precisa de >=1 host NAO-dev (guard settings.py:79), senao
+# o boot em ENVIRONMENT=production aborta; localhost fica para o health-check curl.
+ALLOWED_HOSTS=prodlike.aprender.local,localhost,127.0.0.1,web
 CORS_ALLOWED_ORIGINS=http://localhost:18081,http://localhost:28000
 CSRF_TRUSTED_ORIGINS=http://localhost:18081,http://localhost:28000
 
@@ -34,10 +45,11 @@ DB_PASSWORD=CHANGE_ME_DEV_DB_PASSWORD
 DB_HOST=host.docker.internal
 DB_PORT=5434
 
-# Redis local da stack
+# Redis local da stack. Nao-vazio para espelhar producao (o compose de prod passa
+# --requirepass; app e healthcheck usam o mesmo ${REDIS_PASSWORD}).
 REDIS_HOST=redis
 REDIS_PORT=6379
-REDIS_PASSWORD=
+REDIS_PASSWORD=CHANGE_ME_PRODLIKE_REDIS_PASSWORD
 
 # Feature flags
 GCAL_CLIENT=fake

--- a/v2/infra/Makefile
+++ b/v2/infra/Makefile
@@ -207,6 +207,7 @@ pull-prod-like: ## Pull das imagens do ambiente PROD-LIKE local
 
 up-prod-like: ## Subir ambiente PROD-LIKE local (sem build)
 	@echo "🚀 [PROD-LIKE] subindo ambiente..."
+	@docker network inspect shared_proxy >/dev/null 2>&1 || docker network create shared_proxy
 	$(PRODLIKE_COMPOSE) up -d --no-build
 	@echo "✅ [PROD-LIKE] ambiente iniciado"
 	@echo "🌐 [PROD-LIKE] backend: http://localhost:28000"


### PR DESCRIPTION
## Tema: CI/infra dev-tooling — 3 itens (triagem 2026-07-11 / auditoria 06-19)

Corrige 3 defeitos que produziam **false-green** no CI ou quebravam a DX local. Cada um com prova RED→GREEN no container dev (`aprender_dev-web-1`).

### #1460 — pytest aborta a coleta no Docker dev
`test_pr_security_url_substring.py` montava o path com `parents[4]/infra`, assumindo o checkout completo (host/CI). No container dev o backend é raiz `/app` → `parents[4]=/` → `/infra` inexistente → `ModuleNotFoundError` **na coleta** → run inteira aborta (exit 2, zero testes). Agora localiza `validate_oauth_config.py` varrendo os ancestrais, carrega via `importlib` sem poluir `sys.path`, e pula o módulo se ausente (`allow_module_level`). Cobertura no CI preservada (lá o arquivo existe).
- **Prova:** `apps/core/tests/` passou de exit 2 (0 testes) → **2892 coletados, exit 0**.

### #1459 — detector de impacto backend ignora `setup-python-deps`
`BACKEND_IMPACT_REGEX` não incluía `.github/actions/setup-python-deps/`, consumido pelos jobs backend (`_backend-test.yml`, `backend-typecheck`). Um PR que só editasse a composite action era classificado `backend_changed=false` → suíte backend pulava → gate `[required] tests` ficava **verde-falso** (fluxo merge=prod sem staging). Adicionado ao regex — apenas `setup-python-deps/`, **não** `actions/` inteiro, pois `setup-node-deps` é frontend-only e não deve acoplar ao backend.
- **Prova:** `setup-python-deps/action.yml` → MATCH; `setup-node-deps/action.yml` → no match; `frontend/App.tsx` → no match; `backend/models.py` → MATCH.

### #1458 — CI não valida contrato de prod + template prod-like não boota
- **Template:** `.env.prodlike.example` tinha `SECRET_KEY` de 34 chars (guard `settings.py:93`) e `ALLOWED_HOSTS` só com dev-hosts (guard `settings.py:79`) → boot em `ENVIRONMENT=production` abortava. Corrigido: host de fachada `prodlike.aprender.local` (mantendo `localhost` p/ o health curl), `SECRET_KEY` placeholder de 62 chars, `REDIS_PASSWORD` não-vazio. **Guards não relaxados.**
- **Guard-smoke no CI:** novo step no `docker-parity-backend` (`[required]`) roda `manage.py check` com `--env-file` do template (reusa a imagem prod recém-buildada; `--entrypoint python` pula o wait de DB do entrypoint) → pega drift template↔guards.
- **Contract lint:** novo job `prod-compose-contract` roda `docker compose config -q` do `docker-compose.prod.yml` com o template.
- **UX:** `up-prod-like` cria a rede externa `shared_proxy` idempotentemente (3º bloqueio do fluxo prod-like local).
- **Prova:** RED (template atual → exit 1 nos guards) → GREEN (`manage.py check` → "no issues", exit 0). Forma exata do comando do CI validada (GREEN exit 0 / RED exit 1).

## Validação local
- black / isort / flake8 limpos nos arquivos tocados.
- YAML do `ci.yaml` válido; jobs/steps novos confirmados por parse.
- Todas as provas rodadas no container `aprender_dev-web-1`.

Refs #1460 #1459 #1458
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `7b40a431`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
