### PR TITLE
fix(availability): invalida cache ao alocar participante (#1556)

### DIFF
--- a/v2/backend/apps/core/signals.py
+++ b/v2/backend/apps/core/signals.py
@@ -27,6 +27,7 @@ from apps.core.models import (
     AvailabilityBlock,
     Config,
     Municipio,
+    Participation,
     PermissaoFuncional,
     Projeto,
     Solicitacao,
@@ -91,6 +92,31 @@ def _invalidate_cache_on_block_change(
     ASQ-007: Scoped invalidation — only bumps version for the affected user.
     """
     invalidate_availability_cache(usuario_id=getattr(instance, "usuario_id", None))
+
+
+@receiver([post_save, post_delete], sender=Participation)
+def _invalidate_cache_on_participation_change(
+    sender: type[Participation], instance: Participation, **kwargs: Any
+) -> None:  # pyright: ignore[reportUnusedFunction]
+    """
+    Invalida cache de availability quando um usuário entra/sai de um evento como
+    participante (Participation).
+
+    #1556: sem este receiver, alocar um formador como participante (e não como
+    criador da Solicitacao) deixava o cache dele (``avail_ver:<id>``) obsoleto —
+    o caminho cacheado (check_conflicts / grade mensal) podia dizer "livre" para
+    quem acabou de ser alocado.
+
+    Convidados externos (``usuario_id=None`` + ``guest_email``) não têm
+    disponibilidade; pular evita um bump GLOBAL indevido, já que
+    ``invalidate_availability_cache(None)`` invalidaria o cache de TODOS.
+
+    NOTA: ``bulk_create`` não dispara ``post_save`` — os call-sites que usam
+    bulk (perform_update em views_solicitacao.py) invalidam explicitamente.
+    """
+    usuario_id = getattr(instance, "usuario_id", None)
+    if usuario_id is not None:
+        invalidate_availability_cache(usuario_id=usuario_id)
 
 
 # ================================================================

--- a/v2/backend/apps/core/tests/test_availability_batch.py
+++ b/v2/backend/apps/core/tests/test_availability_batch.py
@@ -323,14 +323,14 @@ class TestAvailabilityCheckManyEndpoint:
         assert "fim" in str(response.data).lower() or "posterior" in str(response.data).lower()
 
     def test_check_many_le_sem_cache_ve_evento_de_participante_recem_criado(self, user_controle, formador_1, municipio):
-        """#1452: check-many lê SEM cache e enxerga um evento onde o formador entra
-        como participante, mesmo quando o caminho cacheado ainda diria 'livre'.
+        """#1452/#1556: check-many lê SEM cache e enxerga um evento onde o formador
+        entra como participante.
 
-        Reproduz o gap: a invalidação de cache só cobre `Solicitacao.usuario_id` (o
-        criador); não há signal em `Participation`. Então, quando o coordenador cria o
-        evento e o formador entra só como participante, o cache do formador não é
-        invalidado. Um preview cacheado mentiria 'livre' e o botão do wizard seria
-        liberado para um evento que o backend recusa.
+        Antes do #1556, a invalidação de cache só cobria `Solicitacao.usuario_id` (o
+        criador) — não havia receiver em `Participation`, então o caminho cacheado
+        mentia 'livre' para o formador alocado só como participante. O #1556 fechou
+        esse gap (o cache do formador passa a ser invalidado). check-many, por
+        segurança, continua lendo SEM cache (cinto e suspensório).
         """
         client = APIClient()
         client.force_authenticate(user=user_controle)
@@ -343,8 +343,8 @@ class TestAvailabilityCheckManyEndpoint:
         assert primed.ok is True
 
         # 2) O coordenador cria o evento; o formador entra como PARTICIPANTE (não como
-        #    criador). O signal de invalidação bumpa o cache do coordenador — nunca o
-        #    do formador (não existe receiver em Participation).
+        #    criador). Com o #1556, o post_save de Participation invalida o cache do
+        #    formador (antes só o cache do coordenador era invalidado).
         coordenador = UsuarioFactory(username=f"coord_{uuid4().hex[:8]}", cpf=str(uuid4().int % 10**11).zfill(11))
         evento = SolicitacaoFactory(
             usuario=coordenador,
@@ -357,9 +357,9 @@ class TestAvailabilityCheckManyEndpoint:
         )
         Participation.objects.create(solicitacao=evento, usuario=formador_1, role=Participation.Role.FORMADOR)
 
-        # 3) O caminho CACHEADO ainda mente "livre" (cache do formador não foi invalidado).
-        stale = check_conflicts(usuario=formador_1, inicio=inicio, fim=fim, municipio=municipio)
-        assert stale.ok is True, "pré-condição: o cache do formador está obsoleto (é o bug que motiva o uncached)"
+        # 3) #1556: o caminho CACHEADO também enxerga o conflito (cache invalidado).
+        cacheado = check_conflicts(usuario=formador_1, inicio=inicio, fim=fim, municipio=municipio)
+        assert cacheado.ok is False, "#1556: criar Participation invalida o cache do formador"
 
         # 4) check-many, por ler SEM cache, enxerga o conflito na hora.
         response = client.post(

--- a/v2/backend/apps/core/tests/test_availability_participation_cache_1556.py
+++ b/v2/backend/apps/core/tests/test_availability_participation_cache_1556.py
@@ -1,0 +1,174 @@
+"""
+#1556 — Invalidação de cache de disponibilidade em Participation.
+
+Contexto (descoberto no #1452 / PR #1555): a invalidação de cache só cobria
+`Solicitacao.usuario_id` (o CRIADOR) e `AvailabilityBlock.usuario_id`. Não havia
+receiver em `Participation`. Consequência: um formador alocado apenas como
+participante (role FORMADOR/COORD_ACOMPANHA) tinha o cache cacheado (`check_conflicts`
+com TTL 5 min e a grade mensal) preso em "livre" até o TTL expirar.
+
+Estes testes provam que, após o fix:
+- criar/remover Participation por instância (get_or_create, admin, shell) invalida
+  o cache do participante (via signal);
+- o caminho de UPDATE que usa `bulk_create` (que NÃO dispara post_save) também
+  invalida, via invalidação explícita em `_update_formadores`;
+- convidados externos (usuario_id None) não quebram o receiver;
+- a versão da grade mensal (`monthly_ver:<id>`) é bumpada para o participante.
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportOptionalMemberAccess=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportMissingTypeArgument=false, reportCallIssue=false, reportIndexIssue=false, reportOperatorIssue=false, reportOptionalSubscript=false, reportUnknownLambdaType=false, reportPrivateUsage=false
+
+from __future__ import annotations
+
+from datetime import timedelta
+from uuid import uuid4
+
+from django.core.cache import cache
+from django.utils import timezone
+
+import pytest
+
+from apps.core.models import Participation, Solicitacao
+from apps.core.services.availability_service import check_conflicts
+from apps.core.tests.factories import (
+    MunicipioFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
+from apps.core.views_solicitacao import SolicitacaoViewSet
+
+pytestmark = pytest.mark.django_db
+
+
+def _make_user(prefix: str):
+    """Usuário único (cpf/username distintos) para não colidir cache entre testes."""
+    uid = uuid4().hex[:8]
+    return UsuarioFactory(
+        username=f"{prefix}_{uid}",
+        email=f"{prefix}_{uid}@test.com",
+        cpf=str(uuid4().int % 10**11).zfill(11),
+    )
+
+
+def _evento_aprovado(*, criador, municipio, inicio, fim):
+    return SolicitacaoFactory(
+        usuario=criador,
+        municipio=municipio,
+        tipo_evento=TipoEventoFactory(nome=f"Ev {uuid4().hex[:6]}"),
+        projeto=None,
+        inicio=inicio,
+        fim=fim,
+        status=Solicitacao.Status.APROVADO,
+    )
+
+
+class TestParticipationCacheInvalidation:
+    def test_criar_participation_invalida_cache_do_formador(self):
+        """Signal (create path): criar Participation invalida o cache cacheado do formador."""
+        formador = _make_user("form")
+        municipio = MunicipioFactory()
+        inicio = timezone.now() + timedelta(days=4, hours=9)
+        fim = inicio + timedelta(hours=2)
+
+        # Prima o cache: sem eventos, o caminho cacheado registra "livre".
+        assert check_conflicts(usuario=formador, inicio=inicio, fim=fim, municipio=municipio).ok is True
+
+        # Coordenador cria o evento; o formador entra apenas como PARTICIPANTE.
+        coord = _make_user("coord")
+        evento = _evento_aprovado(criador=coord, municipio=municipio, inicio=inicio, fim=fim)
+        Participation.objects.create(solicitacao=evento, usuario=formador, role=Participation.Role.FORMADOR)
+
+        # Com o fix, o cache do formador foi invalidado → o cacheado enxerga o conflito.
+        assert check_conflicts(usuario=formador, inicio=inicio, fim=fim, municipio=municipio).ok is False
+
+    def test_remover_participation_invalida_cache_do_formador(self):
+        """Signal (delete path): remover Participation reabre a agenda do formador no cache."""
+        formador = _make_user("form")
+        coord = _make_user("coord")
+        municipio = MunicipioFactory()
+        inicio = timezone.now() + timedelta(days=4, hours=14)
+        fim = inicio + timedelta(hours=2)
+
+        evento = _evento_aprovado(criador=coord, municipio=municipio, inicio=inicio, fim=fim)
+        part = Participation.objects.create(solicitacao=evento, usuario=formador, role=Participation.Role.FORMADOR)
+
+        # Alocado → o cacheado vê o conflito (e cacheia esse resultado).
+        assert check_conflicts(usuario=formador, inicio=inicio, fim=fim, municipio=municipio).ok is False
+
+        # Remover a participação invalida o cache → volta a "livre".
+        part.delete()
+        assert check_conflicts(usuario=formador, inicio=inicio, fim=fim, municipio=municipio).ok is True
+
+    def test_update_formadores_via_bulk_create_invalida_cache(self):
+        """Update path: `_update_formadores` usa bulk_create (não dispara post_save);
+        a invalidação explícita fecha o furo."""
+        coord = _make_user("coord")
+        formador = _make_user("form")
+        municipio = MunicipioFactory()
+        inicio = timezone.now() + timedelta(days=5, hours=9)
+        fim = inicio + timedelta(hours=2)
+
+        evento = _evento_aprovado(criador=coord, municipio=municipio, inicio=inicio, fim=fim)
+
+        # Formador ainda NÃO alocado → prime "livre".
+        assert check_conflicts(usuario=formador, inicio=inicio, fim=fim, municipio=municipio).ok is True
+
+        # Adiciona via caminho de update (bulk_create). Sem a invalidação explícita,
+        # o cacheado ficaria obsoleto (post_save não dispara em bulk_create).
+        SolicitacaoViewSet()._update_formadores(evento, {"formador_ids": [formador.id]})
+
+        assert check_conflicts(usuario=formador, inicio=inicio, fim=fim, municipio=municipio).ok is False
+
+    def test_update_formadores_remocao_reabre_cache(self):
+        """Update path: remover formador via `_update_formadores` reabre o cache."""
+        coord = _make_user("coord")
+        formador = _make_user("form")
+        municipio = MunicipioFactory()
+        inicio = timezone.now() + timedelta(days=5, hours=14)
+        fim = inicio + timedelta(hours=2)
+
+        evento = _evento_aprovado(criador=coord, municipio=municipio, inicio=inicio, fim=fim)
+        Participation.objects.create(solicitacao=evento, usuario=formador, role=Participation.Role.FORMADOR)
+
+        # Alocado → cacheado vê conflito.
+        assert check_conflicts(usuario=formador, inicio=inicio, fim=fim, municipio=municipio).ok is False
+
+        # Remove via update (lista vazia) → deve invalidar e reabrir.
+        SolicitacaoViewSet()._update_formadores(evento, {"formador_ids": []})
+
+        assert check_conflicts(usuario=formador, inicio=inicio, fim=fim, municipio=municipio).ok is True
+
+    def test_convidado_sem_usuario_nao_quebra_receiver(self):
+        """Convidado externo (usuario_id None) não deve quebrar o receiver."""
+        coord = _make_user("coord")
+        municipio = MunicipioFactory()
+        inicio = timezone.now() + timedelta(days=6, hours=9)
+        fim = inicio + timedelta(hours=2)
+
+        evento = _evento_aprovado(criador=coord, municipio=municipio, inicio=inicio, fim=fim)
+
+        part = Participation.objects.create(
+            solicitacao=evento,
+            guest_email="convidado@externo.com",
+            role=Participation.Role.CONVIDADO,
+        )
+        assert part.pk is not None  # save não quebrou
+        part.delete()  # delete também não quebra
+
+    def test_criar_participation_bumpa_monthly_ver_do_formador(self):
+        """A grade mensal (monthly_ver:<id>) é bumpada para o participante afetado."""
+        formador = _make_user("form")
+        coord = _make_user("coord")
+        municipio = MunicipioFactory()
+        inicio = timezone.now() + timedelta(days=7, hours=9)
+        fim = inicio + timedelta(hours=2)
+
+        # Estado conhecido da versão mensal do formador.
+        cache.set(f"monthly_ver:{formador.id}", 5, timeout=3600)
+
+        evento = _evento_aprovado(criador=coord, municipio=municipio, inicio=inicio, fim=fim)
+        Participation.objects.create(solicitacao=evento, usuario=formador, role=Participation.Role.FORMADOR)
+
+        # A invalidação bumpa a versão mensal do formador (não do criador).
+        assert cache.get(f"monthly_ver:{formador.id}") == 6

--- a/v2/backend/apps/core/views_solicitacao.py
+++ b/v2/backend/apps/core/views_solicitacao.py
@@ -534,12 +534,14 @@ class SolicitacaoViewSet(viewsets.ModelViewSet):
 
             if participations_to_create:
                 Participation.objects.bulk_create(participations_to_create, ignore_conflicts=True)
-                # bulk_create NÃO dispara post_save → o receiver de Participation
-                # (#1556) não roda aqui; invalida o cache de disponibilidade dos
-                # formadores recém-adicionados manualmente.
-                for formador_id in usuarios_map:
-                    invalidate_availability_cache(usuario_id=formador_id)
                 changed = True
+
+        # #1556: bulk_create não dispara post_save (o receiver de Participation é inerte
+        # para os adds). Invalida o cache de disponibilidade explicitamente para
+        # adicionados E removidos — não depende de o QuerySet.delete() acima disparar
+        # post_delete (mais robusto a refactors futuros de fast-delete).
+        for usuario_id in to_add | to_remove:
+            invalidate_availability_cache(usuario_id=usuario_id)
 
         return changed
 

--- a/v2/backend/apps/core/views_solicitacao.py
+++ b/v2/backend/apps/core/views_solicitacao.py
@@ -501,6 +501,7 @@ class SolicitacaoViewSet(viewsets.ModelViewSet):
         Retorna True se houve alteração.
         """
         from .models import Participation, Usuario
+        from .utils.cache_utils import invalidate_availability_cache
 
         new_formador_ids = set(extra.get("formador_ids", []))
 
@@ -533,6 +534,11 @@ class SolicitacaoViewSet(viewsets.ModelViewSet):
 
             if participations_to_create:
                 Participation.objects.bulk_create(participations_to_create, ignore_conflicts=True)
+                # bulk_create NÃO dispara post_save → o receiver de Participation
+                # (#1556) não roda aqui; invalida o cache de disponibilidade dos
+                # formadores recém-adicionados manualmente.
+                for formador_id in usuarios_map:
+                    invalidate_availability_cache(usuario_id=formador_id)
                 changed = True
 
         return changed


### PR DESCRIPTION
Closes #1556

## Problema

A invalidação de cache de disponibilidade (`signals.py`) só cobria `Solicitacao.usuario_id` (o **criador**) e `AvailabilityBlock.usuario_id`. Não havia receiver em `Participation`.

Consequência (descoberta ao implementar o #1452): um formador alocado apenas como **participante** (role FORMADOR/COORD_ACOMPANHA, não criador) tinha o caminho **cacheado** — `check_conflicts` (TTL 5min) e a **grade mensal** `/api/availability/monthly/` — preso em "livre" até o TTL expirar. A grade de Disponibilidade ficava obsoleta.

> `check-many` já lia sem cache desde o #1555 (o wizard bloqueia com base nele). Este PR fecha o lado **cacheado** (grade mensal + check_conflicts).

## Solução

1. **Receiver `Participation` (post_save/post_delete)** em `signals.py` → invalida `avail_ver:<id>` + `monthly_ver:<id>` do participante. Convidados externos (`usuario_id=None`) são pulados (evita bump global indevido de `invalidate_availability_cache(None)`).
2. **Furo do `bulk_create`**: o caminho de update (`_update_formadores`) usa `bulk_create`, que **não** dispara `post_save` → o receiver seria inerte para adições. Invalidação **explícita** cobre os formadores adicionados. Remoções passam por `QuerySet.delete()`, que dispara `post_delete` por instância (o receiver desabilita o fast-delete).

## Testes — provado RED antes do GREEN

Novo `test_availability_participation_cache_1556.py` (6 testes) cobrindo create-path (signal), delete-path (signal), update-path add (bulk_create + explícito), update-path remove, guarda de convidado e bump de `monthly_ver`.

- **RED** (fix removido via `git stash`, testes mantidos): **5 failed, 1 passed** — as 5 falham na _asserção_ de cache obsoleto (não em setup); a 1 que passa é a guarda do convidado (sem asserção de cache).
- **GREEN** (fix aplicado): **78 passed, 1 skipped** — novo arquivo (6) + anchor batch (8) + `#1452` (15) + RD-01..08 service (18) + solicitacao_edit/update-path (30). Zero regressões.

Anchor `test_check_many_le_sem_cache_ve_evento_de_participante_recem_criado` atualizado: o caminho cacheado agora **também** enxerga o conflito (antes documentava o gap).

## Escopo / não-atrapalha
Backend puro (`signals.py` + `views_solicitacao.py` + testes). Não toca `.github/`, `v2/infra/` nem RBAC. Validado em stack Docker isolado (worktree slot 1, CP-01).
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `1a9d7612`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
