### PR TITLE
refactor(availability): remove dead code checkAvailability (single) (#1557)

### DIFF
--- a/v2/frontend/src/api/availability.ts
+++ b/v2/frontend/src/api/availability.ts
@@ -11,7 +11,6 @@ import type {
   CurrentUser,
   AvailabilityBlock,
   AvailabilityBlockPayload,
-  AvailabilityCheckResponse,
   AvailabilityCheckManyRequest,
   AvailabilityCheckManyResponse,
   MonthlyGridResponse,
@@ -25,16 +24,6 @@ import { assertCurrentUserPayload } from '../types';
 export interface BlockFilters {
   owner?: string;
   [key: string]: string | undefined;
-}
-
-/**
- * Availability check parameters
- */
-export interface AvailabilityCheckParams {
-  usuario_id: ID;
-  inicio: string;
-  fim: string;
-  municipio_id?: ID;
 }
 
 /**
@@ -104,16 +93,6 @@ export async function deleteBlock(id: ID): Promise<void> {
     method: 'DELETE',
   });
   syncChannel.publish('availability', { action: 'block_deleted' });
-}
-
-/**
- * Checa disponibilidade de um usuário (consultivo).
- *
- * @param params - Parâmetros da checagem
- */
-export async function checkAvailability(params: AvailabilityCheckParams): Promise<AvailabilityCheckResponse> {
-  const url = buildUrl('/availability/check/', params as unknown as QueryParams);
-  return await fetchAPI(url);
 }
 
 /**

--- a/v2/frontend/src/api/solicitacoes.ts
+++ b/v2/frontend/src/api/solicitacoes.ts
@@ -303,6 +303,3 @@ export async function rejectSolicitacoesBatch(ids: ID[]): Promise<BatchOperation
   syncChannel.publish('aprovacoes', { action: 'changed' });
   return result;
 }
-
-// Re-exportar checkAvailability de availability
-export { checkAvailability } from './availability';


### PR DESCRIPTION
## #1557 — remove dead code `checkAvailability` (single)

`checkAvailability` (single-user, `/availability/check/`) não tinha consumidor de produção desde o #1555, que passou a usar `checkAvailabilityMany` (batch). Havia **duas portas** para o mesmo código morto: a função em `api/availability.ts` e o re-export em `api/solicitacoes.ts` — risco de alguém ligar o single-user num loop (N requests contra endpoint com throttle `availability_check`). Removidos a função, a interface `AvailabilityCheckParams` e o re-export.

## Validação local
- `tsc --noEmit` exit 0 (nenhuma referência pendente aos símbolos removidos).
- eslint sem erros nos arquivos tocados.
- 14 testes de availability (hook `useAvailabilityPreview` + wizard) seguem passando.

Nota: o #1556 (outro follow-up do #1452) está coberto pela **PR #1561**; por isso este PR traz só o #1557.

Refs #1557 (follow-up do #1452)
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `4241ae5c`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
