### PR TITLE
fix(rbac): frontend read-only p/ nao-superuser (PR-A P0-1 Tier-0)

### DIFF
--- a/v2/docs/plans/2026-07-17-p0-1-tier0-groupviewset.md
+++ b/v2/docs/plans/2026-07-17-p0-1-tier0-groupviewset.md
@@ -1,0 +1,94 @@
+# P0-1 — Erradicação Tier-0 do GroupViewSet (matriz Grupo×Capability + memberships)
+
+Status: **Planejado — D-1 ratificada (2a)**. Parte 2 da correção definitiva Tier-0 (após P0-0, no ar em prod `v2026.07.17-86afdef`).
+Origem: auditoria `v2/docs/audits/2026-07-17-rbac-security-audit.md` (§4.2) + investigação fan-out (5 agentes, 2026-07-17).
+Plano-mãe: `v2/docs/plans/2026-07-17-rbac-correcao-definitiva.md` (Wave 2).
+Princípio: TDD (RED prova o comportamento **seguro** ausente). Não é paliativo — a fronteira é permanente.
+
+---
+
+## 1. Vetor P0-1 — superfícies de escalada (não-superuser: DAT/Controle)
+
+Mecanismo-raiz: `HasPerm` resolve caps via `PermissaoFuncional.objects.filter(groups__user__id=...)` (`services/rbac_permissions.py:81-83`) — **ligar uma PermissaoFuncional a um grupo concede o codename a TODOS os membros**.
+
+| # | Superfície | file:linha | Escalada |
+|---|---|---|---|
+| A | Editar matriz via `permissao_funcional_ids` | campo `serializers/usuario.py:347-354`; write `usuario.py:428-429`; gate `views/admin.py:487` (`manage_purchases_and_materials`) | PATCH no próprio grupo + `manage_admin_registries`/`approve_solicitation` → superuser-equivalente por capability |
+| B1 | `sync_members` | `views/admin.py:503-574` (**sem** self/privileged/whitelist) | adiciona a própria conta em `Superintendência`+`Gerente` → autoridade de aprovação (fura o self-block do assign_groups) |
+| B2 | `assign_groups` | `views/admin.py:399-469` (whitelist inclui grupos privilegiados) | atribui outra conta a grupo privilegiado → cunha aprovador |
+| B3 | `group_ids` (create/update usuário) | `serializers/usuario.py:94-101`, set em `:258/:275`; gate `admin.py:363` | mesma whitelist ampla no fluxo cadastral |
+| C | Criar/renomear/excluir grupo | create `usuario.py:341-354,412-420`; rename `:399-410`; delete `admin.py:494-501` | `?confirm_reserved=true` é **UX, não autorização**; editar caps de grupo reservado sem guard |
+| D | Reset de senha de não-superuser | `serializers/usuario.py:253/270` (`set_password`) | resetar senha de aprovador (Super+Gerente) → login como ele |
+
+Fronteira residual pós-P0-0: só o bit `is_superuser` (404 em alvos superuser). **Não** contém alcance de capability/aprovação/takeover — por isso o P0-1.
+
+Gap de gate CI: a Living Matrix (`rbac/matrix.py`) é GET-only e não cobre `/api/grupos/`, `assign_groups`, `sync-members` → regressão que amplie a write-surface não dispara o gate da matriz.
+
+---
+
+## 2. Decisões
+
+- **D-1 — escopo (RATIFICADA: 2a, bloqueio total).** Memberships (User→Group) e matriz (Grupo×Capability) → **superuser-only**. DAT mantém CRUD de conta comum (criar, senha, cadastral, ativar/desativar); **não atribui mais grupos**. Fronteira sem classificação para errar. Corrobora o histórico (§audit 2.5): os 13 `SYNC_GROUP_MEMBERS` foram todos do superuser `admin`.
+- **D-2 — matriz (decidida por D17).** Grupo×Capability só no Django Admin superuser-only (`admin_site.py:42`). Remover `permissao_funcional_ids` do REST = ganho puro. *Nuance:* D17 fala só de Grupo×Capability; puxar memberships p/ superuser-only é restrição NOVA da Wave 2 (agora ratificada em D-1).
+- **D-3 — continuidade operacional (OPEN, operacional).** Runbook: superuser primário+backup faz o group-assign no cadastro; SLA de revogação; break-glass/anti-lockout. Delegação futura = RFC com separação de deveres. **Proibido** criar `manage_rbac` (circular).
+
+---
+
+## 3. Sequência de co-deploy
+
+**Frontend ANTES do backend** (`usuario_form_helpers.ts:68` injeta `group_ids` em TODO save; `GruposPage.tsx:291-324` chama `syncGroupMembers` após create/update → escrita parcial). Se o backend 403-ar primeiro, DAT editando só telefone trava a tela inteira.
+
+### PR-A — frontend read-only para não-superuser (primeiro)
+Condicionar por `is_superuser` (`UsuariosPage` já tem `currentIsSuperuser`; `GruposPage` busca via `usePermissions`/checkAuth):
+1. `usuario_form_helpers.ts:68` — **omitir `group_ids`** quando editor não-superuser (destrava edição trivial).
+2. `UsuariosPage.tsx` — Selects `setor_ids`/`funcao_ids` read-only + remover `required` p/ não-superuser (mantém criar/senha/cadastral/ativar).
+3. `GruposPage.tsx` — desabilitar Salvar do modal (matriz `permissao_funcional_ids` + `member_ids`) e Novo/Editar/Excluir p/ não-superuser. Principal superfície.
+4. `SetoresPage.tsx`/`FuncoesPage.tsx` — herdam de GruposPage → read-only.
+5. `adminDAT.ts::assignGroups` — **código morto** (só o teste chama) → remover.
+Manter leitura: `getRBACMeta`, `listPermissoesFuncionais`, `listGroups/getGroup/listUsers` (populam Selects/labels no modo read-only).
+
+### PR-B — backend gate (2a) + bundlados (segundo)
+- remover `permissao_funcional_ids` do write REST (`serializers/usuario.py:347-354`);
+- `assign_groups`/`sync_members`/`group_ids` → **superuser-only** (não-superuser: 403 nas ações de membership; `group_ids` ignorado/rejeitado no serializer);
+- rename/delete de grupo reservado + GroupViewSet CRUD → superuser-only (não confiar em `?confirm_reserved`);
+- **P1-3** (cache reverse) + **P2-2** (serviço de auditoria) no mesmo PR (§5).
+
+---
+
+## 4. Risco G3 — o que o DAT perde (2a) e mitigação
+
+**Perde:** o passo de group-assignment do onboarding (colocar novo usuário em setor+função). **Mantém:** criar conta, senha, cadastral, ativar/desativar (a conta é criada; só o link a grupo se move ao superuser).
+**Mitigação:** runbook D-3 (superuser faz o group-assign no cadastro, Django Admin ou endpoint superuser-gated). Baixo atrito real — membership já é atividade de superuser na prática (audit §2.5).
+
+---
+
+## 5. Itens bundlados no PR-B
+
+**(A) P1-3 — cache reverse.** `rbac_signals.py:26-36` assume `instance=User`; `sync_members` (`admin.py:550` `group.user_set.set`) dispara `m2m_changed` com `instance=Group, reverse=True, pk_set={user_ids}` → invalida a chave errada (`as2:funcperms:{v}:{group_id}`), chaves reais dos usuários persistem → revogação stale ≤300s. **Fix:** ramificar por `reverse` (forward→`instance.id`; reverse→`pk_set` em post_add/remove + snapshot pre_clear→post_clear) via helper existente `invalidate_users_functional_permissions_cache`.
+
+**(B) P2-2 — auditoria.** Buffer global `_PENDING_GROUP_CAP_DELTAS` (`signals.py:46`, cross-thread sem lock) mal-atribui/perde deltas em ops concorrentes. Lacunas (grep=zero AuditLog): DELETE de usuário, `assign_groups`, CRUD REST de grupos, reset de senha admin (janela de takeover invisível), import de usuários. **Fix:** serviço ÚNICO de auditoria transacional (ator + before/after, `transaction.on_commit`) — elimina o buffer de módulo; modelo = o `SYNC_GROUP_MEMBERS` que já emite dentro de atomic (`admin.py:552`).
+
+---
+
+## 6. Testes que travam o comportamento inseguro (reescrever RED→GREEN)
+
+Backend (ficam RED após o fix — reescrever com o alvo seguro = não-superuser 403 / campo removido):
+- `test_admin_api.py::test_dat_can_patch_group_permissoes_funcionais:732` (A) · `..._create_group_as_funcao:698`/`..._rejects_invalid_group_type:719` (C) · `..._rename/delete_reserved_group_requires_confirmation:761/771` (C→guard real).
+- `test_group_sync_members.py::test_dat_can_sync_group_members:69` + `..._replaces_existing:83` + `..._requires_dat_permission:127` (B1) — **+ casos negativos novos**.
+- `test_assign_groups.py::*` (B2 — a whitelist inclui privilegiados; ator DAT vira RED).
+- `test_rbac_service_whitelist.py` (semântica da whitelist).
+- `test_rbac_superuser_target_protection.py::TestDatStillManagesCommonUsers::test_dat_can_still_reset_common_user_password` — **mantém** o reset, mas agora **assertar AuditLog** (P2-2).
+
+Frontend (forma do payload): `UsuariosPage.cpf.test.tsx:48,133-141` (group_ids condicional a superuser) · `adminDAT.test.ts:107,...` (remover assert de `assignGroups` morto; demais seguem a nova write-surface).
+
+Bundlados: **adicionar** teste RED→GREEN da invalidação reversa (P1-3); reescrever `test_pr16_admin_group_capability.py` + `conftest.py:54-56` p/ o serviço transacional (remover reset manual do global); novos asserts de AuditLog em assign_groups/delete/reset.
+
+Fronteira que **não** muda: `test_admin_api.py::test_dat_cannot_patch_is_superuser:550` e toda a suíte `test_rbac_superuser_target_protection.py` (P0-0).
+
+---
+
+## 7. Gates (por PR)
+
+PR-A (frontend): `cd v2/frontend && npm test -- --run <alvo> && npm run typecheck && npm run lint && npm run build && npm run test:checklist`.
+PR-B (backend): `pytest <alvo> --no-migrations` + `scripts/rbac_lint.py` + `pyright` + (se migration) `makemigrations --check`.
+Ambos antes de Ready: `staging-gate.sh` (8/8 + 3 marcadores). Pós-código: `graphify update .`.

--- a/v2/docs/plans/2026-07-17-rbac-correcao-definitiva.md
+++ b/v2/docs/plans/2026-07-17-rbac-correcao-definitiva.md
@@ -51,6 +51,8 @@ Arquivos prováveis: `apps/core/views/admin.py`, `apps/core/serializers/usuario.
 - **Pós-deploy**: revisar access logs; **rotacionar senha de todos os superusers**; invalidar sessões; validar primário+backup. (Rotação = precaução responsável, não afirmação de exploração.)
 
 ## Wave 2 — P0-A Tier-0 (co-deploy backend+frontend)
+> **Detalhamento + D-1 ratificada (2a, bloqueio total):** `v2/docs/plans/2026-07-17-p0-1-tier0-groupviewset.md`.
+> Ordem: PR-A (frontend read-only p/ não-superuser) → PR-B (gate backend superuser-only + P1-3 + P2-2).
 Pré-requisito: continuidade operacional (Wave 0) definida.
 - Grupo × Capability **só no Django Admin superuser-only**; memberships **só superuser**.
 - remover `permissao_funcional_ids` da escrita REST; proteger `assign_groups`, `sync_members`, rename/delete de grupo reservado (remover bypass `confirm_reserved`).

--- a/v2/frontend/src/api/__tests__/adminDAT.test.ts
+++ b/v2/frontend/src/api/__tests__/adminDAT.test.ts
@@ -16,7 +16,6 @@ vi.mock('../../services/syncChannel', () => ({
 }));
 
 import {
-  assignGroups,
   autocompleteMunicipiosAdmin,
   createGroup,
   createUser,
@@ -97,17 +96,6 @@ describe('adminDAT API wrappers (MSW)', () => {
     expect(calls).toHaveLength(1);
     expect(calls[0].method).toBe('POST');
     expect(calls[0].body).toMatchObject(payload);
-  });
-
-  test('assignGroups uses /usuarios-admin/{id}/assign_groups/', async () => {
-    server.use(
-      spyHandler(http.post, apiUrl('/usuarios-admin/10/assign_groups/'), { json: { id: 10 } }, calls),
-    );
-
-    await assignGroups(10, { group_ids: [1, 2, 3] });
-
-    expect(calls).toHaveLength(1);
-    expect(calls[0].body).toEqual({ group_ids: [1, 2, 3] });
   });
 
   test('createGroup accepts group_type_input payload', async () => {

--- a/v2/frontend/src/api/adminDAT.ts
+++ b/v2/frontend/src/api/adminDAT.ts
@@ -49,13 +49,6 @@ export interface UserPayload {
 }
 
 /**
- * Group assignment payload
- */
-export interface AssignGroupsPayload {
-  group_ids: ID[];
-}
-
-/**
  * Group member sync payload
  */
 export interface SyncGroupMembersPayload {
@@ -196,16 +189,6 @@ export async function updateUser(id: ID, data: UserPayload): Promise<AdminUser> 
 export async function deleteUser(id: ID): Promise<void> {
   await fetchWithErrorMapping(`/usuarios-admin/${id}/`, { method: 'DELETE' }, ADMIN_ERROR_MAP);
   syncChannel.publish('usuarios', { action: 'deleted' });
-}
-
-export async function assignGroups(userId: ID, data: AssignGroupsPayload): Promise<AdminUser> {
-  const result = await fetchWithErrorMapping<AdminUser>(
-    `/usuarios-admin/${userId}/assign_groups/`,
-    { method: 'POST', body: JSON.stringify(data) },
-    ADMIN_ERROR_MAP,
-  );
-  syncChannel.publish('usuarios', { action: 'groups_assigned' });
-  return result;
 }
 
 // ========== GRUPOS ==========

--- a/v2/frontend/src/pages/AdminDAT/GruposPage.tsx
+++ b/v2/frontend/src/pages/AdminDAT/GruposPage.tsx
@@ -43,6 +43,7 @@ import {
   updateGroup,
 } from '../../api/adminDAT';
 import type { PermissaoFuncional, RBACMetaPayload } from '../../api/adminDAT';
+import { checkAuth } from '../../api/auth';
 import { PAGE_SIZES } from '../../constants';
 import type { ID } from '../../types';
 
@@ -126,6 +127,10 @@ export default function GruposPage({ forcedType }: GruposPageProps = {}): JSX.El
   const [editingGroup, setEditingGroup] = useState<GroupRecord | null>(null);
   const [savingGroup, setSavingGroup] = useState(false);
   const [deletingGroupId, setDeletingGroupId] = useState<ID | null>(null);
+  // P0-1 Tier-0 (D-1=2a): gestão de grupo/matriz/membership é superuser-only.
+  // Não-superuser vê a lista, mas sem ações de escrita (co-deploy: UI para de
+  // oferecer escrita antes de o backend rejeitar).
+  const [currentIsSuperuser, setCurrentIsSuperuser] = useState(false);
 
   const [usuarios, setUsuarios] = useState<UserRecord[]>([]);
 
@@ -254,6 +259,14 @@ export default function GruposPage({ forcedType }: GruposPageProps = {}): JSX.El
   useEffect(() => {
     fetchUsuarios();
     fetchPermissoesAndMeta();
+    void (async () => {
+      try {
+        const auth = await checkAuth();
+        setCurrentIsSuperuser(Boolean(auth.user?.is_superuser));
+      } catch {
+        setCurrentIsSuperuser(false);
+      }
+    })();
   }, []);
 
   const handleCreate = (): void => {
@@ -439,6 +452,9 @@ export default function GruposPage({ forcedType }: GruposPageProps = {}): JSX.El
       width: 220,
       render: (_, record) => {
         const reserved = isReservedGroup(record.name);
+        if (!currentIsSuperuser) {
+          return <Text type="secondary">Somente superusuário</Text>;
+        }
         return (
           <Space>
             <Button type="link" size="small" icon={<EditOutlined />} onClick={() => void handleEdit(record)}>
@@ -487,9 +503,11 @@ export default function GruposPage({ forcedType }: GruposPageProps = {}): JSX.El
             <Button icon={<ReloadOutlined />} onClick={() => void fetchGrupos()} loading={loading}>
               Atualizar
             </Button>
-            <Button type="primary" icon={<PlusOutlined />} onClick={handleCreate}>
-              {pageTypeMeta ? pageTypeMeta.create : 'Novo Grupo'}
-            </Button>
+            {currentIsSuperuser ? (
+              <Button type="primary" icon={<PlusOutlined />} onClick={handleCreate}>
+                {pageTypeMeta ? pageTypeMeta.create : 'Novo Grupo'}
+              </Button>
+            ) : null}
           </Space>
         </header>
 

--- a/v2/frontend/src/pages/AdminDAT/UsuariosPage.tsx
+++ b/v2/frontend/src/pages/AdminDAT/UsuariosPage.tsx
@@ -693,7 +693,10 @@ export default function UsuariosPage(): JSX.Element {
             name="setor_ids"
             label="Setor (onde trabalha)"
             tooltip="Unidade/área de atuação da pessoa"
-            rules={[{ required: true, message: 'Selecione pelo menos um setor' }]}
+            // P0-1 Tier-0 (D-1=2a): membership é superuser-only. Não-superuser vê
+            // o valor atual, mas não edita (e o helper não envia group_ids). Relaxa
+            // o required p/ não travar o submit de conta comum com o Select disabled.
+            rules={currentIsSuperuser ? [{ required: true, message: 'Selecione pelo menos um setor' }] : []}
           >
             <Select
               mode="multiple"
@@ -703,6 +706,7 @@ export default function UsuariosPage(): JSX.Element {
               maxTagCount="responsive"
               placeholder="Selecione um ou mais setores"
               options={setorOptions}
+              disabled={!currentIsSuperuser}
             />
           </Form.Item>
 
@@ -710,7 +714,8 @@ export default function UsuariosPage(): JSX.Element {
             name="funcao_ids"
             label="Função (o que pode fazer)"
             tooltip="Papel da pessoa no processo"
-            rules={[{ required: true, message: 'Selecione pelo menos uma função' }]}
+            // P0-1 Tier-0 (D-1=2a): membership é superuser-only (ver setor_ids acima).
+            rules={currentIsSuperuser ? [{ required: true, message: 'Selecione pelo menos uma função' }] : []}
           >
             <Select
               mode="multiple"
@@ -720,6 +725,7 @@ export default function UsuariosPage(): JSX.Element {
               maxTagCount="responsive"
               placeholder="Selecione uma ou mais funções"
               options={funcaoOptions}
+              disabled={!currentIsSuperuser}
             />
           </Form.Item>
 

--- a/v2/frontend/src/pages/AdminDAT/__tests__/GruposPage.readonly.test.tsx
+++ b/v2/frontend/src/pages/AdminDAT/__tests__/GruposPage.readonly.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * P0-1 Tier-0 (D-1=2a): GruposPage é READ-ONLY para não-superuser.
+ *
+ * Toda escrita da GruposPage (criar/editar/excluir grupo, matriz de permissões
+ * funcionais, sync de membros) vira superuser-only. O co-deploy exige que a UI
+ * pare de OFERECER escrita antes de o backend (PR-B) passar a rejeitar — senão
+ * um DAT clica em Salvar e leva 403 (+ risco de escrita parcial: grupo criado,
+ * membros barrados).
+ */
+
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+vi.mock('../../../api/auth', () => ({ checkAuth: vi.fn() }));
+vi.mock('../../../api/adminDAT', () => ({
+  listGroups: vi.fn().mockResolvedValue({
+    results: [{ id: 1, name: 'DAT', group_type: 'setor', user_count: 2, permissoes_funcionais: [] }],
+  }),
+  listUsers: vi.fn().mockResolvedValue({ results: [] }),
+  listPermissoesFuncionais: vi.fn().mockResolvedValue({ results: [] }),
+  getRBACMeta: vi.fn().mockResolvedValue({ setor_groups: ['DAT'], funcao_groups: [], categories: [] }),
+  getGroup: vi.fn(),
+  createGroup: vi.fn(),
+  updateGroup: vi.fn(),
+  deleteGroup: vi.fn(),
+  syncGroupMembers: vi.fn(),
+}));
+
+import GruposPage from '../GruposPage';
+import { checkAuth } from '../../../api/auth';
+
+function renderPage(): void {
+  render(
+    <MemoryRouter>
+      <GruposPage />
+    </MemoryRouter>,
+  );
+}
+
+describe('GruposPage — read-only para não-superuser (P0-1 Tier-0)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('não-superuser: sem botão "Novo Grupo" e ações = "Somente superusuário"', async () => {
+    vi.mocked(checkAuth).mockResolvedValue({ user: { is_superuser: false } } as never);
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText(/Grupos RBAC/)).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('Somente superusuário')).toBeInTheDocument());
+
+    expect(screen.queryByText('Novo Grupo')).toBeNull();
+    expect(screen.queryByText('Editar')).toBeNull();
+    expect(screen.queryByText('Excluir')).toBeNull();
+  });
+
+  test('superuser: botão "Novo Grupo" e ações Editar/Excluir presentes', async () => {
+    vi.mocked(checkAuth).mockResolvedValue({ user: { is_superuser: true } } as never);
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('Novo Grupo')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('Editar')).toBeInTheDocument());
+
+    expect(screen.queryByText('Somente superusuário')).toBeNull();
+  });
+});

--- a/v2/frontend/src/pages/AdminDAT/__tests__/UsuariosPage.cpf.test.tsx
+++ b/v2/frontend/src/pages/AdminDAT/__tests__/UsuariosPage.cpf.test.tsx
@@ -144,3 +144,40 @@ describe('buildUsuarioPayload — CPF write-only LGPD (Bug 3 fix)', () => {
     });
   });
 });
+
+describe('buildUsuarioPayload — group_ids gated por superuser (P0-1 Tier-0)', () => {
+  // Memberships (User→Group) viram superuser-only (D-1=2a). O frontend NAO
+  // envia group_ids para editor nao-superuser (co-deploy: para de enviar ANTES
+  // do backend rejeitar). DAT segue editando conta comum (cadastral/senha).
+  test('currentIsSuperuser=false → group_ids OMITIDO', () => {
+    const values = makeValues({ setor_ids: [1], funcao_ids: [2] });
+    const payload = buildUsuarioPayload(values, {
+      isEditing: true,
+      cpfEditUnlocked: false,
+      currentIsSuperuser: false,
+    });
+    expect(payload).not.toHaveProperty('group_ids');
+  });
+
+  test('currentIsSuperuser=true → group_ids presente (superuser mantem gestao)', () => {
+    const values = makeValues({ setor_ids: [1], funcao_ids: [2] });
+    const payload = buildUsuarioPayload(values, {
+      isEditing: false,
+      cpfEditUnlocked: true,
+      currentIsSuperuser: true,
+    });
+    expect(payload.group_ids).toEqual([1, 2]);
+  });
+
+  test('nao-superuser: campos comuns preservados (so group_ids sai)', () => {
+    const values = makeValues({ setor_ids: [1], funcao_ids: [2] });
+    const payload = buildUsuarioPayload(values, {
+      isEditing: true,
+      cpfEditUnlocked: false,
+      currentIsSuperuser: false,
+    });
+    expect(payload.username).toBe('fabiana.veras');
+    expect(payload.telefone).toBe('85999991111');
+    expect(payload.is_active).toBe(true);
+  });
+});

--- a/v2/frontend/src/pages/AdminDAT/usuario_form_helpers.ts
+++ b/v2/frontend/src/pages/AdminDAT/usuario_form_helpers.ts
@@ -61,10 +61,16 @@ export function buildUsuarioPayload(
   // is_superuser: incluir apenas se quem está editando é superuser
   const superuserPayload = currentIsSuperuser ? { is_superuser } : {};
 
+  // group_ids (memberships): P0-1 Tier-0 (D-1=2a) — gestão de grupo é
+  // superuser-only. Editor não-superuser NÃO envia group_ids (co-deploy: para
+  // de enviar antes de o backend rejeitar). DAT segue editando conta comum
+  // (cadastral/senha/ativo) sem tocar em memberships.
+  const groupsPayload = currentIsSuperuser ? { group_ids: [...setor_ids, ...funcao_ids] } : {};
+
   return {
     ...rest,
     ...cpfPayload,
     ...superuserPayload,
-    group_ids: [...setor_ids, ...funcao_ids],
+    ...groupsPayload,
   };
 }


### PR DESCRIPTION
## Contexto

Parte 1 (frontend) da erradicação **P0-1 Tier-0** (o `GroupViewSet` deixa um não-superuser editar a matriz Grupo×Capability e memberships — auditoria `v2/docs/audits/2026-07-17-rbac-security-audit.md` §4.2). Decisão **D-1 = 2a** (bloqueio total: memberships + matriz → superuser-only). Plano: `v2/docs/plans/2026-07-17-p0-1-tier0-groupviewset.md`.

**Co-deploy:** o frontend precisa parar de OFERECER escrita de grupo/matriz/membership a não-superusers **antes** de o backend (PR-B) passar a rejeitar — senão um DAT clica em Salvar e leva 403 (+ risco de escrita parcial). Este é o PR-A.

## O que muda (frontend read-only para não-superuser)

- **`usuario_form_helpers.ts`** — `buildUsuarioPayload` omite `group_ids` quando o editor não é superuser (mesmo padrão já usado para `is_superuser`).
- **`UsuariosPage.tsx`** — Selects de setor/função ficam `disabled` e o `required` é relaxado para não-superuser. **DAT mantém** criar/editar/excluir/senha/cadastral de conta comum.
- **`GruposPage.tsx`** (e `SetoresPage`/`FuncoesPage`, que a reusam) — "Novo" escondido e ações da tabela viram "Somente superusuário" para não-superuser. Toda escrita ali é grupo/matriz/membership.
- **`adminDAT.ts`** — remove `assignGroups` (código morto — nenhuma página chamava) + interface + teste.

## Segurança / escopo

- **Frontend não é fronteira de segurança.** Este PR **sozinho não fecha a falha** — o bloqueio real é o **PR-B (backend)**. Aqui é preparação de co-deploy.
- Por isso é **seguro mergear isolado**: não restringe nada no servidor, só esconde/desabilita UI para não-superuser. Superuser mantém tudo; não há regressão funcional.
- O caminho de **import de usuários** que atribui grupos é backend → tratado no PR-B.

## Testes / gates

- `buildUsuarioPayload`: RED→GREEN (não-superuser não envia `group_ids`).
- `GruposPage`: teste de componente (RED provado desligando o gating) — não-superuser sem botões de escrita; superuser com Novo/Editar/Excluir.
- Suíte completa: **481/481** (44 arquivos). typecheck, eslint, build (vite): limpos.
- checklist (meta/a11y/security): job de CI (não roda no container de dev).

## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local):
```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `f79566f1`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
