### PR TITLE
test(solicitacao): destrava e reforca AuditLog de edicao (#1382)

### DIFF
--- a/v2/backend/apps/core/tests/test_solicitacao_edit.py
+++ b/v2/backend/apps/core/tests/test_solicitacao_edit.py
@@ -390,22 +390,13 @@ class TestSolicitacaoEditBusinessRules:
 class TestSolicitacaoEditAuditLog:
     """Testes de audit log para edições."""
 
-    @pytest.mark.skip(reason="AuditLog para edições em investigação - funcionalidade principal de edição funciona")
     def test_edit_creates_audit_log(self, api_client, usuario_owner, solicitacao_editavel):
-        """Edição cria registro no AuditLog com campos alterados.
+        """Edição cria registro no AuditLog com campos alterados (action UPDATE).
 
-        Nota: O AuditLog é criado no perform_update() do ViewSet quando
-        há campos alterados. Este teste verifica que o mecanismo funciona.
-
-        TODO: Investigar por que perform_update não está gerando AuditLog em testes.
+        O AuditLog é criado no perform_update() do ViewSet quando há campos
+        alterados, com details.changed_fields (old/new), ip_address e user_agent.
         """
         api_client.force_authenticate(user=usuario_owner)
-
-        # Guardar contagem inicial de logs
-        initial_count = AuditLog.objects.filter(
-            action="UPDATE",
-            model_name="Solicitacao",
-        ).count()
 
         response = api_client.patch(
             f"/api/solicitacoes/{solicitacao_editavel.id}/",
@@ -414,6 +405,8 @@ class TestSolicitacaoEditAuditLog:
                 "observacoes": "Novas observações para Audit",
             },
             format="json",
+            REMOTE_ADDR="203.0.113.7",
+            HTTP_USER_AGENT="pytest-edit-agent",
         )
 
         assert response.status_code == status.HTTP_200_OK
@@ -422,20 +415,28 @@ class TestSolicitacaoEditAuditLog:
         solicitacao_editavel.refresh_from_db()
         assert solicitacao_editavel.local == "Novo Local para Audit"
 
-        # Verificar AuditLog - pode haver mais de um se testes anteriores criaram
+        # AuditLog de UPDATE escopado por esta solicitação (rollback por teste
+        # garante isolamento, então esperamos exatamente 1).
         logs = AuditLog.objects.filter(
             action="UPDATE",
             model_name="Solicitacao",
             details__solicitacao_id=solicitacao_editavel.id,
         )
-        assert logs.count() >= 1, "Deveria haver pelo menos 1 AuditLog de UPDATE"
+        assert logs.count() == 1, "Deveria haver exatamente 1 AuditLog de UPDATE"
 
-        # Verificar o log mais recente
-        log = logs.order_by("-created_at").first()
+        log = logs.first()
         assert log is not None
+        assert log.action == "UPDATE"
         assert log.usuario == usuario_owner
         assert log.details["solicitacao_id"] == solicitacao_editavel.id
+        assert log.details["ip_address"] == "203.0.113.7"
+        assert log.details["user_agent"] == "pytest-edit-agent"
         assert "local" in log.details["changed_fields"]
+        assert "observacoes" in log.details["changed_fields"]
+        assert log.details["changed_fields"]["local"] == {
+            "old": "Local Original",
+            "new": "Novo Local para Audit",
+        }
 
     def test_no_audit_log_when_no_changes(self, api_client, usuario_owner, solicitacao_editavel):
         """Não cria AuditLog quando não há mudanças."""


### PR DESCRIPTION
## #1382 — cobrir AuditLog de edição de Solicitação

O `test_edit_creates_audit_log` estava `@pytest.mark.skip` com um TODO stale ("investigar por que perform_update não gera AuditLog em testes"). Na verdade **produção já emite tudo** — `perform_update` (views_solicitacao.py:477-491) cria `AuditLog` action=UPDATE com `changed_fields` (old/new), `ip_address` e `user_agent`. Era só um skip stale.

### Mudanças (test-only, zero produção)
- Remove o `@pytest.mark.skip` + TODO resolvido + var `initial_count` morta.
- Injeta `REMOTE_ADDR`/`HTTP_USER_AGENT` no PATCH (DRF APIClient não os manda por padrão → sem isso `ip_address`='127.0.0.1' e `user_agent`='').
- Reforça asserções: `action=='UPDATE'`, `ip_address`, `user_agent`, `changed_fields` contém `local`+`observacoes` com `{old,new}`, `changed_fields['local']=={'old':'Local Original','new':'Novo Local para Audit'}`, count escopado `==1`.

### Validação local (slot 5 isolado)
- **GREEN**: 2 passed (`TestSolicitacaoEditAuditLog`, inclui o teste negativo já existente).
- **Bite-check (RED)**: neutralizar o write de produção (`if changed_fields` → `if False and…`) faz o teste falhar (`assert 0==1`) → prova que exercita a branch do AuditLog. Revertido.
- black/isort/flake8 limpos.

Refs #1382
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `8c6806e0`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
