### PR TITLE
fix(rbac): backend gate Tier-0 superuser-only (PR-B P0-1)

### DIFF
--- a/v2/backend/apps/core/permissions.py
+++ b/v2/backend/apps/core/permissions.py
@@ -17,6 +17,7 @@ from apps.core.rbac.permissions import (  # noqa: F401
     HasSectorAccess,
     IsGerenteSuperintendencia,
     IsOwnerOrPrivileged,
+    SuperuserOnly,
 )
 
 __all__ = [
@@ -25,4 +26,5 @@ __all__ = [
     "HasSectorAccess",
     "IsGerenteSuperintendencia",
     "IsOwnerOrPrivileged",
+    "SuperuserOnly",
 ]

--- a/v2/backend/apps/core/rbac/permissions.py
+++ b/v2/backend/apps/core/rbac/permissions.py
@@ -125,6 +125,26 @@ class HasFunctionalPermission(permissions.BasePermission):  # type: ignore[misc]
         return self.functional_codename in get_user_functional_permissions(user)
 
 
+class SuperuserOnly(permissions.BasePermission):  # type: ignore[misc]
+    """
+    Tier-0: apenas superusuários (P0-1, auditoria 2026-07-17).
+
+    Usada nos endpoints de administração de privilégio/identidade — CRUD de
+    grupo, matriz Grupo×Capability e membership — onde NENHUMA capability
+    operacional deve conceder acesso. Fecha o vetor de escalada onde um DAT
+    editava a matriz / cunhava aprovadores.
+
+    NÃO usar `rest_framework.permissions.IsAdminUser`: ele checa `is_staff`,
+    não `is_superuser`.
+    """
+
+    message = "Apenas superusuários podem realizar esta ação."
+
+    def has_permission(self, request: Request, view: APIView) -> bool:
+        user = request.user
+        return bool(user and user.is_authenticated and getattr(user, "is_superuser", False))
+
+
 # ============================================================================
 # 3 classes mantidas pós-Epic 5.3 — expressam lógica que `HasPerm(codename)`
 # não cobre:

--- a/v2/backend/apps/core/serializers/usuario.py
+++ b/v2/backend/apps/core/serializers/usuario.py
@@ -243,8 +243,8 @@ class UsuarioAdminSerializer(serializers.ModelSerializer):
         return value
 
     def _actor_is_superuser(self) -> bool:
-        request = self.context.get("request")
-        actor = getattr(request, "user", None)
+        request: Any = self.context.get("request")
+        actor: Any = getattr(request, "user", None)
         return bool(actor and getattr(actor, "is_superuser", False))
 
     def create(self, validated_data: dict[str, Any]) -> Any:

--- a/v2/backend/apps/core/serializers/usuario.py
+++ b/v2/backend/apps/core/serializers/usuario.py
@@ -242,6 +242,11 @@ class UsuarioAdminSerializer(serializers.ModelSerializer):
 
         return value
 
+    def _actor_is_superuser(self) -> bool:
+        request = self.context.get("request")
+        actor = getattr(request, "user", None)
+        return bool(actor and getattr(actor, "is_superuser", False))
+
     def create(self, validated_data: dict[str, Any]) -> Any:
         """Create user with hashed password and groups."""
         groups = validated_data.pop("groups", [])
@@ -253,8 +258,11 @@ class UsuarioAdminSerializer(serializers.ModelSerializer):
             user.set_password(password)
             user.save()
 
-        # Assign groups after user creation
-        if groups:
+        # P0-1 Tier-0 (D-1=2a): membership é superuser-only. group_ids de
+        # não-superuser é ignorado (o frontend já não envia — aqui é a
+        # fronteira real). DAT cria a conta comum; o vínculo a grupo fica a
+        # cargo do superuser.
+        if groups and self._actor_is_superuser():
             user.groups.set(groups)
 
         return user
@@ -270,8 +278,9 @@ class UsuarioAdminSerializer(serializers.ModelSerializer):
             user.set_password(password)
             user.save()
 
-        # Update groups if provided (P1.1 validation already applied)
-        if groups is not None:
+        # P0-1 Tier-0 (D-1=2a): membership é superuser-only (ver create()).
+        # group_ids de não-superuser é ignorado.
+        if groups is not None and self._actor_is_superuser():
             user.groups.set(groups)
 
         return user

--- a/v2/backend/apps/core/tests/test_admin_api.py
+++ b/v2/backend/apps/core/tests/test_admin_api.py
@@ -58,6 +58,12 @@ def usuario_dat(db):
 
 
 @pytest.fixture
+def usuario_super(db):
+    """P0-1 Tier-0: administração de grupo/matriz/membership virou superuser-only."""
+    return UsuarioFactory(username="root_admin_api", cpf="12345670009", superuser=True)
+
+
+@pytest.fixture
 def usuario_controle(db):
     """Usuário do grupo Controle"""
     user = UsuarioFactory(
@@ -695,9 +701,9 @@ class TestRbacFunctionalAPI:
         assert "Gerente" in response.data["funcao_groups"]
         assert "governanca" in response.data["categories"]
 
-    def test_dat_can_create_group_as_funcao_and_meta_reflects(self, api_client, usuario_dat):
-        """Grupo criado como função aparece em funcao_groups do /rbac/meta/."""
-        api_client.force_authenticate(user=usuario_dat)
+    def test_superuser_can_create_group_as_funcao_and_meta_reflects(self, api_client, usuario_super):
+        """Grupo criado como função aparece em funcao_groups do /rbac/meta/ (P0-1: só superuser cria)."""
+        api_client.force_authenticate(user=usuario_super)
 
         create_response = api_client.post(
             "/api/grupos/",
@@ -716,9 +722,9 @@ class TestRbacFunctionalAPI:
         assert meta_response.status_code == status.HTTP_200_OK
         assert "Analista de Campo" in meta_response.data["funcao_groups"]
 
-    def test_dat_create_group_rejects_invalid_group_type(self, api_client, usuario_dat):
-        """Criação de grupo rejeita tipo inválido."""
-        api_client.force_authenticate(user=usuario_dat)
+    def test_superuser_create_group_rejects_invalid_group_type(self, api_client, usuario_super):
+        """Criação de grupo rejeita tipo inválido (P0-1: só superuser cria)."""
+        api_client.force_authenticate(user=usuario_super)
 
         response = api_client.post(
             "/api/grupos/",
@@ -729,8 +735,8 @@ class TestRbacFunctionalAPI:
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert "group_type_input" in response.data["errors"]
 
-    def test_dat_can_patch_group_permissoes_funcionais(self, api_client, usuario_dat):
-        """DAT pode vincular permissões funcionais a um grupo."""
+    def test_superuser_can_patch_group_permissoes_funcionais(self, api_client, usuario_super):
+        """Superuser vincula permissões funcionais a um grupo (P0-1: matriz superuser-only)."""
         group = GroupFactory(name="Equipe Operacional")
         permissao_a = PermissaoFuncional.objects.create(
             codename="rbac.group_patch_a",
@@ -747,7 +753,7 @@ class TestRbacFunctionalAPI:
             is_system=False,
         )
 
-        api_client.force_authenticate(user=usuario_dat)
+        api_client.force_authenticate(user=usuario_super)
         payload = {"permissao_funcional_ids": [permissao_a.id, permissao_b.id]}
         response = api_client.patch(f"/api/grupos/{group.id}/", payload, format="json")
 
@@ -758,20 +764,20 @@ class TestRbacFunctionalAPI:
         returned_ids = {item["id"] for item in response.data["permissoes_funcionais"]}
         assert returned_ids == {permissao_a.id, permissao_b.id}
 
-    def test_rename_reserved_group_requires_confirmation(self, api_client, usuario_dat):
-        """Renomeio de grupo reservado exige ?confirm_reserved=true."""
+    def test_rename_reserved_group_requires_confirmation(self, api_client, usuario_super):
+        """Renomeio de grupo reservado exige ?confirm_reserved=true (P0-1: só superuser)."""
         group = GroupFactory(name="Controle")
-        api_client.force_authenticate(user=usuario_dat)
+        api_client.force_authenticate(user=usuario_super)
 
         response = api_client.patch(f"/api/grupos/{group.id}/", {"name": "Controle Novo"}, format="json")
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert "confirm_reserved=true" in str(response.data)
 
-    def test_delete_reserved_group_requires_confirmation(self, api_client, usuario_dat):
-        """Exclusão de grupo reservado exige ?confirm_reserved=true."""
+    def test_delete_reserved_group_requires_confirmation(self, api_client, usuario_super):
+        """Exclusão de grupo reservado exige ?confirm_reserved=true (P0-1: só superuser)."""
         group = GroupFactory(name="Formador")
-        api_client.force_authenticate(user=usuario_dat)
+        api_client.force_authenticate(user=usuario_super)
 
         response = api_client.delete(f"/api/grupos/{group.id}/")
 

--- a/v2/backend/apps/core/tests/test_admin_user_security.py
+++ b/v2/backend/apps/core/tests/test_admin_user_security.py
@@ -54,6 +54,10 @@ class AdminUserSecurityTests(TestCase):
             cpf="22222222222",  # Unique CPF
         )
 
+        # P0-1 Tier-0 (D-1=2a): atribuição de grupo (membership) via serializer é
+        # superuser-only. Ator das checagens de mecânica de grupo agora é superuser.
+        self.user_super = UsuarioFactory(username="root_sec", cpf="10000000009", superuser=True)
+
         self.factory = APIRequestFactory()
 
     def test_dat_cannot_set_is_superuser_or_is_staff(self):
@@ -143,24 +147,18 @@ class AdminUserSecurityTests(TestCase):
             str(serializer.errors["group_ids"][0]),
         )
 
-    def test_dat_can_assign_whitelisted_groups_to_others(self):
+    def test_superuser_can_assign_whitelisted_groups_to_others(self):
         """
-        P1.1 - DAT pode atribuir grupos da whitelist para OUTROS usuários
-
-        Cenário:
-        - DAT atualiza user_comum
-        - DAT adiciona grupos: Coordenador, Formador (ambos na whitelist)
-
-        Expectativa:
-        - Update bem-sucedido
-        - user_comum recebe os grupos
+        P0-1 Tier-0: atribuição de grupo (membership) é superuser-only. Superuser
+        atribui grupos da whitelist a OUTROS usuários. Que o DAT tem group_ids
+        ignorado é coberto em test_rbac_tier0_group_gate.py.
         """
         data = {
             "group_ids": [self.group_coord.id, self.group_formador.id],
         }
 
         request = self.factory.patch(f"/api/usuarios/{self.user_comum.id}/", data)
-        request.user = self.user_dat
+        request.user = self.user_super
 
         # Update de OUTRO usuário (não de si mesmo)
         serializer = UsuarioAdminSerializer(
@@ -256,13 +254,13 @@ class AdminUserSecurityTests(TestCase):
         - Resposta contém groups: ["Coordenador", "Formador"] (nomes)
         - Não contém group_ids na resposta (write-only)
         """
-        # Atribuir grupos via group_ids
+        # Atribuir grupos via group_ids (P0-1: membership é superuser-only)
         data = {
             "group_ids": [self.group_coord.id, self.group_formador.id],
         }
 
         request = self.factory.patch(f"/api/usuarios/{self.user_comum.id}/", data)
-        request.user = self.user_dat
+        request.user = self.user_super
 
         serializer = UsuarioAdminSerializer(
             instance=self.user_comum,
@@ -337,7 +335,7 @@ class AdminUserSecurityTests(TestCase):
             "group_ids": [dynamic_group.id],
         }
         request = self.factory.patch(f"/api/usuarios/{self.user_comum.id}/", data)
-        request.user = self.user_dat
+        request.user = self.user_super
 
         serializer = UsuarioAdminSerializer(
             instance=self.user_comum,
@@ -400,6 +398,10 @@ class AdminUserSecurityTests(TestCase):
         actor_super = UsuarioFactory(superuser=True, cpf="77777777777")
         actor_super.is_active = False
         actor_super.save(update_fields=["is_active"])
+        # P0-1: setUp cria um superuser ativo (user_super); desativa aqui para
+        # que last_super seja de fato o ÚLTIMO superuser ATIVO neste cenário.
+        self.user_super.is_active = False
+        self.user_super.save(update_fields=["is_active"])
 
         data = {"is_superuser": False}
         request = self.factory.patch(f"/api/usuarios/{last_super.id}/", data)
@@ -424,6 +426,10 @@ class AdminUserSecurityTests(TestCase):
         actor_super = UsuarioFactory(superuser=True, cpf="99999999999")
         actor_super.is_active = False
         actor_super.save(update_fields=["is_active"])
+        # P0-1: ver test_cannot_remove_last_active_superuser — desativa o
+        # user_super do setUp p/ last_super ser o último ATIVO.
+        self.user_super.is_active = False
+        self.user_super.save(update_fields=["is_active"])
 
         data = {"is_active": False}
         request = self.factory.patch(f"/api/usuarios/{last_super.id}/", data)

--- a/v2/backend/apps/core/tests/test_assign_groups.py
+++ b/v2/backend/apps/core/tests/test_assign_groups.py
@@ -28,16 +28,11 @@ def api_client():
 
 @pytest.fixture
 def usuario_dat(db):
-    """Usuário com permissão DAT."""
-    user = UsuarioFactory(
-        username="dat_user",
-        email="dat@example.com",
-        password="testpass123",
-        cpf="11111111111",
-    )
-    grupo_dat = GroupFactory(name="DAT")
-    user.groups.add(grupo_dat)
-    return user
+    """P0-1 Tier-0: `assign_groups` virou superuser-only. O ator destes testes
+    de MECÂNICA (whitelist / self-block / dedup / payload inválido) agora é
+    superuser — a mecânica continua igual, só muda quem pode. Que um DAT (não-
+    superuser) recebe 403 é coberto em `test_rbac_tier0_group_gate.py`."""
+    return UsuarioFactory(username="root_assign", cpf="11111111111", superuser=True)
 
 
 @pytest.fixture

--- a/v2/backend/apps/core/tests/test_group_sync_members.py
+++ b/v2/backend/apps/core/tests/test_group_sync_members.py
@@ -23,13 +23,11 @@ def api_client() -> APIClient:
 
 @pytest.fixture
 def usuario_dat(db) -> Usuario:
-    return UsuarioFactory(
-        username="dat_sync",
-        email="dat_sync@example.com",
-        password="senha123",
-        cpf="81234567890",
-        groups=["DAT"],
-    )
+    # P0-1 Tier-0: sync-members virou superuser-only. O ator das mecânicas
+    # (add/remove/idempotência/auditoria) é superuser. Que um não-superuser
+    # recebe 403 segue em test_sync_members_requires_dat_permission +
+    # test_rbac_tier0_group_gate.py.
+    return UsuarioFactory(username="root_sync", cpf="81234567890", superuser=True)
 
 
 @pytest.fixture

--- a/v2/backend/apps/core/tests/test_rbac_superuser_target_protection.py
+++ b/v2/backend/apps/core/tests/test_rbac_superuser_target_protection.py
@@ -147,9 +147,10 @@ class TestSuperuserTargetProtectionAPI:
         assert resp.status_code == status.HTTP_404_NOT_FOUND
         assert Usuario.objects.filter(pk=superuser.id).exists()
 
-    def test_dat_assign_groups_to_superuser_returns_404_and_groups_unchanged(
-        self, api_client, usuario_dat, superuser, ns
-    ):
+    def test_dat_assign_groups_returns_403_and_groups_unchanged(self, api_client, usuario_dat, superuser, ns):
+        # P0-1 Tier-0: assign_groups virou superuser-only → o DAT recebe 403
+        # (a permissão barra antes do 404-por-invisibilidade do P0-0). O
+        # superuser segue intocado de qualquer forma.
         grupo = GroupFactory(name="Formador")
         api_client.force_authenticate(user=usuario_dat)
         resp = api_client.post(
@@ -157,7 +158,7 @@ class TestSuperuserTargetProtectionAPI:
             {"group_ids": [grupo.id]},
             format="json",
         )
-        assert resp.status_code == status.HTTP_404_NOT_FOUND
+        assert resp.status_code == status.HTTP_403_FORBIDDEN
         superuser.refresh_from_db()
         assert superuser.groups.count() == 0
 

--- a/v2/backend/apps/core/tests/test_rbac_tier0_group_gate.py
+++ b/v2/backend/apps/core/tests/test_rbac_tier0_group_gate.py
@@ -1,0 +1,180 @@
+"""
+P0-1 Tier-0 (D-1=2a): administração de grupo / matriz Grupo×Capability /
+membership é **superuser-only**.
+
+Auditoria 2026-07-17 §4.2: um não-superuser (DAT/Controle) editava a matriz via
+`permissao_funcional_ids`, cunhava aprovadores via `sync_members`/`assign_groups`
+e criava/renomeava/excluía grupos — tudo sob `manage_purchases_and_materials`.
+
+Invariante: só superuser cria/edita/exclui grupo, edita a matriz, ou muta
+membership (sync_members, assign_groups, `group_ids` no cadastro de usuário).
+DAT mantém: CRUD de conta comum + LEITURA de grupos (a tela fica read-only).
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportOptionalMemberAccess=false, reportAttributeAccessIssue=false, reportArgumentType=false
+
+from __future__ import annotations
+
+from django.contrib.auth.models import Group
+from rest_framework import status
+from rest_framework.test import APIClient
+
+import pytest
+
+from apps.core.models import PermissaoFuncional, Usuario
+from apps.core.tests.factories import GroupFactory, UsuarioFactory
+
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+
+@pytest.fixture
+def dat(db):
+    """Não-superuser com manage_admin_registries + manage_purchases_and_materials."""
+    user = UsuarioFactory(username="dat_gate", cpf="91000000001")
+    user.groups.add(GroupFactory(name="DAT"))
+    return user
+
+
+@pytest.fixture
+def root(db):
+    return UsuarioFactory(username="root_gate", cpf="91000000009", superuser=True)
+
+
+@pytest.mark.django_db
+class TestGroupViewSetTier0Gate:
+    def test_dat_cannot_create_group(self, api_client, dat):
+        api_client.force_authenticate(dat)
+        resp = api_client.post("/api/grupos/", {"name": "NovoGrupo", "group_type_input": "setor"}, format="json")
+        assert resp.status_code == status.HTTP_403_FORBIDDEN
+        assert not Group.objects.filter(name="NovoGrupo").exists()
+
+    def test_dat_cannot_edit_group_matrix(self, api_client, dat):
+        grupo = GroupFactory(name="Controle")
+        perm = PermissaoFuncional.objects.create(
+            codename="rbac.gate_test", label="Gate", description="", category="operacao", is_system=False
+        )
+        api_client.force_authenticate(dat)
+        resp = api_client.patch(f"/api/grupos/{grupo.id}/", {"permissao_funcional_ids": [perm.id]}, format="json")
+        assert resp.status_code == status.HTTP_403_FORBIDDEN
+        # A cap que o DAT tentou adicionar NÃO entrou (grupo do seed já tem caps próprias).
+        assert not grupo.permissoes_funcionais.filter(id=perm.id).exists()
+
+    def test_dat_cannot_delete_group(self, api_client, dat):
+        grupo = GroupFactory(name="GrupoDescartavel")
+        api_client.force_authenticate(dat)
+        resp = api_client.delete(f"/api/grupos/{grupo.id}/")
+        assert resp.status_code == status.HTTP_403_FORBIDDEN
+        assert Group.objects.filter(id=grupo.id).exists()
+
+    def test_dat_cannot_sync_members(self, api_client, dat):
+        grupo = GroupFactory(name="Superintendência")
+        api_client.force_authenticate(dat)
+        resp = api_client.post(f"/api/grupos/{grupo.id}/sync-members/", {"user_ids": [dat.id]}, format="json")
+        assert resp.status_code == status.HTTP_403_FORBIDDEN
+        assert grupo.user_set.count() == 0
+
+    def test_dat_can_still_list_and_retrieve_groups(self, api_client, dat):
+        grupo = GroupFactory(name="DAT")
+        api_client.force_authenticate(dat)
+        assert api_client.get("/api/grupos/").status_code == status.HTTP_200_OK
+        assert api_client.get(f"/api/grupos/{grupo.id}/").status_code == status.HTTP_200_OK
+
+    def test_superuser_can_create_group(self, api_client, root):
+        api_client.force_authenticate(root)
+        resp = api_client.post("/api/grupos/", {"name": "NovoSuper", "group_type_input": "setor"}, format="json")
+        assert resp.status_code == status.HTTP_201_CREATED
+
+    def test_superuser_can_edit_group_matrix(self, api_client, root):
+        grupo = GroupFactory(name="Coordenador")
+        perm = PermissaoFuncional.objects.create(
+            codename="rbac.gate_super", label="GateS", description="", category="operacao", is_system=False
+        )
+        api_client.force_authenticate(root)
+        resp = api_client.patch(f"/api/grupos/{grupo.id}/", {"permissao_funcional_ids": [perm.id]}, format="json")
+        assert resp.status_code == status.HTTP_200_OK
+        assert grupo.permissoes_funcionais.count() == 1
+
+
+@pytest.mark.django_db
+class TestAssignGroupsTier0Gate:
+    def test_dat_cannot_assign_groups(self, api_client, dat):
+        grupo = GroupFactory(name="Formador")
+        target = UsuarioFactory(username="alvo_assign", cpf="91000000003")
+        api_client.force_authenticate(dat)
+        resp = api_client.post(
+            f"/api/usuarios-admin/{target.id}/assign_groups/", {"group_ids": [grupo.id]}, format="json"
+        )
+        assert resp.status_code == status.HTTP_403_FORBIDDEN
+        target.refresh_from_db()
+        assert target.groups.count() == 0
+
+    def test_superuser_can_assign_groups(self, api_client, root):
+        grupo = GroupFactory(name="Formador")
+        target = UsuarioFactory(username="alvo_assign2", cpf="91000000004")
+        api_client.force_authenticate(root)
+        resp = api_client.post(
+            f"/api/usuarios-admin/{target.id}/assign_groups/", {"group_ids": [grupo.id]}, format="json"
+        )
+        assert resp.status_code == status.HTTP_200_OK
+        target.refresh_from_db()
+        assert set(target.groups.values_list("name", flat=True)) == {"Formador"}
+
+
+@pytest.mark.django_db
+class TestUserGroupIdsTier0Gate:
+    """`group_ids` no cadastro de usuário é superuser-only (membership)."""
+
+    def test_dat_create_user_group_ids_ignored(self, api_client, dat):
+        grupo = GroupFactory(name="Superintendência")
+        api_client.force_authenticate(dat)
+        resp = api_client.post(
+            "/api/usuarios-admin/",
+            {
+                "username": "novo_comum",
+                "email": "novo_comum@example.com",
+                "cpf": "91000000005",
+                "password": "SecurePass123!",
+                "group_ids": [grupo.id],
+            },
+            format="json",
+        )
+        assert resp.status_code == status.HTTP_201_CREATED
+        novo = Usuario.objects.get(username="novo_comum")
+        assert novo.groups.count() == 0  # membership ignorada p/ não-superuser
+
+    def test_dat_update_user_group_ids_ignored(self, api_client, dat):
+        target = UsuarioFactory(username="alvo_update", cpf="91000000006")
+        grupo = GroupFactory(name="Gerente")
+        api_client.force_authenticate(dat)
+        resp = api_client.patch(f"/api/usuarios-admin/{target.id}/", {"group_ids": [grupo.id]}, format="json")
+        assert resp.status_code == status.HTTP_200_OK
+        target.refresh_from_db()
+        assert target.groups.count() == 0
+
+    def test_dat_can_still_update_common_user_cadastral(self, api_client, dat):
+        target = UsuarioFactory(username="alvo_cad", cpf="91000000007")
+        api_client.force_authenticate(dat)
+        resp = api_client.patch(f"/api/usuarios-admin/{target.id}/", {"telefone": "85911110000"}, format="json")
+        assert resp.status_code == status.HTTP_200_OK
+        target.refresh_from_db()
+        assert target.telefone == "85911110000"
+
+    def test_superuser_create_user_with_group_ids_applies(self, api_client, root):
+        grupo = GroupFactory(name="Formador")
+        api_client.force_authenticate(root)
+        resp = api_client.post(
+            "/api/usuarios-admin/",
+            {
+                "username": "novo_super",
+                "email": "novo_super@example.com",
+                "cpf": "91000000008",
+                "password": "SecurePass123!",
+                "group_ids": [grupo.id],
+            },
+            format="json",
+        )
+        assert resp.status_code == status.HTTP_201_CREATED
+        assert Usuario.objects.get(username="novo_super").groups.count() == 1

--- a/v2/backend/apps/core/views/admin.py
+++ b/v2/backend/apps/core/views/admin.py
@@ -35,7 +35,7 @@ from apps.core.models import (
     Projeto,
     Usuario,
 )
-from apps.core.permissions import HasPerm
+from apps.core.permissions import HasPerm, SuperuserOnly
 from apps.core.rbac.policies import CanAccessAuditLogs
 from apps.core.serializers import (
     AuditLogSerializer,
@@ -396,7 +396,7 @@ class UsuarioAdminViewSet(viewsets.ModelViewSet):
                 raise ValidationError({"detail": "Não é possível remover o último superusuário ativo."})
         instance.delete()
 
-    @action(detail=True, methods=["post"], permission_classes=[HasPerm("manage_purchases_and_materials")])
+    @action(detail=True, methods=["post"], permission_classes=[SuperuserOnly])
     def assign_groups(self, request, pk=None):
         """
         Atribui grupos a um usuário.
@@ -491,6 +491,14 @@ class GroupViewSet(viewsets.ModelViewSet):
     ordering_fields = ["name", "id"]
     ordering = ["name"]
 
+    def get_permissions(self):  # type: ignore[override]
+        # P0-1 Tier-0 (D-1=2a): leitura fica com quem administra cadastros (a
+        # tela vira read-only p/ não-superuser); TODA escrita — create/update/
+        # destroy e a ação sync_members — é superuser-only.
+        if self.action in ("list", "retrieve"):
+            return [HasPerm("manage_purchases_and_materials")()]
+        return [SuperuserOnly()]
+
     def perform_destroy(self, instance: Group) -> None:
         is_reserved = instance.name in RESERVED_GROUPS
         confirmed = str(self.request.query_params.get("confirm_reserved", "")).lower() == "true"
@@ -504,7 +512,6 @@ class GroupViewSet(viewsets.ModelViewSet):
         detail=True,
         methods=["post"],
         url_path="sync-members",
-        permission_classes=[HasPerm("manage_purchases_and_materials")],
     )
     def sync_members(self, request: Request, pk: str | None = None) -> Response:
         """


### PR DESCRIPTION
## Contexto

Parte 2 (backend) da erradicação **P0-1 Tier-0** — a fronteira REAL. O `GroupViewSet` deixava um não-superuser (DAT/Controle) editar a matriz Grupo×Capability via `permissao_funcional_ids`, cunhar aprovadores via `sync_members`/`assign_groups`, e criar/renomear/excluir grupos — tudo sob `manage_purchases_and_materials` (auditoria `v2/docs/audits/2026-07-17-rbac-security-audit.md` §4.2). Decisão **D-1 = 2a** (superuser-only). Plano: `v2/docs/plans/2026-07-17-p0-1-tier0-groupviewset.md`.

## O que muda (gate Tier-0 = superuser-only)

- Nova permission **`SuperuserOnly`** (`is_superuser`, **não** `IsAdminUser`/`is_staff`).
- **GroupViewSet**: `list`/`retrieve` seguem para quem administra cadastros (a tela do PR-A fica read-only); **create/update/destroy** e a ação **`sync_members`** → superuser-only (via `get_permissions()`; o decorator do `sync_members` não reivindica mais permissão, evitando o silent-drop de `@action(permission_classes=...)`).
- **`assign_groups`** → superuser-only.
- **`group_ids`** no cadastro de usuário (`UsuarioAdminSerializer.create/update`) → aplicado só se o ator é superuser; para não-superuser é **ignorado** (o frontend do PR-A já não envia — aqui é a fronteira real).
- Grupo reservado (rename/delete) segue com `confirm_reserved`, mas agora a **autorização** é `SuperuserOnly` (o param do caller deixa de ser a barreira).

**DAT mantém:** CRUD de conta comum (criar/editar/senha/cadastral/ativar) + **leitura** de grupos. Superuser mantém tudo.

## Segurança / co-deploy

⚠️ **NÃO deployar antes do PR-A (#1563).** Se o backend endurecer antes do frontend read-only, o DAT ainda vê os botões antigos e toma 403 (+ risco de escrita parcial). Devem subir juntos (um promote só, sem janela).

## Testes / gates

- **13 testes novos** (`test_rbac_tier0_group_gate.py`, RED→GREEN): DAT → 403 em create/update/delete/`sync_members`/`assign_groups`; `group_ids` ignorado; DAT ainda **lê** grupos e edita cadastral; superuser faz tudo.
- **26 testes existentes reescritos** para o comportamento seguro (flip DAT→superuser nos testes de mecânica de grupo; o P0-0 `assign_groups` passa de 404 para 403).
- Suíte `apps/core`: **2868 passed / 0 falhas**. rbac_lint · black · isort · flake8 · `makemigrations --check`: limpos.

## Próximo

PR-C (backend-only, sem restrição de co-deploy): **P1-3** (invalidação reversa de cache em `sync_members`) + **P2-2** (serviço de auditoria transacional; remove o buffer global `_PENDING_GROUP_CAP_DELTAS`).

## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `907b9518`):
```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
