### PR TITLE
fix(rbac): invalidacao reversa de cache de permissoes (P1-3)

### DIFF
--- a/v2/backend/apps/core/rbac_signals.py
+++ b/v2/backend/apps/core/rbac_signals.py
@@ -17,6 +17,7 @@ from apps.core.services.rbac_permissions import (
     bump_functional_permissions_cache_version,
     invalidate_group_functional_permissions_cache,
     invalidate_user_functional_permissions_cache,
+    invalidate_users_functional_permissions_cache,
 )
 from apps.core.services.rbac_service import invalidate_assignable_groups_cache
 
@@ -28,12 +29,31 @@ def _invalidate_funcperm_on_user_groups_change(
     sender: type[Any],
     instance: Any,
     action: str,
+    reverse: bool = False,
+    pk_set: set[int] | None = None,
     **kwargs: Any,
 ) -> None:
-    if action in {"post_add", "post_remove", "post_clear"}:
-        user_id = getattr(instance, "id", None)
-        if isinstance(user_id, int):
-            invalidate_user_functional_permissions_cache(user_id)
+    # P1-3: Forward (reverse=False) → instance é o User que mudou de grupos.
+    # Reverse (reverse=True) → instance é o Group (ex.: sync_members via
+    # `group.user_set.set(...)`); os usuários afetados vêm em `pk_set`. O handler
+    # antigo assumia sempre instance=User (`instance.id`), então no reverse
+    # invalidava a chave errada e deixava a autorização revogada em cache até o
+    # TTL (300s).
+    if not reverse:
+        if action in {"post_add", "post_remove", "post_clear"}:
+            user_id = getattr(instance, "id", None)
+            if isinstance(user_id, int):
+                invalidate_user_functional_permissions_cache(user_id)
+        return
+
+    if action in {"post_add", "post_remove"} and pk_set:
+        invalidate_users_functional_permissions_cache(pk_set)
+    elif action == "pre_clear":
+        # `group.user_set.clear()` não fornece pk_set → snapshot dos membros
+        # atuais ANTES do clear.
+        member_ids = list(instance.user_set.values_list("id", flat=True))
+        if member_ids:
+            invalidate_users_functional_permissions_cache(member_ids)
 
 
 @receiver(m2m_changed, sender=PermissaoFuncional.groups.through)

--- a/v2/backend/apps/core/tests/test_rbac_cache_reverse_p1_3.py
+++ b/v2/backend/apps/core/tests/test_rbac_cache_reverse_p1_3.py
@@ -1,0 +1,64 @@
+"""
+P1-3: invalidação de cache na mudança REVERSA de membership.
+
+`sync_members` usa `group.user_set.set(...)` (relação reversa: instance=Group,
+pk_set=user_ids). O handler de `m2m_changed` assumia sempre instance=User
+(`instance.id` = user_id) e ignorava `pk_set` → invalidava a chave errada e
+deixava a autorização revogada em cache até CACHE_TTL_SECONDS (300s).
+
+Estes testes provam que remover/limpar membros pela relação reversa invalida o
+cache de permissões funcionais dos USUÁRIOS afetados.
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportAttributeAccessIssue=false
+
+from __future__ import annotations
+
+from django.core.cache import cache
+from django.test import TestCase, override_settings
+
+from apps.core.models import PermissaoFuncional
+from apps.core.services.rbac_permissions import get_user_functional_permissions
+from apps.core.tests.factories import GroupFactory, UsuarioFactory
+
+LOCMEM = {"default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache", "LOCATION": "rbac-p1-3"}}
+
+
+@override_settings(CACHES=LOCMEM)
+class TestReverseMembershipCacheInvalidation(TestCase):
+    def setUp(self):
+        cache.clear()
+        self.user = UsuarioFactory(username="cache_user_p13", cpf="70000000001")
+        self.group = GroupFactory(name="GrupoCacheP13")
+        self.perm = PermissaoFuncional.objects.create(
+            codename="p13.test_cap", label="P13", description="", category="operacao", is_system=False
+        )
+        self.perm.groups.add(self.group)
+
+    def _prime(self):
+        """Adiciona o usuário ao grupo (reverse) e prime o cache com a cap."""
+        self.group.user_set.add(self.user)
+        self.assertIn("p13.test_cap", get_user_functional_permissions(self.user))
+
+    def test_reverse_remove_invalidates_user_cache(self):
+        self._prime()
+        self.group.user_set.remove(self.user)  # revogação via reverse
+        self.assertNotIn("p13.test_cap", get_user_functional_permissions(self.user))
+
+    def test_reverse_set_invalidates_removed_user_cache(self):
+        # sync_members usa group.user_set.set(...).
+        self._prime()
+        self.group.user_set.set([])
+        self.assertNotIn("p13.test_cap", get_user_functional_permissions(self.user))
+
+    def test_reverse_clear_invalidates_members(self):
+        self._prime()
+        self.group.user_set.clear()  # pk_set=None → snapshot no pre_clear
+        self.assertNotIn("p13.test_cap", get_user_functional_permissions(self.user))
+
+    def test_forward_change_still_invalidates(self):
+        # Regressão: forward (user.groups.*) continua invalidando.
+        self.user.groups.add(self.group)
+        self.assertIn("p13.test_cap", get_user_functional_permissions(self.user))
+        self.user.groups.remove(self.group)
+        self.assertNotIn("p13.test_cap", get_user_functional_permissions(self.user))


### PR DESCRIPTION
> **Empilhado sobre o PR-B (#1567)** — base = `fix/rbac-tier0-backend-gate`. Rever/mergear o PR-B primeiro (o diff/base do GitHub re-aponta para `main` quando o PR-B mergear).

## Contexto

P1-3 da erradicação P0-1 (**backend-only, sem restrição de co-deploy** — pode subir sozinho). O handler de `m2m_changed` de `User.groups` (`apps/core/rbac_signals.py`) invalidava o cache de permissões funcionais assumindo **sempre** `instance=User`. No caminho **reverso** (`group.user_set.set/remove/clear` — usado pelo `sync_members`), `instance` é o **Group** e os usuários afetados vêm em `pk_set`. Resultado: invalidava a chave errada → **autorização revogada ficava em cache até 300s** (`CACHE_TTL_SECONDS`).

## O que muda

O handler passa a ramificar forward/reverse:
- **Forward** (`reverse=False`, instance=User): invalida a chave do próprio usuário (inalterado).
- **Reverse** (`reverse=True`, instance=Group): invalida os usuários de `pk_set` no `post_add`/`post_remove`; no `clear` (pk_set=None) faz **snapshot** dos membros no `pre_clear`.

Usa o helper já existente `invalidate_users_functional_permissions_cache`. Sem migration.

## Testes / gates

- **4 testes novos** (`test_rbac_cache_reverse_p1_3.py`, RED→GREEN): reverse `remove`/`set([])`/`clear` invalidam o cache do usuário afetado; forward (`user.groups.*`) continua invalidando.
- Suíte `apps/core`: **2872 passed / 0 falhas**. rbac_lint · black · isort · flake8 · `makemigrations --check`: limpos.

## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, imagens buildadas do HEAD):
```
==============================================
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
==============================================
```
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `f79566f1`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
