### PR TITLE
docs(sdd): versiona scaffold specs/ de mudança + tooling local (worktree, codegraph)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -647,3 +647,11 @@ evidence/
 # Slot de isolamento Docker por worktree (multi-worktree dev). Não versionar —
 # cada worktree tem o seu. Ver v2/infra/scripts/worktree-env.sh
 .dev-slot
+
+# Lista local de arquivos .env a propagar para novos worktrees (aponta segredos,
+# nada no repo consome). Local por máquina — não versionar.
+.worktreeinclude
+
+# Artefato local do codegraph/graphify (banco AST, não referenciado no repo;
+# o SSOT do grafo versionado é graphify-out/). Local — não versionar.
+.codegraph/

--- a/.gitignore
+++ b/.gitignore
@@ -648,10 +648,6 @@ evidence/
 # cada worktree tem o seu. Ver v2/infra/scripts/worktree-env.sh
 .dev-slot
 
-# Lista local de arquivos .env a propagar para novos worktrees (aponta segredos,
-# nada no repo consome). Local por máquina — não versionar.
-.worktreeinclude
-
 # Artefato local do codegraph/graphify (banco AST, não referenciado no repo;
 # o SSOT do grafo versionado é graphify-out/). Local — não versionar.
 .codegraph/

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,7 @@
+.env
+.env.local
+.env.dev
+v2/infra/.env
+v2/backend/.env
+v2/frontend/.env
+v2/frontend/.env.local

--- a/specs/0001-example-auditlog-edit/design.md
+++ b/specs/0001-example-auditlog-edit/design.md
@@ -1,0 +1,46 @@
+# Design — reabilitar AuditLog de edição de Solicitação
+
+- **Spec ID**: 0001-example-auditlog-edit
+
+## Abordagem
+
+Investigar a causa do skip antes de "consertar". Descoberta: a lógica de AuditLog em
+`SolicitacaoViewSet.perform_update()` **já funciona** desde o PR #332 — registra
+`action=UPDATE` com `changed_fields` quando há diff. O skip era **órfão**: o teste nunca
+foi reabilitado após a investigação original. Logo, a mudança é test-only: remover o skip
+e **reforçar os asserts** para cobrir o critério "campos alterados". Nenhuma mudança de
+produção.
+
+Alternativa descartada: alterar `perform_update` — desnecessário, a lógica está correta
+(confirmado por `test_owner_can_edit_own_solicitacao`, que já exercita o caminho).
+
+## Camadas e arquivos a tocar
+
+| Camada | Arquivo | Mudança |
+|---|---|---|
+| teste | `apps/core/tests/test_solicitacao_edit.py` | remover `@pytest.mark.skip`; reforçar asserts |
+| view | `apps/core/views_solicitacao.py` | nenhuma (referência: `perform_update`, ~L400-487) |
+
+## Modelo de dados / migrations
+
+- Sem mudança de schema. Sem migration.
+
+## API (se aplicável)
+
+- N/A — exercita `PATCH /api/solicitacoes/{id}/` já existente.
+
+## RBAC / AuditLog
+
+- `AuditLog.action = UPDATE`, `model_name = "Solicitacao"`.
+- `details`: `solicitacao_id`, `changed_fields` (old/new por campo), `ip_address`, `user_agent`.
+
+## Estratégia de teste
+
+- Reabilitar `test_edit_creates_audit_log`; asserts: presença de `local` e `observacoes`
+  em `changed_fields`, e old/new de `local`.
+- Negativo já coberto por `test_no_audit_log_when_no_changes` (não skipado).
+- Rodar arquivo inteiro + regressão `-k "audit or Audit"`.
+
+## ADRs / docs relacionados
+
+- PA-05 (`.claude/skills/aprender-domain/`). Origem do código: PR #332.

--- a/specs/0001-example-auditlog-edit/requirements.md
+++ b/specs/0001-example-auditlog-edit/requirements.md
@@ -1,0 +1,46 @@
+# Requirements — reabilitar AuditLog de edição de Solicitação
+
+> Exemplo real (concluído). Mostra granularidade e tom esperados.
+
+- **Spec ID**: 0001-example-auditlog-edit
+- **Issue(s)**: #1382
+- **Branch**: `test/1382-auditlog-edicao-solicitacao`
+- **Autor**: Matheus
+- **Status**: pronto p/ PR (verde local; aguarda staging gate + decisão do humano)
+
+## Problema
+
+`test_edit_creates_audit_log` em `apps/core/tests/test_solicitacao_edit.py` estava
+`@pytest.mark.skip` com TODO de "investigação". Edição comum de `Solicitacao` ficava sem
+cobertura de AuditLog, enquanto approve/reject/delete tinham — lacuna concreta em PA-05.
+
+## Objetivo
+
+Garantir, por teste, que editar uma Solicitação registra `AuditLog` com os campos alterados.
+
+## User stories
+
+- Como auditor, quero que toda edição de Solicitação fique no AuditLog, para rastrear quem
+  mudou o quê.
+
+## Critérios de aceite (testáveis)
+
+- [x] O teste não está mais skipado.
+- [x] PATCH com mudança real cria `AuditLog` `action=UPDATE`.
+- [x] PATCH sem mudança não cria log falso.
+- [x] O log contém usuário, `solicitacao_id` e `changed_fields` (old/new).
+- [x] Testes existentes continuam verdes.
+
+## Regras de negócio aplicáveis
+
+- **PA-05** — registrar usuário, data/hora e o que mudou em `AuditLog`.
+- **CP-02** — toda ação de aprovação/edição relevante é auditada.
+
+## Fora de escopo
+
+- Refatorar o sistema de auditoria; mexer na tela de Audit Logs; criar novo modelo.
+
+## Riscos / questões em aberto
+
+- Suspeita inicial: divergência entre serializer/`perform_update`/fixtures. (Não se
+  confirmou — ver `design.md`.)

--- a/specs/0001-example-auditlog-edit/tasks.md
+++ b/specs/0001-example-auditlog-edit/tasks.md
@@ -1,0 +1,38 @@
+# Tasks — reabilitar AuditLog de edição de Solicitação
+
+- **Spec ID**: 0001-example-auditlog-edit
+
+## Pré-implementação
+
+- [x] `requirements.md` e `design.md` coerentes com a `CONSTITUTION.md`.
+- [x] Branch `test/1382-auditlog-edicao-solicitacao` a partir do `main`.
+- [x] Ambiente dev no ar (Docker). **Nota**: usar `up -d --build` — a imagem `latest` de
+      prod não traz `pytest`; só o build do `Dockerfile.dev` instala `requirements-dev`.
+
+## Implementação (Red → Green → Refactor)
+
+- [x] Investigar o skip → confirmar que `perform_update` já gera AuditLog (PR #332).
+- [x] Remover `@pytest.mark.skip` e o TODO do docstring.
+- [x] Reforçar asserts: `observacoes` em `changed_fields`; old/new de `local`.
+- [x] Rodar o teste alvo → **2 passed**.
+
+## Verificação
+
+- [x] Arquivo inteiro `test_solicitacao_edit.py` → **32 passed**.
+- [x] Regressão `-k "audit or Audit"` → **93 passed** (ignorando coleção pré-existente
+      quebrada em `test_pr_security_url_substring.py`, não relacionada).
+- [x] `black`/`isort`/`flake8` limpos no arquivo.
+- [x] Diff test-only (6+/6−); sem segredos.
+
+## Pré-PR (humano conduz)
+
+- [x] Rebase no `main` atual (0 atrás / 1 à frente; verde reconfirmado).
+- [x] Staging gate: `ALL 8 CHECKS PASSED` (rodado localmente).
+- [ ] **Usuário** abre/mergeia o PR (CP-07) — pendente de decisão.
+
+## Notas de execução
+
+- Lição de ambiente: sem `make` no git-bash → rodar `docker compose` direto; `up` sem
+  `--build` reusa imagem prod sem `pytest`.
+- O skip era órfão: nenhuma mudança de produção foi necessária — a aposta do design se
+  confirmou no primeiro run verde.

--- a/specs/CONSTITUTION.md
+++ b/specs/CONSTITUTION.md
@@ -1,0 +1,79 @@
+# Constitution — princípios imutáveis
+
+Leitura **obrigatória** antes de qualquer mudança. Toda spec, todo commit e todo PR
+deve honrar isto. Se uma regra aqui conflita com uma instrução de tarefa, **esta vence**
+— e você sinaliza o conflito em vez de seguir.
+
+---
+
+## 🛑 Hard stops (nunca faça)
+
+1. **Nunca `git push` na `main`.** Sempre branch + PR. (Um hook bloqueia o push direto.)
+2. **Nunca rode o v2 fora do Docker** — sem `python manage.py` no host (CP-01).
+3. **Nunca abra PR sem o staging gate** 8/8 + evidência (`ALL 8 CHECKS PASSED`) no corpo.
+4. **Nunca commite, empurre ou abra PR sem o usuário pedir.** Pare no "teste verde" e relate.
+5. **Nunca** crie classes `Is<Role>` nem `user.groups.filter(name=...)` em views —
+   use `HasPerm("codename")` (bloqueado por lint).
+6. **Nunca** edite migration já aplicada — crie uma nova de fix.
+7. **Nunca** use SQL cru — só ORM.
+8. **Nunca** auto-aprove `Solicitacao` de projeto SUPER (PA-01).
+9. **Nunca** inclua trailer "Claude Code"/"Co-Authored-By" em commit.
+10. **Nunca** declare algo pronto sem rodar e ver o verde.
+
+---
+
+## ⚖️ Cláusulas Pétreas (CP-01..08)
+
+> **SSOT:** [`docs/business-rules/clausulas-petreas.md`](../docs/business-rules/clausulas-petreas.md).
+> O resumo abaixo é para consulta rápida — em qualquer divergência, **o SSOT manda** e é lá que se corrige.
+
+- **CP-01** Docker-only.
+- **CP-02** Política de Aprovação PA-01..07; tudo em `AuditLog`.
+- **CP-03** Regras de Disponibilidade RD-01..08; storage UTC, comparação em `America/Fortaleza`.
+- **CP-04** Workflow: Entender → Planejar → Implementar → Testar → Infra → ETL → UI/UX.
+- **CP-05** v1 congelado (`fix/v1-*` → `main-v1`).
+- **CP-06** Conventional commits: `<tipo>(<escopo>): <mensagem>` minúsculo, ≤72, imperativo.
+- **CP-07** Nunca push direto na `main`; PR obrigatório.
+- **CP-08** `INCLUDE_DEV_TOOLS=false` em produção.
+
+---
+
+## 🏛️ Barras de qualidade (inegociáveis)
+
+- **Camadas** (import-linter, ADR-012): `models` (SSOT, constraints no DB) → `services`
+  (lógica + escrita, `transaction.atomic()`) → `views` (thin) / `serializers` (shape+validação).
+  Views nunca escrevem direto.
+- **Type-safety**: Pyright strict, type hints 100% (PEP 695). Sem `Any` sem justificativa.
+  Frontend TypeScript strict.
+- **RBAC**: capability via `HasPerm`. Aprovador = `is_superuser` ∨ (`Gerente`∧`Superintendência`)
+  ∨ (`Assistente Administrativo`∧`Controle`). Policy pública: `access_solicitation_approvals`.
+- **AuditLog** em writes críticos (APPROVE/REJECT/PUBLISH/CANCEL/UPDATE).
+- **Performance**: `select_related`/`prefetch_related` em `get_queryset` (sem N+1).
+- **Testes**: cobertura ≥ 85% (`--cov-fail-under=85`), ~100% no crítico. Comportamento,
+  não implementação; nomes em 3ª pessoa; 403 antes de 400; `GCAL_CLIENT=fake` em CI.
+- **TDD** (CP-04): teste que falha antes do código.
+- **Legibilidade**: nomes específicos (`usuario_aprovador`, não `user`); early returns;
+  máx. 2-3 níveis de indentação; comentário explica o *porquê*, não o *o quê*.
+
+---
+
+## ✅ Verification gate (antes de dizer "pronto")
+
+- [ ] Rodei o teste/comando de fato?
+- [ ] Vi a saída de sucesso (verde), não suposição?
+- [ ] Verifiquei efeitos colaterais (regressão, lint, tipos)?
+- [ ] Relatei fielmente — se falhou, digo que falhou, com a saída.
+
+---
+
+## 📌 Domínio (índice — SSOT em `docs/business-rules/`)
+
+Referencie as regras por **código**, sempre a partir do SSOT versionado — não parafraseie
+aqui (evita drift de contagem/descrição):
+
+- **RD-01..08** (disponibilidade) → [`regras-disponibilidade.md`](../docs/business-rules/regras-disponibilidade.md)
+- **PA-01..07** (aprovação) → [`politica-aprovacao.md`](../docs/business-rules/politica-aprovacao.md)
+- **RF** (requisitos funcionais) → [`requisitos-funcionais.md`](../docs/business-rules/requisitos-funcionais.md)
+- **CP-01..08** (cláusulas pétreas) → [`clausulas-petreas.md`](../docs/business-rules/clausulas-petreas.md)
+
+Profundidade operacional para o Claude Code: `.claude/skills/aprender-domain/`.

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,0 +1,101 @@
+# Specs — Spec-Driven Development de mudança
+
+Este diretório é a **fonte versionada** de como conduzimos **cada mudança** no Aprender
+Sistema v2. Qualquer agente (Claude, Zed, Cursor, humano) deve ler **`CONSTITUTION.md`
+primeiro** e seguir o fluxo abaixo antes de escrever código.
+
+> **Não confundir com [`v2/docs/specs/`](../v2/docs/specs/INDEX_SDD.md).** Aquela camada
+> (formalizada na [ADR-017](../docs/architecture/project-decisions/ADR-017-spec-driven-documentation.md))
+> é a **documentação viva dos módulos que já existem** — uma spec por módulo/contrato, com
+> frontmatter e `sources_of_truth`. **Esta** pasta (`specs/`) é o **processo por mudança**:
+> uma spec efêmera (requirements → design → tasks) por feature/fix em andamento. Mesma
+> filosofia (spec antes do código), granularidades diferentes.
+>
+> Por que aqui e não em `.claude/`? A pasta `.claude/` é gitignored (local, só o Claude
+> Code vê). `specs/` é versionado: viaja pelo repositório e é visível a **qualquer**
+> agente, em qualquer máquina. Os **contratos enforced** (CP, RD, PA, RF) têm SSOT em
+> `docs/business-rules/` e nas specs de `v2/docs/specs/domain/` (ADR-017 §6): onde houver
+> divergência, **essas fontes mandam** — `CONSTITUTION.md` aqui é um resumo operacional e
+> `.claude/` traz a profundidade extra para o Claude Code.
+
+---
+
+## O que é Spec-Driven Development aqui
+
+Toda mudança não-trivial nasce de uma **spec** antes do código. A spec é três arquivos,
+nesta ordem — cada um responde uma pergunta:
+
+| Arquivo | Pergunta | Foco |
+|---|---|---|
+| `requirements.md` | **O quê / por quê** | User stories, critérios de aceite, RF/RD/PA/CP afetados |
+| `design.md` | **Como** | Camadas tocadas, modelo de dados, API, ADRs, estratégia de teste |
+| `tasks.md` | **Em que ordem** | Checklist executável em ordem TDD, com verificação e gate |
+
+Trivial (typo, bump de dep, ajuste de 1 linha) não precisa de spec — vá direto ao commit
+convencional. Na dúvida, escreva a spec: ela é barata e evita retrabalho.
+
+---
+
+## Fluxo (lifecycle)
+
+```text
+1. requirements  →  2. design  →  3. tasks  →  4. implementar (TDD)  →  5. verificar  →  6. PR
+   (o quê/porquê)     (como)        (ordem)      red → green → refactor   gate verde      humano aprova
+```
+
+1. **requirements** — capture o problema e os critérios de aceite **testáveis**. Referencie
+   as regras de negócio aplicáveis (RF/RD/PA/CP) por código, não por paráfrase.
+2. **design** — decida a abordagem dentro das camadas (`models → services → views`),
+   liste arquivos a tocar, contratos de API, e como vai testar. Cite ADRs relevantes.
+3. **tasks** — quebre em passos pequenos, **cada um com seu teste antes**. Inclua o passo
+   de verificação e o staging gate.
+4. **implementar** — siga `tasks.md`. Red → Green → Refactor. Não pule etapas (CP-04).
+5. **verificar** — rode os testes e veja o verde; rode lint/tipos; confira regressão.
+   Não declare pronto sem isso (ver `CONSTITUTION.md` § Verification gate).
+6. **PR** — só com staging gate `ALL 8 CHECKS PASSED` + evidência. **Só o humano** abre/
+   mergeia o PR (CP-07): o agente para no verde e relata.
+
+---
+
+## Convenção de pastas
+
+Uma spec por mudança, numerada e com slug:
+
+```text
+specs/
+├── README.md                       ← este arquivo (o método)
+├── CONSTITUTION.md                 ← princípios imutáveis (leia primeiro)
+├── templates/                      ← copie para iniciar uma spec nova
+│   ├── requirements.md
+│   ├── design.md
+│   └── tasks.md
+└── NNNN-slug-curto/                ← uma feature/fix (ex.: 0001-example-auditlog-edit)
+    ├── requirements.md
+    ├── design.md
+    └── tasks.md
+```
+
+Para começar: `cp -r specs/templates specs/NNNN-minha-feature` e preencha na ordem.
+`NNNN` = próximo número livre (4 dígitos). O slug deve casar com o nome da branch
+(`<tipo>/NNNN-slug`).
+
+---
+
+## Relação com o que já existe
+
+- **`v2/docs/specs/`** (ADR-017) — documentação viva **por módulo** já existente. Uma spec
+  daqui *implementa* uma mudança; uma spec de lá *descreve* o módulo depois de pronto. Ao
+  fechar uma mudança que altera contrato de módulo, atualize a spec viva correspondente.
+- **Contratos de negócio (SSOT):** `docs/business-rules/` (CP/PA/RD/RF) — não reescreva os
+  códigos aqui, **referencie** por código.
+- **Não duplica** os planos de produto em `v2/docs/plans/` nem as notas em `thoughts/`.
+  Specs aqui são o contrato executável de **uma** mudança; planos lá são estratégia ampla.
+- Regras profundas: `.claude/CLAUDE.md`, `.claude/rules/`, `.claude/skills/aprender-domain/`.
+- Ambientes/comandos: `v2/infra/ENVIRONMENTS.md`.
+
+---
+
+## Exemplo real
+
+`specs/0001-example-auditlog-edit/` — spec preenchida da reabilitação do teste de
+AuditLog de edição de Solicitação. Use como referência de granularidade e tom.

--- a/specs/templates/design.md
+++ b/specs/templates/design.md
@@ -1,0 +1,46 @@
+# Design — <título da mudança>
+
+> **Como**. Só depois de `requirements.md` aprovado.
+> A solução deve caber nas camadas e nas barras de qualidade da `CONSTITUTION.md`.
+
+- **Spec ID**: NNNN-slug
+
+## Abordagem
+
+<2-5 frases: a estratégia escolhida e por quê. Se houve alternativas, registre a descartada
+e o motivo.>
+
+## Camadas e arquivos a tocar
+
+Respeite `models → services → views/serializers`. Liste caminhos reais.
+
+| Camada | Arquivo | Mudança |
+|---|---|---|
+| service | `apps/core/services/____.py` | <…> |
+| view | `apps/core/views/____.py` | <…> |
+| model | `apps/core/models/____.py` | <…/nenhuma> |
+
+## Modelo de dados / migrations
+
+- <campos/constraints novos; ou "sem mudança de schema">
+- Migration: <necessária? reversível? índice CONCURRENTLY?>
+
+## API (se aplicável)
+
+- Rota(s): `/api/...` (canônico; nunca `/api/v1/*`).
+- Request/response shape; erros no formato `{ code, detail, field_errors }`.
+- `@extend_schema`, paginação, permissão (`HasPerm("...")`).
+
+## RBAC / AuditLog
+
+- Capability exigida: `____`.
+- Write crítico → `AuditLog`? Qual `action` e quais `details`?
+
+## Estratégia de teste
+
+- Arquivos de teste e casos (felizes + 403 + edge). Cobertura alvo.
+- Fixtures necessárias; `GCAL_CLIENT=fake` se tocar GCal.
+
+## ADRs / docs relacionados
+
+- ADR-____; `v2/docs/...`

--- a/specs/templates/requirements.md
+++ b/specs/templates/requirements.md
@@ -1,0 +1,43 @@
+# Requirements — <título da mudança>
+
+> **O quê** e **por quê**. Preencha antes de pensar em solução.
+> Copie esta pasta: `cp -r specs/templates specs/NNNN-slug`.
+
+- **Spec ID**: NNNN-slug
+- **Issue(s)**: #____
+- **Branch**: `<tipo>/NNNN-slug`
+- **Autor**: ____
+- **Status**: draft | em design | em implementação | em verificação | pronto p/ PR
+
+## Problema
+
+<1-3 frases: o que está errado/faltando e qual a dor concreta. Evidência, não suposição.>
+
+## Objetivo
+
+<O resultado desejado, observável. Uma frase.>
+
+## User stories
+
+- Como <papel>, quero <ação>, para <benefício>.
+
+## Critérios de aceite (testáveis)
+
+Escreva como afirmações verificáveis — viram testes.
+
+- [ ] <Dado … quando … então …>
+- [ ] <…>
+
+## Regras de negócio aplicáveis
+
+Cite por código (não parafraseie): RF__, RD__, PA__, CP__. Explique o vínculo em 1 linha.
+
+- Ex.: **PA-05** — edição deve gerar `AuditLog`.
+
+## Fora de escopo
+
+- <o que esta spec NÃO faz — evita escopo inflado>
+
+## Riscos / questões em aberto
+
+- <o que pode quebrar; decisões que precisam do humano (needs-decision)>

--- a/specs/templates/tasks.md
+++ b/specs/templates/tasks.md
@@ -1,0 +1,38 @@
+# Tasks — <título da mudança>
+
+> **Em que ordem**. Checklist executável, granular, em ordem **TDD**.
+> Cada passo de código vem **depois** do seu teste. Marque `[x]` ao concluir (com verde).
+
+- **Spec ID**: NNNN-slug
+
+## Pré-implementação
+
+- [ ] `requirements.md` e `design.md` preenchidos e coerentes com a `CONSTITUTION.md`.
+- [ ] Branch criada: `git checkout -b <tipo>/NNNN-slug` (a partir do `main` atual).
+- [ ] Ambiente dev no ar (`cd v2/infra && docker compose --env-file .env.dev -f docker-compose.yml -f docker-compose.override.yml up -d --build`).
+
+## Implementação (Red → Green → Refactor)
+
+- [ ] **Red**: escrever teste que falha — `<arquivo::caso>`. Rodar e ver falhar.
+- [ ] **Green**: código mínimo para passar. Rodar e ver verde.
+- [ ] **Refactor**: limpar mantendo verde.
+- [ ] (repetir por critério de aceite)
+
+## Verificação (gate — ver CONSTITUTION § Verification gate)
+
+- [ ] Arquivo de teste inteiro verde.
+- [ ] Regressão relacionada verde.
+- [ ] `black --check` / `isort --check` / `flake8` / `pyright` limpos (no container `web`).
+- [ ] Cobertura ≥ 85% mantida.
+- [ ] Diff contém **só** o necessário (sem arquivo a mais; segredos fora).
+
+## Pré-PR (humano conduz)
+
+- [ ] Rebase no `main` atual.
+- [ ] Staging gate: `ALL 8 CHECKS PASSED` + evidência no corpo do PR.
+- [ ] Commit convencional (`<tipo>(<escopo>): … (#issue)`); sem trailer "Claude Code".
+- [ ] **Usuário** abre/mergeia o PR (CP-07). O agente para aqui e relata.
+
+## Notas de execução
+
+<o que foi descoberto durante a implementação; decisões; surpresas>


### PR DESCRIPTION
## Contexto

Após atualizar o `main` (estava 108 commits atrás), sobraram 12 arquivos untracked locais de 2026-06-19. Investigação mostrou que **não** eram redundantes: o scaffold `specs/` da raiz é trabalho genuíno nunca versionado, distinto do `v2/docs/specs/` (ADR-017).

## O que este PR faz

**Adota o scaffold `specs/`** (Spec-Driven Development *por mudança*: requirements → design → tasks) como fonte versionada, visível a qualquer agente/humano — não só ao Claude Code.

Com **2 correções** para não colidir com o que já existe:

1. **Desambiguação vs ADR-017.** `v2/docs/specs/` documenta *módulos existentes*; `specs/` (raiz) é o *processo por mudança*. Cross-links adicionados nos dois sentidos.
2. **`CONSTITUTION.md` emagrecido.** Não reescreve mais CP/RD/PA/RF — aponta ao SSOT `docs/business-rules/` (banner de precedência + índice por código), eliminando risco de drift.

**Tooling local:**
- `.worktreeinclude` → **versionado** (commit `b0cc7428`). É recurso oficial do Claude Code: o harness lê a lista ao criar um worktree e copia os arquivos gitignored (`.env`) — que `git worktree add` não leva. Lista **caminhos**, não segredos; os `.env` seguem gitignored. [Doc](https://code.claude.com/docs/en/worktrees.md#copy-gitignored-files-into-worktrees).
- `.codegraph/` → `.gitignore` (banco AST local; SSOT do grafo é `graphify-out/`).

## Descartado (já superado no main)

Drafts locais `PLAN_sdd_documentation_migration` (307 l.) e `DOCUMENTATION_AUDIT` EN (295 l.) — o main já tem as versões canônicas (`PLAN_sdd_migration` 207 l. + `AUDITORIA_DOCUMENTAL` PT), referenciadas pelo INDEX_SDD.

## Validação

- 6 links markdown novos resolvem ✅
- Gates `check_doc_frontmatter`/`check_doc_links` não cobrem `specs/` da raiz (sem regressão) ✅
- markdownlint limpo ✅

## Follow-up

Achado A2/A6 da auditoria (menções stale a `apps.dat_ingest`) rastreado em #1574 — fora do escopo deste PR.