### PR TITLE
fix(dev): isola IMAGE_TAG por worktree slot (follow-up #1559)

### DIFF
--- a/v2/Makefile
+++ b/v2/Makefile
@@ -4,7 +4,11 @@
 # lidas direto pelo compose). Use `source infra/scripts/worktree-env.sh <slot>` para
 # derivar tudo de um número. `?=` respeita env/CLI, então quem não exporta nada não muda.
 PROJECT ?= aprender_dev
-DC = COMPOSE_PROJECT_NAME=$(PROJECT) IMAGE_TAG=latest docker compose -f infra/docker-compose.yml -f infra/docker-compose.override.yml
+# IMAGE_TAG precisa do mesmo tratamento que PROJECT: o override.yml tem `build:`, então
+# `up --build` re-tagueia a imagem. Com o valor chumbado, dois stacks paralelos brigam
+# pela mesma tag e um recreate sem build sobe o código do outro worktree.
+IMAGE_TAG ?= latest
+DC = COMPOSE_PROJECT_NAME=$(PROJECT) IMAGE_TAG=$(IMAGE_TAG) docker compose -f infra/docker-compose.yml -f infra/docker-compose.override.yml
 WEB = $(DC) exec -T web
 
 .PHONY: up down build logs shell migrate collect seed seed-demo seed-rbac \

--- a/v2/infra/scripts/worktree-env.sh
+++ b/v2/infra/scripts/worktree-env.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # worktree-env.sh — isola o stack Docker de dev por worktree (multi-worktree paralelo).
 #
-# Cada worktree paralelo precisa de um stack Docker próprio (nome + portas + volumes)
-# para não colidir com os outros. Este script deriva TUDO de um número de slot e exporta
-# as variáveis que o Makefile (PROJECT) e o compose (portas) leem.
+# Cada worktree paralelo precisa de um stack Docker próprio (nome + portas + volumes +
+# tag de imagem) para não colidir com os outros. Este script deriva TUDO de um número de
+# slot e exporta as variáveis que o Makefile (PROJECT, IMAGE_TAG) e o compose (portas) leem.
 #
 # USO (precisa ser SOURCED, não executado — export só persiste no shell atual):
 #   source infra/scripts/worktree-env.sh 1    # slot explícito
@@ -19,6 +19,9 @@
 #
 # Portas por slot (host): backend=8002+slot*10 · db=5434+slot*10 · redis=6380+slot*10 ·
 # frontend=5173+slot*10  (slot1 -> 8012/5444/6390/5183, slot2 -> 8022/5454/6400/5193, ...)
+#
+# IMAGE_TAG por slot: slot 0 -> `latest` (inalterado); slot N -> `sN`. Sem isso os stacks
+# compartilham a mesma tag e um `up -d` sem `--build` sobe o código do outro worktree.
 
 _wt_slot="${1:-}"
 
@@ -43,8 +46,10 @@ fi
 
 if [ "$_wt_slot" = "0" ]; then
   export PROJECT="aprender_dev"
+  export IMAGE_TAG="latest"
 else
   export PROJECT="aprender_dev_s${_wt_slot}"
+  export IMAGE_TAG="s${_wt_slot}"
 fi
 
 export BACKEND_HOST_PORT=$((8002 + _wt_slot * 10))
@@ -52,6 +57,6 @@ export DB_HOST_PORT=$((5434 + _wt_slot * 10))
 export REDIS_HOST_PORT=$((6380 + _wt_slot * 10))
 export FRONTEND_HOST_PORT=$((5173 + _wt_slot * 10))
 
-echo "worktree slot ${_wt_slot} -> PROJECT=${PROJECT} | backend :${BACKEND_HOST_PORT} | db :${DB_HOST_PORT} | redis :${REDIS_HOST_PORT} | frontend :${FRONTEND_HOST_PORT}"
+echo "worktree slot ${_wt_slot} -> PROJECT=${PROJECT} | IMAGE_TAG=${IMAGE_TAG} | backend :${BACKEND_HOST_PORT} | db :${DB_HOST_PORT} | redis :${REDIS_HOST_PORT} | frontend :${FRONTEND_HOST_PORT}"
 
 unset _wt_slot


### PR DESCRIPTION
## Problema

O #1559 tornou o stack de dev isolável por worktree — `COMPOSE_PROJECT_NAME` e as 4
portas de host passaram a derivar de um slot. Mas a linha do `DC` no `v2/Makefile`
mantinha `IMAGE_TAG=latest` **chumbado**:

```make
PROJECT ?= aprender_dev
DC = COMPOSE_PROJECT_NAME=$(PROJECT) IMAGE_TAG=latest docker compose -f ... -f ...
```

Assimetria: `PROJECT` usa `?=` (respeita env/CLI), `IMAGE_TAG` não. Como o
`docker-compose.override.yml` tem `build:` em web/worker/beat/frontend, todo
`up --build` reconstrói **e re-tagueia** — então dois stacks paralelos disputam
`norjosamatheus/aprender-{backend,frontend}:latest`.

## Como apareceu

Dois checkouts do repo em branches diferentes, rodando lado a lado via slot 0 e slot 1.
Portas, rede, volumes e banco isolados corretamente — mas as imagens, não.

Consequência: um `docker compose up -d` **sem** `--build` sobe o código do outro
worktree, silenciosamente. Containers já de pé não são afetados (ficam presos ao ID da
imagem de criação), mas qualquer recreate pega a tag alheia, e cada `make up` sobrescreve
a tag do vizinho.

## Mudança

Mesmo tratamento que `PROJECT` já recebia:

| Arquivo | O quê |
|---|---|
| `v2/Makefile` | `IMAGE_TAG ?= latest` + `IMAGE_TAG=$(IMAGE_TAG)` no `DC` |
| `v2/infra/scripts/worktree-env.sh` | exporta `IMAGE_TAG` derivado do slot (`0` → `latest`, `N` → `sN`); log e comentários atualizados |

**Retrocompatível.** Slot 0, CI e quem não exporta nada continuam em `latest` — o CI
sequer usa o script, e o default do Makefile não mudou.

Custo: cada slot passa a manter seu próprio par de imagens (disco). Em troca, some a
classe de bug "subi e estava rodando o código da outra branch".

## Verificação

- `bash -n infra/scripts/worktree-env.sh` → OK
- `source worktree-env.sh 0` → `PROJECT=aprender_dev` · `IMAGE_TAG=latest`
- `source worktree-env.sh 1` → `PROJECT=aprender_dev_s1` · `IMAGE_TAG=s1`
- `docker compose config` (slot 1) → `norjosamatheus/aprender-{backend,frontend}:s1`
- `docker compose config` (slot 0) → `...:latest` (inalterado)

Testado com dois stacks simultâneos de pé (`aprender_dev-*` em 8002/5434 e
`aprender_dev_s1-*` em 8012/5444), confirmando que o isolamento de runtime do #1559
funciona e que só faltava a tag.

## Notas

- Não muda nada de produção — `docker-compose.prod.yml` não passa por este `DC`.
- Follow-up direto do #1559; mesmos dois arquivos.