### PR TITLE
fix(security): proíbe apps.dev_tools em produção independente de env var (CP-08)

### DIFF
--- a/v2/backend/apps/core/tests/test_prod_guard_rails.py
+++ b/v2/backend/apps/core/tests/test_prod_guard_rails.py
@@ -198,3 +198,75 @@ class ProductionGuardRailsTests(TestCase):
         # Validar mensagem de erro no stderr
         self.assertIn("SECRET_KEY muito curta", result.stderr)
         self.assertIn("ERRO CRÍTICO", result.stderr)
+
+
+class DevToolsProductionGuardTests(TestCase):
+    """
+    CP-08 (#1466) — `apps.dev_tools` NUNCA carrega sob ENVIRONMENT=production.
+
+    O default de INCLUDE_DEV_TOOLS é `true` e a stack de produção não define a
+    variável, então o app entrava em prod por omissão. O guard força `False` em
+    produção independente da env var (defense-in-depth, mesmo espírito dos guards
+    de SECRET_KEY/ALLOWED_HOSTS).
+
+    Optou-se por forçar o valor em vez de `sys.exit(1)`: produção hoje não define
+    a variável, então abortar o boot transformaria o footgun em indisponibilidade
+    no primeiro deploy.
+    """
+
+    def _installed_apps_under(self, **overrides: str) -> tuple[int, str, str]:
+        """Sobe o Django em subprocess e imprime INSTALLED_APPS."""
+        env = os.environ.copy()
+        env["DEBUG"] = "0"
+        env["ALLOWED_HOSTS"] = "example.com"
+        env["SECRET_KEY"] = "a" * 64
+        env["DB_NAME"] = "test_db"
+        env["DB_USER"] = "test_user"
+        env["DB_PASSWORD"] = "test_password"
+        env["DB_HOST"] = "localhost"
+        env["DB_PORT"] = "5434"
+        env.update(overrides)
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "import django;django.setup();"
+                "from django.conf import settings;"
+                "print('\\n'.join(settings.INSTALLED_APPS))",
+            ],
+            cwd=str(Path(settings.BASE_DIR)),
+            env={**env, "DJANGO_SETTINGS_MODULE": "config.settings"},
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        return result.returncode, result.stdout, result.stderr
+
+    def test_dev_tools_absent_in_production_by_default(self):
+        """CP-08: sem INCLUDE_DEV_TOOLS definido, prod NÃO carrega dev_tools."""
+        code, stdout, stderr = self._installed_apps_under(ENVIRONMENT="production")
+
+        self.assertEqual(code, 0, f"Django não subiu. stderr: {stderr}")
+        self.assertNotIn("apps.dev_tools", stdout.split("\n"))
+
+    def test_dev_tools_absent_in_production_even_if_explicitly_enabled(self):
+        """CP-08: INCLUDE_DEV_TOOLS=true NÃO vence o guard de produção."""
+        code, stdout, stderr = self._installed_apps_under(
+            ENVIRONMENT="production",
+            INCLUDE_DEV_TOOLS="true",
+        )
+
+        self.assertEqual(code, 0, f"Django não subiu. stderr: {stderr}")
+        self.assertNotIn("apps.dev_tools", stdout.split("\n"))
+        self.assertIn("INCLUDE_DEV_TOOLS=true ignorado", stderr)
+
+    def test_dev_tools_present_in_development(self):
+        """Sem regressão: fora de produção o app continua disponível."""
+        code, stdout, stderr = self._installed_apps_under(
+            ENVIRONMENT="development",
+            INCLUDE_DEV_TOOLS="true",
+        )
+
+        self.assertEqual(code, 0, f"Django não subiu. stderr: {stderr}")
+        self.assertIn("apps.dev_tools", stdout.split("\n"))

--- a/v2/backend/config/settings.py
+++ b/v2/backend/config/settings.py
@@ -114,6 +114,23 @@ if os.getenv("INCLUDE_ETL", "false").lower() == "true":
 # Para excluir do deploy: INCLUDE_DEV_TOOLS=false
 INCLUDE_DEV_TOOLS = os.getenv("INCLUDE_DEV_TOOLS", "true").lower() == "true"
 
+# CP-08 (#1466): em produção o app NUNCA carrega, independente da env var.
+# O default acima é `true` e a stack de produção não define INCLUDE_DEV_TOOLS, então
+# `apps.dev_tools` (seeds/backfills/cleanup) entrava em prod por omissão — um seed
+# destrutivo a um `manage.py` de distância. Guard rígido, no espírito dos guards de
+# SECRET_KEY/ALLOWED_HOSTS acima.
+#
+# Força-se o valor em vez de `sys.exit(1)` de propósito: como produção hoje não define
+# a variável, abortar o boot converteria o footgun em indisponibilidade no primeiro
+# deploy. O warning cobre o caso de alguém pedir `true` explicitamente.
+if ENVIRONMENT == "production":
+    if INCLUDE_DEV_TOOLS and os.getenv("INCLUDE_DEV_TOOLS"):
+        print(
+            "⚠️  WARNING: INCLUDE_DEV_TOOLS=true ignorado — apps.dev_tools é proibido em produção (CP-08)",
+            file=sys.stderr,
+        )
+    INCLUDE_DEV_TOOLS = False
+
 # Debug E2E — habilita middlewares auxiliares para testes Playwright
 # (ex: FreezeTimeMiddleware). Gate duplo com INCLUDE_DEV_TOOLS garante que
 # nunca vaza para produção. CP-08: INCLUDE_DEV_TOOLS=false em prod.


### PR DESCRIPTION
Closes #1466

## Problema

`INCLUDE_DEV_TOOLS` tem default **`true`** (`settings.py:115`) e a stack de produção
**não define a variável** — então `apps.dev_tools` entrava em produção por omissão,
violando a **CP-08**.

Isso deixa os 15 management commands de `seed_*`/`backfill_*`/`cleanup_*` disponíveis no
container de produção. Não é exposto por HTTP (exige `exec` no container), mas é um
footgun real antes do go-live: um seed destrutivo rodado contra prod por engano.

## Mudança

Guard rígido em `settings.py`, logo após a leitura da env var:

```python
if ENVIRONMENT == "production":
    if INCLUDE_DEV_TOOLS and os.getenv("INCLUDE_DEV_TOOLS"):
        print("⚠️  WARNING: INCLUDE_DEV_TOOLS=true ignorado — ...", file=sys.stderr)
    INCLUDE_DEV_TOOLS = False
```

Sob `ENVIRONMENT=production` o app nunca carrega, mesmo com `INCLUDE_DEV_TOOLS=true`
explícito — mesmo espírito dos guards de `SECRET_KEY`/`ALLOWED_HOSTS` acima.

### Por que forçar o valor em vez de `sys.exit(1)`

A issue sugere "recusar". Optei por **forçar `False` com warning**, não abortar o boot:
como produção hoje **não define** a variável, um `sys.exit(1)` transformaria o footgun
em **indisponibilidade no primeiro deploy**. O warning cobre o caso de alguém pedir
`true` de propósito.

Se a preferência do time for falhar duro, é uma linha — mas aí o `stack.env` do Portainer
precisa receber `INCLUDE_DEV_TOOLS=false` **antes** do merge.

## Testes

`DevToolsProductionGuardTests` — 3 casos, subprocess que imprime `INSTALLED_APPS`:

| Cenário | Esperado |
|---|---|
| prod, sem a env var | `dev_tools` ausente |
| prod, `INCLUDE_DEV_TOOLS=true` | ausente + warning no stderr |
| development | presente (sem regressão) |

**Verificação TDD:** com `settings.py` revertido, os dois primeiros falham
(`'apps.dev_tools' unexpectedly found in [...]`) e o terceiro passa — confirmando que
os testes medem o guard e não passam por acidente.

## Notas

- Gates locais: `black`, `isort`, `flake8` OK. Pyright não roda no container (sem npm) — fica para o CI.
- **Falha pré-existente, não introduzida aqui:** `test_startup_succeeds_with_valid_production_config`
  estoura `TimeoutExpired` com `timeout=10` neste ambiente (Docker/Windows). Confirmei que falha
  igual na `main` limpa, sem estas mudanças — é o único teste que boota o Django inteiro via
  `check --deploy`. Provavelmente passa nos runners do CI; se falhar lá também, vale issue própria.
- O item 1 da issue (setar `INCLUDE_DEV_TOOLS=false` no Portainer) continua valendo como
  defesa em profundidade, mas deixa de ser a única barreira.
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `5ad7502c`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
