### PR TITLE
test(session): estabiliza flaky em App.session-expiry.test (#1577)

### DIFF
--- a/v2/frontend/src/__tests__/App.session-expiry.test.tsx
+++ b/v2/frontend/src/__tests__/App.session-expiry.test.tsx
@@ -79,8 +79,16 @@ describe('App — sessão expirada global (Issue #1376)', () => {
     await screen.findByTestId('app-routes');
     expect(screen.queryByText('LOGIN_PAGE')).not.toBeInTheDocument();
 
+    // Assenta os passive effects antes de disparar o evento. O commit do DOM
+    // (app-routes visível) pode preceder o flush do effect que sincroniza
+    // `userRef.current` (App.tsx). Sem esta barreira, o handler `auth:expired`
+    // às vezes vê `userRef.current === null`, cai no early-return e a transição
+    // para o login nunca ocorre → `findByText('LOGIN_PAGE')` estoura o timeout
+    // de forma intermitente (flaky #1577). Determinístico, sem tocar produção.
+    await act(async () => {});
+
     // Simula 401 emitido por qualquer chamada da UI → fetchAPI dispara o evento.
-    act(() => {
+    await act(async () => {
       window.dispatchEvent(new Event('auth:expired'));
     });
 


### PR DESCRIPTION
Fecha #1577.

## Causa-raiz
O 1º teste caía intermitentemente em `findByText('LOGIN_PAGE')` (:88). `handleAuthExpired` (App.tsx) é **síncrono** e faz early-return quando `userRef.current` ainda não foi sincronizado pelo passive effect que o atualiza. No React 18 o commit do DOM (`app-routes` visível, que destrava o `findByTestId` da linha 79) pode **preceder** o flush desse passive effect. Quando o teste dispara `auth:expired` logo em seguida, o handler às vezes vê `userRef.current === null`, cai no early-return, `setUser(null)` não roda e a transição para o login nunca ocorre → `findByText` estoura o timeout padrão. Intermitente porque quase sempre o effect já flushou.

**É corrida de teste, não de produção:** num 401 real o `userRef` já está setado há muito tempo. Confirma a suspeita da issue (timeout de `waitFor`/`findBy`), mas a raiz é ordem de flush de effects, não falta de retry — por isso apenas aumentar timeout **não** resolveria (no caminho de falha o `LOGIN_PAGE` nunca aparece).

## Fix (test-only, zero produção)
Barreira `await act(async () => {})` para assentar os passive effects antes do dispatch; o dispatch passa a `await act(async () => {...})`. Determinístico.

## Evidência
- **20/20 execuções consecutivas verdes** (critério de aceite da issue), processos isolados
- `tsc --noEmit` limpo
- diff: 1 arquivo (`App.session-expiry.test.tsx`), +9/-1 — nenhum código de produção tocado

## Nota
Investiguei se a raiz seria escopo faltante do #1376 (flagged no handoff): **não é** — o comportamento de produção do handler está correto; o flake é puramente ordenação de effects no ambiente de teste.