### PR TITLE
fix(sw): não cachear /api/me/* + limpar cache de API no logout (#1461)

### DIFF
--- a/v2/frontend/public/sw.js
+++ b/v2/frontend/public/sw.js
@@ -5,7 +5,7 @@
  * and network-first with cache fallback for API requests.
  */
 
-const CACHE_VERSION = 'v3';
+const CACHE_VERSION = 'v4';
 const STATIC_CACHE_NAME = `aprender-v2-static-${CACHE_VERSION}`;
 const API_CACHE_NAME = `aprender-v2-api-${CACHE_VERSION}`;
 
@@ -18,10 +18,12 @@ const STATIC_ASSETS = [
   '/manifest.json',
 ];
 
-// API routes that can be cached for offline use
+// API routes that can be cached for offline use.
+// NB: /api/me/* é intencionalmente EXCLUÍDO — identidade e policies nunca são
+// cacheadas (Issue #1461), para não servir dados de um usuário anterior offline
+// em dispositivo compartilhado. Ver isCacheableApiRoute().
 const CACHEABLE_API_ROUTES = [
   '/api/options/',
-  '/api/me/',
   '/api/config/',
 ];
 
@@ -162,7 +164,12 @@ async function cacheFirstWithNetwork(request) {
  * Check if URL is a cacheable API route.
  */
 function isCacheableApiRoute(url) {
-  return CACHEABLE_API_ROUTES.some((route) => url.includes(route));
+  const { pathname } = new URL(url);
+  // Identidade/policies NUNCA são cacheadas (Issue #1461): exclusão explícita,
+  // não por substring — impede vazamento cross-user offline. Mesmo que /api/me/
+  // volte a CACHEABLE_API_ROUTES por engano, este guard mantém a exclusão.
+  if (pathname.startsWith('/api/me/')) return false;
+  return CACHEABLE_API_ROUTES.some((route) => pathname.startsWith(route));
 }
 
 // Handle messages from clients

--- a/v2/frontend/src/App.tsx
+++ b/v2/frontend/src/App.tsx
@@ -20,6 +20,7 @@ import { logout as apiLogout } from './api/auth';
 import { Toaster } from 'react-hot-toast';
 import { LAYOUT } from './constants';
 import { preloadSearchData } from './services/preloadSearchData';
+import { clearApiCaches } from './services/swCache';
 import OfflineBanner from './components/OfflineBanner';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { FullscreenLoader } from './components/FullscreenLoader';
@@ -154,6 +155,10 @@ function AppContent(): JSX.Element {
       logger.error('Erro no logout:', error);
       message.warning('Sessão encerrada localmente');
     } finally {
+      // Remove os caches de identidade do SW antes do reload (Issue #1461):
+      // impede servir /api/me/* de um usuário anterior offline. Roda mesmo se o
+      // POST de logout falhar (está no finally) e nunca lança (no-op seguro).
+      await clearApiCaches();
       setUser(null);
       window.location.reload();
     }

--- a/v2/frontend/src/services/__tests__/swCache.test.ts
+++ b/v2/frontend/src/services/__tests__/swCache.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Limpeza do Cache Storage do Service Worker no logout (Issue #1461).
+ *
+ * Garante que os caches de API do SW (`aprender-v2-api-*`), que podem conter
+ * `/api/me/*` de um usuário anterior, sejam removidos — sem tocar nos caches de
+ * assets estáticos nem em caches de terceiros.
+ */
+import { describe, test, expect, vi, afterEach } from 'vitest';
+import { clearApiCaches } from '../swCache';
+
+type GlobalWithCaches = { caches?: CacheStorage };
+
+afterEach(() => {
+  delete (globalThis as GlobalWithCaches).caches;
+  vi.restoreAllMocks();
+});
+
+describe('clearApiCaches (Issue #1461)', () => {
+  test('remove os caches de API do SW e preserva os demais', async () => {
+    const keys = [
+      'aprender-v2-api-v4',
+      'aprender-v2-api-v3',
+      'aprender-v2-static-v4',
+      'workbox-precache',
+    ];
+    const del = vi.fn().mockResolvedValue(true);
+    (globalThis as GlobalWithCaches).caches = {
+      keys: vi.fn().mockResolvedValue(keys),
+      delete: del,
+    } as unknown as CacheStorage;
+
+    await clearApiCaches();
+
+    expect(del).toHaveBeenCalledWith('aprender-v2-api-v4');
+    expect(del).toHaveBeenCalledWith('aprender-v2-api-v3');
+    expect(del).not.toHaveBeenCalledWith('aprender-v2-static-v4');
+    expect(del).not.toHaveBeenCalledWith('workbox-precache');
+    expect(del).toHaveBeenCalledTimes(2);
+  });
+
+  test('é no-op quando Cache Storage não existe (não lança)', async () => {
+    delete (globalThis as GlobalWithCaches).caches;
+    await expect(clearApiCaches()).resolves.toBeUndefined();
+  });
+
+  test('não lança se caches.keys() rejeitar', async () => {
+    (globalThis as GlobalWithCaches).caches = {
+      keys: vi.fn().mockRejectedValue(new Error('cache storage indisponível')),
+      delete: vi.fn(),
+    } as unknown as CacheStorage;
+
+    await expect(clearApiCaches()).resolves.toBeUndefined();
+  });
+});

--- a/v2/frontend/src/services/swCache.ts
+++ b/v2/frontend/src/services/swCache.ts
@@ -1,0 +1,28 @@
+/**
+ * Limpeza do Cache Storage do Service Worker (Issue #1461).
+ *
+ * O SW (`public/sw.js`) mantém caches de API nomeados `aprender-v2-api-*`. Como
+ * eles podem conter respostas de `/api/me/*` de um usuário anterior, precisam ser
+ * removidos no logout — senão, offline e em dispositivo compartilhado, a identidade
+ * antiga pode ser servida do cache. Os caches de assets estáticos podem permanecer.
+ */
+
+/** Prefixo dos caches de API do SW (espelha `API_CACHE_NAME` em public/sw.js). */
+const API_CACHE_PREFIX = 'aprender-v2-api-';
+
+/**
+ * Remove todos os caches de API do SW. No-op seguro quando o Cache Storage não
+ * está disponível (SSR, navegador sem suporte, jsdom) ou quando a API falha —
+ * o logout nunca deve travar por causa disso.
+ */
+export async function clearApiCaches(): Promise<void> {
+  if (typeof caches === 'undefined') return;
+  try {
+    const keys = await caches.keys();
+    await Promise.all(
+      keys.filter((name) => name.startsWith(API_CACHE_PREFIX)).map((name) => caches.delete(name)),
+    );
+  } catch {
+    // Cache Storage indisponível/erro — segue o logout sem bloquear.
+  }
+}


### PR DESCRIPTION
Fecha #1461.

## Problema
O Service Worker (`public/sw.js`) tratava `/api/me/` como cacheável (casado por `url.includes` substring, capturando também `/api/me/policies/` e `/api/me/events/`) e o Cache Storage **nunca era limpo no logout**. Network-first, então o vazamento é **offline** — mas o público (formadores, conexão instável, dispositivos compartilhados) é exatamente o pior caso: identidade/policies de um usuário anterior servidas do cache.

## Correção (defesa em profundidade)
1. **Root fix — `public/sw.js`:** `/api/me/*` **nunca** é cacheado (exclusão explícita no `isCacheableApiRoute`, não por substring; troca `url.includes` por `pathname.startsWith`). `CACHE_VERSION` v3→v4 → o handler `activate` purga o cache de API antigo (possivelmente envenenado) no próximo boot do SW.
2. **Logout — `src/services/swCache.ts` + `App.tsx`:** `clearApiCaches()` remove os caches `aprender-v2-api-*` no `finally` do `handleLogout` (roda mesmo se o POST de logout falhar; no-op seguro se Cache Storage indisponível).

## Testes (TDD)
- `swCache.test.ts` — **RED por assertion visto antes da implementação** (stub → teste quebra no comportamento → impl → verde). 3 casos: remove só os `api-*`, no-op sem Cache Storage, resiliente a erro de `keys()`.
- `sw.js` não é unit-testável neste harness (script SW standalone, fora do module graph do Vite; repo tem zero teste de SW) → mudança direta. O comportamento crítico de segurança (limpeza no logout) está coberto por teste.

## Validação local
- swCache 3/3, App.session-expiry 2/2, `tsc --noEmit` limpo, `eslint .` limpo
- Suite completo: as 12 falhas observadas são timeouts de contenção de carga (passam isoladas), mesma classe do #1577 — não relacionadas a este diff

## Staging gate
Será executado via `staging-gate.sh --pr` (não fabricado). A evidência 8/8 é anexada pelo script quando passar.
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `37bdad8a`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
