### PR TITLE
fix(rbac): canManageInternalActions via policy manage_internal_actions (#1263)

### DIFF
--- a/v2/frontend/src/App.tsx
+++ b/v2/frontend/src/App.tsx
@@ -28,6 +28,7 @@ import { AppSidebar } from './components/AppSidebar';
 import { AppHeader } from './components/AppHeader';
 import { AppRoutes } from './components/AppRoutes';
 import { usePermissions } from './hooks/usePermissions';
+import { useCanAccess } from './hooks/useCanAccess';
 import { useResponsive } from './hooks/useResponsive';
 import { useGCalAlertsPolling } from './hooks/useGCalAlertsPolling';
 import { useUnreadNotificationsPolling } from './hooks/useUnreadNotificationsPolling';
@@ -57,6 +58,9 @@ function AppContent(): JSX.Element {
 
   // ── Permissions (single source of truth) ──
   const permissions = usePermissions(user);
+  // Issue #1263: Ações Internas é policy-driven (manage_internal_actions), não mais
+  // a flag legacy por grupo. Policy-only, então basta `policies` (sem legacy flags).
+  const access = useCanAccess(policies);
 
   // ── Load user ──
   // `getMe()` primeiro (estabelece sessão); `getMyPolicies()` depois APENAS se
@@ -113,7 +117,7 @@ function AppContent(): JSX.Element {
 
   // ── Notification badge polling ──
   const { unreadNotifications } = useUnreadNotificationsPolling({
-    enabled: permissions.canAcoesInternas,
+    enabled: access.canManageInternalActions,
     userId: user?.id,
   });
 
@@ -208,7 +212,7 @@ function AppContent(): JSX.Element {
           }}>
             <AppHeader
               user={user}
-              canAcoesInternas={permissions.canAcoesInternas}
+              canManageInternalActions={access.canManageInternalActions}
               unreadNotifications={unreadNotifications}
               isMobile={isMobile}
               sidebarCollapsed={sidebarCollapsed}

--- a/v2/frontend/src/components/AppHeader.tsx
+++ b/v2/frontend/src/components/AppHeader.tsx
@@ -16,7 +16,7 @@ const { Text } = Typography;
 
 interface AppHeaderProps {
   user: { name?: string; username?: string };
-  canAcoesInternas: boolean;
+  canManageInternalActions: boolean;
   unreadNotifications: number;
   isMobile: boolean;
   sidebarCollapsed: boolean;
@@ -30,7 +30,7 @@ interface AppHeaderProps {
 
 export function AppHeader({
   user,
-  canAcoesInternas,
+  canManageInternalActions,
   unreadNotifications,
   isMobile,
   sidebarCollapsed,
@@ -106,7 +106,7 @@ export function AppHeader({
           <UserOutlined />
           <Text strong>{user.name || user.username || 'Usuário'}</Text>
         </Link>
-        {canAcoesInternas && (
+        {canManageInternalActions && (
           <Popover
             trigger="click"
             open={popoverOpen}

--- a/v2/frontend/src/components/AppRoutes.tsx
+++ b/v2/frontend/src/components/AppRoutes.tsx
@@ -83,7 +83,7 @@ interface AppRoutesProps {
 
 export function AppRoutes({ user, permissions, policies }: AppRoutesProps): JSX.Element {
   const {
-    canCoordenador, canControle, canDAT, canAcoesInternas,
+    canCoordenador, canControle, canDAT,
     canDashboardOverview, canDashboardEquipe, canDashboardGcal, canDashboardCompras,
     canMapaBrasil, canDisponibilidade, isFormador,
   } = permissions;
@@ -146,9 +146,9 @@ export function AppRoutes({ user, permissions, policies }: AppRoutesProps): JSX.
         <Route path="/pre-agenda" element={canControle ? <PreAgendaPage /> : <Forbidden />} />
 
         {/* Ações/Notificações */}
-        <Route path="/acoes-notificacao" element={canAcoesInternas ? <AcoesNotificacaoPage /> : <Forbidden />} />
-        <Route path="/acoes-notificacao/timeline" element={canAcoesInternas ? <AcoesTimelinePage /> : <Forbidden />} />
-        <Route path="/notificacoes-internas" element={canAcoesInternas ? <NotificacoesInternasPage /> : <Forbidden />} />
+        <Route path="/acoes-notificacao" element={access.canManageInternalActions ? <AcoesNotificacaoPage /> : <Forbidden />} />
+        <Route path="/acoes-notificacao/timeline" element={access.canManageInternalActions ? <AcoesTimelinePage /> : <Forbidden />} />
+        <Route path="/notificacoes-internas" element={access.canManageInternalActions ? <NotificacoesInternasPage /> : <Forbidden />} />
         {/* DAT Module */}
         <Route path="/dat/admin" element={canDAT ? <AdminDATHomePage /> : <Forbidden />} />
         <Route path="/dat/admin/usuarios" element={canDAT ? <UsuariosPage /> : <Forbidden />} />

--- a/v2/frontend/src/components/AppSidebar.tsx
+++ b/v2/frontend/src/components/AppSidebar.tsx
@@ -195,7 +195,7 @@ export function AppSidebar({
   const { openKeys, onOpenChange, closeAllSubmenus } = useMenuOpenKeys();
 
   const {
-    canCoordenador, canControle, canDAT, canAcoesInternas, isFormador,
+    canCoordenador, canControle, canDAT, isFormador,
     canDashboardOverview, canDashboardEquipe, canDashboardGcal, canDashboardCompras,
     canMapaBrasil, canDashboardsMenu, canDisponibilidade,
   } = permissions;
@@ -308,7 +308,7 @@ export function AppSidebar({
               </SubMenu>
             )}
 
-            {canAcoesInternas && (
+            {access.canManageInternalActions && (
               <SubMenu
                 key="acoes-notificacao-submenu"
                 icon={<Badge count={unreadNotifications} size="small" offset={[6, 0]}><BellOutlined /></Badge>}

--- a/v2/frontend/src/components/__tests__/AppSidebar.menu.test.tsx
+++ b/v2/frontend/src/components/__tests__/AppSidebar.menu.test.tsx
@@ -154,6 +154,7 @@ const ACTORS: ActorSnapshot[] = [
     policies: [
       'access_audit_logs',
       'access_solicitation_approvals',
+      'manage_internal_actions',
       'view_all_availability',
       'view_compras_dashboard',
       'view_overview_dashboard',
@@ -206,12 +207,13 @@ const ACTORS: ActorSnapshot[] = [
       'view_compras_dashboard',
     ],
     // Sem 'Aprovações' (sem policy), sem 'Controle' (canControle=false).
+    // Sem 'Ações Internas': agora policy-gated por `manage_internal_actions` (#1263),
+    // ausente no seed do DAT — antes aparecia via grupo e levava a 403.
     // 'Bloqueios' aparece via canBloqueios = canCoordenador (DAT atua como coord operacional).
     expectedVisible: [
       'Página Inicial',
       'Meus Eventos',
       'Bloqueios',
-      'Ações Internas',
       'Deslocamentos',
       'Dashboards',
       'DAT',
@@ -303,13 +305,13 @@ const ACTORS: ActorSnapshot[] = [
       'view_reports',
     ],
     // Aprovações via policy. Bloqueios via view_all_availability.
-    // Sem dashboards (Gerente Sup não tem dashboard próprio).
+    // Sem 'Ações Internas': policy-gated por `manage_internal_actions` (#1263),
+    // ausente para Gerente Sup. Sem dashboards (Gerente Sup não tem dashboard próprio).
     expectedVisible: [
       'Página Inicial',
       'Meus Eventos',
       'Aprovações',
       'Bloqueios',
-      'Ações Internas',
       'Deslocamentos',
       'Grade Mensal',
     ],
@@ -329,10 +331,10 @@ const ACTORS: ActorSnapshot[] = [
     policies: [],
     // Sem 'Aprovações' (não é Sup), sem 'Bloqueios' (sem view_all e sem canBloqueios).
     // Sem 'Deslocamentos' (não tem nenhuma das 4 condições).
+    // Sem 'Ações Internas': policy-gated por `manage_internal_actions` (#1263), ausente aqui.
     expectedVisible: [
       'Página Inicial',
       'Meus Eventos',
-      'Ações Internas',
       'Grade Mensal',
     ],
     expectedDashboardsChildren: [],
@@ -352,7 +354,7 @@ const ACTORS: ActorSnapshot[] = [
       'Página Inicial',
       'Meus Eventos',
       'Bloqueios', // canBloqueios via canCoordenador
-      'Ações Internas',
+      // Sem 'Ações Internas': policy-gated por `manage_internal_actions` (#1263), ausente aqui.
       'Deslocamentos', // via canCoordenador
       'Grade Mensal',
       'Solicitações',
@@ -371,11 +373,11 @@ const ACTORS: ActorSnapshot[] = [
       canDisponibilidade: true,
     },
     policies: [],
+    // Sem 'Ações Internas': policy-gated por `manage_internal_actions` (#1263), ausente aqui.
     expectedVisible: [
       'Página Inicial',
       'Meus Eventos',
       'Bloqueios',
-      'Ações Internas',
       'Deslocamentos',
       'Grade Mensal',
       'Solicitações',
@@ -598,5 +600,23 @@ describe('AppSidebar — Aprovações é policy-only (PR 10 hardening RBAC)', ()
   test('policy access_solicitation_approvals sem flag legacy → Aprovações VISÍVEL', () => {
     renderSidebar(EMPTY_PERMISSIONS, ['access_solicitation_approvals']);
     expect(screen.getByRole('link', { name: /^Aprovações$/i })).toBeInTheDocument();
+  });
+});
+
+describe('AppSidebar — Ações Internas é policy-only (Issue #1263)', () => {
+  test('legacy canAcoesInternas=true sem policy → Ações Internas ESCONDIDA', () => {
+    // Bug #1263: a flag legacy por grupo mostrava o menu para DAT/Coordenador/
+    // Gerente, mas o backend exige `manage_internal_actions` (0 grupos no seed).
+    // Sem a policy, o item some — alinhando frontend e backend (fim do menu→403).
+    renderSidebar(
+      { ...EMPTY_PERMISSIONS, canAcoesInternas: true, inDAT: true, canCoordenador: true },
+      [], // policy ausente
+    );
+    expect(isTopLevelVisible('Ações Internas')).toBe(false);
+  });
+
+  test('policy manage_internal_actions sem flag legacy → Ações Internas VISÍVEL', () => {
+    renderSidebar(EMPTY_PERMISSIONS, ['manage_internal_actions']);
+    expect(isTopLevelVisible('Ações Internas')).toBe(true);
   });
 });

--- a/v2/frontend/src/hooks/__tests__/useCanAccess.test.ts
+++ b/v2/frontend/src/hooks/__tests__/useCanAccess.test.ts
@@ -111,3 +111,28 @@ describe('computeAccess.canCreateSolicitation — legacy-only today', () => {
     expect(access.canCreateSolicitation).toBe(false);
   });
 });
+
+describe('computeAccess.canManageInternalActions — policy-only (Issue #1263)', () => {
+  test('sem policy → false (grupo DAT/Coordenador/Gerente não basta)', () => {
+    const access = computeAccess([]);
+    expect(access.canManageInternalActions).toBe(false);
+  });
+
+  test('policy manage_internal_actions presente → true (superuser recebe todas)', () => {
+    const access = computeAccess(['manage_internal_actions']);
+    expect(access.canManageInternalActions).toBe(true);
+  });
+
+  test('policy unrelated → false', () => {
+    const access = computeAccess(['view_compras_dashboard']);
+    expect(access.canManageInternalActions).toBe(false);
+  });
+
+  test('não depende de flags legacy — grupo não concede a capability', () => {
+    // O bug do #1263: a flag legacy `canAcoesInternas` retornava true para DAT/
+    // Coordenador/Gerente, mas o backend exige a policy `manage_internal_actions`
+    // (0 grupos no seed). A nova flag ignora legacy: sem policy → sem acesso.
+    const access = computeAccess([], { canCoordenador: true, canBloqueios: true });
+    expect(access.canManageInternalActions).toBe(false);
+  });
+});

--- a/v2/frontend/src/hooks/useCanAccess.ts
+++ b/v2/frontend/src/hooks/useCanAccess.ts
@@ -68,6 +68,15 @@ export interface AccessState {
    * Legacy fallback preservado durante transição.
    */
   canViewComprasDashboard: boolean;
+
+  /**
+   * Pode gerenciar ações internas (notificações internas + timeline). Fonte de
+   * verdade exclusiva: policy pública `manage_internal_actions` (Issue #1263).
+   * SEM fallback legacy — o backend exige a policy (0 grupos no seed atual), então
+   * decidir por grupo (`usePermissions.canAcoesInternas`) sobre-concedia e o menu
+   * levava a 403. Superuser recebe todas as policies, logo obtém a flag.
+   */
+  canManageInternalActions: boolean;
 }
 
 /**
@@ -97,6 +106,10 @@ export function computeAccess(
     can('view_compras_dashboard') ||
     legacy.canDashboardCompras === true;
 
+  // Issue #1263: policy-only (sem legacy). Backend exige `manage_internal_actions`;
+  // decidir por grupo mostrava o menu de Ações Internas que o backend nega (403).
+  const canManageInternalActions = can('manage_internal_actions');
+
   return {
     policies,
     can,
@@ -104,6 +117,7 @@ export function computeAccess(
     canAccessBlocks,
     canCreateSolicitation,
     canViewComprasDashboard,
+    canManageInternalActions,
   };
 }
 

--- a/v2/frontend/src/hooks/usePermissions.ts
+++ b/v2/frontend/src/hooks/usePermissions.ts
@@ -24,6 +24,12 @@ export interface Permissions {
   canCoordenador: boolean;
   canControle: boolean;
   canDAT: boolean;
+  /**
+   * @deprecated Use `useCanAccess(policies).canManageInternalActions` (Issue #1263).
+   * Decide por grupo (DAT/Coordenador/Gerente) e sobre-concede: o backend exige a
+   * policy `manage_internal_actions` (0 grupos no seed), então esta flag levava o
+   * menu de Ações Internas a 403. Mantida por compat; não usar em novos call sites.
+   */
   canAcoesInternas: boolean;
   canDashboardOverview: boolean;
   canDashboardEquipe: boolean;


### PR DESCRIPTION
Fecha #1263. Epic #1252.

## Problema
`usePermissions.canAcoesInternas` (`:96`) decide por grupo: `is_superuser || inDAT || isCoordenador || isGerente`. Mas o backend exige a policy `manage_internal_actions` — **0 grupos no seed atual** → só superuser passa. Resultado: o menu de Ações Internas aparecia para **4 grupos** e o backend negava **3** (menu → 403, divergência semântica).

## Correção
- **`useCanAccess.ts`:** nova derived flag `canManageInternalActions = can('manage_internal_actions')` — **policy-only, sem fallback legacy** (mesmo padrão de `canAccessApprovals`). Superuser recebe todas as policies → mantém acesso.
- **`usePermissions.canAcoesInternas`:** marcada `@deprecated` (comportamento inalterado; snapshot preservado).
- **Callers migrados:** `AppSidebar` (menu), `AppRoutes` (3 rotas `/acoes-notificacao*`), `App.tsx` (polling enable + prop) e `AppHeader` (prop renomeado → `canManageInternalActions`).

Quando D-4 atribuir o grupo à policy no banco, o menu volta para os perfis certos **sem tocar frontend**.

## Testes (TDD)
- `useCanAccess.test.ts`: **RED por assertion visto antes da impl** (flag undefined → assert falha), depois GREEN. Casos: sem policy → false; policy → true; unrelated → false; legacy não concede.
- `AppSidebar.menu.test.tsx`: matriz viva atualizada — Ações Internas agora policy-gated (Superuser ganha a policy; DAT/Gerente/Coordenador/Apoio deixam de ver, alinhando com o backend). + teste focado `policy-only`.

## Validação local
- 231 testes afetados verdes (useCanAccess, usePermissions regressão, rbac_matrix, AppSidebar.menu, AppRoutes×2, App.session-expiry)
- `tsc --noEmit` limpo, `eslint .` limpo
- Escopo: 8 arquivos, 100% `v2/frontend`

## Staging gate
Será executado via `staging-gate.sh --pr` (não fabricado); evidência 8/8 anexada pelo script.
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `00d3c112`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
