### PR TITLE
fix(rbac): canCreateSolicitation consome policy create_solicitation (#1265)

### DIFF
--- a/v2/frontend/src/hooks/__tests__/useCanAccess.test.ts
+++ b/v2/frontend/src/hooks/__tests__/useCanAccess.test.ts
@@ -100,13 +100,23 @@ describe('computeAccess.canViewComprasDashboard — Onda 2 A2 consome policy', (
   });
 });
 
-describe('computeAccess.canCreateSolicitation — legacy-only today', () => {
-  test('legacy canCoordenador=true → true', () => {
+describe('computeAccess.canCreateSolicitation — policy create_solicitation + legacy (Issue #1265)', () => {
+  test('policy create_solicitation → true (mesmo sem legacy)', () => {
+    const access = computeAccess(['create_solicitation']);
+    expect(access.canCreateSolicitation).toBe(true);
+  });
+
+  test('legacy canCoordenador=true sem policy → true (fallback durante transição)', () => {
     const access = computeAccess([], { canCoordenador: true });
     expect(access.canCreateSolicitation).toBe(true);
   });
 
-  test('no legacy → false (no public policy maps to this today)', () => {
+  test('policy + legacy → true', () => {
+    const access = computeAccess(['create_solicitation'], { canCoordenador: true });
+    expect(access.canCreateSolicitation).toBe(true);
+  });
+
+  test('sem policy e sem legacy → false', () => {
     const access = computeAccess(['view_compras_dashboard'], {});
     expect(access.canCreateSolicitation).toBe(false);
   });

--- a/v2/frontend/src/hooks/useCanAccess.ts
+++ b/v2/frontend/src/hooks/useCanAccess.ts
@@ -57,8 +57,10 @@ export interface AccessState {
   canAccessBlocks: boolean;
 
   /**
-   * Pode criar nova solicitação. Hoje: 100% legacy (Coordenador / Apoio de Coordenação / Gerente / Superuser).
-   * Sem policy pública mapeada — frontend confere flag, backend ainda valida via permission_classes específica.
+   * Pode criar nova solicitação. Fonte primária: policy pública `create_solicitation`
+   * (Issue #1265). Fallback legacy `canCoordenador` preservado durante a transição —
+   * remover em Onda 3+ quando o staging validar a policy. Backend continua validando
+   * via permission_classes específica.
    */
   canCreateSolicitation: boolean;
 
@@ -99,7 +101,10 @@ export function computeAccess(
     can('view_all_availability') ||
     legacy.canBloqueios === true;
 
+  // Issue #1265: policy `create_solicitation` como fonte primária; legacy `canCoordenador`
+  // mantido como fallback durante a transição (remover em Onda 3+ após validar em staging).
   const canCreateSolicitation =
+    can('create_solicitation') ||
     legacy.canCoordenador === true;
 
   const canViewComprasDashboard =


### PR DESCRIPTION
Fecha #1265. Epic #1252.

## Correção
`canCreateSolicitation` era 100% legacy (`legacy.canCoordenador`). Agora consome a policy pública **`create_solicitation`** como fonte primária, com o legacy preservado como **fallback** durante a transição:

```ts
const canCreateSolicitation = can('create_solicitation') || legacy.canCoordenador === true;
```

Comentário no código marca o fallback para remoção em Onda 3+ (após validar a policy em staging). Users existentes continuam idênticos; users com a policy passam a ter acesso.

## ⚠️ Desvio consciente do plano do issue — `canAccessApprovals`
O issue pedia migrar **dois** flags e re-adicionar o fallback legacy em ambos:
> `canAccessApprovals = can('access_solicitation_approvals') || legacy.canApproveSuper`

**Não fiz isso** e é intencional: o **PR 10 hardening RBAC (#1315)** já tornou `canAccessApprovals` **policy-only** e *removeu* o `canApproveSuper` de propósito — há inclusive teste de regressão (`AppSidebar.menu`: "legacy canApproveSuper=true sem policy → Aprovações ESCONDIDA"). Re-adicionar o fallback **regrediria** o hardening. O plano do issue está desatualizado em relação ao código atual; `canAccessApprovals` já está correto (mais rígido que o pedido).

## Testes (TDD)
- **RED por assertion** visto antes da impl (policy sem legacy → false).
- 4 casos novos: policy-only → true; legacy-only → true (fallback); ambos → true; nenhum → false.
- 196 testes afetados verdes (useCanAccess, rbac_matrix, AppRoutes, AppSidebar.menu), `tsc` e `eslint` limpos.

## Escopo
2 arquivos (`useCanAccess.ts` + teste), 100% `v2/frontend`.

## Staging gate
Via `staging-gate.sh --pr` (não fabricado).
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `a7a40854`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
