### PR TITLE
fix(rbac): gate forte em /solicitacoes/:id/editar (#1169)

### DIFF
--- a/v2/frontend/src/components/AppRoutes.tsx
+++ b/v2/frontend/src/components/AppRoutes.tsx
@@ -83,7 +83,7 @@ interface AppRoutesProps {
 
 export function AppRoutes({ user, permissions, policies }: AppRoutesProps): JSX.Element {
   const {
-    canCoordenador, canControle, canDAT,
+    canCoordenador, canControle, canDAT, canApproveSuper,
     canDashboardOverview, canDashboardEquipe, canDashboardGcal, canDashboardCompras,
     canMapaBrasil, canDisponibilidade, isFormador,
   } = permissions;
@@ -116,7 +116,7 @@ export function AppRoutes({ user, permissions, policies }: AppRoutesProps): JSX.
         {/* Páginas pré-existentes mantidas */}
         <Route path="/solicitacoes/minhas" element={access.canCreateSolicitation ? <MySolicitacoesPage /> : <Forbidden />} />
         <Route path="/solicitacoes/nova" element={access.canCreateSolicitation ? <NewSolicitacaoWizard /> : <Forbidden />} />
-        <Route path="/solicitacoes/:id/editar" element={user ? <EditSolicitacaoPage /> : <Forbidden />} />
+        <Route path="/solicitacoes/:id/editar" element={canCoordenador || canApproveSuper ? <EditSolicitacaoPage /> : <Forbidden />} />
 
         {/* Páginas movidas para sob /solicitacoes/* (com redirects abaixo) */}
         <Route path="/solicitacoes/aprovacoes" element={access.canAccessApprovals ? <ApprovalsPage /> : <Forbidden />} />

--- a/v2/frontend/src/components/__tests__/AppRoutes.access-by-profile.test.tsx
+++ b/v2/frontend/src/components/__tests__/AppRoutes.access-by-profile.test.tsx
@@ -72,6 +72,11 @@ vi.mock('../../api/availability', () => ({
 vi.mock('../../api/stats', () => ({
   getHomeStats: vi.fn().mockResolvedValue({}),
 }));
+// Issue #1169: este teste cobre o GATE de rota de /solicitacoes/:id/editar, não a
+// página em si (que depende de getSolicitacao/lookup não mockados aqui). Stub isola o gate.
+vi.mock('../../pages/Solicitacoes/EditSolicitacaoPage', () => ({
+  default: () => 'EDIT_PAGE',
+}));
 
 // ============================================================================
 // Setup
@@ -598,5 +603,32 @@ describe('AppRoutes — sanity da matriz', () => {
     ]);
     const actual = new Set(ACTORS.map((a) => a.actor));
     expect(actual).toEqual(expected);
+  });
+});
+
+// ============================================================================
+// Gate de /solicitacoes/:id/editar (Issue #1169, Item 1)
+// ============================================================================
+// Antes: `element={user ? <EditSolicitacaoPage /> : <Forbidden />}` — qualquer
+// autenticado abria a tela e falhava no submit (backend IsOwnerOrPrivileged → 403).
+// Depois: gate alinhado ao menu — só canCoordenador (owner plausível) ou
+// canApproveSuper (privilegiado) carregam. Backend segue autoritativo.
+describe('AppRoutes — gate de /solicitacoes/:id/editar (Issue #1169)', () => {
+  const EDITAR = '/solicitacoes/42/editar';
+
+  test('autenticado sem canCoordenador nem canApproveSuper → Forbidden', async () => {
+    renderRoute(EDITAR, BASE_USER, { ...EMPTY_PERMISSIONS }, []);
+    expect(await screen.findByText(FORBIDDEN_TEXT)).toBeInTheDocument();
+  });
+
+  test('canCoordenador → carrega a edição (não Forbidden)', async () => {
+    renderRoute(EDITAR, BASE_USER, { ...EMPTY_PERMISSIONS, canCoordenador: true }, []);
+    expect(await screen.findByText('EDIT_PAGE')).toBeInTheDocument();
+    expect(screen.queryByText(FORBIDDEN_TEXT)).not.toBeInTheDocument();
+  });
+
+  test('canApproveSuper → carrega a edição (não Forbidden)', async () => {
+    renderRoute(EDITAR, BASE_USER, { ...EMPTY_PERMISSIONS, canApproveSuper: true }, []);
+    expect(await screen.findByText('EDIT_PAGE')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Fecha #1169.

## Item 1 — gate fraco em `/solicitacoes/:id/editar` ✅ corrigido
Antes: `element={user ? <EditSolicitacaoPage /> : <Forbidden />}` — só checava `user != null`, então **qualquer autenticado** abria a tela e só falhava no submit (backend `IsOwnerOrPrivileged` → 403). UX inconsistente com o resto do AppRoutes.

Depois: `element={canCoordenador || canApproveSuper ? … : <Forbidden />}` — gate alinhado ao menu (owner plausível ou privilegiado). **Backend segue autoritativo** (a ownership real é validada no submit); este é um gate de UX.

## Item 2 — flag negativa `canDisponibilidade` ✅ **já estava resolvido**
O issue descreve `canDisponibilidade = is_superuser || !inControle` (`:82`), mas o código atual (pós decisões **D8/D9**, #1288) já é uma **allowlist afirmativa**, sem negação:
```ts
const canDisponibilidade = user.is_superuser || inControle || inDAT || isGerente || isCoordenador;
```
A regra de negócio inclusive mudou (Controle agora é ALLOW, documentado nas linhas 115-127). **Nenhuma mudança necessária** — o débito do Item 2 já foi pago.

## Testes (TDD)
- **RED por assertion** visto antes do fix: BASE_USER (autenticado, sem perms) carregava a página (Forbidden ausente). Após o gate, retorna Forbidden.
- 3 casos focados em `AppRoutes.access-by-profile` (stub da página isola o gate): forbidden + canCoordenador + canApproveSuper.
- 130 testes de rota verdes; `tsc` e `eslint` limpos.

## Escopo
2 arquivos (`AppRoutes.tsx` + teste), 100% `v2/frontend`.

## Staging gate
Via `staging-gate.sh --pr` (não fabricado).
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `c84918cf`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
