### PR TITLE
feat(rbac): introduz useIdentity + useCapabilities (#1269)

### DIFF
--- a/v2/frontend/src/hooks/__tests__/useCapabilities.test.ts
+++ b/v2/frontend/src/hooks/__tests__/useCapabilities.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Tests: useCapabilities + computeCapabilities (Issue #1269, RBAC 3.1).
+ *
+ * `useCapabilities` responde "o que o usuário pode fazer", derivado
+ * EXCLUSIVAMENTE de `policies` (subset das PUBLIC_POLICY_KEYS do backend). Sem
+ * fallback legacy, sem organograma. É a fonte de verdade de autorização no
+ * frontend (o backend continua autoritativo).
+ */
+import { describe, test, expect } from 'vitest';
+import { computeCapabilities } from '../useCapabilities';
+
+describe('computeCapabilities — can() genérico', () => {
+  test('policies vazias → can(qualquer) é false', () => {
+    const caps = computeCapabilities([]);
+    expect(caps.can('access_solicitation_approvals')).toBe(false);
+    expect(caps.can('create_solicitation')).toBe(false);
+  });
+
+  test('policy presente → can(policy) true; ausente → false', () => {
+    const caps = computeCapabilities(['use_gcal']);
+    expect(caps.can('use_gcal')).toBe(true);
+    expect(caps.can('view_reports')).toBe(false);
+  });
+
+  test('policies expostas via .policies', () => {
+    expect(computeCapabilities(['use_gcal']).policies).toEqual(['use_gcal']);
+  });
+});
+
+describe('computeCapabilities — flags nomeadas por ator', () => {
+  test('anônimo (sem policies) → todas as capabilities false', () => {
+    const caps = computeCapabilities([]);
+    expect(caps.canAccessApprovals).toBe(false);
+    expect(caps.canCreateSolicitation).toBe(false);
+    expect(caps.canManageInternalActions).toBe(false);
+    expect(caps.canViewOverviewDashboard).toBe(false);
+    expect(caps.canViewComprasDashboard).toBe(false);
+    expect(caps.canUseGcal).toBe(false);
+  });
+
+  test('Coordenador → canCreateSolicitation', () => {
+    const caps = computeCapabilities(['create_solicitation']);
+    expect(caps.canCreateSolicitation).toBe(true);
+    expect(caps.canAccessApprovals).toBe(false);
+  });
+
+  test('Aprovador → canAccessApprovals', () => {
+    const caps = computeCapabilities(['access_solicitation_approvals']);
+    expect(caps.canAccessApprovals).toBe(true);
+    expect(caps.canCreateSolicitation).toBe(false);
+  });
+
+  test('DAT → imports + registries + compras dashboard', () => {
+    const caps = computeCapabilities([
+      'import_availability_blocks',
+      'import_compras',
+      'import_generic_spreadsheet',
+      'manage_admin_registries',
+      'view_compras_dashboard',
+    ]);
+    expect(caps.canImportAvailabilityBlocks).toBe(true);
+    expect(caps.canImportCompras).toBe(true);
+    expect(caps.canImportGenericSpreadsheet).toBe(true);
+    expect(caps.canManageAdminRegistries).toBe(true);
+    expect(caps.canViewComprasDashboard).toBe(true);
+    expect(caps.canViewOverviewDashboard).toBe(false);
+  });
+
+  test('Diretoria → dashboards de visão geral/compras/mapa', () => {
+    const caps = computeCapabilities([
+      'view_overview_dashboard',
+      'view_compras_dashboard',
+      'view_map_metrics',
+    ]);
+    expect(caps.canViewOverviewDashboard).toBe(true);
+    expect(caps.canViewComprasDashboard).toBe(true);
+    expect(caps.canViewMapMetrics).toBe(true);
+    expect(caps.canManageInternalActions).toBe(false);
+  });
+
+  test('cada uma das 18 flags reflete exatamente sua policy', () => {
+    const CASES: ReadonlyArray<readonly [keyof ReturnType<typeof computeCapabilities>, string]> = [
+      ['canAccessAuditLogs', 'access_audit_logs'],
+      ['canAccessApprovals', 'access_solicitation_approvals'],
+      ['canCreateSolicitation', 'create_solicitation'],
+      ['canManageSolicitacaoStatus', 'manage_solicitacao_status'],
+      ['canViewComprasDashboard', 'view_compras_dashboard'],
+      ['canViewComprasPendencias', 'view_compras_pendencias'],
+      ['canViewComprasStats', 'view_compras_stats'],
+      ['canViewOverviewDashboard', 'view_overview_dashboard'],
+      ['canViewMapMetrics', 'view_map_metrics'],
+      ['canViewReports', 'view_reports'],
+      ['canUseGcal', 'use_gcal'],
+      ['canViewAllAvailability', 'view_all_availability'],
+      ['canImportAvailabilityBlocks', 'import_availability_blocks'],
+      ['canImportCompras', 'import_compras'],
+      ['canImportGenericSpreadsheet', 'import_generic_spreadsheet'],
+      ['canManageAdminRegistries', 'manage_admin_registries'],
+      ['canManageInternalActions', 'manage_internal_actions'],
+      ['canManagePurchasesAndMaterials', 'manage_purchases_and_materials'],
+    ];
+    for (const [flag, policy] of CASES) {
+      const caps = computeCapabilities([policy]);
+      expect(caps[flag], `${String(flag)} deve refletir ${policy}`).toBe(true);
+    }
+  });
+});

--- a/v2/frontend/src/hooks/__tests__/useIdentity.test.ts
+++ b/v2/frontend/src/hooks/__tests__/useIdentity.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Tests: useIdentity + computeIdentity (Issue #1269, RBAC 3.1).
+ *
+ * `useIdentity` responde "quem é o usuário" (organograma: setor/função) e dados
+ * de display (displayName, badge). É DISPLAY-ONLY — não decide autorização (isso
+ * é `useCapabilities`, derivado de policies). Co-existe com `usePermissions`
+ * (legacy) até a migração de callers (ondas 3.2/3.3).
+ */
+import { describe, test, expect } from 'vitest';
+import { computeIdentity } from '../useIdentity';
+import type { CurrentUser } from '../../types';
+
+function makeUser(over: Partial<CurrentUser> = {}): CurrentUser {
+  return {
+    id: 1,
+    username: 'user',
+    email: 'user@test.com',
+    first_name: 'First',
+    last_name: 'Last',
+    name: 'Fulano de Tal',
+    groups: [],
+    setores: [],
+    funcoes: [],
+    is_superuser: false,
+    is_superintendencia: false,
+    can_approve_super: false,
+    permissions: [],
+    ...over,
+  };
+}
+
+describe('computeIdentity (Issue #1269)', () => {
+  test('null user → identidade anônima', () => {
+    const id = computeIdentity(null);
+    expect(id.isAdmin).toBe(false);
+    expect(id.isCoordenador).toBe(false);
+    expect(id.isFormador).toBe(false);
+    expect(id.isGerente).toBe(false);
+    expect(id.inSuperintendencia).toBe(false);
+    expect(id.inDAT).toBe(false);
+    expect(id.inControle).toBe(false);
+    expect(id.inDiretoria).toBe(false);
+    expect(id.displayName).toBe('');
+    expect(id.badge).toBe('Usuário');
+  });
+
+  test('superuser → isAdmin + badge Admin', () => {
+    const id = computeIdentity(makeUser({ is_superuser: true, name: 'Super' }));
+    expect(id.isAdmin).toBe(true);
+    expect(id.displayName).toBe('Super');
+    expect(id.badge).toBe('Admin');
+  });
+
+  test('Coordenador (Vidas) → isCoordenador + badge Coordenador', () => {
+    const id = computeIdentity(makeUser({ funcoes: ['Coordenador'], setores: ['Vidas'], name: 'Coord' }));
+    expect(id.isCoordenador).toBe(true);
+    expect(id.isFormador).toBe(false);
+    expect(id.badge).toBe('Coordenador');
+    expect(id.displayName).toBe('Coord');
+  });
+
+  test('Apoio de Coordenação → isCoordenador + badge Apoio de Coordenação', () => {
+    const id = computeIdentity(makeUser({ funcoes: ['Apoio de Coordenação'] }));
+    expect(id.isCoordenador).toBe(true);
+    expect(id.badge).toBe('Apoio de Coordenação');
+  });
+
+  test('Formador → isFormador + badge Formador', () => {
+    const id = computeIdentity(makeUser({ funcoes: ['Formador'] }));
+    expect(id.isFormador).toBe(true);
+    expect(id.badge).toBe('Formador');
+  });
+
+  test('Gerente da Superintendência → isGerente + inSuperintendencia + badge Gerente', () => {
+    const id = computeIdentity(makeUser({ funcoes: ['Gerente'], setores: ['Superintendência'] }));
+    expect(id.isGerente).toBe(true);
+    expect(id.inSuperintendencia).toBe(true);
+    expect(id.badge).toBe('Gerente');
+  });
+
+  test('DAT sem função → inDAT + badge do setor (fallback)', () => {
+    const id = computeIdentity(makeUser({ setores: ['DAT'] }));
+    expect(id.inDAT).toBe(true);
+    expect(id.badge).toBe('DAT');
+  });
+
+  test('displayName cai para username quando name vazio', () => {
+    const id = computeIdentity(makeUser({ name: '', username: 'jdoe' }));
+    expect(id.displayName).toBe('jdoe');
+  });
+});

--- a/v2/frontend/src/hooks/useCapabilities.ts
+++ b/v2/frontend/src/hooks/useCapabilities.ts
@@ -1,0 +1,75 @@
+/**
+ * useCapabilities — "o que o usuário pode fazer" (Issue #1269, RBAC 3.1).
+ *
+ * Deriva capabilities EXCLUSIVAMENTE de `policies` (subset das PUBLIC_POLICY_KEYS
+ * do backend, via `GET /api/me/policies/`). Sem fallback legacy, sem organograma —
+ * essa é a diferença para `usePermissions`/`useCanAccess`. É a fonte de verdade de
+ * autorização no frontend; o backend permanece autoritativo.
+ *
+ * Para "quem é o usuário" (setor/função, display) use `useIdentity`. Co-existe com
+ * `usePermissions` (legacy) até a migração de callers (ondas 3.2/3.3).
+ *
+ * Cada flag `can*` espelha 1:1 uma policy key. Ao adicionar uma policy pública nova
+ * no backend, adicione a flag correspondente aqui + um caso no teste de completude.
+ */
+import { useMemo } from 'react';
+
+export interface Capabilities {
+  /** Subset das PUBLIC_POLICY_KEYS que o usuário possui. */
+  readonly policies: readonly string[];
+  /** Match exato contra uma policy key (escape hatch p/ keys sem flag nomeada). */
+  can: (key: string) => boolean;
+
+  canAccessAuditLogs: boolean;
+  canAccessApprovals: boolean;
+  canCreateSolicitation: boolean;
+  canManageSolicitacaoStatus: boolean;
+  canViewComprasDashboard: boolean;
+  canViewComprasPendencias: boolean;
+  canViewComprasStats: boolean;
+  canViewOverviewDashboard: boolean;
+  canViewMapMetrics: boolean;
+  canViewReports: boolean;
+  canUseGcal: boolean;
+  canViewAllAvailability: boolean;
+  canImportAvailabilityBlocks: boolean;
+  canImportCompras: boolean;
+  canImportGenericSpreadsheet: boolean;
+  canManageAdminRegistries: boolean;
+  canManageInternalActions: boolean;
+  canManagePurchasesAndMaterials: boolean;
+}
+
+/** Versão pura (sem React) — usada em tests e call sites sem render. */
+export function computeCapabilities(policies: readonly string[]): Capabilities {
+  const policySet = new Set(policies);
+  const can = (key: string): boolean => policySet.has(key);
+
+  return {
+    policies,
+    can,
+    canAccessAuditLogs: can('access_audit_logs'),
+    canAccessApprovals: can('access_solicitation_approvals'),
+    canCreateSolicitation: can('create_solicitation'),
+    canManageSolicitacaoStatus: can('manage_solicitacao_status'),
+    canViewComprasDashboard: can('view_compras_dashboard'),
+    canViewComprasPendencias: can('view_compras_pendencias'),
+    canViewComprasStats: can('view_compras_stats'),
+    canViewOverviewDashboard: can('view_overview_dashboard'),
+    canViewMapMetrics: can('view_map_metrics'),
+    canViewReports: can('view_reports'),
+    canUseGcal: can('use_gcal'),
+    canViewAllAvailability: can('view_all_availability'),
+    canImportAvailabilityBlocks: can('import_availability_blocks'),
+    canImportCompras: can('import_compras'),
+    canImportGenericSpreadsheet: can('import_generic_spreadsheet'),
+    canManageAdminRegistries: can('manage_admin_registries'),
+    canManageInternalActions: can('manage_internal_actions'),
+    canManagePurchasesAndMaterials: can('manage_purchases_and_materials'),
+  };
+}
+
+/** Hook React memoizado por `policies`. */
+export function useCapabilities(policies: readonly string[]): Capabilities {
+  return useMemo(() => computeCapabilities(policies), [policies]);
+}

--- a/v2/frontend/src/hooks/useIdentity.ts
+++ b/v2/frontend/src/hooks/useIdentity.ts
@@ -1,0 +1,104 @@
+/**
+ * useIdentity — "quem é o usuário" (Issue #1269, RBAC 3.1).
+ *
+ * Camada de **identidade/organograma**: setor e função do usuário + dados de
+ * display (nome, badge). É **DISPLAY-ONLY** — NÃO decide autorização. Para "o que
+ * o usuário pode fazer", use `useCapabilities(policies)`, derivado exclusivamente
+ * de policies públicas.
+ *
+ * A separação existe para o lint (futuro) distinguir "quem é" de "o que pode":
+ * `useIdentity.*` em contexto de route/guard/gate é um smell (autorizar por
+ * organograma). Co-existe com `usePermissions` (legacy) até a migração de callers
+ * (ondas 3.2/3.3); `usePermissions` será removido na onda 4.5.
+ */
+import { useMemo } from 'react';
+import type { CurrentUser } from '../types';
+
+export interface Identity {
+  /** `is_superuser`. Escape hatch de admin — não usar para regra de negócio. */
+  isAdmin: boolean;
+  isCoordenador: boolean;
+  isFormador: boolean;
+  isGerente: boolean;
+  inSuperintendencia: boolean;
+  inDAT: boolean;
+  inControle: boolean;
+  inDiretoria: boolean;
+  /** Nome legível: `name` do backend, com fallback para `username`. */
+  displayName: string;
+  /**
+   * Rótulo curto de papel para exibição (chip/tag). Prioridade determinística:
+   * Admin > Gerente > Coordenador/Apoio > Formador > primeiro setor > 'Usuário'.
+   * Display-only — o caller pode sobrescrever com um rótulo específico da tela.
+   */
+  badge: string;
+}
+
+const ANONYMOUS_IDENTITY: Identity = {
+  isAdmin: false,
+  isCoordenador: false,
+  isFormador: false,
+  isGerente: false,
+  inSuperintendencia: false,
+  inDAT: false,
+  inControle: false,
+  inDiretoria: false,
+  displayName: '',
+  badge: 'Usuário',
+};
+
+interface RoleFlags {
+  isAdmin: boolean;
+  isGerente: boolean;
+  isCoordenador: boolean;
+  isFormador: boolean;
+}
+
+function computeBadge(user: CurrentUser, roles: RoleFlags): string {
+  if (roles.isAdmin) return 'Admin';
+  if (roles.isGerente) return 'Gerente';
+  if (roles.isCoordenador) {
+    return (user.funcoes || []).includes('Coordenador') ? 'Coordenador' : 'Apoio de Coordenação';
+  }
+  if (roles.isFormador) return 'Formador';
+  return (user.setores || [])[0] ?? 'Usuário';
+}
+
+/** Versão pura (sem React) — usada em tests e call sites sem render. */
+export function computeIdentity(user: CurrentUser | null): Identity {
+  if (!user) return ANONYMOUS_IDENTITY;
+
+  const setores = user.setores || [];
+  const funcoes = user.funcoes || [];
+
+  const isAdmin = user.is_superuser === true;
+  const isCoordenador = funcoes.includes('Coordenador') || funcoes.includes('Apoio de Coordenação');
+  const isFormador = funcoes.includes('Formador');
+  const isGerente = funcoes.includes('Gerente');
+
+  const inSuperintendencia = setores.includes('Superintendência');
+  const inDAT = setores.includes('DAT');
+  const inControle = setores.includes('Controle');
+  const inDiretoria = setores.includes('Diretoria');
+
+  const displayName = user.name || user.username || '';
+  const badge = computeBadge(user, { isAdmin, isGerente, isCoordenador, isFormador });
+
+  return {
+    isAdmin,
+    isCoordenador,
+    isFormador,
+    isGerente,
+    inSuperintendencia,
+    inDAT,
+    inControle,
+    inDiretoria,
+    displayName,
+    badge,
+  };
+}
+
+/** Hook React memoizado por `user`. */
+export function useIdentity(user: CurrentUser | null): Identity {
+  return useMemo(() => computeIdentity(user), [user]);
+}

--- a/v2/frontend/src/hooks/usePermissions.ts
+++ b/v2/frontend/src/hooks/usePermissions.ts
@@ -1,6 +1,12 @@
 import { useMemo } from 'react';
 import type { CurrentUser } from '../types';
 
+/**
+ * @deprecated (Issue #1269) Mistura identidade (setor/função) e capabilities num
+ * único objeto, sem separar "quem é" de "o que pode". Prefira `useIdentity()`
+ * (display) + `useCapabilities(policies)` (autorização por policy). Mantido até a
+ * migração de callers (ondas 3.2/3.3); remoção na onda 4.5. Não usar em novos call sites.
+ */
 export interface Permissions {
   /**
    * `is_superuser` exposto via flag canônica para escape hatches de admin
@@ -162,6 +168,9 @@ function computePermissionsInternal(user: CurrentUser): Permissions {
 /**
  * Compute all RBAC permission flags from user data.
  * Single source of truth for permission checks (Setor + Função).
+ *
+ * @deprecated (Issue #1269) Prefira `useIdentity()` (quem é) + `useCapabilities(policies)`
+ * (o que pode). Mantido durante a migração de callers; remoção na onda 4.5.
  */
 export function usePermissions(user: CurrentUser | null): Permissions {
   return useMemo(() => {
@@ -172,6 +181,8 @@ export function usePermissions(user: CurrentUser | null): Permissions {
 
 /**
  * Pure function version for testing (no React dependency).
+ *
+ * @deprecated (Issue #1269) Ver `computeIdentity` + `computeCapabilities`.
  */
 export function computePermissions(user: CurrentUser | null): Permissions {
   if (!user) return EMPTY_PERMISSIONS;


### PR DESCRIPTION
Fecha #1269. Epic #1254. Destrava #1270, #1271, #1281.

## Contexto
`usePermissions` mistura 5 sector flags + 4 role flags + 11 capabilities num objeto só — sem separar **"quem é"** de **"o que pode"**. Componentes consomem `inDAT` para autz e capabilities para display sem distinção.

## Correção (aditivo)
Dois hooks novos, **puros e co-existentes** com o legacy:

- **`useIdentity(user)`** → organograma (`isAdmin, isCoordenador, isFormador, isGerente, inSuperintendencia, inDAT, inControle, inDiretoria`) + display (`displayName`, `badge`). **Display-only, não autoriza.**
- **`useCapabilities(policies)`** → 18 flags `can*` derivadas **exclusivamente** de policies (1:1 com `PUBLIC_POLICY_KEYS`), sem fallback legacy nem organograma. Fonte de verdade de autz no frontend (backend segue autoritativo).

`usePermissions` marcado `@deprecated` (só JSDoc — sem regra de deprecation no eslint, comportamento inalterado). **Não** migro callers (ondas 3.2/3.3) nem removo `usePermissions` (onda 4.5), conforme o issue.

Sobre `badge`: não havia conceito de rótulo de papel na UI; defini uma prioridade determinística (Admin > Gerente > Coordenador/Apoio > Formador > setor > 'Usuário'), documentada e sobrescrevível pelo caller.

## Testes (TDD)
- **RED por assertion** visto antes da impl em **ambos** os hooks (stub → asserts falham → impl).
- 17 testes novos: useIdentity (null + 6 atores + fallback de displayName); useCapabilities (anônimo + 4 atores + `can()` genérico + **completude das 18 flags**).
- Regressão `usePermissions.test` intacta. Total 49 verdes; `tsc` e `eslint` limpos.

## Escopo
5 arquivos, 388 inserções, 100% `v2/frontend` (2 hooks + 2 testes + JSDoc @deprecated).

## Staging gate
Via `staging-gate.sh --pr` (não fabricado).
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `d1705cc9`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
