### PR TITLE
fix(security): aborta boot em produção se REDIS_PASSWORD vazio (SEC-002 #1457)

### DIFF
--- a/v2/backend/apps/core/tests/test_prod_guard_rails.py
+++ b/v2/backend/apps/core/tests/test_prod_guard_rails.py
@@ -131,6 +131,7 @@ class ProductionGuardRailsTests(TestCase):
         env["DEBUG"] = "0"
         env["ALLOWED_HOSTS"] = "example.com,api.example.com"
         env["SECRET_KEY"] = "a" * 64  # 64 chars (>= 50 recomendado)
+        env["REDIS_PASSWORD"] = "senha-redis-valida"  # SEC-002 #1457: passar o outro guard
         env["DB_NAME"] = "test_db"
         env["DB_USER"] = "test_user"
         env["DB_PASSWORD"] = "test_password"
@@ -220,6 +221,7 @@ class DevToolsProductionGuardTests(TestCase):
         env["DEBUG"] = "0"
         env["ALLOWED_HOSTS"] = "example.com"
         env["SECRET_KEY"] = "a" * 64
+        env["REDIS_PASSWORD"] = "senha-redis-valida"  # SEC-002 #1457: passar o outro guard
         env["DB_NAME"] = "test_db"
         env["DB_USER"] = "test_user"
         env["DB_PASSWORD"] = "test_password"
@@ -270,3 +272,64 @@ class DevToolsProductionGuardTests(TestCase):
 
         self.assertEqual(code, 0, f"Django não subiu. stderr: {stderr}")
         self.assertIn("apps.dev_tools", stdout.split("\n"))
+
+
+class RedisPasswordProductionGuardTests(TestCase):
+    """
+    SEC-002 (#1457, regressão de #800) — REDIS_PASSWORD vazio aborta o boot em produção.
+
+    `settings.py` monta as URLs de cache/broker com `os.getenv('REDIS_PASSWORD', '')`
+    (linhas 274, 304, 585). Com valor vazio a URL vira `redis://:@host:6379/N` e o
+    compose de prod propaga `--requirepass ""` — Redis sobe **sem autenticação**, em
+    silêncio. Os templates entregam `REDIS_PASSWORD=` vazio, então o footgun é o
+    caminho default: basta o operador esquecer o secret.
+
+    Aqui o `sys.exit(1)` é adequado (ao contrário do #1466): produção já define a senha
+    (#1089), então o guard não derruba deploy nenhum — só impede que a ausência passe
+    despercebida. Mesmo padrão dos guards de SECRET_KEY/ALLOWED_HOSTS.
+    """
+
+    def _run_check(self, **overrides: str) -> subprocess.CompletedProcess[str]:
+        env = os.environ.copy()
+        env["ENVIRONMENT"] = "production"
+        env["DEBUG"] = "0"
+        env["ALLOWED_HOSTS"] = "example.com"
+        env["SECRET_KEY"] = "a" * 64
+        env["DB_NAME"] = "test_db"
+        env["DB_USER"] = "test_user"
+        env["DB_PASSWORD"] = "test_password"
+        env["DB_HOST"] = "localhost"
+        env["DB_PORT"] = "5434"
+        # Herdar REDIS_PASSWORD do ambiente mascararia o cenário sob teste.
+        env.pop("REDIS_PASSWORD", None)
+        env.update(overrides)
+
+        return subprocess.run(
+            [sys.executable, "manage.py", "check", "--deploy"],
+            cwd=str(Path(settings.BASE_DIR)),
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+
+    def test_startup_fails_when_redis_password_missing_in_production(self):
+        """REDIS_PASSWORD ausente em produção -> sys.exit(1)."""
+        result = self._run_check()
+
+        self.assertEqual(result.returncode, 1, f"stdout: {result.stdout}")
+        self.assertIn("REDIS_PASSWORD", result.stderr)
+        self.assertIn("ERRO CRÍTICO", result.stderr)
+
+    def test_startup_fails_when_redis_password_empty_in_production(self):
+        """REDIS_PASSWORD='' (o que os templates entregam) -> sys.exit(1)."""
+        result = self._run_check(REDIS_PASSWORD="")
+
+        self.assertEqual(result.returncode, 1, f"stdout: {result.stdout}")
+        self.assertIn("REDIS_PASSWORD", result.stderr)
+
+    def test_startup_succeeds_when_redis_password_set_in_production(self):
+        """Com senha definida o boot segue normal (sem regressão)."""
+        result = self._run_check(REDIS_PASSWORD="uma-senha-forte-de-redis")
+
+        self.assertNotEqual(result.returncode, 1, f"stderr: {result.stderr}")

--- a/v2/backend/config/settings.py
+++ b/v2/backend/config/settings.py
@@ -94,6 +94,17 @@ if ENVIRONMENT == "production":
         print("❌ ERRO CRÍTICO: SECRET_KEY muito curta (mínimo: 50 caracteres)", file=sys.stderr)
         sys.exit(1)
 
+    # SEC-002 (#1457, regressão de #800): REDIS_PASSWORD vazio deixa o Redis sem auth.
+    # As URLs de cache/broker usam os.getenv("REDIS_PASSWORD", "") e viram
+    # redis://:@host:6379/N; o compose de prod propaga --requirepass "" e o Redis sobe
+    # anônimo, em silêncio. Os templates entregam a variável vazia, então esse é o
+    # caminho default — basta esquecer o secret.
+    if not os.getenv("REDIS_PASSWORD", "").strip():
+        print("❌ ERRO CRÍTICO: REDIS_PASSWORD vazio ou ausente em produção", file=sys.stderr)
+        print("   Redis subiria sem autenticação (--requirepass vazio).", file=sys.stderr)
+        print("   Defina REDIS_PASSWORD com um secret forte.", file=sys.stderr)
+        sys.exit(1)
+
     # WARNING: GCAL_CLIENT=fake em produção
     if os.getenv("GCAL_CLIENT", "fake") == "fake":
         print("⚠️  WARNING: GCAL_CLIENT=fake em produção", file=sys.stderr)


### PR DESCRIPTION
Closes #1457

## Problema

As URLs de cache/broker usam `os.getenv("REDIS_PASSWORD", "")` (`settings.py:274,304,585`)
e viram `redis://:@host:6379/N`; o `docker-compose.prod.yml` propaga `--requirepass ""` →
**Redis sobe sem autenticação, em silêncio.** Os templates entregam a variável vazia
(`.env.production.example:40`), então esse é o caminho default — basta o operador esquecer
o secret. É o gap residual da **#800** (SEC-002), fechada como COMPLETED sem entregar o
guard/teste prometidos.

## Mudança

Guard no bloco PRODUCTION GUARD RAILS, junto aos de SECRET_KEY/ALLOWED_HOSTS:

```python
if not os.getenv("REDIS_PASSWORD", "").strip():
    print("❌ ERRO CRÍTICO: REDIS_PASSWORD vazio ou ausente em produção", file=sys.stderr)
    sys.exit(1)
```

### Por que `sys.exit(1)` aqui (e `force=False` no #1466)

No #1466 (dev_tools) evitei abortar porque prod não definia a variável — matar o boot
viraria indisponibilidade. **Aqui é o oposto:** produção **já define** `REDIS_PASSWORD`
(verificado no Portainer em 2026-07-18), então o guard não derruba deploy nenhum — só
impede que a ausência passe despercebida. Mesma família de guard, decisões opostas porque
o risco real é diferente.

## TDD — RED observado antes da implementação

| Teste | Papel |
|---|---|
| `test_startup_fails_when_redis_password_missing` | RED provado: `AssertionError: 0 != 1` (Django sobe quando deveria abortar) |
| `test_startup_fails_when_redis_password_empty` | o valor que os templates entregam |
| `test_startup_succeeds_when_redis_password_set` | sem regressão |

GREEN após o guard. **A checagem de regressão pegou 3 testes** que não setavam
`REDIS_PASSWORD` e passaram a abortar — corrigidos para setar valor válido. Suite completa:
**10/10**.

## Notas

- Gates locais: black, isort, flake8 OK. Pyright roda no CI.
- **Não vai no deploy de hoje** (`v2026.07.18-94f2765`, já em prod) — entra num release
  próprio, por ser a única mudança com modo de falha "container não sobe". Como prod já tem
  a senha, é seguro, mas merece deploy isolado.
- Falha pré-existente conhecida: `test_startup_succeeds_with_valid_production_config` estoura
  `TimeoutExpired(10s)` em Docker/Windows local; passa no CI. Não introduzida aqui.
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `38605fd3`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
