### PR TITLE
feat(rbac): AppSidebar consome useCapabilities (#1270)

### DIFF
--- a/v2/frontend/src/components/AppSidebar.tsx
+++ b/v2/frontend/src/components/AppSidebar.tsx
@@ -13,7 +13,7 @@ import {
   TableOutlined,
 } from '@ant-design/icons';
 import type { Permissions } from '../hooks/usePermissions';
-import { useCanAccess } from '../hooks/useCanAccess';
+import { useCapabilities } from '../hooks/useCapabilities';
 import { LAYOUT } from '../constants';
 
 const { Sider } = Layout;
@@ -194,22 +194,16 @@ export function AppSidebar({
 }: AppSidebarProps): JSX.Element {
   const { openKeys, onOpenChange, closeAllSubmenus } = useMenuOpenKeys();
 
+  // #1270 (RBAC 3.2): os itens de menu derivam de `useCapabilities` (policy pura,
+  // fonte de verdade do backend). As flags legacy de organograma permanecem SÓ onde
+  // não há policy pública equivalente: escopo próprio de Formador/Coordenador em
+  // Bloqueios/Deslocamentos e o acesso scoped da Grade Mensal (`canDisponibilidade`).
+  // Todas são flags can*/is* (não `in*`).
   const {
-    canCoordenador, canControle, canDAT, isFormador,
-    canDashboardOverview, canDashboardEquipe, canDashboardGcal, canDashboardCompras,
-    canMapaBrasil, canDashboardsMenu, canDisponibilidade,
+    canCoordenador, canControle, canDAT, isFormador, canDisponibilidade,
   } = permissions;
 
-  // Camada de tradução semântica (Epic 3, Issue #1228): derived flags do policy layer.
-  // Itens de menu consomem `access.canAccessApprovals` etc. — origem (policy vs legacy) é detalhe.
-  // PR 10 hardening RBAC (2026-04-30): Aprovações depende exclusivamente da
-  // policy `access_solicitation_approvals`. Legacy `canApproveSuper` não é
-  // mais passado ao hook (campo segue na API, mas não decide acesso aqui).
-  const access = useCanAccess(policies, {
-    canBloqueios: canControle || canCoordenador || isFormador,
-    canDashboardCompras,
-    canCoordenador,
-  });
+  const caps = useCapabilities(policies);
 
   return (
     <>
@@ -284,19 +278,21 @@ export function AppSidebar({
               <Link to="/solicitacoes/meus-eventos">Meus Eventos</Link>
             </Menu.Item>
 
-            {access.canAccessApprovals && (
+            {caps.canAccessApprovals && (
               <Menu.Item key="aprovacoes" icon={<SafetyOutlined />} onClick={closeAllSubmenus}>
                 <Link to="/solicitacoes/aprovacoes">Aprovações</Link>
               </Menu.Item>
             )}
 
-            {access.canAccessBlocks && (
+            {/* Bloqueios: policy view_all_availability + escopo próprio de Formador/Coordenador
+                (sem policy pública) e Controle (access_controle_section). */}
+            {(caps.canViewAllAvailability || canControle || canCoordenador || isFormador) && (
               <Menu.Item key="bloqueios" icon={<CalendarOutlined />} onClick={closeAllSubmenus}>
                 <Link to="/solicitacoes/bloqueios">Bloqueios</Link>
               </Menu.Item>
             )}
 
-            {canControle && (
+            {caps.canAccessControleSection && (
               <SubMenu key="controle-submenu" icon={<CheckCircleOutlined />} title="Controle">
                 <Menu.Item key="controle-acoes"><Link to="/controle/acoes">Ações</Link></Menu.Item>
                 <Menu.Item key="controle-compras"><Link to="/controle/compras">Compras</Link></Menu.Item>
@@ -308,7 +304,7 @@ export function AppSidebar({
               </SubMenu>
             )}
 
-            {access.canManageInternalActions && (
+            {caps.canManageInternalActions && (
               <SubMenu
                 key="acoes-notificacao-submenu"
                 icon={<Badge count={unreadNotifications} size="small" offset={[6, 0]}><BellOutlined /></Badge>}
@@ -320,37 +316,41 @@ export function AppSidebar({
               </SubMenu>
             )}
 
-            {(access.can('view_all_availability') || canControle || canCoordenador || canDAT) && (
+            {(caps.canViewAllAvailability || canControle || canCoordenador || canDAT) && (
               <Menu.Item key="deslocamentos" icon={<CalendarOutlined />} onClick={closeAllSubmenus}>
                 <Link to="/solicitacoes/deslocamentos">Deslocamentos</Link>
               </Menu.Item>
             )}
 
-            {canDashboardsMenu && (
+            {(caps.canViewOverviewDashboard ||
+              caps.canViewComprasDashboard ||
+              caps.canViewTeamDashboard ||
+              caps.canViewGcalDashboard ||
+              caps.canViewMapMetrics) && (
               <SubMenu key="dashboards-submenu" icon={<BarChartOutlined />} title="Dashboards">
-                {canDashboardOverview && (
+                {caps.canViewOverviewDashboard && (
                   <Menu.Item key="dashboard-geral"><Link to="/dashboards">Dashboard Geral</Link></Menu.Item>
                 )}
-                {access.canViewComprasDashboard && (
+                {caps.canViewComprasDashboard && (
                   <Menu.Item key="dashboard-compras"><Link to="/dashboards/compras">Dashboard Compras</Link></Menu.Item>
                 )}
-                {canDashboardEquipe && (
+                {caps.canViewTeamDashboard && (
                   <Menu.Item key="dashboard-equipe"><Link to="/dashboards/equipe">Dashboard Equipe</Link></Menu.Item>
                 )}
-                {canDashboardGcal && (
+                {caps.canViewGcalDashboard && (
                   <Menu.Item key="gcal-dashboard">
                     <Link to="/dashboards/gcal">
                       <Badge count={gcalErrorCount} offset={[10, 0]} size="small">Dashboard GCal</Badge>
                     </Link>
                   </Menu.Item>
                 )}
-                {canMapaBrasil && (
+                {caps.canViewMapMetrics && (
                   <Menu.Item key="mapa-brasil"><Link to="/mapa-brasil">Mapa do Brasil</Link></Menu.Item>
                 )}
               </SubMenu>
             )}
 
-            {canDAT && (
+            {caps.canManageAdminRegistries && (
               <SubMenu key="dat-submenu" icon={<SolutionOutlined />} title="DAT">
                 <Menu.Item key="dat-admin"><Link to="/dat/admin">Administração</Link></Menu.Item>
                 <Menu.Item key="dat-cadastros"><Link to="/dat/cadastros">Cadastros</Link></Menu.Item>
@@ -359,13 +359,15 @@ export function AppSidebar({
               </SubMenu>
             )}
 
-            {(access.can('view_all_availability') || canDisponibilidade) && (
+            {/* Grade Mensal: policy view_all_availability (Controle/DAT global) + acesso
+                scoped de Coordenador/Apoio/Gerente via canDisponibilidade (sem policy pública). */}
+            {(caps.canViewAllAvailability || canDisponibilidade) && (
               <Menu.Item key="grade-mensal" icon={<TableOutlined />} onClick={closeAllSubmenus}>
                 <Link to="/solicitacoes/disponibilidade">Grade Mensal</Link>
               </Menu.Item>
             )}
 
-            {canCoordenador && (
+            {caps.canCreateSolicitation && (
               <SubMenu key="solicitacoes-submenu" icon={<FileTextOutlined />} title="Solicitações">
                 <Menu.Item key="minhas-solicitacoes"><Link to="/solicitacoes/minhas">Minhas Solicitações</Link></Menu.Item>
                 <Menu.Item key="nova-solicitacao"><Link to="/solicitacoes/nova">Nova Solicitação</Link></Menu.Item>

--- a/v2/frontend/src/components/__tests__/AppSidebar.menu.test.tsx
+++ b/v2/frontend/src/components/__tests__/AppSidebar.menu.test.tsx
@@ -171,6 +171,9 @@ const ACTORS: ActorSnapshot[] = [
       'view_map_metrics',
       'view_overview_dashboard',
       'view_reports',
+      'access_controle_section',
+      'view_team_dashboard',
+      'view_gcal_dashboard',
     ],
     expectedVisible: [
       'Página Inicial',
@@ -222,8 +225,12 @@ const ACTORS: ActorSnapshot[] = [
       'view_compras_pendencias',
       'view_compras_stats',
       'view_reports',
+      'view_team_dashboard',
+      'view_gcal_dashboard',
     ],
-    // Sem 'Aprovações' (sem policy), sem 'Controle' (canControle=false).
+    // Sem 'Aprovações' (sem policy), sem 'Controle' (sem access_controle_section).
+    // #1270: 'Solicitações' e 'Mapa do Brasil' saem — DAT não tem create_solicitation
+    // nem view_map_metrics; antes apareciam via grupo (over-showing), backend nega.
     // Sem 'Ações Internas': agora policy-gated por `manage_internal_actions` (#1263),
     // ausente no seed do DAT — antes aparecia via grupo e levava a 403.
     // 'Bloqueios' aparece via canBloqueios = canCoordenador (DAT atua como coord operacional).
@@ -235,14 +242,13 @@ const ACTORS: ActorSnapshot[] = [
       'Dashboards',
       'DAT',
       'Grade Mensal',
-      'Solicitações',
     ],
     expectedDashboardsChildren: [
-      // 'Dashboard Geral' escondido (canDashboardOverview=false; só Diretoria/superuser)
+      // 'Dashboard Geral' escondido (sem view_overview_dashboard; só Diretoria/superuser)
+      // 'Mapa do Brasil' escondido (#1270: sem view_map_metrics — Diretoria-only)
       'Dashboard Compras',
       'Dashboard Equipe',
       'Dashboard GCal',
-      'Mapa do Brasil',
     ],
     expectedDatChildren: ['Administração', 'Cadastros', 'Importações', 'Registros de Turmas'],
   },
@@ -269,6 +275,8 @@ const ACTORS: ActorSnapshot[] = [
       'view_compras_pendencias',
       'view_compras_stats',
       'view_reports',
+      'access_controle_section',
+      'view_gcal_dashboard',
     ],
     // Sem 'Aprovações' (sem policy access_solicitation_approvals — Controle puro).
     // Sem 'DAT', sem 'Solicitações', sem 'Ações Internas'.
@@ -299,7 +307,7 @@ const ACTORS: ActorSnapshot[] = [
       // canDisponibilidade=false (D8/D9: Diretoria removida da Grade Mensal).
     },
     // Policies verificadas em produção (#1588).
-    policies: ['view_compras_dashboard', 'view_compras_pendencias', 'view_map_metrics', 'view_overview_dashboard'],
+    policies: ['view_compras_dashboard', 'view_compras_pendencias', 'view_map_metrics', 'view_overview_dashboard', 'view_team_dashboard', 'view_gcal_dashboard'],
     expectedVisible: ['Página Inicial', 'Meus Eventos', 'Dashboards'],
     expectedDashboardsChildren: [
       'Dashboard Geral',
@@ -334,12 +342,15 @@ const ACTORS: ActorSnapshot[] = [
     //   NÃO tem em produção) e não há fallback legacy (canControle/canCoordenador/isFormador
     //   todos false). #1588 corrigiu a fixture que afirmava o contrário.
     // 'Grade Mensal' aparece via canDisponibilidade (legacy, inclui isGerente).
+    // #1270: 'Solicitações' passa a aparecer — Gerente Sup TEM create_solicitation
+    // (antes escondido: o gate legacy era canCoordenador, false aqui — under-showing).
     // Sem 'Ações Internas' (manage_internal_actions ausente) e sem dashboards próprios.
     expectedVisible: [
       'Página Inicial',
       'Meus Eventos',
       'Aprovações',
       'Grade Mensal',
+      'Solicitações',
     ],
     expectedDashboardsChildren: [],
     expectedDatChildren: [],
@@ -360,10 +371,13 @@ const ACTORS: ActorSnapshot[] = [
     // Sem 'Aprovações' (não é Sup), sem 'Bloqueios' (sem view_all e sem canBloqueios).
     // Sem 'Deslocamentos' (não tem nenhuma das 4 condições).
     // Sem 'Ações Internas': policy-gated por `manage_internal_actions` (#1263), ausente aqui.
+    // #1270: 'Solicitações' passa a aparecer — tem create_solicitation (antes escondido
+    // pelo gate legacy canCoordenador, false p/ Função Gerente — under-showing).
     expectedVisible: [
       'Página Inicial',
       'Meus Eventos',
       'Grade Mensal',
+      'Solicitações',
     ],
     expectedDashboardsChildren: [],
     expectedDatChildren: [],
@@ -458,6 +472,8 @@ const ACTORS: ActorSnapshot[] = [
       'view_compras_pendencias',
       'view_compras_stats',
       'view_reports',
+      'access_controle_section',
+      'view_gcal_dashboard',
     ],
     expectedVisible: [
       'Página Inicial',

--- a/v2/frontend/src/hooks/__tests__/useCapabilities.test.ts
+++ b/v2/frontend/src/hooks/__tests__/useCapabilities.test.ts
@@ -78,7 +78,18 @@ describe('computeCapabilities — flags nomeadas por ator', () => {
     expect(caps.canManageInternalActions).toBe(false);
   });
 
-  test('cada uma das 18 flags reflete exatamente sua policy', () => {
+  test('policies de seção de menu (#1270): controle, team dashboard, gcal dashboard', () => {
+    expect(computeCapabilities(['access_controle_section']).canAccessControleSection).toBe(true);
+    expect(computeCapabilities(['view_team_dashboard']).canViewTeamDashboard).toBe(true);
+    expect(computeCapabilities(['view_gcal_dashboard']).canViewGcalDashboard).toBe(true);
+    // Não vazam entre si nem para flags não relacionadas.
+    const c = computeCapabilities(['access_controle_section']);
+    expect(c.canViewTeamDashboard).toBe(false);
+    expect(c.canViewGcalDashboard).toBe(false);
+    expect(c.canManageInternalActions).toBe(false);
+  });
+
+  test('cada uma das 21 flags reflete exatamente sua policy', () => {
     const CASES: ReadonlyArray<readonly [keyof ReturnType<typeof computeCapabilities>, string]> = [
       ['canAccessAuditLogs', 'access_audit_logs'],
       ['canAccessApprovals', 'access_solicitation_approvals'],
@@ -98,6 +109,9 @@ describe('computeCapabilities — flags nomeadas por ator', () => {
       ['canManageAdminRegistries', 'manage_admin_registries'],
       ['canManageInternalActions', 'manage_internal_actions'],
       ['canManagePurchasesAndMaterials', 'manage_purchases_and_materials'],
+      ['canAccessControleSection', 'access_controle_section'],
+      ['canViewTeamDashboard', 'view_team_dashboard'],
+      ['canViewGcalDashboard', 'view_gcal_dashboard'],
     ];
     for (const [flag, policy] of CASES) {
       const caps = computeCapabilities([policy]);

--- a/v2/frontend/src/hooks/useCapabilities.ts
+++ b/v2/frontend/src/hooks/useCapabilities.ts
@@ -38,6 +38,12 @@ export interface Capabilities {
   canManageAdminRegistries: boolean;
   canManageInternalActions: boolean;
   canManagePurchasesAndMaterials: boolean;
+  // Policies de seção de menu (#1589) — paridade exata com os gates legacy do
+  // usePermissions (canControle / canDashboardEquipe / canDashboardGcal). Consumidas
+  // pelo AppSidebar em #1270.
+  canAccessControleSection: boolean;
+  canViewTeamDashboard: boolean;
+  canViewGcalDashboard: boolean;
 }
 
 /** Versão pura (sem React) — usada em tests e call sites sem render. */
@@ -66,6 +72,9 @@ export function computeCapabilities(policies: readonly string[]): Capabilities {
     canManageAdminRegistries: can('manage_admin_registries'),
     canManageInternalActions: can('manage_internal_actions'),
     canManagePurchasesAndMaterials: can('manage_purchases_and_materials'),
+    canAccessControleSection: can('access_controle_section'),
+    canViewTeamDashboard: can('view_team_dashboard'),
+    canViewGcalDashboard: can('view_gcal_dashboard'),
   };
 }
 


### PR DESCRIPTION
Closes #1270. Epic #1254. Desbloqueado pelo #1589 (3 policies novas).

## O que muda
Migra o menu lateral do `AppSidebar` de flags legacy de organograma (`usePermissions` + `useCanAccess`) para **`useCapabilities`** (policy pura). `useCanAccess` **removido** do componente. **Zero `inDAT`/`inControle`/`inDiretoria`** em condicional (acceptance).

- **`useCapabilities`**: +3 flags (`canAccessControleSection`, `canViewTeamDashboard`, `canViewGcalDashboard`) espelhando as policies do #1589. Paridade exata com `canControle`/`canDashboardEquipe`/`canDashboardGcal` (verificado contra o seed no #1589).

## Paridade vs deltas
**8 itens migram com paridade exata** (Aprovações, Ações Internas, Controle, Dashboards Geral/Compras/Equipe/GCal, DAT).

**2 deltas backend-aligned** (mesmo padrão do #1263 — corrige menu→403):
| Item | Delta | Motivo |
|---|---|---|
| Mapa do Brasil | DAT **perde** | `view_map_metrics` = Diretoria-only; DAT via grupo era over-showing |
| Solicitações | DAT **perde**; Gerente + Gerente Sup **ganham** | `create_solicitation` = Coord/Apoio/Gerente; DAT não tem (over-showing), Gerente tinha mas menu escondia (under-showing) |

Flags legacy `can*`/`is*` permanecem **só** onde não há policy pública: escopo próprio Formador/Coordenador (Bloqueios/Deslocamentos) e Grade Mensal scoped (`canDisponibilidade`).

## Testes (TDD)
- `useCapabilities.test`: RED→GREEN nas 3 flags novas + completude (21 flags).
- `AppSidebar.menu` (matriz viva, 10 personas): **37/37**. **Prova retroativa** — reverter a condição de Solicitações p/ `canCoordenador` torna o teste **RED** exatamente nos 3 atores (DAT/Gerente/Gerente Sup), confirmando que os deltas são reais.
- `tsc`/`eslint` limpos.

## Nota sobre o suite completo
13 falhas no `vitest run` completo são **timeouts de carga (0 assertions)**, pré-existentes (mesma classe do #1577). O `AppSidebar` só é renderizado por `AppSidebar.menu.test` (passa isolado, 3×); `App.session-expiry` o mocka. Meu diff não pode causar as outras falhas.

## Escopo
4 arquivos, 100% `v2/frontend` (2 hooks-relacionados + 1 componente + testes).

## Staging gate
Via `staging-gate.sh --pr` (não fabricado).
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `f70e2220`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
