### PR TITLE
refactor(rbac): AvailabilityBlockViewSet privilégio via policy + docs PA-02 (#1272 #1378)

### DIFF
--- a/v2/backend/apps/core/tests/test_availability_privileged_invariant.py
+++ b/v2/backend/apps/core/tests/test_availability_privileged_invariant.py
@@ -1,0 +1,102 @@
+"""
+Sentinela do invariante de privilégio do AvailabilityBlockViewSet (#1272, RBAC 3.4).
+
+Invariante travado aqui:
+  1. `AvailabilityBlockViewSet.permission_classes == [IsAuthenticated]`.
+     `view_all_availability` NUNCA pode virar gate de entrada (`permission_classes`)
+     — seria a regressão que quebra o fluxo own-block do Formador (RD-02/RD-03: o
+     Formador declara o próprio bloqueio SEM ter a capability). A capability é
+     bypass de escopo aplicado DENTRO do `get_queryset`.
+  2. `is_privileged_user` roteia pela SSOT da Policy (`user_has_policy`) e mantém
+     paridade EXATA com a checagem de capability crua: superuser → True; usuário
+     com `view_all_availability` → True; sem a cap → False.
+
+Contexto: descoberto na auditoria RBAC (#1254). Tentativas anteriores de exigir
+`view_all_availability` em `permission_classes` (Issue #1221) quebraram J06/J07.
+Este teste é a rede que impede a re-introdução do bug.
+
+NÃO testa o escopo por gerência em si (coberto por test_multi_sector_permissions,
+test_availability_block_idor). Aqui é meta: a forma da autorização.
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportAttributeAccessIssue=false, reportUnknownMemberType=false
+
+from __future__ import annotations
+
+from django.contrib.auth.models import Group
+from django.core.management import call_command
+from rest_framework.permissions import IsAuthenticated
+
+import pytest
+
+from apps.core.models import PermissaoFuncional
+from apps.core.tests.factories import UsuarioFactory
+from apps.core.views_availability import AvailabilityBlockViewSet, is_privileged_user
+
+pytestmark = pytest.mark.django_db
+
+_CPF = {"i": 0}
+
+
+def _cpf() -> str:
+    _CPF["i"] += 1
+    return f"97788{_CPF['i']:06d}"
+
+
+def _user_with_caps(*codenames: str):
+    user = UsuarioFactory(username=f"priv_inv_{_CPF['i']}", password="x", cpf=_cpf())
+    if codenames:
+        group = Group.objects.create(name=f"grp-priv-inv-{_CPF['i']}")
+        user.groups.add(group)
+        for code in codenames:
+            perm = PermissaoFuncional.objects.filter(codename=code).first()
+            assert perm is not None, f"capability '{code}' ausente do seed"
+            perm.groups.add(group)
+    return user
+
+
+@pytest.fixture
+def seeded(db):
+    call_command("seed_rbac")
+
+
+class TestAvailabilityPrivilegedInvariant:
+    def test_viewset_permission_class_stays_isauthenticated(self):
+        """
+        A GUARDA CENTRAL: permission_classes é exatamente [IsAuthenticated].
+        Se alguém trocar por [CanViewAllAvailability] (ou qualquer gate de cap), o
+        Formador sem a capability perde o fluxo own-block (RD-02/RD-03). Falha aqui
+        com mensagem explícita.
+        """
+        assert AvailabilityBlockViewSet.permission_classes == [IsAuthenticated], (
+            "AvailabilityBlockViewSet.permission_classes DEVE permanecer [IsAuthenticated]. "
+            "view_all_availability é bypass de escopo no get_queryset, NUNCA gate de entrada — "
+            "movê-lo para permission_classes quebra o own-block do Formador (RD-02/RD-03, #1221)."
+        )
+
+    def test_privileged_helper_true_for_view_all_availability(self, seeded):
+        user = _user_with_caps("view_all_availability")
+        assert is_privileged_user(user) is True
+
+    def test_privileged_helper_false_without_capability(self, seeded):
+        # Formador comum (sem view_all_availability) — NÃO é privilegiado.
+        user = _user_with_caps()
+        assert is_privileged_user(user) is False
+
+    def test_privileged_helper_true_for_superuser(self, seeded):
+        user = UsuarioFactory(superuser=True)
+        assert is_privileged_user(user) is True
+
+    def test_privileged_helper_routes_through_policy_layer(self, seeded):
+        """
+        Paridade SSOT: is_privileged_user deve produzir o mesmo resultado que
+        user_has_policy('view_all_availability') para todos os atores — provando que
+        a checagem roteia pela camada de Policy, não por caminho paralelo.
+        """
+        from apps.core.rbac.policies import user_has_policy
+
+        priv = _user_with_caps("view_all_availability")
+        common = _user_with_caps()
+        su = UsuarioFactory(superuser=True)
+        for user in (priv, common, su):
+            assert is_privileged_user(user) == user_has_policy(user, "view_all_availability")

--- a/v2/backend/apps/core/views_availability.py
+++ b/v2/backend/apps/core/views_availability.py
@@ -41,10 +41,20 @@ def is_privileged_user(user):
     bloqueios de terceiros em `AvailabilityBlockViewSet.get_queryset` e
     alargá-lo expõe dados sensíveis. Para consulta de conflito (RD-04 etc.)
     via /api/availability/check/, usar `can_check_availability_for_others`.
-    """
-    from apps.core.rbac_helpers import user_has_any_perm
 
-    return user_has_any_perm(user, "view_all_availability")
+    Invariante (RBAC 3.4, #1272): `view_all_availability` é BYPASS de escopo
+    aplicado DENTRO do `get_queryset`, NUNCA gate de entrada. A `permission_classes`
+    do `AvailabilityBlockViewSet` permanece `[IsAuthenticated]` — mover a capability
+    para lá quebraria o fluxo own-block do Formador (RD-02/RD-03: declara o próprio
+    bloqueio sem ter a capability). Travado por `test_availability_privileged_invariant`.
+
+    Roteia pela SSOT da camada de Policy (`user_has_policy`) em vez de checar a
+    capability crua — `view_all_availability` é policy single-cap, então a semântica
+    é idêntica (superuser bypassa em ambos; mesma capability única).
+    """
+    from apps.core.rbac.policies import user_has_policy
+
+    return user_has_policy(user, "view_all_availability")
 
 
 def can_check_availability_for_others(user):

--- a/v2/backend/apps/core/views_availability.py
+++ b/v2/backend/apps/core/views_availability.py
@@ -32,9 +32,10 @@ def is_privileged_user(user):
     Verifica se o usuário tem permissão para acessar dados de outros usuários.
 
     Epic 3.2 RBAC Refactor (2026-04-23): hardcoded
-    `groups.filter(name__in=["Superintendência", "Controle"])` trocado por
-    capability `pode_ver_todas_disponibilidades`. Expansão deliberada para
-    Gerência+Diretoria (documentada no PR #1183).
+    `groups.filter(name__in=["Superintendência", "Controle"])` trocado pela
+    capability `view_all_availability` (renomeada de `pode_ver_todas_disponibilidades`
+    nas migrations 0075/0076; grupos atribuídos por seed — SSOT em
+    `functional_permissions_seed.py`).
 
     Semântica restrita a `view_all_availability`. NÃO incluir caps de
     create/approve solicitação aqui — esse helper governa visibilidade de

--- a/v2/backend/apps/core/views_availability_monthly.py
+++ b/v2/backend/apps/core/views_availability_monthly.py
@@ -12,8 +12,9 @@ Query params:
 
 Permissões (Bug 1 fix pós RBAC Access Policy Realignment, 2026-04-27):
     - Superusers: acesso a todas as gerências
-    - Capability `view_all_availability` (Controle/Gerente/Coordenador/
-      Apoio de Coordenação por seed 0077): acesso a todas as gerências
+    - Capability `view_all_availability` (grupos atribuídos por seed — SSOT em
+      `functional_permissions_seed.py`; não duplicar a lista aqui p/ evitar drift):
+      acesso a todas as gerências
     - Sem capability + sem gerencia_id: comportamento SUPER (permitido)
     - Sem capability + com gerencia_id: verifica EquipeGerencia
 
@@ -72,9 +73,9 @@ class MonthlyAvailabilityView(APIView):
     """
 
     # Bug 1 fix (2026-04-27): camada de tradução semântica.
-    # Quem tem capability `view_all_availability` (Controle/Gerente via seed
-    # 0078 — realinhada para excluir Coord/Apoio que devem ser scoped por
-    # setor vinculado) bypassa scope. Quem não tem cai em HasSectorAccess
+    # Quem tem capability `view_all_availability` (grupos por seed — SSOT em
+    # functional_permissions_seed.py; Coord/Apoio ficam scoped por setor vinculado,
+    # não recebem a cap) bypassa scope. Quem não tem cai em HasSectorAccess
     # (verificação por gerencia_id via EquipeGerencia).
     permission_classes = [IsAuthenticated, CanViewAllAvailability | HasSectorAccess]  # type: ignore[list-item]
 
@@ -172,7 +173,7 @@ class MonthlyAvailabilityView(APIView):
                     status=status.HTTP_400_BAD_REQUEST,
                 )
         # Sem gerencia_id, restringir escopo para evitar vazamento global:
-        # - Perfis amplos (super/capability pode_ver_todas_disponibilidades): visão ampla
+        # - Perfis amplos (super/capability view_all_availability): visão ampla
         # - Demais perfis: limitar aos usuários das gerências vinculadas
         #
         # Epic 3.2 RBAC Refactor (2026-04-23): hardcoded

--- a/v2/backend/apps/core/views_solicitacao.py
+++ b/v2/backend/apps/core/views_solicitacao.py
@@ -138,7 +138,10 @@ class SolicitacaoViewSet(viewsets.ModelViewSet):
     ViewSet para Solicitações de Evento.
 
     PA-01: Status sempre começa pendente.
-    PA-02 (Adaptada): Superintendência, DAT e Superusuários podem aprovar/reprovar.
+    PA-02 (Adaptada): aprovar/reprovar exige a policy `access_solicitation_approvals`
+    (CanAccessSolicitationApprovals) — Gerente da Superintendência OU Assistente
+    Administrativo do Controle OU superuser. (Doc antiga dizia "Superintendência, DAT
+    e Superusuários"; corrigido em #1378 — regra real em rbac/policies.py.)
     PR 8/N: Apenas Coordenador ou DAT podem criar solicitações.
     """
 
@@ -608,7 +611,10 @@ class SolicitacaoViewSet(viewsets.ModelViewSet):
 
     @extend_schema(
         summary="Aprovar solicitação",
-        description="Aprova uma solicitação pendente. Apenas Superintendência, DAT ou superuser (PA-02).",
+        description=(
+            "Aprova uma solicitação pendente. Requer a policy access_solicitation_approvals "
+            "(PA-02): Gerente da Superintendência, Assistente Administrativo do Controle ou superuser."
+        ),
         request=None,
         responses={
             200: SolicitacaoSerializer,
@@ -624,7 +630,7 @@ class SolicitacaoViewSet(viewsets.ModelViewSet):
         url_path="approve",
     )
     def approve(self, request, pk=None):
-        """Aprovar solicitação (PA-02 Adaptada: Superintendência, DAT e Superusuários)."""
+        """Aprovar solicitação (PA-02: Gerente da Superintendência, Assistente Administrativo do Controle ou superuser)."""
         solicitacao = self.get_object()
         justificativa = request.data.get("reason") or request.data.get("justificativa", "")
 
@@ -646,7 +652,11 @@ class SolicitacaoViewSet(viewsets.ModelViewSet):
 
     @extend_schema(
         summary="Reprovar solicitação",
-        description="Reprova uma solicitação pendente. Requer justificativa. Apenas Superintendência, DAT ou superuser (PA-02).",
+        description=(
+            "Reprova uma solicitação pendente. Requer justificativa e a policy "
+            "access_solicitation_approvals (PA-02): Gerente da Superintendência, "
+            "Assistente Administrativo do Controle ou superuser."
+        ),
         request=None,
         responses={
             200: SolicitacaoSerializer,
@@ -662,7 +672,7 @@ class SolicitacaoViewSet(viewsets.ModelViewSet):
         url_path="reject",
     )
     def reject(self, request, pk=None):
-        """Reprovar solicitação (PA-02 Adaptada: Superintendência, DAT e Superusuários)."""
+        """Reprovar solicitação (PA-02: Gerente da Superintendência, Assistente Administrativo do Controle ou superuser)."""
         solicitacao = self.get_object()
         justificativa = request.data.get("reason") or request.data.get("justificativa", "")
 
@@ -836,7 +846,8 @@ class SolicitacaoViewSet(viewsets.ModelViewSet):
 
         Response 200: { "approved": 2, "errors": [{"id": 3, "detail": "..."}] }
 
-        Permissão: Superintendência, DAT ou superusers (PA-02 Adaptada).
+        Permissão: policy access_solicitation_approvals (PA-02) — Gerente da
+        Superintendência, Assistente Administrativo do Controle ou superuser.
         PA-05: Cada solicitação gera um AuditLog individual com batch=true.
         Limite: máximo 100 solicitações por requisição.
         """
@@ -872,7 +883,8 @@ class SolicitacaoViewSet(viewsets.ModelViewSet):
 
         Response 200: { "rejected": 2, "errors": [{"id": 3, "detail": "..."}] }
 
-        Permissão: Superintendência, DAT ou superusers (PA-02 Adaptada).
+        Permissão: policy access_solicitation_approvals (PA-02) — Gerente da
+        Superintendência, Assistente Administrativo do Controle ou superuser.
         PA-05: Cada solicitação gera um AuditLog individual com batch=true.
         Limite: máximo 100 solicitações por requisição.
         """


### PR DESCRIPTION
Fecha duas issues de baixo risco da Trilha C (arquivos disjuntos, agrupados p/ 1 gate run).

Closes #1272
Closes #1378

---

## #1272 — `is_privileged_user` roteia por `user_has_policy` + sentinela do invariante

**Refactor (no-op comportamental).** O helper chamava `user_has_any_perm("view_all_availability")`
direto; passa a delegar a `user_has_policy("view_all_availability")`, roteando pela SSOT da
camada de Policy. Paridade **exata** (`view_all_availability` é policy single-cap; ambas
bypassam superuser idêntico). Testes de IDOR/multi-setor/d9 existentes seguem verdes.

**O valor real — sentinela do invariante:** `AvailabilityBlockViewSet.permission_classes`
DEVE permanecer `[IsAuthenticated]`. `view_all_availability` é bypass de escopo **dentro do
`get_queryset`**, nunca gate de entrada — movê-lo para `permission_classes` quebra o own-block
do Formador (RD-02/RD-03; já aconteceu na #1221, quebrou J06/J07).

- Guarda central: `permission_classes == [IsAuthenticated]`.
- **RED simulado:** troquei por `[HasPerm("view_all_availability")]` → o sentinela falha com
  `HasPerm(...) != IsAuthenticated`.
- Paridade do helper: superuser/priv/comum + `is_privileged_user == user_has_policy`.

## #1378 — docs PA-02 obsoletas + nome antigo de capability

Docs-only, zero comportamento.

- **`views_solicitacao.py`** (docstrings + `@extend_schema description` → schema OpenAPI):
  aprovação dizia *"Superintendência, DAT ou superuser"* → regra real **"Gerente da
  Superintendência OU Assistente Administrativo do Controle OU superuser"** (policy
  `access_solicitation_approvals`). Confirmado contra `_user_has_solicitation_approvals`. É a
  mesma discrepância que o sentinela do #1261 travou.
- **`views_availability{,_monthly}.py`**: nome antigo `pode_ver_todas_disponibilidades` →
  `view_all_availability`; listas de grupos hardcoded (que já divergiam entre si — "Gerente"
  vs seed real "DAT") → ponteiro para a SSOT (`functional_permissions_seed.py`), evitando
  re-drift.

## Verificação

- `test_openapi` (schema aceita as novas descriptions) + sentinelas de availability e
  solicitacao: **40/40**.
- Gates: black/isort/flake8 OK. Pyright no CI (desta vez revisei o arquivo p/ o padrão
  isinstance-on-object que me pegou no #1261; este não tem).
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `4ea11b46`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
