### PR TITLE
docs(v2): remove stale apps.dat_ingest references from live docs

### DIFF
--- a/v2/docs/PROJETO_ORIGEM.md
+++ b/v2/docs/PROJETO_ORIGEM.md
@@ -47,9 +47,9 @@ O sistema original funcionava integralmente sobre planilhas Google/Excel, que ac
 ### 2.2 Estrutura de Código
 
 #### Backend (`v2/backend`)
-- **Apps**: `apps.core` (domínio principal) e `apps.dat_ingest` (ETLs e ingestão)
+- **Apps**: `apps.core` (domínio principal). O antigo `apps.dat_ingest` (ETLs e ingestão) foi removido (ver §2.4)
 - **Configurações**: `config/` (settings, urls, wsgi, celery)
-- **Comandos ETL**: `apps/dat_ingest/management/commands/` (21 comandos)
+- **Importação de Dados**: `apps/core/imports/` (pipeline export-contract, ADR-012)
 
 #### Frontend (`v2/frontend`)
 - **Framework**: React 18 + Vite 7

--- a/v2/docs/PYRIGHT_SETUP.md
+++ b/v2/docs/PYRIGHT_SETUP.md
@@ -45,13 +45,13 @@ Configuração principal em `v2/backend/pyproject.toml`:
 [tool.pyright]
 typeCheckingMode = "strict"  # Modo mais rigoroso
 pythonVersion = "3.12"       # Python 3.12.12
-include = ["apps/core", "apps/dat_ingest", "config"]
+include = ["apps/core", "apps/dev_tools", "config"]
 exclude = ["**/migrations", "**/tests", "**/__pycache__"]
 ```
 
 **Arquivos incluídos** (35% do projeto):
 - `apps/core/` - 24 services, 5 models, 21 views, 1 serializer, 1 tasks
-- `apps/dat_ingest/` - 11 services, models, views
+- `apps/dev_tools/`
 - `config/` - Settings, URLs
 
 **Arquivos excluídos** (temporário):
@@ -106,7 +106,7 @@ O CI roda automaticamente em cada push/PR:
 - name: Type check with Pyright
   run: |
     cd v2/backend
-    pyright apps/core apps/dat_ingest config
+    pyright apps/core apps/dev_tools config
   continue-on-error: true  # Não bloqueia CI (baseline)
 ```
 
@@ -274,7 +274,7 @@ print(f\"Files: {summary['filesAnalyzed']}\")
 
 ```bash
 cd v2/backend
-pyright apps/core/services/ apps/dat_ingest/services/
+pyright apps/core/services/
 ```
 
 ---
@@ -305,7 +305,7 @@ pyright --outputjson > pyright-baseline.json
 - name: Type check with Pyright
   run: |
     cd v2/backend
-    pyright apps/core apps/dat_ingest config
+    pyright apps/core apps/dev_tools config
   continue-on-error: true  # Baseline: não bloqueia
 ```
 


### PR DESCRIPTION
# docs(v2): remove stale apps.dat_ingest references from live docs

## Summary

`apps.dat_ingest` (the old ETL/ingestion pipeline) was removed in #967/#971 and its absence is already documented in `PROJETO_ORIGEM.md` §2.4. However, two live docs still described `apps.dat_ingest` as an active app and listed `apps/dat_ingest` in pyright config/examples, contradicting the removal notice. This PR updates those stale references to match the actual backend layout (`apps/core`, `apps/dev_tools`, `config`) and point readers at the current import pipeline (`apps/core/imports/`).

Fixes #1574

## Changes

- `v2/docs/PROJETO_ORIGEM.md` (§2.2 Backend):
  - Apps line no longer lists `apps.dat_ingest` as an active app; it now states the old app was removed and points to §2.4.
  - The "Comandos ETL: `apps/dat_ingest/management/commands/` (21 comandos)" bullet is replaced with an "Importação de Dados" bullet pointing to `apps/core/imports/` (pipeline export-contract, ADR-012), consistent with §2.4.
- `v2/docs/PYRIGHT_SETUP.md`:
  - `include` example updated from `apps/dat_ingest` to `apps/dev_tools`, matching the real `v2/backend/pyproject.toml` (`include = ["apps/core", "apps/dev_tools", "config"]`).
  - The "Arquivos incluídos" bullet for `apps/dat_ingest/` (11 services) replaced with `apps/dev_tools/`.
  - Two CI examples (`pyright apps/core apps/dat_ingest config`) and the "Verificar Apenas Services" example (`... apps/dat_ingest/services/`) updated to drop the removed app.

No changes to content outside these two files. `v2/README.md` and `docs/guides/etl.md` (which already carry removal banners) and `RELEASE_NOTES`/ADR files (intentionally preserved historical mentions) were left untouched.

## Testing

Docs-only change; no runtime surface to exercise. Verification performed instead of build/test:

- Confirmed `v2/backend/apps/dat_ingest/` does not exist; `v2/backend/apps/` contains only `core` and `dev_tools`.
- Confirmed `v2/backend/pyproject.toml` `include` is `["apps/core", "apps/dev_tools", "config"]`, so the updated doc example matches the real config.
- `grep -n "dat_ingest" v2/docs/PYRIGHT_SETUP.md` returns no matches; `grep -n "dat_ingest" v2/docs/PROJETO_ORIGEM.md` returns only the intentional removal references (new §2.2 note + the pre-existing §2.4 notice).
- `markdownlint-cli2` could not be run: `sandbox-run` had no DNS and no local `markdownlint` binary exists on this machine. The edits introduce no new markdown constructs (tables, lists, fenced blocks all unchanged in structure), so no linter-regressions are expected.

---
### AI assistance disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.
