### PR TITLE
feat(rbac): AppRoutes gateia rotas por <RequirePolicy> (#1271)

### DIFF
--- a/v2/frontend/src/components/AppRoutes.tsx
+++ b/v2/frontend/src/components/AppRoutes.tsx
@@ -1,8 +1,9 @@
 import { lazy, Suspense } from 'react';
-import { Routes, Route, Navigate, Link } from 'react-router-dom';
-import { Spin, Result, Button } from 'antd';
+import { Routes, Route, Navigate } from 'react-router-dom';
+import { Spin } from 'antd';
 import type { Permissions } from '../hooks/usePermissions';
 import { useCanAccess } from '../hooks/useCanAccess';
+import { RequirePolicy } from './access/RequirePolicy';
 import type { CurrentUser } from '../types';
 
 // Lazy-loaded pages (code-splitting)
@@ -55,26 +56,6 @@ function PageLoader(): JSX.Element {
   );
 }
 
-/**
- * Forbidden inline (mantido para rotas que ainda não usam <RequirePolicy>).
- * Mesma mensagem genérica do `RequirePolicy` (OWASP — não revelar
- * existência do recurso ou permission necessária).
- */
-function Forbidden(): JSX.Element {
-  return (
-    <Result
-      status="info"
-      title="Recurso indisponível"
-      subTitle="Esta página não está disponível ou não pode ser acessada pela sua conta."
-      extra={
-        <Link to="/">
-          <Button type="primary">Voltar ao início</Button>
-        </Link>
-      }
-    />
-  );
-}
-
 interface AppRoutesProps {
   user: CurrentUser;
   permissions: Permissions;
@@ -83,20 +64,14 @@ interface AppRoutesProps {
 
 export function AppRoutes({ user, permissions, policies }: AppRoutesProps): JSX.Element {
   const {
-    canCoordenador, canControle, canDAT, canApproveSuper,
-    canDashboardOverview, canDashboardEquipe, canDashboardGcal, canDashboardCompras,
-    canMapaBrasil, canDisponibilidade, isFormador,
+    canCoordenador, canControle, canDAT, canApproveSuper, canDisponibilidade, isFormador,
   } = permissions;
 
-  // Camada de tradução semântica (Epic 3): derived flags a partir de policies + legacy.
-  // Componentes consomem `access.canAccessApprovals` direto.
-  // PR 10 hardening RBAC (2026-04-30): aprovações dependem exclusivamente
-  // da policy `access_solicitation_approvals`; legacy `canApproveSuper`
-  // saiu do contrato deste hook.
+  // #1271: rotas gateadas por <RequirePolicy> (policy= direto p/ policies públicas, allow=
+  // p/ composites/auth). `access` (useCanAccess) permanece só para os composites de
+  // disponibilidade/bloqueios (view_all_availability OU escopo próprio, sem policy única).
   const access = useCanAccess(policies, {
     canBloqueios: canControle || canCoordenador || isFormador,
-    canCoordenador,
-    canDashboardCompras,
   });
 
   return (
@@ -105,26 +80,30 @@ export function AppRoutes({ user, permissions, policies }: AppRoutesProps): JSX.
         <Route path="/" element={<HomePage />} />
         <Route path="/home" element={<HomePage />} />
 
-        {/* Dashboards */}
-        <Route path="/dashboards" element={canDashboardOverview ? <DashboardsPage /> : <Forbidden />} />
-        <Route path="/dashboards/compras" element={access.canViewComprasDashboard ? <ComprasDashboardPage /> : <Forbidden />} />
-        <Route path="/dashboards/equipe" element={canDashboardEquipe ? <EquipeDashboardPage /> : <Forbidden />} />
-        <Route path="/dashboards/gcal" element={canDashboardGcal ? <GCalDashboardPage /> : <Forbidden />} />
-        <Route path="/mapa-brasil" element={canMapaBrasil ? <MapaBrasilPage /> : <Forbidden />} />
+        {/* Dashboards — #1271: gate por policy pública (RequirePolicy). Fallback padrão
+            do RequirePolicy é a mesma tela genérica ("Recurso indisponível", OWASP). */}
+        <Route path="/dashboards" element={<RequirePolicy policy="view_overview_dashboard" policies={policies}><DashboardsPage /></RequirePolicy>} />
+        <Route path="/dashboards/compras" element={<RequirePolicy policy="view_compras_dashboard" policies={policies}><ComprasDashboardPage /></RequirePolicy>} />
+        <Route path="/dashboards/equipe" element={<RequirePolicy policy="view_team_dashboard" policies={policies}><EquipeDashboardPage /></RequirePolicy>} />
+        <Route path="/dashboards/gcal" element={<RequirePolicy policy="view_gcal_dashboard" policies={policies}><GCalDashboardPage /></RequirePolicy>} />
+        <Route path="/mapa-brasil" element={<RequirePolicy policy="view_map_metrics" policies={policies}><MapaBrasilPage /></RequirePolicy>} />
 
         {/* === Solicitações (agrupamento — Epic 3, Issue #1227) === */}
         {/* Páginas pré-existentes mantidas */}
-        <Route path="/solicitacoes/minhas" element={access.canCreateSolicitation ? <MySolicitacoesPage /> : <Forbidden />} />
-        <Route path="/solicitacoes/nova" element={access.canCreateSolicitation ? <NewSolicitacaoWizard /> : <Forbidden />} />
-        <Route path="/solicitacoes/:id/editar" element={canCoordenador || canApproveSuper ? <EditSolicitacaoPage /> : <Forbidden />} />
+        <Route path="/solicitacoes/minhas" element={<RequirePolicy policy="create_solicitation" policies={policies}><MySolicitacoesPage /></RequirePolicy>} />
+        <Route path="/solicitacoes/nova" element={<RequirePolicy policy="create_solicitation" policies={policies}><NewSolicitacaoWizard /></RequirePolicy>} />
+        {/* :id/editar — composite (#1169): owner plausível OU privilegiado, sem policy única. */}
+        <Route path="/solicitacoes/:id/editar" element={<RequirePolicy allow={canCoordenador || canApproveSuper}><EditSolicitacaoPage /></RequirePolicy>} />
 
         {/* Páginas movidas para sob /solicitacoes/* (com redirects abaixo) */}
-        <Route path="/solicitacoes/aprovacoes" element={access.canAccessApprovals ? <ApprovalsPage /> : <Forbidden />} />
-        <Route path="/solicitacoes/disponibilidade" element={access.can('view_all_availability') || canDisponibilidade ? <MonthlyPage /> : <Forbidden />} />
-        <Route path="/solicitacoes/bloqueios" element={access.canAccessBlocks ? <DisponibilidadeBlocks /> : <Forbidden />} />
-        <Route path="/solicitacoes/deslocamentos" element={access.can('view_all_availability') || canControle || canCoordenador || canDAT ? <DeslocamentosPage /> : <Forbidden />} />
-        <Route path="/solicitacoes/meus-eventos" element={user ? <MeusEventosPage /> : <Forbidden />} />
-        <Route path="/perfil" element={user ? <PerfilPage user={user} /> : <Forbidden />} />
+        <Route path="/solicitacoes/aprovacoes" element={<RequirePolicy policy="access_solicitation_approvals" policies={policies}><ApprovalsPage /></RequirePolicy>} />
+        {/* Grade Mensal / Bloqueios / Deslocamentos — composites: policy view_all_availability
+            OU acesso scoped/próprio (Coordenador/Formador) sem policy pública. */}
+        <Route path="/solicitacoes/disponibilidade" element={<RequirePolicy allow={access.can('view_all_availability') || canDisponibilidade}><MonthlyPage /></RequirePolicy>} />
+        <Route path="/solicitacoes/bloqueios" element={<RequirePolicy allow={access.canAccessBlocks}><DisponibilidadeBlocks /></RequirePolicy>} />
+        <Route path="/solicitacoes/deslocamentos" element={<RequirePolicy allow={access.can('view_all_availability') || canControle || canCoordenador || canDAT}><DeslocamentosPage /></RequirePolicy>} />
+        <Route path="/solicitacoes/meus-eventos" element={<RequirePolicy allow={!!user}><MeusEventosPage /></RequirePolicy>} />
+        <Route path="/perfil" element={<RequirePolicy allow={!!user}><PerfilPage user={user} /></RequirePolicy>} />
 
         {/* Redirects de URLs legadas → novas (preserva deep-links/bookmarks) */}
         <Route path="/aprovacoes" element={<Navigate to="/solicitacoes/aprovacoes" replace />} />
@@ -133,44 +112,45 @@ export function AppRoutes({ user, permissions, policies }: AppRoutesProps): JSX.
         <Route path="/deslocamentos" element={<Navigate to="/solicitacoes/deslocamentos" replace />} />
         <Route path="/meus-eventos" element={<Navigate to="/solicitacoes/meus-eventos" replace />} />
 
-        {/* Controle Module */}
-        <Route path="/controle" element={canControle ? <ControlePage /> : <Forbidden />} />
-        <Route path="/controle/acoes" element={canControle ? <AcoesPage /> : <Forbidden />} />
-        <Route path="/controle/compras" element={(canControle || canDAT) ? <DATComprasPage /> : <Forbidden />} />
-        <Route path="/controle/coordenadores" element={canControle ? <CoordenadoresPage /> : <Forbidden />} />
-        <Route path="/compras-materiais" element={(canControle || canDAT) ? <DATComprasPage /> : <Forbidden />} />
+        {/* Controle Module — #1271: policy access_controle_section (paridade com canControle);
+            compras somam DAT via allow (composite sem policy única). */}
+        <Route path="/controle" element={<RequirePolicy policy="access_controle_section" policies={policies}><ControlePage /></RequirePolicy>} />
+        <Route path="/controle/acoes" element={<RequirePolicy policy="access_controle_section" policies={policies}><AcoesPage /></RequirePolicy>} />
+        <Route path="/controle/compras" element={<RequirePolicy allow={canControle || canDAT}><DATComprasPage /></RequirePolicy>} />
+        <Route path="/controle/coordenadores" element={<RequirePolicy policy="access_controle_section" policies={policies}><CoordenadoresPage /></RequirePolicy>} />
+        <Route path="/compras-materiais" element={<RequirePolicy allow={canControle || canDAT}><DATComprasPage /></RequirePolicy>} />
         {/* /deslocamentos movido para /solicitacoes/deslocamentos (Epic 3, Issue #1227 — redirect já registrado acima) */}
-        <Route path="/controle/formacoes" element={canControle ? <FormacoesPage /> : <Forbidden />} />
-        <Route path="/controle/plano-formacoes" element={canControle ? <PlanoFormacoesPage /> : <Forbidden />} />
-        <Route path="/controle/pre-agenda" element={canControle ? <PreAgendaPage /> : <Forbidden />} />
-        <Route path="/pre-agenda" element={canControle ? <PreAgendaPage /> : <Forbidden />} />
+        <Route path="/controle/formacoes" element={<RequirePolicy policy="access_controle_section" policies={policies}><FormacoesPage /></RequirePolicy>} />
+        <Route path="/controle/plano-formacoes" element={<RequirePolicy policy="access_controle_section" policies={policies}><PlanoFormacoesPage /></RequirePolicy>} />
+        <Route path="/controle/pre-agenda" element={<RequirePolicy policy="access_controle_section" policies={policies}><PreAgendaPage /></RequirePolicy>} />
+        <Route path="/pre-agenda" element={<RequirePolicy policy="access_controle_section" policies={policies}><PreAgendaPage /></RequirePolicy>} />
 
-        {/* Ações/Notificações */}
-        <Route path="/acoes-notificacao" element={access.canManageInternalActions ? <AcoesNotificacaoPage /> : <Forbidden />} />
-        <Route path="/acoes-notificacao/timeline" element={access.canManageInternalActions ? <AcoesTimelinePage /> : <Forbidden />} />
-        <Route path="/notificacoes-internas" element={access.canManageInternalActions ? <NotificacoesInternasPage /> : <Forbidden />} />
-        {/* DAT Module */}
-        <Route path="/dat/admin" element={canDAT ? <AdminDATHomePage /> : <Forbidden />} />
-        <Route path="/dat/admin/usuarios" element={canDAT ? <UsuariosPage /> : <Forbidden />} />
-        <Route path="/dat/admin/municipios" element={canDAT ? <MunicipiosPage /> : <Forbidden />} />
-        <Route path="/dat/admin/projetos" element={canDAT ? <ProjetosPage /> : <Forbidden />} />
-        <Route path="/dat/admin/grupos" element={canDAT ? <GruposPage /> : <Forbidden />} />
-        <Route path="/dat/admin/setores" element={canDAT ? <SetoresPage /> : <Forbidden />} />
-        <Route path="/dat/admin/funcoes" element={canDAT ? <FuncoesPage /> : <Forbidden />} />
-        <Route path="/dat/admin/gerencias" element={canDAT ? <GerenciasPage /> : <Forbidden />} />
-        <Route path="/dat/admin/produtos" element={canDAT ? <ProdutosPage /> : <Forbidden />} />
-        <Route path="/dat/admin/configuracoes" element={canDAT ? <ConfiguracoesPage /> : <Forbidden />} />
-        <Route path="/dat/admin/colecoes" element={canDAT ? <ColecoesImportPage /> : <Forbidden />} />
-        <Route path="/dat/admin/equipe-gerencia" element={canDAT ? <EquipeGerenciaImportPage /> : <Forbidden />} />
-        <Route path="/dat/cadastros" element={canDAT ? <CadastrosPage /> : <Forbidden />} />
-        <Route path="/dat/compras-materiais" element={(canControle || canDAT) ? <DATComprasPage /> : <Forbidden />} />
-        <Route path="/dat/coordenadores" element={canControle ? <CoordenadoresPage /> : <Forbidden />} />
+        {/* Ações/Notificações — #1271: policy manage_internal_actions. */}
+        <Route path="/acoes-notificacao" element={<RequirePolicy policy="manage_internal_actions" policies={policies}><AcoesNotificacaoPage /></RequirePolicy>} />
+        <Route path="/acoes-notificacao/timeline" element={<RequirePolicy policy="manage_internal_actions" policies={policies}><AcoesTimelinePage /></RequirePolicy>} />
+        <Route path="/notificacoes-internas" element={<RequirePolicy policy="manage_internal_actions" policies={policies}><NotificacoesInternasPage /></RequirePolicy>} />
+        {/* DAT Module — #1271: policy manage_admin_registries (paridade com canDAT). */}
+        <Route path="/dat/admin" element={<RequirePolicy policy="manage_admin_registries" policies={policies}><AdminDATHomePage /></RequirePolicy>} />
+        <Route path="/dat/admin/usuarios" element={<RequirePolicy policy="manage_admin_registries" policies={policies}><UsuariosPage /></RequirePolicy>} />
+        <Route path="/dat/admin/municipios" element={<RequirePolicy policy="manage_admin_registries" policies={policies}><MunicipiosPage /></RequirePolicy>} />
+        <Route path="/dat/admin/projetos" element={<RequirePolicy policy="manage_admin_registries" policies={policies}><ProjetosPage /></RequirePolicy>} />
+        <Route path="/dat/admin/grupos" element={<RequirePolicy policy="manage_admin_registries" policies={policies}><GruposPage /></RequirePolicy>} />
+        <Route path="/dat/admin/setores" element={<RequirePolicy policy="manage_admin_registries" policies={policies}><SetoresPage /></RequirePolicy>} />
+        <Route path="/dat/admin/funcoes" element={<RequirePolicy policy="manage_admin_registries" policies={policies}><FuncoesPage /></RequirePolicy>} />
+        <Route path="/dat/admin/gerencias" element={<RequirePolicy policy="manage_admin_registries" policies={policies}><GerenciasPage /></RequirePolicy>} />
+        <Route path="/dat/admin/produtos" element={<RequirePolicy policy="manage_admin_registries" policies={policies}><ProdutosPage /></RequirePolicy>} />
+        <Route path="/dat/admin/configuracoes" element={<RequirePolicy policy="manage_admin_registries" policies={policies}><ConfiguracoesPage /></RequirePolicy>} />
+        <Route path="/dat/admin/colecoes" element={<RequirePolicy policy="manage_admin_registries" policies={policies}><ColecoesImportPage /></RequirePolicy>} />
+        <Route path="/dat/admin/equipe-gerencia" element={<RequirePolicy policy="manage_admin_registries" policies={policies}><EquipeGerenciaImportPage /></RequirePolicy>} />
+        <Route path="/dat/cadastros" element={<RequirePolicy policy="manage_admin_registries" policies={policies}><CadastrosPage /></RequirePolicy>} />
+        <Route path="/dat/compras-materiais" element={<RequirePolicy allow={canControle || canDAT}><DATComprasPage /></RequirePolicy>} />
+        <Route path="/dat/coordenadores" element={<RequirePolicy policy="access_controle_section" policies={policies}><CoordenadoresPage /></RequirePolicy>} />
         {/* PR-C DAT Imports (2026-04-29): /dat/importacao (singular, página antiga
             de Cadastros DAT) redireciona para /dat/importacoes (plural, página
             unificada de imports). Evita 404 em links antigos. */}
         <Route path="/dat/importacao" element={<Navigate to="/dat/importacoes" replace />} />
-        <Route path="/dat/importacoes" element={canDAT ? <DATImportacoesPage /> : <Forbidden />} />
-        <Route path="/dat/registros" element={canDAT ? <DATRegistrosPage /> : <Forbidden />} />
+        <Route path="/dat/importacoes" element={<RequirePolicy policy="manage_admin_registries" policies={policies}><DATImportacoesPage /></RequirePolicy>} />
+        <Route path="/dat/registros" element={<RequirePolicy policy="manage_admin_registries" policies={policies}><DATRegistrosPage /></RequirePolicy>} />
       </Routes>
     </Suspense>
   );

--- a/v2/frontend/src/components/__tests__/AppRoutes.access-by-profile.test.tsx
+++ b/v2/frontend/src/components/__tests__/AppRoutes.access-by-profile.test.tsx
@@ -192,13 +192,30 @@ const ACTORS: ActorSnapshot[] = [
       canSeeAllSectors: true,
       canApproveSuper: true,
     },
+    // Superuser recebe todas as PUBLIC_POLICY_KEYS (bypass no backend). #1271: inclui
+    // as 3 policies de menu do #1589.
     policies: [
       'access_audit_logs',
       'access_solicitation_approvals',
+      'access_controle_section',
+      'create_solicitation',
+      'import_availability_blocks',
+      'import_compras',
+      'import_generic_spreadsheet',
+      'manage_admin_registries',
+      'manage_internal_actions',
+      'manage_purchases_and_materials',
+      'manage_solicitacao_status',
+      'use_gcal',
       'view_all_availability',
       'view_compras_dashboard',
-      'view_overview_dashboard',
+      'view_compras_pendencias',
+      'view_compras_stats',
+      'view_gcal_dashboard',
       'view_map_metrics',
+      'view_overview_dashboard',
+      'view_reports',
+      'view_team_dashboard',
     ],
     expectedAccess: {
       '/dashboards': true,
@@ -230,6 +247,7 @@ const ACTORS: ActorSnapshot[] = [
       canDashboardsMenu: true,
       canDisponibilidade: true,
     },
+    // Prod-verificado (#1588) + view_team/gcal_dashboard (#1589: DAT via manage_admin_registries).
     policies: [
       'access_audit_logs',
       'import_availability_blocks',
@@ -237,14 +255,20 @@ const ACTORS: ActorSnapshot[] = [
       'import_generic_spreadsheet',
       'manage_admin_registries',
       'manage_purchases_and_materials',
+      'view_all_availability',
       'view_compras_dashboard',
+      'view_compras_pendencias',
+      'view_compras_stats',
+      'view_reports',
+      'view_team_dashboard',
+      'view_gcal_dashboard',
     ],
     expectedAccess: {
-      '/dashboards': false, // canDashboardOverview=false (Diretoria/superuser only)
+      '/dashboards': false, // sem view_overview_dashboard (Diretoria/superuser only)
       '/dashboards/compras': true,
-      '/dashboards/equipe': true,
-      '/dashboards/gcal': true,
-      '/mapa-brasil': true,
+      '/dashboards/equipe': true, // view_team_dashboard (via manage_admin_registries)
+      '/dashboards/gcal': true, // view_gcal_dashboard
+      '/mapa-brasil': false, // #1271: sem view_map_metrics (Diretoria-only) — antes via grupo
       '/solicitacoes/aprovacoes': false, // sem policy
       '/solicitacoes/disponibilidade': true, // canDisponibilidade
       '/solicitacoes/bloqueios': true, // canCoordenador (via inDAT) → canBloqueios
@@ -266,17 +290,19 @@ const ACTORS: ActorSnapshot[] = [
     },
     policies: [
       'access_audit_logs',
+      'access_controle_section',
       'manage_purchases_and_materials',
       'manage_solicitacao_status',
       'use_gcal',
       'view_all_availability',
+      'view_gcal_dashboard',
       'view_reports',
     ],
     expectedAccess: {
       '/dashboards': false,
-      '/dashboards/compras': false, // sem policy view_compras_dashboard nem canDashboardCompras
-      '/dashboards/equipe': false,
-      '/dashboards/gcal': true,
+      '/dashboards/compras': false, // sem policy view_compras_dashboard
+      '/dashboards/equipe': false, // sem view_team_dashboard
+      '/dashboards/gcal': true, // view_gcal_dashboard
       '/mapa-brasil': false,
       '/solicitacoes/aprovacoes': false, // Controle puro: sem policy
       '/solicitacoes/disponibilidade': true,
@@ -299,12 +325,18 @@ const ACTORS: ActorSnapshot[] = [
       canMapaBrasil: true,
       canDashboardsMenu: true,
     },
-    policies: ['view_compras_dashboard', 'view_overview_dashboard', 'view_map_metrics'],
+    policies: [
+      'view_compras_dashboard',
+      'view_gcal_dashboard',
+      'view_map_metrics',
+      'view_overview_dashboard',
+      'view_team_dashboard',
+    ],
     expectedAccess: {
       '/dashboards': true,
       '/dashboards/compras': true,
-      '/dashboards/equipe': true,
-      '/dashboards/gcal': true,
+      '/dashboards/equipe': true, // view_team_dashboard
+      '/dashboards/gcal': true, // view_gcal_dashboard
       '/mapa-brasil': true,
       '/solicitacoes/aprovacoes': false,
       '/solicitacoes/disponibilidade': false, // D8/D9: removida
@@ -457,20 +489,22 @@ const ACTORS: ActorSnapshot[] = [
     },
     policies: [
       'access_audit_logs',
+      'access_controle_section',
       'access_solicitation_approvals',
       'manage_purchases_and_materials',
       'manage_solicitacao_status',
       'use_gcal',
       'view_all_availability',
+      'view_gcal_dashboard',
       'view_reports',
     ],
     expectedAccess: {
       '/dashboards': false,
       '/dashboards/compras': false,
-      '/dashboards/equipe': false,
-      '/dashboards/gcal': true,
+      '/dashboards/equipe': false, // sem view_team_dashboard
+      '/dashboards/gcal': true, // view_gcal_dashboard
       '/mapa-brasil': false,
-      '/solicitacoes/aprovacoes': true, // composite recebe policy
+      '/solicitacoes/aprovacoes': true, // access_solicitation_approvals
       '/solicitacoes/disponibilidade': true,
       '/solicitacoes/bloqueios': true,
       '/solicitacoes/deslocamentos': true,

--- a/v2/frontend/src/components/__tests__/AppRoutes.dat-imports.test.tsx
+++ b/v2/frontend/src/components/__tests__/AppRoutes.dat-imports.test.tsx
@@ -70,11 +70,17 @@ const DAT_PERMISSIONS: Permissions = {
   canSeeAllSectors: false,
 };
 
+// #1271: as rotas /dat/* passaram a ser gateadas por <RequirePolicy
+// policy="manage_admin_registries"> (antes: flag legacy canDAT). O DAT em
+// produção possui essa policy pública — o fixture reflete isso para exercitar
+// o caminho autorizado (redirect + load direto).
+const DAT_POLICIES = ['manage_admin_registries'];
+
 describe('AppRoutes — DAT Imports redirect (PR-C)', () => {
   test('rota /dat/importacao redireciona para /dat/importacoes', async () => {
     render(
       <MemoryRouter initialEntries={['/dat/importacao']}>
-        <AppRoutes user={DAT_USER} permissions={DAT_PERMISSIONS} policies={[]} />
+        <AppRoutes user={DAT_USER} permissions={DAT_PERMISSIONS} policies={DAT_POLICIES} />
       </MemoryRouter>,
     );
 
@@ -87,7 +93,7 @@ describe('AppRoutes — DAT Imports redirect (PR-C)', () => {
   test('rota /dat/importacoes carrega ImportacoesPage diretamente para DAT', async () => {
     render(
       <MemoryRouter initialEntries={['/dat/importacoes']}>
-        <AppRoutes user={DAT_USER} permissions={DAT_PERMISSIONS} policies={[]} />
+        <AppRoutes user={DAT_USER} permissions={DAT_PERMISSIONS} policies={DAT_POLICIES} />
       </MemoryRouter>,
     );
 


### PR DESCRIPTION
## O quê

Migra o `AppRoutes` dos ternários de autorização `cond ? <Page/> : <Forbidden/>` para o componente **`<RequirePolicy>`** (RBAC 3.3, onda pós-#1269/#1270). As rotas passam a ser gateadas por **policies públicas** (`policy="..."` + `policies={policies}`), com composites/auth mantidos via `allow={bool}`.

## Por quê

Fecha o ciclo iniciado em #1269 (`useCapabilities`/`useIdentity`) e #1270 (AppSidebar por `useCapabilities`): a **autorização de rota** deixa de depender de flags legacy do organograma (`canControle`, `canDashboardEquipe`, `canDAT`…) e passa a espelhar 1:1 as `PUBLIC_POLICY_KEYS` do backend (SSOT). O backend continua autoritativo; o frontend só reflete.

## Mudanças

- **`AppRoutes.tsx`**
  - `import { RequirePolicy }`; remove o `<Forbidden>` inline (o `RequirePolicy` já renderiza a mesma tela genérica "Recurso indisponível" — OWASP, sem vazar policy/setor).
  - Rotas por **policy pública**: `view_overview_dashboard`, `view_compras_dashboard`, `view_team_dashboard`, `view_gcal_dashboard`, `view_map_metrics`, `create_solicitation`, `access_solicitation_approvals`, `access_controle_section`, `manage_internal_actions`, `manage_admin_registries`.
  - **Composites** via `allow=`: disponibilidade/bloqueios/deslocamentos (`view_all_availability` **OU** escopo próprio Coord/Formador/DAT), compras (`canControle || canDAT`), `/solicitacoes/:id/editar` (#1169), `/meus-eventos` e `/perfil` (auth).
  - Limpa imports órfãos (`Link`, `Result`, `Button`) e flags legacy não mais usadas no destructuring.

- **`AppRoutes.access-by-profile.test.tsx`** (living-matrix, oráculo de paridade)
  - Fixtures das 10 personas canônicas reconciliadas às policies públicas por persona (paridade com produção).

## Delta de comportamento (backend-aligned, esperado)

- **DAT perde `/mapa-brasil`**: `view_map_metrics` é Diretoria-only; o acesso anterior vinha de grupo legacy, não de policy pública. Mesma classe de correção do #1263. Capturado no living-matrix (`'/mapa-brasil': false`).

## Testes

- `AppRoutes.access-by-profile.test.tsx` → **130 passed** (10 personas × 12 rotas críticas + OWASP).
- `tsc --noEmit` limpo · `eslint .` limpo.
- RED→GREEN real no delta DAT `/mapa-brasil` (true→false).

## Escopo

Somente `v2/frontend/src/**`. Nenhuma alteração em `v2/backend/`.

Closes #1271
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `4a339e6a`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
