### PR TITLE
chore(ci): staging gate isolado por slot + filtro test-aware (#1581, #1582)

### DIFF
--- a/.github/workflows/staging-gate-audit.yml
+++ b/.github/workflows/staging-gate-audit.yml
@@ -40,13 +40,11 @@ jobs:
           changed_files="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")"
           printf '%s\n' "$changed_files"
 
-          requires_staging_gate=false
           # Staging gate evidence is required only for runtime-impacting changes.
-          # CI/docs/test-only changes are intentionally excluded.
-          runtime_regex='^(v2/backend/(apps/|config/|requirements\.txt$)|v2/frontend/(src/|public/|Dockerfile\.prod$)|v2/infra/(docker-compose(\.[^/]*)?\.yml$|Dockerfile(\.prod|\.dev)?$|scripts/smoke_test_staging\.sh$))'
-          if echo "$changed_files" | grep -Eq "$runtime_regex"; then
-            requires_staging_gate=true
-          fi
+          # CI/docs/test-only changes are intentionally excluded. A detecção test-aware
+          # vive em v2/infra/scripts/staging-gate-scope.sh (testada em bats) para que
+          # PRs somente-de-teste (que moram sob src/ e apps/) não disparem o gate — #1582.
+          requires_staging_gate="$(printf '%s\n' "$changed_files" | bash v2/infra/scripts/staging-gate-scope.sh)"
 
           echo "requires_staging_gate=$requires_staging_gate" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/staging-gate-bats.yml
+++ b/.github/workflows/staging-gate-bats.yml
@@ -1,0 +1,52 @@
+name: Staging Gate Bats
+
+# Roda a suite bats dos scripts do staging gate (derivacao de slot #1581 + filtro
+# test-aware #1582). Ate agora a logica que decide `requires_staging_gate` — que gateia
+# TODO PR que toca runtime — nao tinha teste de CI; uma regressao no regex passaria batido.
+#
+# NAO e [required] no ruleset da main (o path filter e seguro: PR que nao toca os scripts
+# do gate nem dispara). Promover a required = passo de settings (follow-up do dono do repo).
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "v2/infra/scripts/staging-gate.sh"
+      - "v2/infra/scripts/staging-gate-scope.sh"
+      - "v2/infra/scripts/smoke_test_staging.sh"
+      - "v2/infra/scripts/tests/**"
+      - ".github/workflows/staging-gate-bats.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "v2/infra/scripts/staging-gate.sh"
+      - "v2/infra/scripts/staging-gate-scope.sh"
+      - "v2/infra/scripts/smoke_test_staging.sh"
+      - "v2/infra/scripts/tests/**"
+      - ".github/workflows/staging-gate-bats.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  bats:
+    name: staging gate bats (slot #1581 + scope #1582)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
+
+      - name: Instala bats
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq bats
+
+      - name: bats tests/
+        working-directory: v2/infra/scripts
+        run: bats tests/

--- a/v2/infra/scripts/.gitattributes
+++ b/v2/infra/scripts/.gitattributes
@@ -1,0 +1,5 @@
+# Scripts de shell e suites bats rodam no CI (ubuntu-latest) e localmente via bash.
+# CRLF quebraria o shebang / a execucao (ex.: `bash staging-gate-scope.sh` no workflow).
+# Forca LF no blob independentemente do core.autocrlf do cliente (ex.: Windows).
+*.sh   text eol=lf
+*.bats text eol=lf

--- a/v2/infra/scripts/smoke_test_staging.sh
+++ b/v2/infra/scripts/smoke_test_staging.sh
@@ -26,6 +26,9 @@ BACKEND_URL="${BACKEND_URL:-http://localhost:18002}"
 FRONTEND_URL="${FRONTEND_URL:-http://localhost:15173}"
 MAX_WAIT="${MAX_WAIT:-120}"
 STAGING_TAG="${STAGING_TAG:-staging-local}"
+# Projeto Compose do gate isolado por slot (#1581). Vazio = usa o do --env-file
+# (aprender_staging), preservando o comportamento standalone historico.
+STAGING_PROJECT="${STAGING_PROJECT:-}"
 
 # Python interpreter: verify it actually works (Windows python3 alias may be a Store stub)
 if [ -z "${PYTHON:-}" ]; then
@@ -42,13 +45,18 @@ PYTHON="${PYTHON:-python3}"
 BACKEND_CURL="curl -sf -H X-Forwarded-Proto:https"
 
 # ── Compose helper (anchored to INFRA_DIR) ───────────────────────
+# Passa -p quando STAGING_PROJECT estiver setado (gate isolado por slot, #1581): sem
+# isso os checks de Celery (worker/beat) procurariam containers no projeto errado.
 compose_cmd() {
   (
     cd "${INFRA_DIR}"
-    IMAGE_TAG="${STAGING_TAG}" docker compose \
-      --env-file .env.staging \
-      -f docker-compose.yml \
-      "$@"
+    if [ -n "${STAGING_PROJECT}" ]; then
+      IMAGE_TAG="${STAGING_TAG}" docker compose -p "${STAGING_PROJECT}" \
+        --env-file .env.staging -f docker-compose.yml "$@"
+    else
+      IMAGE_TAG="${STAGING_TAG}" docker compose \
+        --env-file .env.staging -f docker-compose.yml "$@"
+    fi
   )
 }
 

--- a/v2/infra/scripts/staging-gate-scope.sh
+++ b/v2/infra/scripts/staging-gate-scope.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# staging-gate-scope.sh — decide se um conjunto de arquivos alterados exige o staging gate.
+#
+# O staging gate (evidencia 8/8) e [required] APENAS para mudancas que impactam RUNTIME
+# (backend app/config, frontend src/public, imagens/compose de infra). Mudancas de CI,
+# docs e SOMENTE-TESTE nao tocam runtime e sao intencionalmente dispensadas — como o
+# comentario do workflow sempre prometeu.
+#
+# Bug corrigido (issue #1582): o runtime_regex casa `v2/frontend/src/` e `v2/backend/apps/`,
+# que TAMBEM contem os testes (`src/__tests__/*.test.tsx`, `apps/**/tests/test_*.py`). Um PR
+# so-de-teste (zero runtime) caia no gate `[required]`. Evidencia: PR #1580 (1 arquivo
+# `App.session-expiry.test.tsx`, +9/-1) falhou o gate sem tocar codigo de producao.
+#
+# Correcao: remover os caminhos de teste ANTES de avaliar o runtime_regex. Se, depois de
+# tirar os testes, ainda sobra algum arquivo de runtime -> o gate e exigido. E seguro: so
+# dispensamos o gate quando TODOS os candidatos a runtime sao arquivos de teste (nunca
+# pulamos o gate por causa de um arquivo de runtime de verdade).
+#
+# Uso:
+#   git diff --name-only BASE HEAD | staging-gate-scope.sh   # imprime: true|false
+#   printf '%s\n' "$lista_de_arquivos" | staging-gate-scope.sh
+#
+# Saida (stdout): `true`  -> exige o gate (havia arquivo de runtime nao-teste)
+#                 `false` -> dispensa (docs/CI/somente-teste)
+# Exit code: sempre 0 — a decisao esta no stdout, nao no status.
+
+set -uo pipefail
+
+# Caminhos SOMENTE-TESTE (dispensados). Cobre os layouts reais do repo:
+#   frontend: src/**/__tests__/**, *.test.{ts,tsx,js,jsx}, *.spec.{ts,tsx,js,jsx}
+#   backend:  apps/**/tests/**, test_*.py, conftest*.py
+TEST_PATH_REGEX='(^|/)(__tests__|tests)/|(^|/)conftest[^/]*\.py$|(^|/)test_[^/]*\.py$|\.(test|spec)\.[cm]?[jt]sx?$'
+
+# Caminhos que impactam RUNTIME (exigem o gate). Identico ao filtro historico do workflow.
+RUNTIME_REGEX='^(v2/backend/(apps/|config/|requirements\.txt$)|v2/frontend/(src/|public/|Dockerfile\.prod$)|v2/infra/(docker-compose(\.[^/]*)?\.yml$|Dockerfile(\.prod|\.dev)?$|scripts/smoke_test_staging\.sh$))'
+
+changed="$(cat)"
+
+# 1) Tira os arquivos SOMENTE-TESTE da consideracao (`|| true`: se tudo era teste, o
+#    grep -v nao casa nada e retornaria 1 sob pipefail).
+runtime_candidates="$(printf '%s\n' "$changed" | grep -Ev "$TEST_PATH_REGEX" || true)"
+
+# 2) Sobrou algum arquivo de runtime? Entao o gate e exigido.
+if printf '%s\n' "$runtime_candidates" | grep -Eq "$RUNTIME_REGEX"; then
+  echo "true"
+else
+  echo "false"
+fi

--- a/v2/infra/scripts/staging-gate.sh
+++ b/v2/infra/scripts/staging-gate.sh
@@ -2,11 +2,23 @@
 # staging-gate.sh — roda o staging gate local (build imagens prod + up + migrate + smoke)
 # e, opcionalmente, atualiza um PR com os 3 marcadores + evidencia e marca Ready.
 #
+# ISOLADO POR SLOT (#1581): projeto Compose, tag de imagem e portas de host sao derivados
+# de um numero de slot — igual ao stack de dev (worktree-env.sh, #1559/#1576). Dois gates
+# em slots diferentes rodam em PARALELO sem se atropelar (projetos/portas/tags distintos) e
+# o `down -v` de um NAO destroi a stack do outro. Slot 0 (default) mantem o comportamento
+# historico: projeto aprender_staging, tag staging-local, portas 18002/15173/15434/16380.
+#
+# Resolucao do slot (primeiro que existir): --slot N > env DEV_SLOT > arquivo `.dev-slot`
+# na raiz do worktree > 0. Reutiliza o MESMO `.dev-slot` do stack de dev, entao um worktree
+# ja marcado com `echo 1 > .dev-slot` isola o gate automaticamente (sem sourcing).
+#
 # Substitui o copia-e-cola manual do gate. Equivale a `make staging-full` (que quebra
 # no Windows GnuWin32 por causa do $(MAKE) recursivo) + a colagem dos marcadores.
 #
 # Uso:
 #   v2/infra/scripts/staging-gate.sh                  # so roda o gate; imprime resultado
+#   v2/infra/scripts/staging-gate.sh --slot 2         # forca slot 2 (projeto/portas/tag do slot 2)
+#   v2/infra/scripts/staging-gate.sh --print-config   # imprime a config derivada e sai (nao toca Docker)
 #   v2/infra/scripts/staging-gate.sh --pr 1494        # roda o gate; se 8/8, atualiza PR #1494 + marca Ready
 #   v2/infra/scripts/staging-gate.sh --pr 1494 --no-ready   # atualiza o body mas NAO marca Ready
 #   v2/infra/scripts/staging-gate.sh --keep           # nao derruba a stack no fim (debug)
@@ -20,18 +32,24 @@
 # agente aprender-deployer, na VM01, pega o ponteiro assinado e aplica por digest.
 #
 # Exit codes: 0 ok | 2 precheck | 3 build backend | 4 build frontend | 5 up | 6 migrate
-#             | 7 smoke falhou | 8 sem gh | 9 PR nao encontrado | 10 gh edit falhou | 64 arg invalido
+#             | 7 smoke falhou | 8 sem gh | 9 PR nao encontrado | 10 gh edit falhou
+#             | 11 outro gate no mesmo slot em curso | 64 arg invalido
 set -uo pipefail
 
 PR=""
 DO_READY=1
 KEEP=0
+SLOT_ARG=""
+PRINT_CONFIG=0
 while [ $# -gt 0 ]; do
   case "$1" in
-    --pr)       PR="${2:-}"; shift 2;;
-    --pr=*)     PR="${1#*=}"; shift;;
-    --no-ready) DO_READY=0; shift;;
-    --keep)     KEEP=1; shift;;
+    --pr)           PR="${2:-}"; shift 2;;
+    --pr=*)         PR="${1#*=}"; shift;;
+    --slot)         SLOT_ARG="${2:-}"; shift 2;;
+    --slot=*)       SLOT_ARG="${1#*=}"; shift;;
+    --no-ready)     DO_READY=0; shift;;
+    --keep)         KEEP=1; shift;;
+    --print-config) PRINT_CONFIG=1; shift;;
     -h|--help)  tail -n +2 "$0" | grep '^#' | sed 's/^#\{1,\} \{0,1\}//; s/^#//'; exit 0;;
     *) echo "arg desconhecido: $1 (use --help)" >&2; exit 64;;
   esac
@@ -42,20 +60,85 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 INFRA_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"   # v2/infra
 cd "$INFRA_DIR" || { echo "nao consegui cd para $INFRA_DIR" >&2; exit 1; }
 
-TAG="staging-local"
+# ---------- resolve slot + deriva projeto/tag/portas (isolamento #1581) ----------
+SLOT="$SLOT_ARG"
+[ -z "$SLOT" ] && SLOT="${DEV_SLOT:-}"
+if [ -z "$SLOT" ]; then
+  WT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+  [ -n "$WT_ROOT" ] && [ -f "$WT_ROOT/.dev-slot" ] && SLOT="$(tr -d '[:space:]' < "$WT_ROOT/.dev-slot")"
+fi
+SLOT="${SLOT:-0}"
+case "$SLOT" in ''|*[!0-9]*) echo "slot invalido '$SLOT' (use inteiro >= 0)" >&2; exit 64;; esac
+
+if [ "$SLOT" = "0" ]; then
+  PROJECT_STAGING="aprender_staging"
+  TAG="staging-local"
+else
+  PROJECT_STAGING="aprender_staging_s${SLOT}"
+  TAG="staging-local-s${SLOT}"
+fi
+# Portas de host por slot (offset +10, como no worktree-env.sh). Base = .env.staging.
+STAGING_BACKEND_PORT=$((18002 + SLOT * 10))
+STAGING_DB_PORT=$((15434 + SLOT * 10))
+STAGING_REDIS_PORT=$((16380 + SLOT * 10))
+STAGING_FRONTEND_PORT=$((15173 + SLOT * 10))
+
 BACKEND_IMG="norjosamatheus/aprender-backend:$TAG"
 FRONTEND_IMG="norjosamatheus/aprender-frontend:$TAG"
-GATE() { IMAGE_TAG="$TAG" docker compose --env-file .env.staging -f docker-compose.yml -f docker-compose.staging-gate.yml "$@"; }
+
+if [ "$PRINT_CONFIG" -eq 1 ]; then
+  echo "slot=$SLOT"
+  echo "project=$PROJECT_STAGING"
+  echo "tag=$TAG"
+  echo "backend_image=$BACKEND_IMG"
+  echo "frontend_image=$FRONTEND_IMG"
+  echo "backend_port=$STAGING_BACKEND_PORT"
+  echo "db_port=$STAGING_DB_PORT"
+  echo "redis_port=$STAGING_REDIS_PORT"
+  echo "frontend_port=$STAGING_FRONTEND_PORT"
+  exit 0
+fi
+
+# Helper Compose: -p explicito + portas/tag inline. As vars inline vencem o --env-file
+# (.env.staging) E qualquer BACKEND_HOST_PORT/etc herdado do worktree-env.sh de dev
+# (provado: var inline > --env-file na interpolacao do Compose).
+GATE() {
+  COMPOSE_PROJECT_NAME="$PROJECT_STAGING" \
+  IMAGE_TAG="$TAG" \
+  BACKEND_HOST_PORT="$STAGING_BACKEND_PORT" \
+  DB_HOST_PORT="$STAGING_DB_PORT" \
+  REDIS_HOST_PORT="$STAGING_REDIS_PORT" \
+  FRONTEND_HOST_PORT="$STAGING_FRONTEND_PORT" \
+  docker compose -p "$PROJECT_STAGING" --env-file .env.staging \
+    -f docker-compose.yml -f docker-compose.staging-gate.yml "$@"
+}
+
+# ---------- lock por slot (defesa contra dois gates no MESMO slot por engano) ----------
+LOCK_DIR="${TMPDIR:-/tmp}/aprender-staging-gate-${PROJECT_STAGING}.lock"
+if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+  echo "[gate] FALHOU: ja existe um gate rodando no slot ${SLOT} (lock: $LOCK_DIR)." >&2
+  echo "[gate]   use outro slot (--slot N) ou, se tiver certeza que nada roda, remova: rmdir '$LOCK_DIR'" >&2
+  exit 11
+fi
 
 teardown() {
-  if [ "$KEEP" -eq 1 ]; then echo "[gate] --keep: stack mantida (derrube depois com: make -C v2/infra staging-down)"; return; fi
-  echo "[gate] teardown (down -v)..."
+  rmdir "$LOCK_DIR" 2>/dev/null || true
+  if [ "$KEEP" -eq 1 ]; then
+    echo "[gate] --keep: stack (slot $SLOT / $PROJECT_STAGING) mantida. Para derrubar:"
+    echo "       docker compose -p $PROJECT_STAGING --env-file .env.staging -f docker-compose.yml -f docker-compose.staging-gate.yml down -v"
+    return
+  fi
+  echo "[gate] teardown (down -v, projeto $PROJECT_STAGING)..."
   GATE down -v >/dev/null 2>&1 || true
 }
 trap teardown EXIT
 
 LOG="$(mktemp)"
 fail() { echo "[gate] FALHOU: $1" >&2; exit "${2:-1}"; }
+
+echo "==> [gate] slot=$SLOT | projeto=$PROJECT_STAGING | tag=$TAG | backend :$STAGING_BACKEND_PORT | frontend :$STAGING_FRONTEND_PORT"
+
+[ -f .env.staging ] || fail ".env.staging nao encontrado em $INFRA_DIR — crie a partir do template: cp .env.staging.example .env.staging" 2
 
 echo "==> [1/5] precheck (compose valido / !reset suportado)"
 GATE config >/dev/null 2>&1 || fail "precheck (atualize Docker Compose >= 2.24.6 p/ !reset)" 2
@@ -77,6 +160,10 @@ GATE up -d --no-build || fail "up" 5
 GATE run --rm web python manage.py migrate --noinput || fail "migrate" 6
 
 echo "==> [5/5] smoke (8 checks)"
+BACKEND_URL="http://localhost:${STAGING_BACKEND_PORT}" \
+FRONTEND_URL="http://localhost:${STAGING_FRONTEND_PORT}" \
+STAGING_TAG="$TAG" \
+STAGING_PROJECT="$PROJECT_STAGING" \
 PYTHON=python bash scripts/smoke_test_staging.sh | tee "$LOG"
 SMOKE=${PIPESTATUS[0]}
 
@@ -111,7 +198,7 @@ NEWBODY="$(mktemp)"
   echo "- [x] make staging-full executado com sucesso (8/8 PASS)"
   echo "- [x] Evidencia anexada no PR"
   echo
-  echo "Evidencia (gate local, commit \`$SHA\`):"
+  echo "Evidencia (gate local, commit \`$SHA\`, slot \`$SLOT\` / projeto \`$PROJECT_STAGING\`):"
   echo
   echo '```'
   printf '%s\n' "$EVID"

--- a/v2/infra/scripts/tests/staging_gate_scope.bats
+++ b/v2/infra/scripts/tests/staging_gate_scope.bats
@@ -1,0 +1,102 @@
+#!/usr/bin/env bats
+# staging_gate_scope.bats — unit do filtro test-aware do staging gate (issue #1582).
+#
+# Garante que PRs SOMENTE-DE-TESTE (que moram sob src/ e apps/) NAO exigem o gate, sem
+# nunca dispensar o gate quando ha arquivo de runtime de verdade.
+#
+# Rodar:  bats v2/infra/scripts/tests/staging_gate_scope.bats
+#     ou:  docker run --rm -v "$PWD:/code" -w /code bats/bats v2/infra/scripts/tests/
+
+setup() {
+  SCOPE="${BATS_TEST_DIRNAME}/../staging-gate-scope.sh"
+}
+
+# decide <arquivo...> -> imprime true|false (uma linha por arquivo no stdin do script)
+decide() { printf '%s\n' "$@" | bash "$SCOPE"; }
+
+# ---------------- dispensa: SOMENTE-TESTE (o bug do #1582) ----------------
+
+@test "PR #1580 (App.session-expiry.test.tsx) dispensa o gate" {
+  run decide "v2/frontend/src/__tests__/App.session-expiry.test.tsx"
+  [ "$status" -eq 0 ]
+  [ "$output" = "false" ]
+}
+
+@test "teste backend em apps/**/tests dispensa" {
+  run decide "v2/backend/apps/core/tests/test_availability_service.py"
+  [ "$output" = "false" ]
+}
+
+@test "conftest.py dispensa" {
+  run decide "v2/backend/apps/core/tests/conftest.py"
+  [ "$output" = "false" ]
+}
+
+@test "spec de frontend dispensa" {
+  run decide "v2/frontend/src/components/Foo.spec.tsx"
+  [ "$output" = "false" ]
+}
+
+@test "teste .js legado dispensa" {
+  run decide "v2/frontend/src/hooks/__tests__/useConfig.test.js"
+  [ "$output" = "false" ]
+}
+
+@test "so testes (backend + frontend juntos) dispensa" {
+  run decide "v2/backend/apps/core/tests/test_x.py" "v2/frontend/src/__tests__/y.test.tsx"
+  [ "$output" = "false" ]
+}
+
+# ---------------- exige: RUNTIME de verdade (nunca pular o gate) ----------------
+
+@test "runtime frontend (App.tsx) exige o gate" {
+  run decide "v2/frontend/src/App.tsx"
+  [ "$output" = "true" ]
+}
+
+@test "runtime backend (views.py) exige o gate" {
+  run decide "v2/backend/apps/core/views.py"
+  [ "$output" = "true" ]
+}
+
+@test "requirements.txt exige o gate" {
+  run decide "v2/backend/requirements.txt"
+  [ "$output" = "true" ]
+}
+
+@test "Dockerfile.prod do frontend exige o gate" {
+  run decide "v2/frontend/Dockerfile.prod"
+  [ "$output" = "true" ]
+}
+
+@test "docker-compose de infra exige o gate" {
+  run decide "v2/infra/docker-compose.yml"
+  [ "$output" = "true" ]
+}
+
+@test "smoke_test_staging.sh exige o gate" {
+  run decide "v2/infra/scripts/smoke_test_staging.sh"
+  [ "$output" = "true" ]
+}
+
+@test "runtime + teste juntos exige o gate (nao pular por causa do teste)" {
+  run decide "v2/frontend/src/App.tsx" "v2/frontend/src/__tests__/App.test.tsx"
+  [ "$output" = "true" ]
+}
+
+# ---------------- dispensa: nao-runtime que ja era dispensado ----------------
+
+@test "docs dispensa" {
+  run decide "docs/guia.md"
+  [ "$output" = "false" ]
+}
+
+@test "workflow de CI dispensa" {
+  run decide ".github/workflows/frontend-ci.yml"
+  [ "$output" = "false" ]
+}
+
+@test "diff vazio dispensa" {
+  run decide ""
+  [ "$output" = "false" ]
+}

--- a/v2/infra/scripts/tests/staging_gate_slot.bats
+++ b/v2/infra/scripts/tests/staging_gate_slot.bats
@@ -1,0 +1,84 @@
+#!/usr/bin/env bats
+# staging_gate_slot.bats — unit da derivacao de config do gate por slot (issue #1581).
+#
+# Garante que projeto Compose, tag de imagem e portas de host sao derivados do slot, de
+# forma que dois gates em slots diferentes NAO colidam. Slot 0 = comportamento historico.
+# Usa `--print-config` (nao toca Docker), entao roda deterministico e offline.
+#
+# Rodar:  bats v2/infra/scripts/tests/staging_gate_slot.bats
+#     ou:  docker run --rm -v "$PWD:/code" -w /code bats/bats v2/infra/scripts/tests/
+
+setup() {
+  GATE="${BATS_TEST_DIRNAME}/../staging-gate.sh"
+}
+
+# cfg <chave> a partir da saida de --print-config (KEY=VALUE por linha)
+val() { printf '%s\n' "$1" | grep -E "^${2}=" | cut -d= -f2-; }
+
+# ---------------- slot 0: retrocompat (comportamento historico) ----------------
+
+@test "slot 0: projeto/tag/portas = valores historicos (.env.staging)" {
+  run bash "$GATE" --slot 0 --print-config
+  [ "$status" -eq 0 ]
+  [ "$(val "$output" project)" = "aprender_staging" ]
+  [ "$(val "$output" tag)" = "staging-local" ]
+  [ "$(val "$output" backend_port)" = "18002" ]
+  [ "$(val "$output" db_port)" = "15434" ]
+  [ "$(val "$output" redis_port)" = "16380" ]
+  [ "$(val "$output" frontend_port)" = "15173" ]
+}
+
+# ---------------- slot 1 e 2: isolados ----------------
+
+@test "slot 1: projeto/tag/portas com sufixo e offset do slot" {
+  run bash "$GATE" --slot 1 --print-config
+  [ "$status" -eq 0 ]
+  [ "$(val "$output" project)" = "aprender_staging_s1" ]
+  [ "$(val "$output" tag)" = "staging-local-s1" ]
+  [ "$(val "$output" backend_image)" = "norjosamatheus/aprender-backend:staging-local-s1" ]
+  [ "$(val "$output" backend_port)" = "18012" ]
+  [ "$(val "$output" db_port)" = "15444" ]
+  [ "$(val "$output" redis_port)" = "16390" ]
+  [ "$(val "$output" frontend_port)" = "15183" ]
+}
+
+@test "slot 2 via DEV_SLOT (env)" {
+  DEV_SLOT=2 run bash "$GATE" --print-config
+  [ "$status" -eq 0 ]
+  [ "$(val "$output" project)" = "aprender_staging_s2" ]
+  [ "$(val "$output" tag)" = "staging-local-s2" ]
+  [ "$(val "$output" backend_port)" = "18022" ]
+}
+
+@test "--slot tem precedencia sobre DEV_SLOT" {
+  DEV_SLOT=2 run bash "$GATE" --slot 3 --print-config
+  [ "$(val "$output" project)" = "aprender_staging_s3" ]
+  [ "$(val "$output" backend_port)" = "18032" ]
+}
+
+# ---------------- slots distintos NAO colidem (o objetivo do #1581) ----------------
+
+@test "slots 1 e 2 produzem projeto/portas/tag disjuntos" {
+  run bash "$GATE" --slot 1 --print-config; local o1="$output"
+  run bash "$GATE" --slot 2 --print-config; local o2="$output"
+  [ "$(val "$o1" project)"      != "$(val "$o2" project)" ]
+  [ "$(val "$o1" tag)"          != "$(val "$o2" tag)" ]
+  [ "$(val "$o1" backend_port)" != "$(val "$o2" backend_port)" ]
+  [ "$(val "$o1" db_port)"      != "$(val "$o2" db_port)" ]
+  [ "$(val "$o1" redis_port)"   != "$(val "$o2" redis_port)" ]
+  [ "$(val "$o1" frontend_port)" != "$(val "$o2" frontend_port)" ]
+}
+
+# ---------------- validacao de entrada ----------------
+
+@test "slot nao-inteiro -> exit 64" {
+  run bash "$GATE" --slot abc --print-config
+  [ "$status" -eq 64 ]
+}
+
+@test "--print-config nao exige Docker (sai antes do build/up)" {
+  # Sem daemon Docker acessivel, ainda assim deve imprimir e sair 0.
+  DOCKER_HOST=tcp://127.0.0.1:1 run bash "$GATE" --slot 1 --print-config
+  [ "$status" -eq 0 ]
+  [ "$(val "$output" project)" = "aprender_staging_s1" ]
+}


### PR DESCRIPTION
## Resumo

Conserta a **infraestrutura do staging gate** — `[required]` para todo PR que toca `v2/backend|frontend|infra`. Duas correcoes irmas na mesma lane (meta-trabalho que destrava o paralelismo entre sessoes):

- **#1581** — o gate era um **singleton**: projeto Compose, tag de imagem e portas de host FIXOS (`aprender_staging` / `staging-local` / `18002...`) + `down -v` no teardown. Dois gates simultaneos colidiam e o `down -v` de um destruia a stack do outro (falha-fantasma, ou 8/8 do codigo errado). Agora projeto/tag/portas sao **derivados do slot**, como o `worktree-env.sh` ja faz para o dev (#1559/#1576).
- **#1582** — o filtro de caminhos casava `v2/frontend/src/` e `v2/backend/apps/`, que **contem os testes** -> PR so-de-teste falhava o gate sem tocar runtime (evidencia: PR #1580). Agora o filtro e **test-aware**.

## #1582 — filtro test-aware (prova RED -> GREEN)

Detecção extraida para `v2/infra/scripts/staging-gate-scope.sh` (remove caminhos de teste antes do `runtime_regex`; so dispensa quando TODOS os candidatos a runtime sao testes — nunca pula por um arquivo de runtime real). Regex antigo (RED) vs. script novo (GREEN):

| Caso | Antigo | Novo |
|---|---|---|
| PR #1580 `App.session-expiry.test.tsx` (so-teste) | `true` :x: | `false` :white_check_mark: |
| backend `apps/**/tests/test_*.py` (so-teste) | `true` :x: | `false` :white_check_mark: |
| runtime `src/App.tsx` | `true` | `true` :white_check_mark: |
| runtime **+** teste juntos | `true` | `true` :white_check_mark: (nao pula) |
| docs / CI | `false` | `false` :white_check_mark: |

## #1581 — isolamento por slot (prova RED -> GREEN)

`GATE()` passa `-p` + portas/tag **inline**, que vencem o `.env.staging` **e** vars de dev herdadas (var inline > `--env-file` na interpolacao do Compose — verificado empiricamente). Sob shell poluido com dev-slot-1 (`source worktree-env.sh`), `docker compose config` extraindo `projeto | porta-web | tag`:

~~~
RED  (gate antigo, fixo, herda o dev):
  slot 1 -> aprender_dev_s1 | 8012 | staging-local
  slot 2 -> aprender_dev_s1 | 8012 | staging-local     (identicos -> colisao tripla)

GREEN (gate novo, -p + inline por slot):
  slot 1 -> aprender_staging_s1 | 18012 | staging-local-s1
  slot 2 -> aprender_staging_s2 | 18022 | staging-local-s2   (disjuntos)
~~~

Resolucao do slot: `--slot N > DEV_SLOT > .dev-slot > 0`. **Slot 0 = comportamento historico** (retrocompativel; CI e uso single-session inalterados). Lock por slot como defesa contra dois gates no mesmo slot; teardown derruba **so** o proprio projeto.

## Testes

- **bats 23/23** em `v2/infra/scripts/tests/` (derivacao de slot + filtro test-aware), rodando no novo `staging-gate-bats.yml` (path-filtered, nao-required, no molde do `deployer-bats.yml`).
- **shellcheck** limpo nos scripts tocados; **actionlint** verde nos 2 workflows; `bash -n` ok.
- `.gitattributes` novo forca LF nos `.sh`/`.bats` (rodam no CI ubuntu).

## Checklist Tecnico

- [x] Arquitetura e SOLID: derivacao por slot espelha o padrao ja existente do dev; deteccao de scope isolada e testavel
- [x] Seguranca: sem segredo (`.env.staging` gitignored); sem novo vetor
- [x] Performance: infra; sem regressao (slot 0 inalterado)
- [x] Tratamento de erros: exit codes por etapa, lock por slot, slot invalido -> 64, `.env.staging` ausente -> mensagem clara
- [x] Condicoes de fronteira: slot 0 / diff vazio / slot nao-inteiro cobertos por bats

## Workflow

- [x] Escopo definido (lane da Sessao D; sem tocar areas de C/B/E)
- [x] Testes criados para comportamento novo/corrigido (bats)
- [x] Evidencias anexadas (tabelas RED/GREEN acima)

## Staging Gate

<!-- PR toca runtime (smoke_test_staging.sh) -> gate exigido. -->
- [ ] `make staging-full` executado com sucesso (8/8 PASS)
- [ ] Evidencia anexada no PR

> :white_check_mark: **Validacao E2E concluida** na janela coordenada � dois gates simultaneos (slot 1 `:18012` + slot 4 `:18042`), 8/8 cada, sem se derrubar (teardown de um nao toca o outro). Detalhes no comentario de validacao.

## Validacoes

- [ ] Checks `[required]` verdes
- [x] Sem alteracoes fora do escopo combinado (so `v2/infra/scripts/**` + workflows do gate)

Closes #1581
Closes #1582
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `affe84bc`, slot `1` / projeto `aprender_staging_s1`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local-s1, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```

