### PR TITLE
fix(imports): valida CPF por mod-11 no export-contract e separa skips (#1578)

### DIFF
--- a/v2/backend/apps/core/services/export_contract_importer.py
+++ b/v2/backend/apps/core/services/export_contract_importer.py
@@ -30,6 +30,7 @@ from django.contrib.auth.models import Group
 from django.db import transaction
 
 from apps.core.constants import ALLOWED_USER_GROUPS
+from apps.core.imports.normalization import normalize_cpf_digits
 from apps.core.models import (
     DATAcao,
     DATArea,
@@ -44,6 +45,7 @@ from apps.core.models import (
 )
 from apps.core.services.equipe_gerencia_import import PAPEL_MAPPING
 from apps.core.services.export_contract_projeto_resolver import build_projeto_index, resolve_projeto_export
+from apps.core.validators import CPF_ABSENT, CPF_INVALID, classify_cpf, is_valid_cpf
 
 # Campos protegidos por entidade — NUNCA sobrescrever em update (decisão humana).
 PROTECTED_FIELDS: dict[str, set[str]] = {
@@ -188,9 +190,11 @@ class ExportContractImporter:
         return {(_norm(n), (u or "").upper()): mid for mid, n, u in Municipio.objects.values_list("id", "nome", "uf")}
 
     # ── handlers da fatia implementada ──
-    def _classify_master(self, name: str) -> dict[str, int]:
+    def _classify_master(self, name: str) -> dict[str, Any]:
         rows = self._load(name)
-        tally = {k: 0 for k in ("would_create", "would_update", "would_skip_same", "protected_diff", "would_reject")}
+        tally: dict[str, Any] = {
+            k: 0 for k in ("would_create", "would_update", "would_skip_same", "protected_diff", "would_reject")
+        }
         protected = PROTECTED_FIELDS.get(name, set())
 
         if name == "dat_area":
@@ -246,23 +250,37 @@ class ExportContractImporter:
                 tally[st] += 1
 
         elif name == "usuario":
-            # NK = CPF (unique), fallback email. PII: só conta/resolve, nunca imprime valores.
+            # NK = CPF válido (mod-11), fallback email para dedup. CPF estruturalmente
+            # inválido ou placeholder NÃO é NK: rejeita com motivo explícito (não infla
+            # would_create). Os três skips ficam distinguíveis em `reject_reasons`:
+            #   sem_nk       -> sem CPF e sem email (nada para identificar);
+            #   cpf_invalido -> tem CPF, não-placeholder, mas DV/comprimento inválido;
+            #   sem_cpf      -> tem email mas CPF ausente/placeholder (username=cpf exige CPF).
+            # ("já existe" já aparece como would_skip_same.) PII: só conta, nunca imprime.
             cpfs = {
-                re.sub(r"\D", "", c)
+                normalize_cpf_digits(c)
                 for c in Usuario.objects.values_list("cpf", flat=True)
-                if re.sub(r"\D", "", c or "")
+                if normalize_cpf_digits(c)
             }
             emails = {(e or "").lower() for e in Usuario.objects.values_list("email", flat=True) if e}
+            reasons = {"sem_nk": 0, "cpf_invalido": 0, "sem_cpf": 0}
             for r in rows:
-                cpf = re.sub(r"\D", "", r.get("cpf") or "")
+                cpf = normalize_cpf_digits(r.get("cpf") or "")
                 email = (r.get("email") or "").lower().strip()
-                if not cpf and not email:
+                cpf_status = classify_cpf(r.get("cpf") or "")
+                if cpf_status == CPF_INVALID:
                     tally["would_reject"] += 1
+                    reasons["cpf_invalido"] += 1
+                    continue
+                if cpf_status == CPF_ABSENT:
+                    tally["would_reject"] += 1
+                    reasons["sem_cpf" if email else "sem_nk"] += 1
                     continue
                 existe = (cpf in cpfs) or (email in emails)
                 # sem comparação de campo (evita PII); existência decide skip vs create.
                 st, _ = diff_and_classify({} if existe else None, {}, protected)
                 tally[st] += 1
+            tally["reject_reasons"] = reasons
 
         elif name == "tipo_evento":
             idx = {_norm(n): {"cor": (c or "")} for n, c in TipoEvento.objects.values_list("nome", "cor")}
@@ -390,7 +408,7 @@ class ExportContractImporter:
         """Mapa cpf(11 dig) -> papel canonico, de equipe_gerencia.csv (fonte primaria do papel)."""
         idx: dict[str, str] = {}
         for r in self._load("equipe_gerencia"):
-            cpf = re.sub(r"\D", "", r.get("usuario_cpf") or "")
+            cpf = normalize_cpf_digits(r.get("usuario_cpf") or "")
             papel = _resolve_papel(r.get("papel"))
             if len(cpf) == 11 and papel:
                 idx.setdefault(cpf, papel)
@@ -401,23 +419,25 @@ class ExportContractImporter:
 
         Papel: equipe_gerencia.papel (primario, por CPF) -> usuario.cargo (fallback). NUNCA
         default Coordenador. Sem papel ou grupo inexistente -> cria sem grupo. Senha
-        inutilizavel (login real via OAuth Google). len(cpf)==11 == RegexValidator do model.
+        inutilizavel (login real via OAuth Google). NK exige CPF valido por mod-11
+        (is_valid_cpf): placeholder/DV-invalido NAO cria — o dry-run reporta o motivo.
         """
         papel_by_cpf = self._papel_index_from_equipe()
         existing_cpfs = {
-            re.sub(r"\D", "", c) for c in Usuario.objects.values_list("cpf", flat=True) if re.sub(r"\D", "", c or "")
+            normalize_cpf_digits(c) for c in Usuario.objects.values_list("cpf", flat=True) if normalize_cpf_digits(c)
         }
         existing_emails = {(e or "").lower() for e in Usuario.objects.values_list("email", flat=True) if e}
         created = 0
         for r in rows:
-            cpf = re.sub(r"\D", "", r.get("cpf") or "")
+            cpf = normalize_cpf_digits(r.get("cpf") or "")
             email = (r.get("email") or "").strip().lower()
-            if len(cpf) != 11 and not email:
-                continue  # would_reject: sem NK
-            if (cpf and cpf in existing_cpfs) or (email and email in existing_emails):
+            # NK exige CPF estruturalmente valido (mod-11). Placeholder/DV-invalido NAO
+            # cria (username=cpf); nunca escreve CPF bogus (evita usuario fantasma e
+            # colisao de unique). O dry-run ja reporta sem_nk/cpf_invalido/sem_cpf.
+            if not is_valid_cpf(r.get("cpf") or ""):
+                continue
+            if (cpf in existing_cpfs) or (email and email in existing_emails):
                 continue  # ja existe -> skip (create-only)
-            if len(cpf) != 11:
-                continue  # cpf obrigatorio (11 digitos); sem cpf valido nao cria
             nome = (r.get("nome_completo") or "").strip()
             first, _, last = nome.partition(" ")
             usuario = Usuario(

--- a/v2/backend/apps/core/tests/test_cpf_validator.py
+++ b/v2/backend/apps/core/tests/test_cpf_validator.py
@@ -1,0 +1,103 @@
+"""
+Testes do validador de CPF (mod-11) — #1578.
+
+O importer export-contract (e futuros callers) precisam REJEITAR CPF
+estruturalmente inválido, não só checar comprimento (`len == 11`). Este módulo
+(`apps.core.validators`) é o SSOT da validação; os testes fixam o contrato:
+
+- ``is_valid_cpf``      : 11 dígitos + dígitos verificadores mod-11 conferem.
+- ``is_cpf_placeholder``: sequências de dígito repetido (00000000000..99999999999).
+- ``classify_cpf``      : ``absent`` (vazio/placeholder) | ``valid`` | ``invalid``.
+
+CPFs abaixo são SINTÉTICOS (dígitos verificadores calculados), não são de pessoas
+reais — não há PII aqui.
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false
+
+from __future__ import annotations
+
+import pytest
+
+from apps.core.validators import (
+    CPF_ABSENT,
+    CPF_INVALID,
+    CPF_VALID,
+    classify_cpf,
+    is_cpf_placeholder,
+    is_valid_cpf,
+    normalize_cpf,
+)
+
+# Válidos: dígitos verificadores conferem (mod-11).
+VALID_CPFS = ["11144477735", "22255588846", "33366699957"]
+# Inválidos por checksum: 11 dígitos, NÃO placeholder, DV errado. Inclui os CPFs
+# que a suíte antiga usava como se fossem válidos (11122233344, 55566677788).
+INVALID_CHECKSUM_CPFS = ["12345678900", "11122233344", "55566677788", "12398712399"]
+# Placeholders: dígito repetido (passam no checksum mas são inválidos por definição).
+PLACEHOLDER_CPFS = ["00000000000", "11111111111", "99999999999"]
+
+
+class TestIsValidCpf:
+    @pytest.mark.parametrize("cpf", VALID_CPFS)
+    def test_accepts_valid(self, cpf):
+        assert is_valid_cpf(cpf) is True
+
+    @pytest.mark.parametrize("cpf", INVALID_CHECKSUM_CPFS)
+    def test_rejects_bad_checksum(self, cpf):
+        assert is_valid_cpf(cpf) is False
+
+    @pytest.mark.parametrize("cpf", PLACEHOLDER_CPFS)
+    def test_rejects_placeholder(self, cpf):
+        assert is_valid_cpf(cpf) is False
+
+    def test_rejects_wrong_length(self):
+        assert is_valid_cpf("123") is False
+        assert is_valid_cpf("111444777350") is False  # 12 dígitos
+        assert is_valid_cpf("") is False
+
+    def test_accepts_masked_input(self):
+        # Aceita máscara — conta só os dígitos (reusa normalize_cpf_digits).
+        assert is_valid_cpf("111.444.777-35") is True
+
+    def test_none_is_not_valid(self):
+        assert is_valid_cpf(None) is False
+
+
+class TestIsCpfPlaceholder:
+    @pytest.mark.parametrize("cpf", PLACEHOLDER_CPFS)
+    def test_repeated_digits_are_placeholder(self, cpf):
+        assert is_cpf_placeholder(cpf) is True
+
+    def test_real_cpf_is_not_placeholder(self):
+        assert is_cpf_placeholder("11144477735") is False
+
+    def test_short_repeated_is_not_placeholder(self):
+        # Placeholder exige 11 dígitos; "000" não é.
+        assert is_cpf_placeholder("000") is False
+
+
+class TestClassifyCpf:
+    @pytest.mark.parametrize("cpf", VALID_CPFS)
+    def test_valid(self, cpf):
+        assert classify_cpf(cpf) == CPF_VALID
+
+    @pytest.mark.parametrize("cpf", INVALID_CHECKSUM_CPFS + ["123"])
+    def test_invalid(self, cpf):
+        # DV errado ou comprimento errado (não-placeholder) → inválido.
+        assert classify_cpf(cpf) == CPF_INVALID
+
+    @pytest.mark.parametrize("cpf", ["", "   ", None])
+    def test_empty_is_absent(self, cpf):
+        assert classify_cpf(cpf) == CPF_ABSENT
+
+    @pytest.mark.parametrize("cpf", PLACEHOLDER_CPFS)
+    def test_placeholder_is_absent(self, cpf):
+        # Item 4 da #1578: placeholder tratado como AUSENTE, não "inválido".
+        assert classify_cpf(cpf) == CPF_ABSENT
+
+
+def test_normalize_cpf_strips_mask_and_tolerates_none():
+    assert normalize_cpf("111.444.777-35") == "11144477735"
+    assert normalize_cpf(None) == ""
+    assert normalize_cpf("  111 444 777 35 ") == "11144477735"

--- a/v2/backend/apps/core/tests/test_export_contract_importer.py
+++ b/v2/backend/apps/core/tests/test_export_contract_importer.py
@@ -182,9 +182,9 @@ def test_classify_produto(tmp_path):
 
 
 def test_classify_usuario(tmp_path):
-    UsuarioFactory(username="u_imp_exist", password="x", cpf="11122233344", email="u.exist@ex.com")
+    UsuarioFactory(username="u_imp_exist", password="x", cpf="11144477735", email="u.exist@ex.com")
     # existente por cpf -> skip; novo -> create; sem cpf/email -> reject
-    csv = "nome_completo,cpf,email\nFulano,11122233344,u.exist@ex.com\nBeltrano,55566677788,novo@ex.com\nSem Id,,\n"
+    csv = "nome_completo,cpf,email\nFulano,11144477735,u.exist@ex.com\nBeltrano,22255588846,novo@ex.com\nSem Id,,\n"
     r = ExportContractImporter(path=_write_export(tmp_path, {"usuario": csv})).run()["por_entidade"]["usuario"]
     assert r["would_skip_same"] == 1
     assert r["would_create"] == 1
@@ -300,7 +300,7 @@ def test_demo_dez_entidades_implementadas(tmp_path):
         "municipio": "nome,uf,ativo\nC,CE,True\n",
         "projeto_geral": "nome,usa_avaliar\nPG,True\n",
         "produto": "codigo,nome\nC1,N\n",
-        "usuario": "nome_completo,cpf,email\nF,11111111111,f@ex.com\n",
+        "usuario": "nome_completo,cpf,email\nF,11144477735,f@ex.com\n",
         "tipo_evento": "nome,cor\nT,#000000\n",
         "gerencia": "nome,nome_setor\nSetor,Setor\n",
         "dat_coordenador": "usuario,area\ncoord@ex.com,Area\n",

--- a/v2/backend/apps/core/tests/test_export_contract_importer_apply_masters.py
+++ b/v2/backend/apps/core/tests/test_export_contract_importer_apply_masters.py
@@ -99,13 +99,13 @@ def test_apply_tipo_evento_rejects_empty_nome(tmp_path):
 
 # ══════════════════════════ usuario (PR-C, + atribuicao de Group) ══════════════════════════
 def test_apply_usuario_creates_username_cpf_unusable_password(tmp_path):
-    csv = "nome_completo,cpf,email,cargo\nMaria Silva Souza,11122233344,maria@ex.com,Coordenadores\n"
+    csv = "nome_completo,cpf,email,cargo\nMaria Silva Souza,11144477735,maria@ex.com,Coordenadores\n"
     path = _write_export(tmp_path, {"usuario": csv})
     _seed_funcao_groups()
     r = ExportContractImporter(path=path, apply=True, allow=("usuario",)).run()
     assert r["applied"]["usuario"] == 1
-    u = Usuario.objects.get(cpf="11122233344")
-    assert u.username == "11122233344"  # username derivado do CPF (estavel, unique)
+    u = Usuario.objects.get(cpf="11144477735")
+    assert u.username == "11144477735"  # username derivado do CPF (estavel, unique)
     assert u.has_usable_password() is False  # senha inutilizavel (login via OAuth Google)
     assert u.first_name == "Maria"
     assert u.last_name == "Silva Souza"
@@ -114,82 +114,82 @@ def test_apply_usuario_creates_username_cpf_unusable_password(tmp_path):
 
 def test_apply_usuario_assigns_group_from_cargo(tmp_path):
     csv = (
-        "nome_completo,cpf,email,cargo\n" "Joao Coord,11122233344,,Coordenadores\n" "Ana Form,55566677788,,Formadores\n"
+        "nome_completo,cpf,email,cargo\n" "Joao Coord,11144477735,,Coordenadores\n" "Ana Form,22255588846,,Formadores\n"
     )
     path = _write_export(tmp_path, {"usuario": csv})
     _seed_funcao_groups()
     ExportContractImporter(path=path, apply=True, allow=("usuario",)).run()
-    assert Usuario.objects.get(cpf="11122233344").groups.filter(name="Coordenador").exists()
-    assert Usuario.objects.get(cpf="55566677788").groups.filter(name="Formador").exists()
+    assert Usuario.objects.get(cpf="11144477735").groups.filter(name="Coordenador").exists()
+    assert Usuario.objects.get(cpf="22255588846").groups.filter(name="Formador").exists()
 
 
 def test_apply_usuario_equipe_gerencia_papel_takes_precedence(tmp_path):
     # cargo diz Formadores, mas equipe_gerencia diz COORDENADOR (fonte primaria) -> Coordenador
     files = {
-        "usuario": "nome_completo,cpf,email,cargo\nBia,11122233344,,Formadores\n",
-        "equipe_gerencia": "gerencia,usuario_cpf,usuario_email,papel\nG,11122233344,,COORDENADOR\n",
+        "usuario": "nome_completo,cpf,email,cargo\nBia,11144477735,,Formadores\n",
+        "equipe_gerencia": "gerencia,usuario_cpf,usuario_email,papel\nG,11144477735,,COORDENADOR\n",
     }
     path = _write_export(tmp_path, files)
     _seed_funcao_groups()
     ExportContractImporter(path=path, apply=True, allow=("usuario",)).run()
-    u = Usuario.objects.get(cpf="11122233344")
+    u = Usuario.objects.get(cpf="11144477735")
     assert u.groups.filter(name="Coordenador").exists()
     assert not u.groups.filter(name="Formador").exists()
 
 
 def test_apply_usuario_no_papel_creates_without_group(tmp_path):
     # sem cargo e sem equipe_gerencia -> cria SEM grupo (NUNCA chuta Coordenador)
-    csv = "nome_completo,cpf,email,cargo\nSem Papel,11122233344,,\n"
+    csv = "nome_completo,cpf,email,cargo\nSem Papel,11144477735,,\n"
     path = _write_export(tmp_path, {"usuario": csv})
     _seed_funcao_groups()
     ExportContractImporter(path=path, apply=True, allow=("usuario",)).run()
-    assert Usuario.objects.get(cpf="11122233344").groups.count() == 0
+    assert Usuario.objects.get(cpf="11144477735").groups.count() == 0
 
 
 def test_apply_usuario_group_missing_creates_without_group(tmp_path):
     # Simula prod ANTES do seed_rbac: o grupo alvo nao existe. (Nos testes, uma fixture
     # autouse semeia os grupos RBAC, entao deletamos explicitamente para reproduzir o caso.)
     Group.objects.filter(name__iexact="Coordenador").delete()
-    csv = "nome_completo,cpf,email,cargo\nSemGrupo,11122233344,,Coordenadores\n"
+    csv = "nome_completo,cpf,email,cargo\nSemGrupo,11144477735,,Coordenadores\n"
     path = _write_export(tmp_path, {"usuario": csv})
     r = ExportContractImporter(path=path, apply=True, allow=("usuario",)).run()
     assert r["applied"]["usuario"] == 1  # usuario e criado mesmo sem o grupo (nao quebra)
-    assert Usuario.objects.get(cpf="11122233344").groups.count() == 0
+    assert Usuario.objects.get(cpf="11144477735").groups.count() == 0
 
 
 def test_apply_usuario_idempotent(tmp_path):
-    csv = "nome_completo,cpf,email,cargo\nRepetido,11122233344,,Coordenadores\n"
+    csv = "nome_completo,cpf,email,cargo\nRepetido,11144477735,,Coordenadores\n"
     path = _write_export(tmp_path, {"usuario": csv})
     _seed_funcao_groups()
     ExportContractImporter(path=path, apply=True, allow=("usuario",)).run()
     r2 = ExportContractImporter(path=path, apply=True, allow=("usuario",)).run()
     assert r2["applied"]["usuario"] == 0
-    assert Usuario.objects.filter(cpf="11122233344").count() == 1
+    assert Usuario.objects.filter(cpf="11144477735").count() == 1
 
 
 def test_apply_usuario_create_only_skips_existing(tmp_path):
-    UsuarioFactory(username="u_exist_ap", password="x", cpf="11122233344", email="exist@ex.com", first_name="Antigo")
-    csv = "nome_completo,cpf,email,cargo\nNome Novo,11122233344,exist@ex.com,Coordenadores\n"
+    UsuarioFactory(username="u_exist_ap", password="x", cpf="11144477735", email="exist@ex.com", first_name="Antigo")
+    csv = "nome_completo,cpf,email,cargo\nNome Novo,11144477735,exist@ex.com,Coordenadores\n"
     path = _write_export(tmp_path, {"usuario": csv})
     _seed_funcao_groups()
     r = ExportContractImporter(path=path, apply=True, allow=("usuario",)).run()
     assert r["applied"]["usuario"] == 0
-    assert Usuario.objects.get(cpf="11122233344").first_name == "Antigo"  # nao sobrescreve
+    assert Usuario.objects.get(cpf="11144477735").first_name == "Antigo"  # nao sobrescreve
 
 
 def test_apply_usuario_rejects_invalid_cpf(tmp_path):
     # cpf invalido (nao 11 dig) e sem email -> nao cria; linha valida cria
-    csv = "nome_completo,cpf,email,cargo\nInvalidoXYZ,123,,\nValido,11122233344,,\n"
+    csv = "nome_completo,cpf,email,cargo\nInvalidoXYZ,123,,\nValido,11144477735,,\n"
     path = _write_export(tmp_path, {"usuario": csv})
     _seed_funcao_groups()
     r = ExportContractImporter(path=path, apply=True, allow=("usuario",)).run()
     assert r["applied"]["usuario"] == 1
-    assert Usuario.objects.filter(username="11122233344").exists()
+    assert Usuario.objects.filter(username="11144477735").exists()
     assert not Usuario.objects.filter(first_name="InvalidoXYZ").exists()
 
 
 def test_apply_usuario_allowlist_blocks(tmp_path):
-    csv = "nome_completo,cpf,email,cargo\nBloq,11122233344,,Coordenadores\n"
+    csv = "nome_completo,cpf,email,cargo\nBloq,11144477735,,Coordenadores\n"
     path = _write_export(tmp_path, {"usuario": csv})
     before = Usuario.objects.count()
     r = ExportContractImporter(path=path, apply=True, allow=()).run()

--- a/v2/backend/apps/core/tests/test_export_contract_importer_cpf_1578.py
+++ b/v2/backend/apps/core/tests/test_export_contract_importer_cpf_1578.py
@@ -1,0 +1,140 @@
+"""
+Testes de contrato do CPF no importer export-contract — #1578.
+
+Defeito: o importer só checava ``len(cpf) == 11``. Consequências:
+1. dry-run classificava CPF estruturalmente inválido (DV errado) ou placeholder
+   (00000000000) como ``would_create`` — o dry-run MENTIA sobre o que o apply faria.
+2. apply escrevia usuário com CPF bogus, e três causas de skip distintas
+   ("sem NK", "já existe", "CPF inválido") caíam no mesmo ``continue`` mudo.
+
+Este módulo prova (RED→GREEN #1578):
+- dry-run rejeita CPF inválido/placeholder (não conta como create);
+- placeholder é tratado como AUSENTE (item 4), não como "inválido";
+- as causas de reject aparecem distinguíveis em ``reject_reasons``;
+- apply NÃO escreve CPF inválido/placeholder;
+- nada de PII (CPF/email/nome) no relatório.
+
+CPFs sintéticos (DV calculado) — não são PII de pessoas reais.
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportAttributeAccessIssue=false, reportOptionalMemberAccess=false
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from django.contrib.auth.models import Group
+
+import pytest
+
+from apps.core.models import Usuario
+from apps.core.services.export_contract_importer import ExportContractImporter
+from apps.core.tests.factories import UsuarioFactory
+
+pytestmark = pytest.mark.django_db
+
+VALID_CPF_A = "11144477735"  # DV mod-11 confere
+VALID_CPF_B = "22255588846"  # DV mod-11 confere
+INVALID_CHECKSUM_CPF = "12345678900"  # 11 díg, não-placeholder, DV errado
+PLACEHOLDER_CPF = "00000000000"  # dígito repetido → tratado como ausente
+
+
+def _write_export(tmp_path, files: dict[str, str]) -> str:
+    d = tmp_path / "export"
+    d.mkdir()
+    manifest: dict[str, Any] = {"generated_at": "2026-06-02", "snapshot_date": "2026-05-19", "entities": {}}
+    for name, content in files.items():
+        (d / f"{name}.csv").write_text(content, encoding="utf-8")
+        manifest["entities"][name] = {"file_csv": f"{name}.csv", "rows": max(content.strip().count("\n"), 0)}
+    (d / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+    return str(d)
+
+
+def _seed_funcao_groups() -> None:
+    for g in ("Coordenador", "Formador", "Gerente", "Apoio de Coordenação"):
+        Group.objects.get_or_create(name=g)
+
+
+# ───────── dry-run: validação estrutural ─────────
+def test_dryrun_rejects_checksum_invalid_cpf_not_create(tmp_path):
+    csv = f"nome_completo,cpf,email\nFulano,{INVALID_CHECKSUM_CPF},\n"
+    r = ExportContractImporter(path=_write_export(tmp_path, {"usuario": csv})).run()["por_entidade"]["usuario"]
+    assert r["would_create"] == 0  # NÃO cria CPF com DV errado
+    assert r["would_reject"] == 1
+    assert r["reject_reasons"]["cpf_invalido"] == 1
+
+
+def test_dryrun_placeholder_cpf_treated_as_absent(tmp_path):
+    csv = f"nome_completo,cpf,email\nFulano,{PLACEHOLDER_CPF},\n"
+    r = ExportContractImporter(path=_write_export(tmp_path, {"usuario": csv})).run()["por_entidade"]["usuario"]
+    assert r["would_create"] == 0
+    # Placeholder é AUSENTE (sem NK, pois sem email), NÃO "cpf_invalido".
+    assert r["reject_reasons"]["sem_nk"] == 1
+    assert r["reject_reasons"]["cpf_invalido"] == 0
+
+
+def test_dryrun_separates_three_skip_causes(tmp_path):
+    UsuarioFactory(username="u1578_exist", password="x", cpf=VALID_CPF_A, email="exist1578@ex.com")
+    csv = (
+        "nome_completo,cpf,email\n"
+        f"Existe,{VALID_CPF_A},exist1578@ex.com\n"  # já existe → would_skip_same
+        f"Novo,{VALID_CPF_B},novo1578@ex.com\n"  # válido novo → would_create
+        "SemId,,\n"  # sem CPF e sem email → sem_nk
+        f"Ruim,{INVALID_CHECKSUM_CPF},\n"  # CPF inválido (DV) → cpf_invalido
+        "SoEmail,,soemail1578@ex.com\n"  # tem email, sem CPF válido → sem_cpf
+    )
+    r = ExportContractImporter(path=_write_export(tmp_path, {"usuario": csv})).run()["por_entidade"]["usuario"]
+    assert r["would_skip_same"] == 1  # "já existe"
+    assert r["would_create"] == 1
+    assert r["reject_reasons"] == {"sem_nk": 1, "cpf_invalido": 1, "sem_cpf": 1}
+    assert r["would_reject"] == 3
+
+
+def test_dryrun_valid_new_cpf_is_create(tmp_path):
+    csv = f"nome_completo,cpf,email\nNovo,{VALID_CPF_A},novo.valido@ex.com\n"
+    r = ExportContractImporter(path=_write_export(tmp_path, {"usuario": csv})).run()["por_entidade"]["usuario"]
+    assert r["would_create"] == 1
+    assert r["would_reject"] == 0
+
+
+def test_dryrun_reject_reasons_have_no_pii(tmp_path):
+    csv = f"nome_completo,cpf,email\nSecreto,{INVALID_CHECKSUM_CPF},secreto1578@ex.com\n"
+    report = ExportContractImporter(path=_write_export(tmp_path, {"usuario": csv})).run()
+    blob = json.dumps(report)
+    assert INVALID_CHECKSUM_CPF not in blob  # CPF não vaza
+    assert "secreto1578@ex.com" not in blob  # email não vaza
+    assert "Secreto" not in blob  # nome não vaza
+
+
+# ───────── apply: nunca escreve CPF inválido/placeholder ─────────
+def test_apply_skips_checksum_invalid_cpf(tmp_path):
+    csv = f"nome_completo,cpf,email,cargo\nRuim,{INVALID_CHECKSUM_CPF},,\n"
+    _seed_funcao_groups()
+    r = ExportContractImporter(path=_write_export(tmp_path, {"usuario": csv}), apply=True, allow=("usuario",)).run()
+    assert r["applied"]["usuario"] == 0
+    assert not Usuario.objects.filter(cpf=INVALID_CHECKSUM_CPF).exists()
+
+
+def test_apply_skips_placeholder_creates_only_valid(tmp_path):
+    # Dois placeholders + um válido: só o válido é criado; nenhum usuário bogus.
+    csv = (
+        "nome_completo,cpf,email,cargo\n"
+        f"Dummy1,{PLACEHOLDER_CPF},,\n"
+        "Dummy2,11111111111,,\n"
+        f"Bom,{VALID_CPF_A},,\n"
+    )
+    _seed_funcao_groups()
+    r = ExportContractImporter(path=_write_export(tmp_path, {"usuario": csv}), apply=True, allow=("usuario",)).run()
+    assert r["applied"]["usuario"] == 1  # só o válido
+    assert not Usuario.objects.filter(cpf=PLACEHOLDER_CPF).exists()
+    assert not Usuario.objects.filter(cpf="11111111111").exists()
+    assert Usuario.objects.filter(cpf=VALID_CPF_A).exists()
+
+
+def test_apply_valid_cpf_is_created(tmp_path):
+    csv = f"nome_completo,cpf,email,cargo\nBom,{VALID_CPF_B},,\n"
+    _seed_funcao_groups()
+    r = ExportContractImporter(path=_write_export(tmp_path, {"usuario": csv}), apply=True, allow=("usuario",)).run()
+    assert r["applied"]["usuario"] == 1
+    assert Usuario.objects.get(cpf=VALID_CPF_B).username == VALID_CPF_B

--- a/v2/backend/apps/core/validators.py
+++ b/v2/backend/apps/core/validators.py
@@ -1,0 +1,90 @@
+"""
+Validação de CPF (mod-11) — SSOT reutilizável do backend.
+
+Criado para a #1578: o importer export-contract (e futuros callers) precisam
+REJEITAR CPF estruturalmente inválido, não apenas checar ``len == 11``. O model
+``Usuario.cpf`` só tem ``RegexValidator(r"^\\d{11}$")`` (comprimento), então a
+validação de dígitos verificadores vive aqui, na camada de aplicação, sem tocar
+o model (que exigiria migration e afetaria dado real em produção).
+
+Funções puras: sem I/O, sem ORM, sem mutação. Entrada tolerante (``None`` / com
+máscara / dígitos) — conta apenas os dígitos via ``normalize_cpf_digits`` (SSOT
+de normalização de import).
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from apps.core.imports.normalization import normalize_cpf_digits
+
+__all__ = [
+    "CPF_ABSENT",
+    "CPF_INVALID",
+    "CPF_VALID",
+    "classify_cpf",
+    "is_cpf_placeholder",
+    "is_valid_cpf",
+    "normalize_cpf",
+]
+
+# Estados retornados por ``classify_cpf``.
+CPF_VALID: Final[str] = "valid"
+CPF_INVALID: Final[str] = "invalid"
+CPF_ABSENT: Final[str] = "absent"
+
+_CPF_LEN: Final[int] = 11
+
+
+def normalize_cpf(raw: object) -> str:
+    """Retorna só os dígitos de ``raw`` (tolera ``None``/máscara). Não valida."""
+    return normalize_cpf_digits(raw)
+
+
+def is_cpf_placeholder(raw: object) -> bool:
+    """
+    ``True`` para sequências de dígito repetido (``00000000000`` até
+    ``99999999999``).
+
+    Esses valores passam na aritmética do dígito verificador, mas são inválidos
+    por definição — usados como placeholder / "sem CPF". A #1578 os trata como
+    AUSENTES (não como "CPF inválido").
+    """
+    digits = normalize_cpf(raw)
+    return len(digits) == _CPF_LEN and digits == digits[0] * _CPF_LEN
+
+
+def _check_digit(digits: str, first_weight: int) -> str:
+    """Dígito verificador mod-11 de ``digits`` com pesos ``first_weight``..2."""
+    total = sum(int(d) * w for d, w in zip(digits, range(first_weight, 1, -1)))
+    remainder = total % 11
+    return "0" if remainder < 2 else str(11 - remainder)
+
+
+def is_valid_cpf(raw: object) -> bool:
+    """
+    ``True`` se ``raw`` é um CPF estruturalmente válido: exatamente 11 dígitos,
+    não é placeholder de dígito repetido, e os dois dígitos verificadores mod-11
+    conferem.
+    """
+    digits = normalize_cpf(raw)
+    if len(digits) != _CPF_LEN or is_cpf_placeholder(digits):
+        return False
+    return digits[9] == _check_digit(digits[:9], 10) and digits[10] == _check_digit(digits[:10], 11)
+
+
+def classify_cpf(raw: object) -> str:
+    """
+    Classifica ``raw`` em três estados, para o relatório de import distinguir os
+    motivos de skip (#1578):
+
+    - ``CPF_ABSENT``  : vazio OU placeholder de dígito repetido → tratar como
+      ausente (não é NK, não é "inválido").
+    - ``CPF_VALID``   : dígitos verificadores mod-11 conferem.
+    - ``CPF_INVALID`` : tem dígitos, não é placeholder, mas é estruturalmente
+      inválido (comprimento ≠ 11 ou DV errado).
+    """
+    digits = normalize_cpf(raw)
+    if not digits or is_cpf_placeholder(digits):
+        return CPF_ABSENT
+    return CPF_VALID if is_valid_cpf(digits) else CPF_INVALID

--- a/v2/docs/imports/templates/usuarios.template.csv
+++ b/v2/docs/imports/templates/usuarios.template.csv
@@ -1,2 +1,2 @@
 cpf,nome,email,telefone,cargo,is_active,grupos
-00000000000,Maria de Souza Exemplo,maria.exemplo@example.com,85999999999,Formadora,true,"Superintendência,Formador"
+11144477735,Maria de Souza Exemplo,maria.exemplo@example.com,85999999999,Formadora,true,"Superintendência,Formador"


### PR DESCRIPTION
## Resumo

`export_contract_importer.py` so validava `len(cpf) == 11` — nao havia mod-11 em lugar nenhum do repo. Dois efeitos (bug real, com o `--apply` da pipeline prestes a rodar):

1. **dry-run mentia**: CPF com digito verificador errado ou placeholder (`00000000000`) era classificado como `would_create` — o dry-run nao expunha que o registro seria rejeitado/bogus.
2. **skips mudos no apply**: as tres causas distintas ("sem NK", "ja existe", "CPF invalido") caiam no mesmo `continue` silencioso; `_apply_usuario` retornava so uma contagem e a pessoa nao-criada sumia do relatorio — exatamente o que o dry-run deveria expor.

**Entregue** (#1578):
- **`apps/core/validators.py` (novo, SSOT reutilizavel)** — `is_valid_cpf` / `is_cpf_placeholder` / `classify_cpf` (digitos verificadores mod-11). Placeholder de digito repetido e tratado como **ausente**, nao como "invalido". Funcoes puras; **nao toca o model** (evitaria migration + afetaria dado real em prod).
- **`export_contract_importer.py`** — dry-run (`_classify_master`) e apply (`_apply_usuario`) de `usuario` validam por mod-11. O dry-run reporta os motivos em **`reject_reasons`** (`sem_nk` / `cpf_invalido` / `sem_cpf`); "ja existe" continua como `would_skip_same`. O apply nunca escreve CPF invalido/placeholder (nem cria usuario fantasma nem arrisca colisao de unique).
- **template `usuarios.template.csv`** — exemplo `00000000000` (placeholder) -> CPF valido.

### TDD — RED provado antes do fix (container, slot 3)

RED (codigo atual, sem o fix):
```
test_cpf_validator.py                      -> ERRO de colecao: ModuleNotFoundError: apps.core.validators (33 testes bloqueados)
test_export_contract_importer_cpf_1578.py  -> 5 failed, 3 passed
  dryrun invalido    : would_create == 1  (esperado 0)
  dryrun placeholder : would_create == 1  (esperado 0)
  dryrun 3 causas    : would_create == 3  (esperado 1)
  apply invalido     : applied == 1       (esperado 0)   <- o apply CRIAVA o CPF bogus
  apply placeholder  : applied == 3       (esperado 1)
```

GREEN (apos o fix):
```
80 passed        (test_cpf_validator + test_export_contract_importer_cpf_1578 + os 2 arquivos existentes)
3013 passed, 37 skipped   (apps/core/tests inteiro — sem regressao)
```

Lint nos arquivos tocados: black / isort / flake8 limpos. Pyright: nao roda no container (sem node) e o host nao tem o venv; o unico erro real de tipo que o pyright do host apontou (`dict[str,int]`) foi corrigido; gate autoritativo = CI.

Fixtures antigas usavam CPFs que **falham** mod-11 (`11122233344`, `55566677788`, `12398712399`) — corrigidas para CPFs sinteticos validos.

### Follow-up (nao implementado — fora desta lane)
`usuarios_import.py` (`_validate_cpf`, Sessao C) tem o **mesmo gap** (`len==11 + isdigit`) e ja expoe `pendencias.cpf_invalid` — deveria consumir o mesmo validador. Nao alterado aqui.

Closes #1578

## Checklist Tecnico (Code Review Expert - Slim)

- [x] Arquitetura e SOLID: validador isolado (SSOT), importer delega; sem duplicacao de logica de CPF
- [x] Seguranca: sem segredo; **PII (CPF/email/nome) mantida fora do relatorio** (teste dedicado)
- [x] Performance: funcao pura O(1) por linha; mesmo laco, nenhuma query extra
- [x] Tratamento de erros: CPF invalido/placeholder rejeitado com motivo explicito (nao `continue` mudo)
- [x] Condicoes de fronteira: vazio, None, mascara, comprimento errado, placeholder e DV errado cobertos

## Workflow (Superpowers - Parcial)

- [x] Escopo definido (SCOPE.md; 5 entregaveis)
- [x] Testes criados/ajustados para o comportamento corrigido (RED->GREEN)
- [x] Evidencias anexadas (outputs RED e GREEN acima)

## Staging Gate

- [ ] `make staging-full` — **PENDENTE**: o gate e singleton; aguardando o bastao do Coordenador (Sessao D esta consertando o gate). Nao rodei para nao atropelar outra lane.

### Evidencia Staging Gate (obrigatorio para merge)

```text
PENDENTE — aguardando o bastao do gate (singleton). Sera anexado apos rodar.
```

## Validacoes

- [ ] Checks `[required]` verdes — aguardando CI
- [x] Sem alteracoes fora do escopo combinado (apenas arquivos permitidos no SCOPE; `SCOPE.md` nao commitado)
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `8ebb6731`, slot `3` / projeto `aprender_staging_s3`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local-s3, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
