### PR TITLE
fix(ci): destrava Container Scan e Frontend Dependencies (#1676)

### DIFF
--- a/.github/scripts/npm-audit-gate.mjs
+++ b/.github/scripts/npm-audit-gate.mjs
@@ -1,0 +1,148 @@
+// Gate de dependencias de producao do frontend (`[required] Frontend Dependencies`).
+//
+// Por que existe em vez do `node -e` de uma linha que havia antes:
+// o `npm audit` conta PACOTES vulneraveis, nao ADVISORIES. Corrigir uma
+// vulnerabilidade real pode AUMENTAR o contador — foi o que aconteceu ao subir
+// react-router 7.17.0 -> 7.18.2: as advisories chx6 (DoS) e wrjc (open redirect)
+// foram corrigidas, mas `high` foi de 1 para 2, porque `react-router-dom` passou
+// a ser contado junto com `react-router` pela mesma advisory remanescente.
+// Um gate que le so `metadata.vulnerabilities.high` nao consegue distinguir
+// "corrigiram algo" de "piorou", nem conceder excecao a uma advisory especifica.
+//
+// Este script resolve as advisories transitivas (o campo `via` pode conter o NOME
+// de outro pacote vulneravel em vez do objeto da advisory) e so bloqueia quando
+// sobra ao menos uma advisory HIGH/CRITICAL fora da allowlist.
+//
+// Codigos de saida (contrato preservado do parser anterior):
+//   0  = gate passou
+//   10 = HIGH/CRITICAL bloqueante encontrada
+//   2  = relatorio ausente/ilegivel
+//   3  = npm audit devolveu erro de API
+
+import { readFileSync } from "node:fs";
+
+// ---------------------------------------------------------------------------
+// Advisories aceitas conscientemente (TTL — revisar trimestralmente,
+// proxima revisao 2026-10-30). Mesmo padrao ja usado no gate Python
+// (`pip-audit --ignore-vuln`, security-scan.yml).
+//
+// Cada entrada precisa de: por que nao se aplica AQUI e qual o plano de saida.
+// ---------------------------------------------------------------------------
+const ADVISORIES_ACEITAS = new Map([
+  [
+    "GHSA-qwww-vcr4-c8h2",
+    {
+      pacote: "react-router",
+      motivo:
+        "CSRF bypass no RSC Mode (React Server Components). Este frontend e' " +
+        "SPA cliente puro: build `tsc --noEmit && vite build`, roteamento por " +
+        "<BrowserRouter>, sem @react-router/*, sem entrypoint SSR e a imagem de " +
+        "producao so serve /dist por nginx. Nao existe RSC em execucao, entao o " +
+        "vetor nao e' alcancavel.",
+      saida:
+        "sem correcao no pacote em uso: react-router-dom nao tem linha 8.x " +
+        "publicada (ultima e' 7.18.2, ja adotada). O patch so existe em " +
+        "react-router 8.3.0, que exige React >= 19.2.7 — o projeto esta no " +
+        "React 18.3.1. Remover esta excecao ao concluir o upgrade para " +
+        "React 19 (issue #1675).",
+    },
+  ],
+]);
+
+const CAMINHO = process.argv[2] ?? "npm-audit-report.json";
+const BLOQUEANTES = new Set(["high", "critical"]);
+
+let relatorio;
+try {
+  relatorio = JSON.parse(readFileSync(CAMINHO, "utf8"));
+} catch {
+  process.exit(2);
+}
+
+if (relatorio?.error) {
+  const detalhe =
+    relatorio.error.summary || relatorio.error.message || "desconhecido";
+  console.log(`npm audit reportou erro de API: ${detalhe}`);
+  process.exit(3);
+}
+
+const vulnerabilidades = relatorio?.vulnerabilities;
+if (!vulnerabilidades || typeof vulnerabilidades !== "object") {
+  // Sem o mapa detalhado nao da' para raciocinar por advisory. Fail-closed:
+  // se o metadata acusa HIGH/CRITICAL, bloqueia; senao trata como ausente.
+  const meta = relatorio?.metadata?.vulnerabilities;
+  if (!meta) process.exit(2);
+  const total = Number(meta.high || 0) + Number(meta.critical || 0);
+  console.log(`npm audit (prod) sem detalhamento; metadata high+critical=${total}`);
+  process.exit(total > 0 ? 10 : 0);
+}
+
+/**
+ * Coleta as advisories HIGH/CRITICAL de um pacote, seguindo `via` transitivo.
+ * `via` traz ora o objeto da advisory, ora o NOME de outro pacote vulneravel.
+ */
+function coletarAdvisories(nomePacote, vistos = new Set()) {
+  if (vistos.has(nomePacote)) return [];
+  vistos.add(nomePacote);
+
+  const entrada = vulnerabilidades[nomePacote];
+  if (!entrada) return [];
+
+  const encontradas = [];
+  for (const via of entrada.via ?? []) {
+    if (typeof via === "string") {
+      encontradas.push(...coletarAdvisories(via, vistos));
+      continue;
+    }
+    if (!BLOQUEANTES.has(via?.severity)) continue;
+    const id = String(via.url ?? "").split("/").pop() || via.source || "?";
+    encontradas.push({ id, titulo: via.title ?? "", severidade: via.severity });
+  }
+  return encontradas;
+}
+
+const bloqueiam = [];
+const dispensadas = [];
+
+for (const [nome, entrada] of Object.entries(vulnerabilidades)) {
+  if (!BLOQUEANTES.has(entrada?.severity)) continue;
+
+  const advisories = coletarAdvisories(nome);
+  // Sem advisory identificavel nao ha como conceder excecao: bloqueia.
+  if (advisories.length === 0) {
+    bloqueiam.push({ pacote: nome, id: "(advisory nao identificada)", titulo: "" });
+    continue;
+  }
+
+  for (const adv of advisories) {
+    const alvo = ADVISORIES_ACEITAS.has(adv.id) ? dispensadas : bloqueiam;
+    alvo.push({ pacote: nome, ...adv });
+  }
+}
+
+const meta = relatorio?.metadata?.vulnerabilities ?? {};
+console.log(
+  `npm audit (prod) pacotes: high=${Number(meta.high || 0)} ` +
+    `critical=${Number(meta.critical || 0)}`,
+);
+
+if (dispensadas.length > 0) {
+  console.log("\nAdvisories aceitas conscientemente (TTL 2026-10-30):");
+  for (const d of new Map(dispensadas.map((x) => [x.id, x])).values()) {
+    const ctx = ADVISORIES_ACEITAS.get(d.id);
+    console.log(`  - ${d.id} (${ctx.pacote}): ${d.titulo}`);
+    console.log(`    motivo: ${ctx.motivo}`);
+    console.log(`    saida : ${ctx.saida}`);
+  }
+}
+
+if (bloqueiam.length > 0) {
+  console.error("\nGate de dependencias de producao REPROVADO:");
+  for (const b of bloqueiam) {
+    console.error(`  - [${b.severidade ?? "?"}] ${b.pacote}: ${b.id} ${b.titulo}`);
+  }
+  process.exit(10);
+}
+
+console.log("\nGate de dependencias de producao aprovado.");
+process.exit(0);

--- a/.github/workflows/dependency-review-scorecard.yml
+++ b/.github/workflows/dependency-review-scorecard.yml
@@ -60,9 +60,11 @@ jobs:
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
         with:
           fail-on-severity: high
-          # Precisa espelhar a allowlist de .github/scripts/npm-audit-gate.mjs:
-          # sao dois gates [required] sobre o mesmo fato, e se discordarem um PR
-          # aprovado num reprova no outro. Ao mexer aqui, mexer la tambem.
+          # ATENCAO: este step NAO roda hoje — o repositorio e' privado, entao
+          # quem avalia o frontend e' o step de fallback mais abaixo (que usa
+          # .github/scripts/npm-audit-gate.mjs). Mantido correto para o caso de
+          # a visibilidade mudar; se isso acontecer, a allowlist daqui precisa
+          # continuar espelhando a do script, senao os dois gates divergem.
           #
           # GHSA-qwww-vcr4-c8h2 (react-router) — TTL 2026-10-30.
           # CSRF no RSC Mode. Nao alcancavel aqui: SPA cliente puro, build
@@ -97,7 +99,20 @@ jobs:
         run: |
           set -euo pipefail
           cd v2/frontend
-          npm audit --omit=dev --audit-level=high
+          # Usa o MESMO gate do job `[required] Frontend Dependencies`
+          # (security-scan.yml) em vez de `npm audit --audit-level=high` cru.
+          #
+          # Motivo: os dois sao checks [required] sobre o mesmo fato. Com
+          # logicas diferentes, um PR aprovado num reprova no outro — foi
+          # exatamente o que aconteceu ao adotar react-router 7.18.2.
+          # Alem disso o `--audit-level=high` nao distingue advisory de
+          # pacote e nao aceita excecao, entao nao ha onde registrar um
+          # aceite com TTL.
+          #
+          # `npm audit` sai com codigo != 0 quando encontra qualquer
+          # vulnerabilidade; quem decide bloquear e' o script.
+          npm audit --omit=dev --json > npm-audit-report.json || true
+          node "${GITHUB_WORKSPACE}/.github/scripts/npm-audit-gate.mjs" npm-audit-report.json
 
       - name: Dependency gate summary
         if: always()

--- a/.github/workflows/dependency-review-scorecard.yml
+++ b/.github/workflows/dependency-review-scorecard.yml
@@ -60,6 +60,19 @@ jobs:
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
         with:
           fail-on-severity: high
+          # Precisa espelhar a allowlist de .github/scripts/npm-audit-gate.mjs:
+          # sao dois gates [required] sobre o mesmo fato, e se discordarem um PR
+          # aprovado num reprova no outro. Ao mexer aqui, mexer la tambem.
+          #
+          # GHSA-qwww-vcr4-c8h2 (react-router) — TTL 2026-10-30.
+          # CSRF no RSC Mode. Nao alcancavel aqui: SPA cliente puro, build
+          # `tsc --noEmit && vite build`, <BrowserRouter>, sem @react-router/*,
+          # sem entrypoint SSR, imagem de producao so serve /dist por nginx.
+          # Sem correcao disponivel no pacote em uso: react-router-dom nao tem
+          # linha 8.x publicada (ultima e' 7.18.2, ja adotada aqui) — o patch
+          # so existe em react-router 8.3.0, que exige React >= 19.2.7.
+          # Plano de saida: issue #1675 (upgrade React 18 -> 19). Remover ao concluir.
+          allow-ghsas: GHSA-qwww-vcr4-c8h2
 
       # Private repositories without GHAS can not use dependency-review-action.
       # Fallback keeps a blocking dependency gate for changed dependency manifests.

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -267,7 +267,10 @@ jobs:
               parse_exit=2
             else
               set +e
-              node -e 'const fs=require("fs"); let report; try {report=JSON.parse(fs.readFileSync("npm-audit-report.json","utf8"));} catch {process.exit(2);} if (report?.metadata?.vulnerabilities) {const high=Number(report.metadata.vulnerabilities.high||0); const critical=Number(report.metadata.vulnerabilities.critical||0); console.log(`npm audit (prod) high=${high} critical=${critical}`); process.exit(high+critical>0?10:0);} if (report?.error){console.log(`npm audit reported API error: ${report.error.summary || report.error.message || "unknown"}`); process.exit(3);} process.exit(2);'
+              # Contrato de saida preservado (0 ok / 10 bloqueia / 2 ilegivel /
+              # 3 erro de API). O script raciocina por ADVISORY, nao pelo
+              # contador agregado de pacotes — ver o cabecalho dele.
+              node "${GITHUB_WORKSPACE}/.github/scripts/npm-audit-gate.mjs" npm-audit-report.json
               parse_exit=$?
               set -e
             fi

--- a/v2/frontend/package-lock.json
+++ b/v2/frontend/package-lock.json
@@ -17,7 +17,7 @@
         "react-dom": "^18.3.1",
         "react-hot-toast": "^2.6.0",
         "react-leaflet": "^4.2.1",
-        "react-router-dom": "^7.15.0"
+        "react-router-dom": "^7.18.0"
       },
       "devDependencies": {
         "@axe-core/playwright": "^4.10.1",
@@ -10111,9 +10111,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.17.0.tgz",
-      "integrity": "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -10133,12 +10133,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.17.0.tgz",
-      "integrity": "sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.17.0"
+        "react-router": "7.18.2"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/v2/frontend/package.json
+++ b/v2/frontend/package.json
@@ -35,7 +35,7 @@
     "react-dom": "^18.3.1",
     "react-hot-toast": "^2.6.0",
     "react-leaflet": "^4.2.1",
-    "react-router-dom": "^7.15.0"
+    "react-router-dom": "^7.18.0"
   },
   "overrides": {
     "baseline-browser-mapping": "^2.10.0",

--- a/v2/infra/Dockerfile.prod
+++ b/v2/infra/Dockerfile.prod
@@ -69,8 +69,25 @@ RUN chmod +x /app/infra/scripts/*.sh
 
 # Cleanup: remove __pycache__ and .pyc files
 # Note: do NOT remove "test"/"tests" dirs — django.test is a runtime module
+#
+# Tambem remove o SBOM CycloneDX que o pip >= 26.2 passou a embarcar em
+# pip/_vendor/bom.cdx.json. O Trivy trata esse arquivo como INVENTARIO DE
+# PACOTES INSTALADOS e reporta as dependencias vendorizadas do pip como se
+# estivessem instaladas na imagem — o proprio Trivy avisa no log
+# ("Third-party SBOM may lead to inaccurate vulnerability detection").
+#
+# Resultado pratico: o gate de publicacao passou a bloquear com 2 HIGH que
+# nao existem como pacote instalado. `setuptools 70.3.0` e' fantasma (o real
+# na venv e' 83.0.0, acima do fix) e `msgpack 1.1.2` e' copia privada que so
+# o cache HTTP do proprio pip usa — nao importavel pela aplicacao. Ambos com
+# PkgPath vazio no relatorio, prova de que nao vieram de .dist-info.
+#
+# Isto NAO cega o scanner: os pacotes reais continuam sendo detectados via
+# .dist-info (verificado — as vulnerabilidades MEDIUM do pip seguem sendo
+# reportadas depois da remocao).
 RUN find /opt/venv -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null; \
     find /opt/venv -name "*.pyc" -delete 2>/dev/null; \
+    find /opt/venv -name "bom.cdx.json" -delete 2>/dev/null; \
     find /app -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null; \
     true
 


### PR DESCRIPTION
## Por que

A fila de merge esta travada. Dois checks `[required]` estao vermelhos e a ruleset "Protect main" tem `bypass_actors: []` + `strict: true` — **nenhum PR entra**, inclusive os do Dependabot. Detalhe e evidencia em #1676.

Consequencia pratica: a correcao P0 de escalada de privilegio (#1608, ja na main como `ccbe1e05`) **nao consegue chegar a producao**, porque o build de release falha no gate e sem build nao ha tag para promover. Producao segue em `v2026.07.18-94f2765`.

**Nenhum dos dois bloqueios veio de mudanca de codigo.** O mesmo commit `45d6f9c4` rodou o `security-scan.yml` com `success` em 20/07 e `failure` em 26/07.

## O que muda

### 1. `v2/infra/Dockerfile.prod` — Container Scan

O pip >= 26.2 embarca um SBOM CycloneDX em `pip/_vendor/bom.cdx.json`, e o Trivy o le como inventario de pacotes instalados (ele proprio avisa: *"Third-party SBOM may lead to inaccurate vulnerability detection"*). Como a linha 28 faz `pip install --upgrade pip` sem pin, o build de hoje trouxe o pip novo e o inventario falso junto.

Os 2 achados nao sao pacote instalado — ambos com `PkgPath` vazio, ao contrario das MEDIUM do mesmo Result:

| Achado | Realidade |
|---|---|
| `setuptools 70.3.0` | fantasma; o real na venv e `83.0.0`, acima do fix `78.1.1` |
| `msgpack 1.1.2` | copia privada do pip, usada so pelo cache HTTP dele; nao importavel pela app |

Remover pip/setuptools/wheel do runtime seria mais limpo, mas esta **bloqueado**: `ci.yaml:505` (`[required] docker parity (backend)`) roda `pip install -r requirements.txt` dentro desta imagem.

### 2. `react-router-dom` 7.15.0 -> 7.18.2 — corrige 2 advisories reais

- `GHSA-chx6-hx7r-mcp5` (HIGH, DoS por route matching ineficiente)
- `GHSA-wrjc-x8rr-h8h6` (open redirect em `<Link>`/`useNavigate` — o unico dos cinco que se aplica a um SPA cliente)

### 3. `.github/scripts/npm-audit-gate.mjs` — gate passa a raciocinar por advisory

O parser anterior lia so `metadata.vulnerabilities.high`. **`npm audit` conta pacotes vulneraveis, nao advisories** — subir 7.17.0 -> 7.18.2 corrigiu as duas advisories acima e ainda assim o contador foi de **1 para 2**, porque `react-router-dom` passou a ser contado junto com `react-router` pela advisory remanescente. Um contador agregado nao distingue "corrigiram" de "piorou", nem permite excecao pontual.

O novo gate resolve `via` transitivo e so bloqueia quando sobra advisory HIGH/CRITICAL fora da allowlist. Contrato de saida preservado (`0` ok / `10` bloqueia / `2` ilegivel / `3` erro de API).

### 4. Excecao com TTL — `GHSA-qwww-vcr4-c8h2`

CSRF no RSC Mode. **Inalcancavel aqui**: SPA cliente puro, build `tsc --noEmit && vite build`, `<BrowserRouter>`, sem `@react-router/*`, sem entrypoint SSR, e a imagem de producao so serve `/dist` por nginx.

**Sem correcao no pacote em uso**: `react-router-dom` nao tem linha 8.x publicada (ultima e `7.18.2`, ja adotada). O patch so existe em `react-router@8.3.0`, que exige `react >= 19.2.7` contra os `18.3.1` do projeto — e isso puxa `react-leaflet` 4->5 e o shim `@ant-design/v5-patch-for-react-19`. Escopo real levantado em **#1675**, que e o plano de saida.

TTL **2026-10-30**. A excecao esta espelhada nos **dois** gates `[required]` que avaliam o mesmo fato, com aviso reciproco no comentario: se divergirem, um PR aprovado em um reprova no outro.

## Validacao

**Container Scan** — build local com os mesmos parametros do CI (`os,library` / `CRITICAL,HIGH,MEDIUM` / `ignore-unfixed`):

```
HIGH/CRITICAL: 2 -> 0
bom.cdx.json na imagem: 0 ocorrencias
pacotes reais preservados: 97 (.dist-info)
MEDIUM do pip: seguem sendo reportadas  <- nao cega o scanner
imagem funcional: django 5.2.16 + DRF importam
```

**Gate de npm** — a excecao nao esconde o que tem correcao:

| Versao | Resultado | Motivo |
|---|---|---|
| 7.17.0 | REPROVA (exit 10) | pega `chx6`, que tem fix |
| 7.18.2 | aprova (exit 0) | so resta a `qwww`, allowlisted |

**Frontend** — `tsc --noEmit` limpo, **541 testes passando / 0 falhas**. Diff do `package-lock.json` restrito a `react-router` e `react-router-dom`, sem transitivas.

## Ordem apos o merge

1. `deploy.yaml` dispara no push e gera a tag
2. `promote.yml` (gate `production`) leva o P0 do #1608 a producao
3. Rebase de #1673 e #1674 (dev-only, sem pressa)

Closes #1676
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `7773562f`, slot `1` / projeto `aprender_staging_s1`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local-s1, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```

---

<sub>Nota de processo: o check `[required] staging gate evidence` roda um scan do corpo do PR. A primeira execucao ocorreu antes de o gate escrever os marcadores, entao reprovou corretamente. Um `gh run rerun` NAO resolve esse caso: ele reexecuta com o payload do evento original, que carrega o corpo antigo congelado — e ainda registra uma falha mais recente no commit. O correto e gerar um evento `edited` novo, que e o que esta nota faz.</sub>
