### PR TITLE
fix(deploy): cosign vira o gate de assinatura; attestation SLSA condicional

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -122,7 +122,21 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
-      - name: Gate duro — imagens DEVEM estar assinadas (cosign + attestation)
+      # GATE DURO = assinatura cosign. Ela amarra o digest a identidade OIDC do
+      # slsa-provenance.yml e funciona em repo publico ou privado — nunca e' opcional:
+      # falha aqui aborta a promocao.
+      #
+      # A attestation SLSA e' defesa-em-profundidade sobre a MESMA identidade OIDC. A
+      # API do GitHub que a persiste nao atende repositorio privado de conta pessoal,
+      # entao exigi-la incondicionalmente tornava QUALQUER release impromovivel a
+      # partir do momento em que o repo deixou de ser publico (2026-07-20).
+      #
+      # Semantica adotada, alinhada ao deployer (lib/verify_image.sh, REQUIRE_ATTESTATION
+      # default 0 — decisao #4 do ADR-018): se a attestation EXISTE, ela e' verificada e
+      # um bundle invalido REPROVA. Se nao existe, registra aviso e segue com o cosign.
+      # Ausente != adulterada. Nada aqui testa visibilidade do repo: se o repo voltar a
+      # ser publico, a attestation passa a existir e volta a ser exigida sozinha.
+      - name: Gate duro — imagens DEVEM estar assinadas (cosign)
         env:
           BE: ${{ steps.digests.outputs.backend }}
           FE: ${{ steps.digests.outputs.frontend }}
@@ -131,16 +145,43 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          attested=0
+          missing=0
+
           for pair in "${BACKEND_IMAGE}@${BE}" "${FRONTEND_IMAGE}@${FE}"; do
+            # --- obrigatorio ---
             cosign verify "$pair" \
               --certificate-oidc-issuer "${OIDC_ISSUER}" \
               --certificate-identity-regexp "${IMAGE_IDENTITY_RE}" >/dev/null
-            gh attestation verify "oci://${pair}" \
+            echo "cosign OK: ${pair}"
+
+            # --- defesa em profundidade: so exigido se a attestation existir ---
+            att_out="$(gh attestation verify "oci://${pair}" \
               --repo "${GITHUB_REPOSITORY}" \
               --signer-workflow "${SIGNER_WORKFLOW}" \
-              --bundle-from-oci >/dev/null
+              --bundle-from-oci 2>&1)" && att_rc=0 || att_rc=$?
+
+            if [ "$att_rc" -eq 0 ]; then
+              echo "attestation OK: ${pair}"
+              attested=$((attested + 1))
+            # Padrao ESTREITO de proposito. A mensagem exata do gh quando nao ha
+            # provenance publicada e "no attestations found in the OCI registry"
+            # (verificada contra a imagem real de v2026.07.30-e686d42, rc=1).
+            # Algo como 'not found' generico casaria com falha de verificacao de
+            # assinatura e trataria adulteracao como ausencia. Qualquer erro que
+            # nao seja este cai no ramo de baixo e REPROVA — fail-closed.
+            elif printf '%s' "$att_out" | grep -qiF 'no attestations found'; then
+              echo "::warning title=Attestation ausente::${pair} nao tem provenance SLSA (esperado em repo privado de conta pessoal). Gate mantido pela assinatura cosign."
+              missing=$((missing + 1))
+            else
+              # Existe mas nao validou: adulteracao ou identidade errada. Fail-closed.
+              echo "::error title=Attestation invalida::${pair}" >&2
+              printf '%s\n' "$att_out" >&2
+              exit 1
+            fi
           done
-          echo "Imagens verificadas (assinatura + attestation)."
+
+          echo "Imagens verificadas — cosign: 2/2 | attestation: ${attested}/2 (ausentes: ${missing})."
 
       - name: Montar production.json
         id: build

--- a/.github/workflows/slsa-provenance.yml
+++ b/.github/workflows/slsa-provenance.yml
@@ -140,7 +140,23 @@ jobs:
             echo "frontend_digest=${fe}"
           } >> "$GITHUB_OUTPUT"
 
+      # A attestation SLSA do GitHub NAO esta disponivel em repositorio privado de
+      # conta pessoal — o proprio action falha com "Failed to persist attestation:
+      # Feature not available for user-owned private repositories". Este repo era
+      # publico ate 2026-07-20 (quando o job passava inteiro) e virou privado depois.
+      #
+      # `continue-on-error` em vez de `if:` por VISIBILIDADE de proposito: nada aqui
+      # afirma "o repo e privado". A attestation simplesmente TENTA. Se o repo voltar
+      # a ser publico, ela passa, o step de verificacao abaixo volta a rodar sozinho e
+      # a exigencia se restabelece — sem precisar editar workflow de novo.
+      #
+      # O que NAO e opcional: a assinatura cosign logo abaixo. Ela nao depende da API
+      # de attestation do GitHub (usa Fulcio/Rekor) e funciona em repo privado. E ela
+      # que amarra o digest a identidade OIDC deste workflow, e e' o gate duro do
+      # promote.yml e do deployer (que ja tratava attestation como opt-in — #1526).
       - name: Generate SLSA provenance attestation (backend)
+        id: attest_backend
+        continue-on-error: true
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
         with:
           # registry-qualified (index.docker.io/): sem o prefixo o attest interpreta
@@ -150,6 +166,8 @@ jobs:
           push-to-registry: true
 
       - name: Generate SLSA provenance attestation (frontend)
+        id: attest_frontend
+        continue-on-error: true
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
         with:
           subject-name: index.docker.io/${{ env.FRONTEND_IMAGE }}
@@ -189,7 +207,12 @@ jobs:
             --certificate-identity-regexp "${CERT_IDENTITY_REGEX}" \
             > cosign-verify-frontend.json
 
+      # So verifica o que foi efetivamente gerado. Se as duas attestations passaram
+      # (repo publico), a verificacao roda e continua sendo bloqueante — um bundle
+      # invalido derruba o job. Se nao foram geradas, nao ha o que verificar e o
+      # gate segue sendo a assinatura cosign, ja verificada acima.
       - name: Verify provenance attestations
+        if: steps.attest_backend.outcome == 'success' && steps.attest_frontend.outcome == 'success'
         env:
           BACKEND_IMAGE: ${{ env.BACKEND_IMAGE }}
           FRONTEND_IMAGE: ${{ env.FRONTEND_IMAGE }}
@@ -220,6 +243,7 @@ jobs:
           FRONTEND_IMAGE: ${{ env.FRONTEND_IMAGE }}
           BACKEND_DIGEST: ${{ steps.digests.outputs.backend_digest }}
           FRONTEND_DIGEST: ${{ steps.digests.outputs.frontend_digest }}
+          ATTESTATION_OK: ${{ steps.attest_backend.outcome == 'success' && steps.attest_frontend.outcome == 'success' }}
         run: |
           set -euo pipefail
           {
@@ -228,8 +252,15 @@ jobs:
             echo "- Release tag: \`${RELEASE_TAG}\`"
             echo "- Backend: \`${BACKEND_IMAGE}@${BACKEND_DIGEST}\`"
             echo "- Frontend: \`${FRONTEND_IMAGE}@${FRONTEND_DIGEST}\`"
-            echo "- Attestation predicate: \`https://slsa.dev/provenance/v1\`"
+            echo "- Assinatura cosign (keyless, OIDC): **obrigatoria e verificada**"
             echo "- Signer workflow: \`${GITHUB_REPOSITORY}/.github/workflows/slsa-provenance.yml\`"
+            if [ "${ATTESTATION_OK}" = "true" ]; then
+              echo "- Attestation SLSA: **gerada e verificada** (\`https://slsa.dev/provenance/v1\`)"
+            else
+              echo "- Attestation SLSA: **indisponivel** — a API do GitHub nao suporta"
+              echo "  repositorio privado de conta pessoal. O gate segue sendo a assinatura"
+              echo "  cosign acima. Volta a ser gerada e exigida sozinha se o repo virar publico."
+            fi
           } | tee slsa-summary.md
 
           cat slsa-summary.md >> "$GITHUB_STEP_SUMMARY"
@@ -239,11 +270,14 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: slsa-provenance-${{ github.run_id }}
+          # `warn` e nao `error`: os arquivos de attestation-verify so existem quando
+          # a attestation foi gerada. Com `error` o upload derruba o job justamente
+          # no cenario que este PR trata — foi o segundo erro do run 30555294751.
           path: |
             slsa-summary.md
             cosign-verify-backend.json
             cosign-verify-frontend.json
             attestation-verify-backend.json
             attestation-verify-frontend.json
-          if-no-files-found: error
+          if-no-files-found: warn
           retention-days: 30


### PR DESCRIPTION
## Por que

A release **`v2026.07.30-e686d42`** foi buildada, publicada no registry e tagueada — mas **nao pode ser promovida**. Ela carrega a correcao P0 de escalada de privilegio do #1608, que esta em producao ha 12 dias.

O job de assinatura falha assim:

```
Error: Failed to persist attestation: Feature not available for
user-owned private repositories.
```

O repositorio era **publico ate 2026-07-20** — o build daquele dia (`45d6f9c4`) passou com todos os steps verdes, mesmo workflow, mesmo codigo. Depois disso o repo virou privado, e a API de attestation do GitHub nao atende repositorio privado de conta pessoal.

**O efeito nao ficou contido na attestation.** O step era bloqueante e vinha antes do cosign, entao o job morria ali:

```
failure   Generate SLSA provenance attestation (backend)
skipped   Install Cosign
skipped   Sign images with keyless Cosign      <-- nunca rodou
skipped   Verify Cosign signatures
```

As imagens nao foram assinadas **de forma nenhuma**. E `promote.yml` tinha um gate duro exigindo cosign **e** attestation — logo, impasse total.

## O que muda

Nada aqui testa a visibilidade do repositorio. A attestation apenas **tenta**.

### `slsa-provenance.yml`
- os dois steps de attestation ganham `continue-on-error` e um `id`;
- o step que as verifica roda apenas `if` ambas tiveram sucesso — e continua bloqueante nesse caso;
- o cosign deixa de depender delas e **volta a assinar sempre**;
- `Upload SLSA artifacts` passa a `if-no-files-found: warn`. Com `error` ele derrubava o job justamente quando os JSONs de attestation nao existem — foi a segunda falha do run `30555294751`.

### `promote.yml`
`cosign verify` continua **gate duro e incondicional**. A attestation passa a ter semantica de *"verifique o que existir"*:

| Situacao | Resultado |
|---|---|
| presente e valida | ✅ verificada, contabilizada |
| ausente | ⚠️ aviso; gate mantido pelo cosign |
| presente mas invalida | ❌ **reprova** |
| erro desconhecido | ❌ **reprova** (fail-closed) |

**Ausente != adulterada.** Isso alinha o promote com o deployer, que ja tratava attestation como opt-in (`lib/verify_image.sh`, `REQUIRE_ATTESTATION=0`, decisao #4 do ADR-018) — ou seja, o promote exigia mais do que o proprio consumidor do ponteiro.

## Se o repositorio voltar a ser publico

Volta a funcionar sozinho, sem editar workflow: a attestation passa a ser gerada, o `if` do step de verificacao fica verdadeiro, e o promote volta a verifica-la nas duas imagens. Esse e o primeiro cenario de teste abaixo.

## Validacao

Os 4 caminhos do gate exercitados com `gh`/`cosign` mockados:

```
attestation valida (repo publico) -> passa   (cosign 2/2 | attestation 2/2)
ausente (repo privado)            -> passa   (cosign 2/2 | attestation 0/2, aviso)
presente mas INVALIDA             -> REPROVA (exit 1)
erro desconhecido com 'not found' -> REPROVA (exit 1)
```

O padrao que distingue ausencia e `no attestations found`, literal e estreito, conferido contra a **saida real** do `gh` na imagem `v2026.07.30-e686d42` sem provenance (`rc=1`). Um padrao generico como `not found` classificaria falha de verificacao de assinatura como ausencia — o 4o cenario cobre exatamente essa armadilha, que eu quase introduzi.

Diff restrito a `.github/workflows/`. Ambos os arquivos validados como YAML.

## Depois do merge

1. novo build gera tag com imagens **assinadas por cosign**;
2. `promote.yml` (gate `production`) leva o P0 a producao.

A tag `v2026.07.30-e686d42` fica orfa — suas imagens nao tem assinatura e ela nao deve ser promovida.
