### PR TITLE
fix(security): genericiza erro de importer/health (CodeQL py/stack-trace-exposure)

### DIFF
--- a/v2/backend/apps/core/imports/row_errors.py
+++ b/v2/backend/apps/core/imports/row_errors.py
@@ -1,0 +1,40 @@
+"""Tratamento uniforme de erros inesperados por linha nos importers.
+
+CodeQL `py/stack-trace-exposure`: a mensagem crua de uma excecao inesperada
+(erro de banco, integridade, parse do arquivo) NAO pode voltar ao cliente —
+ela pode carregar nome de constraint, coluna interna, caminho de arquivo, etc.
+
+Os importers ja tratam as falhas ESPERADAS (campo obrigatorio ausente, valor
+invalido) com mensagens controladas e amigaveis. Este helper cobre so o
+catch-all do inesperado: registra a excecao no log (com traceback, para
+diagnostico) e devolve ao cliente uma mensagem generica e estavel.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger("apps.core.imports")
+
+# Mensagem unica devolvida ao cliente quando uma linha falha por erro inesperado.
+# Mantida generica de proposito: o detalhe real vai para o log, nunca para a resposta.
+MENSAGEM_ERRO_LINHA = "Erro interno ao processar a linha; verifique o formato dos dados."
+
+
+def registrar_erro_import(*, importer: str, linha: int) -> str:
+    """Loga a excecao corrente e devolve a mensagem segura para o cliente.
+
+    DEVE ser chamada de dentro de um bloco ``except`` — usa o contexto de
+    excecao ativo (``logging.exception``) para capturar o traceback completo
+    no log. O valor de retorno e' a unica coisa que pode chegar ao cliente;
+    nunca inclui ``str(excecao)``.
+
+    Args:
+        importer: nome curto do importer (ex.: "municipios") para rastrear no log.
+        linha: numero da linha do arquivo que falhou (1-based).
+
+    Returns:
+        Mensagem generica e estavel, segura para exibir ao usuario.
+    """
+    logger.exception("Erro inesperado no import '%s' (linha %d)", importer, linha)
+    return MENSAGEM_ERRO_LINHA

--- a/v2/backend/apps/core/services/bloqueios_import.py
+++ b/v2/backend/apps/core/services/bloqueios_import.py
@@ -25,6 +25,7 @@ from django.db import transaction
 import pandas as pd
 
 from apps.core.imports.normalization import normalize_blank
+from apps.core.imports.row_errors import registrar_erro_import
 from apps.core.models import AvailabilityBlock
 from apps.core.services.resolvers import resolve_user_by_name
 
@@ -71,12 +72,12 @@ def import_bloqueios_from_file(*, path: str, dry_run: bool = True) -> dict[str, 
             try:
                 with transaction.atomic():  # savepoint
                     _process_row(row, idx, stats, pendencias)
-            except Exception as e:
+            except Exception:
                 stats["skipped"]["other"] += 1
                 pendencias["outros"].append(
                     {
                         "linha": idx,
-                        "erro": str(e),
+                        "erro": registrar_erro_import(importer="bloqueios", linha=idx),
                         "row": str(row),
                     }
                 )

--- a/v2/backend/apps/core/services/colecoes_import.py
+++ b/v2/backend/apps/core/services/colecoes_import.py
@@ -22,6 +22,7 @@ from django.db import transaction
 import pandas as pd
 
 from apps.core.imports.normalization import normalize_active_flag, normalize_blank
+from apps.core.imports.row_errors import registrar_erro_import
 from apps.core.models import Colecao, Projeto
 from apps.core.services.resolvers import resolve_projeto
 
@@ -67,12 +68,12 @@ def import_colecoes_from_file(*, path: str, dry_run: bool = True) -> dict[str, A
             try:
                 with transaction.atomic():  # savepoint
                     _process_row(row, idx, stats, pendencias, projeto_cache)
-            except Exception as e:
+            except Exception:
                 stats["skipped"]["other"] += 1
                 pendencias["outros"].append(
                     {
                         "linha": idx,
-                        "erro": str(e),
+                        "erro": registrar_erro_import(importer="colecoes", linha=idx),
                         "row": str(row),
                     }
                 )

--- a/v2/backend/apps/core/services/controle_acoes_import.py
+++ b/v2/backend/apps/core/services/controle_acoes_import.py
@@ -27,6 +27,7 @@ from django.conf import settings
 from django.db import transaction
 
 from apps.core.imports.hashing import stable_import_hash
+from apps.core.imports.row_errors import registrar_erro_import
 from apps.core.models import AcaoControle, Municipio, Projeto, Usuario
 from apps.core.services.resolvers import (
     resolve_municipio,
@@ -78,12 +79,12 @@ def import_acoes_controle(file_path: str, dry_run: bool = False) -> dict[str, An
                     result: str | None = _process_row(row, idx, stats, pendencias)
                     if result == "skip":
                         continue
-            except Exception as e:
+            except Exception:
                 stats["skipped"]["other"] += 1
                 pendencias["outros"].append(
                     {
                         "linha": idx,
-                        "erro": str(e),
+                        "erro": registrar_erro_import(importer="controle_acoes", linha=idx),
                         "row": row,
                     }
                 )

--- a/v2/backend/apps/core/services/dat_cadastros_import.py
+++ b/v2/backend/apps/core/services/dat_cadastros_import.py
@@ -27,6 +27,7 @@ from django.conf import settings
 from django.db import transaction
 
 from apps.core.imports.hashing import stable_import_hash
+from apps.core.imports.row_errors import registrar_erro_import
 from apps.core.models import AcaoDAT, Municipio, Projeto, TipoAcaoDAT, Usuario
 from apps.core.services.normalize import norm_text
 from apps.core.services.resolvers import resolve_municipio, resolve_user_by_email, resolve_user_by_name
@@ -112,12 +113,12 @@ def import_dat_cadastros(file_path: str, dry_run: bool = False) -> dict[str, Any
                     result: str | None = _process_row(row, idx, stats, pendencias)
                     if result == "skip":
                         continue
-            except Exception as e:
+            except Exception:
                 stats["skipped"]["other"] += 1
                 pendencias["outros"].append(
                     {
                         "linha": idx,
-                        "erro": str(e),
+                        "erro": registrar_erro_import(importer="dat_cadastros", linha=idx),
                         "row": row,
                     }
                 )

--- a/v2/backend/apps/core/services/deslocamentos_import.py
+++ b/v2/backend/apps/core/services/deslocamentos_import.py
@@ -27,6 +27,7 @@ import pandas as pd
 
 from apps.core.imports.hashing import stable_import_hash
 from apps.core.imports.normalization import normalize_blank
+from apps.core.imports.row_errors import registrar_erro_import
 from apps.core.models import Deslocamento
 from apps.core.services.resolvers import resolve_user_by_email, resolve_user_by_name
 
@@ -72,12 +73,12 @@ def import_deslocamentos_from_file(*, path: str, dry_run: bool = True) -> dict[s
             try:
                 with transaction.atomic():  # savepoint
                     _process_row(row, idx, stats, pendencias, dry_run)
-            except Exception as e:
+            except Exception:
                 stats["skipped"]["other"] += 1
                 pendencias["outros"].append(
                     {
                         "linha": idx,
-                        "erro": str(e),
+                        "erro": registrar_erro_import(importer="deslocamentos", linha=idx),
                         "row": str(row),
                     }
                 )

--- a/v2/backend/apps/core/services/equipe_gerencia_import.py
+++ b/v2/backend/apps/core/services/equipe_gerencia_import.py
@@ -25,6 +25,7 @@ from django.db import transaction
 import pandas as pd
 
 from apps.core.imports.normalization import normalize_active_flag, normalize_blank, normalize_cpf_digits
+from apps.core.imports.row_errors import registrar_erro_import
 from apps.core.models import EquipeGerencia, Gerencia, Usuario
 from apps.core.services.resolvers import resolve_user_by_email, resolve_user_by_name
 
@@ -116,12 +117,12 @@ def import_equipe_gerencia_from_file(*, path: str, dry_run: bool = True) -> dict
             try:
                 with transaction.atomic():  # savepoint
                     _process_row(row, idx, stats, pendencias)
-            except Exception as e:
+            except Exception:
                 stats["skipped"]["other"] += 1
                 pendencias["outros"].append(
                     {
                         "linha": idx,
-                        "erro": str(e),
+                        "erro": registrar_erro_import(importer="equipe_gerencia", linha=idx),
                         "row": str(row),
                     }
                 )

--- a/v2/backend/apps/core/services/eventos_import.py
+++ b/v2/backend/apps/core/services/eventos_import.py
@@ -42,6 +42,7 @@ import pandas as pd
 
 from apps.core.imports.hashing import stable_import_hash
 from apps.core.imports.normalization import normalize_blank
+from apps.core.imports.row_errors import registrar_erro_import
 from apps.core.models import Participation, Solicitacao
 from apps.core.services.resolvers import (
     resolve_municipio,
@@ -111,12 +112,12 @@ def import_eventos_from_file(*, path: str, dry_run: bool = True) -> dict[str, An
             try:
                 with transaction.atomic():  # savepoint
                     _process_row(row, idx, stats, pendencias)
-            except Exception as e:
+            except Exception:
                 stats["skipped"]["other"] += 1
                 pendencias["outros"].append(
                     {
                         "linha": idx,
-                        "erro": str(e),
+                        "erro": registrar_erro_import(importer="eventos", linha=idx),
                         "row": str(row),
                     }
                 )

--- a/v2/backend/apps/core/services/municipios_import.py
+++ b/v2/backend/apps/core/services/municipios_import.py
@@ -22,6 +22,7 @@ from django.db import transaction
 import pandas as pd
 
 from apps.core.imports.normalization import normalize_active_flag, normalize_blank, normalize_uf
+from apps.core.imports.row_errors import registrar_erro_import
 from apps.core.models import Municipio
 from apps.core.services.options_cache import invalidate_municipios_options_cache
 
@@ -63,12 +64,12 @@ def import_municipios_from_file(*, path: str, dry_run: bool = True) -> dict[str,
             try:
                 with transaction.atomic():  # savepoint
                     _process_row(row, idx, stats, pendencias)
-            except Exception as e:
+            except Exception:
                 stats["skipped"]["other"] += 1
                 pendencias["outros"].append(
                     {
                         "linha": idx,
-                        "erro": str(e),
+                        "erro": registrar_erro_import(importer="municipios", linha=idx),
                         "row": str(row),
                     }
                 )

--- a/v2/backend/apps/core/services/produtos_import.py
+++ b/v2/backend/apps/core/services/produtos_import.py
@@ -23,6 +23,7 @@ from django.db import transaction
 import pandas as pd
 
 from apps.core.imports.normalization import normalize_active_flag, normalize_blank
+from apps.core.imports.row_errors import registrar_erro_import
 from apps.core.models import Produto, Projeto
 from apps.core.services.resolvers import _nfkd
 
@@ -70,12 +71,12 @@ def import_produtos_from_file(*, path: str, dry_run: bool = True) -> dict[str, A
             try:
                 with transaction.atomic():  # savepoint
                     _process_row(row, idx, stats, pendencias, projeto_cache, dry_run)
-            except Exception as e:
+            except Exception:
                 stats["skipped"]["other"] += 1
                 pendencias["outros"].append(
                     {
                         "linha": idx,
-                        "erro": str(e),
+                        "erro": registrar_erro_import(importer="produtos", linha=idx),
                         "row": str(row),
                     }
                 )

--- a/v2/backend/apps/core/services/usuarios_import.py
+++ b/v2/backend/apps/core/services/usuarios_import.py
@@ -33,6 +33,7 @@ from django.db import transaction
 import pandas as pd
 
 from apps.core.imports.normalization import normalize_active_flag, normalize_blank, normalize_cpf_digits
+from apps.core.imports.row_errors import registrar_erro_import
 from apps.core.models import Usuario
 
 
@@ -87,12 +88,12 @@ def import_usuarios_from_file(*, path: str, dry_run: bool = True, actor: Any = N
             try:
                 with transaction.atomic():  # savepoint
                     _process_row(row, idx, stats, pendencias, dry_run, actor)
-            except Exception as e:
+            except Exception:
                 stats["skipped"]["other"] += 1
                 pendencias["outros"].append(
                     {
                         "linha": idx,
-                        "erro": str(e),
+                        "erro": registrar_erro_import(importer="usuarios", linha=idx),
                         "row": str(row),
                     }
                 )

--- a/v2/backend/apps/core/tests/test_import_row_errors.py
+++ b/v2/backend/apps/core/tests/test_import_row_errors.py
@@ -1,0 +1,34 @@
+"""Tests para o helper de erro de linha dos importers (CodeQL py/stack-trace-exposure)."""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false
+
+from __future__ import annotations
+
+import logging
+
+from apps.core.imports.row_errors import MENSAGEM_ERRO_LINHA, registrar_erro_import
+
+
+def test_registrar_erro_import_devolve_mensagem_generica():
+    sentinel = "segredo_interno_constraint_users_pkey_xyz"
+    try:
+        raise ValueError(sentinel)
+    except ValueError:
+        msg = registrar_erro_import(importer="teste", linha=7)
+
+    # O valor devolvido ao cliente e' generico e nunca contem a excecao crua.
+    assert msg == MENSAGEM_ERRO_LINHA
+    assert sentinel not in msg
+
+
+def test_registrar_erro_import_loga_traceback(caplog):
+    sentinel = "detalhe_interno_para_o_log_apenas_abc"
+    with caplog.at_level(logging.ERROR, logger="apps.core.imports"):
+        try:
+            raise RuntimeError(sentinel)
+        except RuntimeError:
+            registrar_erro_import(importer="usuarios", linha=42)
+
+    # O detalhe real (traceback) vai para o log — nao para a resposta.
+    assert "usuarios" in caplog.text
+    assert sentinel in caplog.text

--- a/v2/backend/apps/core/tests/test_municipios_import_service.py
+++ b/v2/backend/apps/core/tests/test_municipios_import_service.py
@@ -27,3 +27,31 @@ def test_import_municipios_apply_invalidates_options_cache(tmp_path):
     assert report["stats"]["created"] == 1
     assert Municipio.objects.filter(nome="Fortaleza", uf="CE", ibge_code="2304400").exists()
     assert cache.get(MUNICIPIOS_OPTIONS_CACHE_KEY) is None
+
+
+def test_unexpected_row_error_does_not_leak_exception_message(tmp_path, monkeypatch):
+    """CodeQL py/stack-trace-exposure: a mensagem crua de uma excecao inesperada
+    por linha nao pode voltar ao cliente no relatorio de pendencias.
+    """
+    import json
+
+    from apps.core.imports.row_errors import MENSAGEM_ERRO_LINHA
+    from apps.core.services import municipios_import
+
+    sentinel = "LEAK_pg_UniqueViolation_municipio_pkey_SECRET_42"
+
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError(sentinel)
+
+    monkeypatch.setattr(municipios_import, "_process_row", _boom)
+
+    csv_path = tmp_path / "municipios.csv"
+    csv_path.write_text("nome,uf\nFortaleza,CE\n", encoding="utf-8")
+
+    report = import_municipios_from_file(path=str(csv_path), dry_run=True)
+
+    outros = report["pendencias"]["outros"]
+    assert len(outros) == 1
+    assert outros[0]["erro"] == MENSAGEM_ERRO_LINHA
+    # a mensagem crua da excecao nao pode aparecer em nenhum campo do relatorio
+    assert sentinel not in json.dumps(report, default=str)

--- a/v2/backend/apps/core/tests/test_readyz.py
+++ b/v2/backend/apps/core/tests/test_readyz.py
@@ -105,7 +105,8 @@ def test_readyz_returns_503_when_database_fails():
 
     data = res.json()
     assert data["status"] == "unhealthy"
-    assert "error:" in data["checks"]["database"]
+    # SEC/CodeQL py/stack-trace-exposure: status generico, sem a mensagem crua da excecao.
+    assert data["checks"]["database"] == "error"
 
 
 @patch("django.core.cache.cache.set")
@@ -123,7 +124,8 @@ def test_readyz_cache_failure_is_warning_not_503(mock_cache_set):
 
     data = res.json()
     assert data["status"] == "healthy"
-    assert "warning:" in data["checks"]["cache"]
+    # SEC/CodeQL py/stack-trace-exposure: warning generico, sem a mensagem crua da excecao.
+    assert data["checks"]["cache"] == "warning"
 
 
 # ============================================================================

--- a/v2/backend/apps/core/tests/test_security_hardening.py
+++ b/v2/backend/apps/core/tests/test_security_hardening.py
@@ -14,6 +14,8 @@ Covers:
 
 from __future__ import annotations
 
+from unittest import mock
+
 from django.test import TestCase, override_settings
 
 from apps.core.views_auth import (
@@ -61,6 +63,30 @@ class TestHealthzMinimalPayload(TestCase):
         assert response.status_code == 200
         data = response.json()
         assert "checks" in data
+
+
+class TestHealthzDetailedNoErrorLeak(TestCase):
+    """SEC-RECON-01 / CodeQL py/stack-trace-exposure: uma falha de dependencia
+    reporta status generico, nunca a mensagem crua da excecao."""
+
+    def test_cache_error_reported_as_generic_status(self):
+        from django.core.cache import cache
+
+        sentinel = "LEAK_redis_AUTH_password_wrong_SECRET"
+        real_set = cache.set
+
+        def _fail_only_probe(key, *args, **kwargs):
+            # Falha so no probe do health check; deixa a sessao (outra chave) passar.
+            if key == "health_check_key":
+                raise RuntimeError(sentinel)
+            return real_set(key, *args, **kwargs)
+
+        with mock.patch.object(cache, "set", side_effect=_fail_only_probe):
+            response = self.client.get("/healthz/detailed/", REMOTE_ADDR="127.0.0.1")
+
+        assert response.status_code == 200
+        assert sentinel not in response.content.decode()
+        assert response.json()["checks"]["redis"] == "error"
 
 
 # ================================================================
@@ -112,6 +138,31 @@ class TestReadyzConditionalPayload(TestCase):
         data = response.json()
         assert "status" in data
         assert "checks" in data
+
+    def test_readyz_cache_error_reported_as_generic_status(self):
+        """CodeQL py/stack-trace-exposure: falha de cache nao vaza a excecao crua."""
+        from django.contrib.auth import get_user_model
+        from django.core.cache import cache
+
+        User = get_user_model()
+        admin = User.objects.create_user("admin_readyz_leak", "rl@b.com", "pass1234", is_staff=True)
+        self.client.force_login(admin)
+
+        sentinel = "LEAK_redis_connection_refused_10_0_0_5_SECRET"
+        real_set = cache.set
+
+        def _fail_only_probe(key, *args, **kwargs):
+            # Falha so no probe do readyz; deixa a sessao (outra chave) salvar.
+            if key == "_healthcheck":
+                raise RuntimeError(sentinel)
+            return real_set(key, *args, **kwargs)
+
+        with mock.patch.object(cache, "set", side_effect=_fail_only_probe):
+            response = self.client.get("/api/readyz/")
+
+        assert response.status_code == 200
+        assert sentinel not in response.content.decode()
+        assert response.json()["checks"]["cache"] == "warning"
 
 
 class TestVersionConditionalPayload(TestCase):

--- a/v2/backend/apps/core/views_health.py
+++ b/v2/backend/apps/core/views_health.py
@@ -7,6 +7,7 @@ Health Check and Features Views
 from __future__ import annotations
 
 import json
+import logging
 import os
 from pathlib import Path
 
@@ -17,6 +18,8 @@ from rest_framework.decorators import api_view, permission_classes, throttle_cla
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
+
+logger = logging.getLogger(__name__)
 
 
 @api_view(["GET"])
@@ -41,8 +44,9 @@ def readyz(request: Request) -> Response:
                 checks["database"] = "ok"
             else:
                 checks["database"] = "error: unexpected result"
-    except Exception as e:
-        checks["database"] = f"error: {str(e)}"
+    except Exception:
+        logger.exception("readyz: falha no check de banco")
+        checks["database"] = "error"
 
     # Redis/Cache check (optional - warnings only)
     try:
@@ -52,8 +56,9 @@ def readyz(request: Request) -> Response:
             checks["cache"] = "ok"
         else:
             checks["cache"] = "warning: set/get failed"
-    except Exception as e:
-        checks["cache"] = f"warning: {str(e)}"
+    except Exception:
+        logger.exception("readyz: falha no check de cache")
+        checks["cache"] = "warning"
 
     # Only database failures cause unhealthy status
     db_ok = checks["database"] == "ok"

--- a/v2/backend/config/urls.py
+++ b/v2/backend/config/urls.py
@@ -6,6 +6,7 @@ URL configuration for AS v2 project.
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from django.conf import settings
@@ -14,6 +15,8 @@ from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.urls import include, path
 
 from apps.core.admin_site import admin_site  # Custom admin site (superusers only)
+
+logger = logging.getLogger(__name__)
 
 
 def _metrics_gate(request: HttpRequest) -> HttpResponse:
@@ -63,16 +66,18 @@ def healthz_detailed(request: HttpRequest) -> JsonResponse:
         with connection.cursor() as cursor:
             cursor.execute("SELECT 1")
         checks["database"] = "ok"
-    except Exception as e:
-        checks["database"] = f"error: {str(e)[:100]}"
+    except Exception:
+        logger.exception("healthz_detailed: falha no check de banco")
+        checks["database"] = "error"
 
     # Redis cache check
     try:
         cache.set("health_check_key", "ok", 1)
         result = cache.get("health_check_key")
         checks["redis"] = "ok" if result == "ok" else "fail"
-    except Exception as e:
-        checks["redis"] = f"error: {str(e)[:100]}"
+    except Exception:
+        logger.exception("healthz_detailed: falha no check de redis")
+        checks["redis"] = "error"
 
     # GCal circuit breaker check
     try:
@@ -81,8 +86,9 @@ def healthz_detailed(request: HttpRequest) -> JsonResponse:
         checks["gcal_circuit"] = get_circuit_state()
     except ImportError:
         checks["gcal_circuit"] = "not_configured"
-    except Exception as e:
-        checks["gcal_circuit"] = f"error: {str(e)[:100]}"
+    except Exception:
+        logger.exception("healthz_detailed: falha no check do circuit breaker do GCal")
+        checks["gcal_circuit"] = "error"
 
     # Determine overall status
     core_checks = [checks.get("database"), checks.get("redis")]

--- a/v2/infra/configs/vm01/nginx.conf
+++ b/v2/infra/configs/vm01/nginx.conf
@@ -95,9 +95,15 @@ http {
         }
 
         # Health check (sem rate limit)
+        # SEC-RECON-01: sobrescreve X-Forwarded-For para o guard de /healthz/detailed/.
+        # Sem isto, o cliente poderia enviar "X-Forwarded-For: 127.0.0.1" e passar pelo
+        # teste de rede interna do Django. $remote_addr = peer real, nao forjavel.
         location /healthz/ {
             proxy_pass http://django;
             proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $remote_addr;
+            proxy_set_header X-Forwarded-Proto $scheme;
             access_log off;
         }
 


### PR DESCRIPTION
## Objetivo

Fecha os **12 alertas CodeQL `py/stack-trace-exposure`** (todos `medium`) do
code-scanning. Os importers e os endpoints de health devolviam a **mensagem
crua da excecao** (`str(e)`) ao cliente — que pode carregar nome de constraint,
coluna interna, caminho de arquivo ou detalhe de conexao.

## O que muda

- **10 importers** (`apps/core/services/*_import.py`): o catch-all do erro
  **inesperado** por linha passa a usar o helper novo
  `apps/core/imports/row_errors.py`, que **loga o traceback** e devolve uma
  mensagem generica e estavel. As falhas **esperadas** (campo ausente, valor
  invalido) seguem com suas mensagens amigaveis — a UX de "qual linha falhou"
  nao regride.
- **`readyz` / `healthz_detailed`**: status generico (`"error"` / `"warning"`)
  no lugar de `f"error: {str(e)}"`. O detalhe real vai so para o log. A logica
  de status (`startswith("error")`, `== "ok"`) foi preservada.
- **nginx `/healthz/`**: sobrescreve `X-Forwarded-For` com `$remote_addr`.
  Sem isto, o bloco nao sanitizava o header e um cliente podia enviar
  `X-Forwarded-For: 127.0.0.1` e passar pelo guard de rede interna do
  `healthz/detailed/`. Defesa em profundidade — a genericizacao acima ja remove
  o dado sensivel mesmo que o guard seja burlado.

## Testes

- `test_import_row_errors.py` (novo): helper devolve generico + loga traceback.
- `test_municipios_import_service.py`: vazamento no importer — **prova RED**
  confirmada (com `str(e)` o sentinel aparecia no relatorio).
- `test_security_hardening.py` / `test_readyz.py`: health reporta status
  generico; contrato antigo (`"error: <msg>"`) atualizado.
- 40 testes locais verdes (`readyz` + `security_hardening` + novos + municipios).

## ⚠️ Deploy manual (nginx)

`v2/infra/configs/vm01/nginx.conf` e' o **nginx do host VM01**, aplicado
manualmente via Portainer/host — **nao** sobe pela imagem. Este diff e' a SSOT;
o bloco `location /healthz/` na VM precisa ser atualizado a mao e o nginx
recarregado para o reforco do XFF valer. O restante (backend) sobe pelo fluxo
normal de imagem + promote. Obs.: o nginx vivo pode ja divergir deste arquivo
(ver #1671) — conferir na VM.

## Escopo

Fecha os 12 alertas de code-scanning. Nao toca dados nem RBAC. Requer evidencia
do staging gate (muda `v2/backend/apps/`).

---

## Evidencia do staging gate

Rodado localmente contra o HEAD deste branch (`8f6e6961`), stack isolada do gate
(projeto `aprender_staging`, portas 18002/15173), pipeline fiel ao `staging-full`
(precheck -> build backend+frontend prod -> up -> migrate -> smoke -> teardown).

```
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR
