### PR TITLE
fix(openapi): /me/policies declara array de strings, nao objeto (#1463)

### DIFF
--- a/v2/backend/apps/core/tests/test_me_policies.py
+++ b/v2/backend/apps/core/tests/test_me_policies.py
@@ -328,3 +328,16 @@ class TestMenuPolicies1589:
         policies = _policies_for(UsuarioFactory(superuser=True))
         for key in self.NEW_KEYS:
             assert key in policies, f"superuser deveria ter {key} (bypass)"
+
+
+def test_openapi_me_policies_declara_array_de_strings():
+    """Guard de drift (#1463 item #10): o schema OpenAPI de GET /api/me/policies/
+    deve declarar um ARRAY de strings — nao um objeto {policies: [...]} — porque o
+    runtime devolve a lista crua (`Response(resolve_public_policies(...))`).
+    Regenera o schema e trava a forma para pegar regressao de annotation.
+    """
+    from drf_spectacular.generators import SchemaGenerator
+
+    schema = SchemaGenerator().get_schema(request=None, public=True)
+    resp = schema["paths"]["/api/me/policies/"]["get"]["responses"]["200"]["content"]["application/json"]["schema"]
+    assert resp == {"type": "array", "items": {"type": "string"}}

--- a/v2/backend/apps/core/views/me.py
+++ b/v2/backend/apps/core/views/me.py
@@ -100,11 +100,11 @@ class MeEventsListView(generics.ListAPIView):
             "expõe apenas policy keys do registro público. Keys são imutáveis "
             "após release (renomear = breaking; ver `feedback_capability_policy_layer_pattern.md` §6)."
         ),
+        # Schema drift (#1463 item #10): o runtime devolve um ARRAY de strings
+        # (`Response(resolve_public_policies(...))`), nao `{policies: [...]}`.
+        # ListSerializer(child=CharField) gera `{type: array, items: {type: string}}`.
         responses={
-            200: inline_serializer(
-                name="MePoliciesResponse",
-                fields={"policies": serializers.ListField(child=serializers.CharField())},
-            ),
+            200: serializers.ListSerializer(child=serializers.CharField()),
             401: COMMON_ERROR_RESPONSES[401],
         },
         tags=["me"],


### PR DESCRIPTION
Fecha o **item #10+G9** do #1463 (os outros 6 itens do guarda-chuva foram entregues por #1571).

## Drift #10 (corrigido)
`GET /api/me/policies/` declarava `{policies: [...]}` (objeto) na annotation drf-spectacular, mas o runtime devolve a **lista crua** de strings. Trocado por `ListSerializer(child=CharField)`.

**Verificado regenerando o schema:**
- antes: `{$ref: MePoliciesResponse}` (objeto)
- depois: `{type: array, items: {type: string}}` · `MePoliciesResponse` deixou de existir

## G9 (ja estava resolvida)
`/me/events/`, `/imports/`, `/solicitacoes/` **ja** retornam `PaginatedXList` no schema (drf-spectacular envelopa `ListAPIView` sozinho). O concern do audit (jun/2026) ficou defasado.

## Teste
Guard de regressao novo: gera o schema via `SchemaGenerator` e trava `/me/policies/` como array de strings. `test_me_policies.py` 20/20.

## Fora de escopo (follow-up)
`spectacular --validate` no CI: hoje o schema tem **274 warnings pre-existentes** (APIViews sem serializer_class, ex. versionz/validate) — ligar o gate agora reprovaria tudo. Precisa de triagem propria antes.

Closes #1463.

---

## Evidencia do staging gate

HEAD deste branch (`3c8c74fc`), stack isolada do gate (projeto `aprender_staging`, portas 18002/15173), pipeline fiel ao `staging-full`.

```
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR
