### PR TITLE
fix(infra): admin Django alcancavel em prod — /admin/ + /static/ + collectstatic (#1671)

### DIFF
--- a/v2/frontend/nginx.conf
+++ b/v2/frontend/nginx.conf
@@ -85,6 +85,34 @@ server {
         proxy_connect_timeout 120s;
     }
 
+    # #1671: Django admin — proxy ao backend, senao /admin/ cai no catch-all do SPA
+    # e vira index.html. O admin_site e superuser-only por construcao; expor a rota
+    # nao afrouxa a auth (o Django segue exigindo login + is_superuser).
+    location /admin/ {
+        set $backend http://web:8000;
+        proxy_pass $backend;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+        proxy_read_timeout 120s;
+        proxy_connect_timeout 120s;
+    }
+
+    # #1671: estaticos do Django (CSS/JS do admin) servidos pelo whitenoise no
+    # backend. Sem esta rota, /static/* cai no SPA (devolve index.html) e o admin
+    # sobe sem estilo/JS — quebrando o filter_horizontal usado para Group x Capability.
+    location /static/ {
+        set $backend http://web:8000;
+        proxy_pass $backend;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+        proxy_read_timeout 120s;
+        proxy_connect_timeout 120s;
+    }
+
     # SPA fallback - serve index.html for all routes
     # no-cache ensures browser always checks for new version after deploy
     location / {

--- a/v2/infra/Dockerfile.prod
+++ b/v2/infra/Dockerfile.prod
@@ -67,6 +67,13 @@ COPY infra/gunicorn.conf.py /app/infra/gunicorn.conf.py
 COPY infra/scripts /app/infra/scripts
 RUN chmod +x /app/infra/scripts/*.sh
 
+# #1671: coleta os estaticos (admin CSS/JS) no BUILD para o whitenoise servir em
+# /static/ em producao. Feito no build (nao no boot) para deployar pela imagem, sem
+# tocar o stack. Aqui ENVIRONMENT nao esta setado (=development), entao os guards de
+# producao (SECRET_KEY etc.) nao disparam e a chave dev serve; collectstatic nao
+# acessa o banco. O chown -R appuser mais abaixo cobre /app/staticfiles.
+RUN DJANGO_SETTINGS_MODULE=config.settings python manage.py collectstatic --noinput
+
 # Cleanup: remove __pycache__ and .pyc files
 # Note: do NOT remove "test"/"tests" dirs — django.test is a runtime module
 #


### PR DESCRIPTION
Closes #1671.

## Problema
O Django admin era inalcancavel em prod pelo HTTPS — bloqueando a D17 (Group×Capability admin-driven). O nginx do **container frontend** (o que atende prod, nao o `vm01/nginx.conf`) nao tinha `location /admin/` nem `/static/`, entao ambos caiam no catch-all do SPA e devolviam `index.html`. O Django servia o admin certo; a **borda** e que falhava.

## Fix — tudo pela imagem, ZERO mexida manual na VM
- **`v2/frontend/nginx.conf`**: `location /admin/` + `location /static/` (proxy p/ `web:8000`, espelham o `/api/`).
- **`v2/infra/Dockerfile.prod`**: `collectstatic` no **build** (nao no boot). No build `ENVIRONMENT` nao esta setado (=development), entao os guards de prod nao disparam, a chave dev serve e collectstatic nao toca o banco. O `chown -R appuser` cobre `/app/staticfiles`.

## Verificado no staging gate (imagens prod reais)
```
[1/8]..[8/8] smoke: ALL 8 CHECKS PASSED
/admin/login/            -> HTTP 200, <title>Acessar | AS v2 Admin</title>  (admin Django, nao SPA)
/static/admin/css/base.css -> HTTP 200, content-type text/css  ("DJANGO Admin styles")
```

## Seguranca
O `admin_site` e **superuser-only por construcao** — expor a rota nao afrouxa auth (Django segue exigindo login + is_superuser). O 301 http→https do `/static/` (SECURE_SSL_REDIRECT) continua ativo.

## Evidencia do staging gate

HEAD `85c3f7ed`, stack isolada `aprender_staging` (18002/15173), build das imagens prod + smoke.

```
ALL 8 CHECKS PASSED
```

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR