### PR TITLE
fix(audit): serviço transacional de auditoria de privilégio (#1672)

### DIFF
--- a/v2/backend/apps/core/admin.py
+++ b/v2/backend/apps/core/admin.py
@@ -121,6 +121,60 @@ class UsuarioAdmin(admin.ModelAdmin):
 
         return response
 
+    def save_model(self, request: HttpRequest, obj: Usuario, form: Any, change: bool) -> None:
+        """
+        #1672: audita flips de flags de privilégio (is_superuser/is_staff/is_active)
+        feitos pelo Django admin — caminho superuser-only que antes não deixava
+        trilha (contraste com a mutação equivalente via API, que gera auditoria).
+        Mudança de grupos vai pelo `save_related` (m2m). O change_view do admin já
+        roda em `transaction.atomic()`, então o on_commit reflete o commit real.
+        """
+        from apps.core.services.audit import registrar_auditoria
+
+        before: dict[str, Any] = {}
+        if change and obj.pk:
+            before = Usuario.objects.filter(pk=obj.pk).values("is_superuser", "is_staff", "is_active").first() or {}
+        super().save_model(request, obj, form, change)
+
+        changes: dict[str, Any] = {}
+        for flag in ("is_superuser", "is_staff", "is_active"):
+            after_val = bool(getattr(obj, flag))
+            before_val = before.get(flag)
+            # Em criação (change=False) só audita flag LIGADA (concessão inicial).
+            if (change and before_val != after_val) or (not change and after_val):
+                changes[flag] = {"before": before_val, "after": after_val}
+        if changes:
+            registrar_auditoria(
+                actor=request.user,
+                action=AuditLog.Action.USER_PRIVILEGE_CHANGED,
+                model_name="Usuario",
+                details={
+                    "target_user_id": obj.pk,
+                    "target_username": obj.username,
+                    "changes": changes,
+                    "via": "django_admin",
+                },
+            )
+
+    def save_related(self, request: HttpRequest, form: Any, formsets: Any, change: bool) -> None:
+        """
+        #1672: audita mudança de grupos (membership = privilégio) feita pelo Django
+        admin. Captura before/after e delega a `auditar_assign_groups` — mesma trilha
+        ASSIGN_GROUPS emitida pela API REST.
+        """
+        from apps.core.services.audit import auditar_assign_groups
+
+        obj: Usuario = form.instance
+        before_group_ids = set(obj.groups.values_list("pk", flat=True)) if obj.pk else set()
+        super().save_related(request, form, formsets, change)
+        after_group_ids = set(obj.groups.values_list("pk", flat=True))
+        auditar_assign_groups(
+            actor=request.user,
+            target_user=obj,
+            before_group_ids=before_group_ids,
+            after_group_ids=after_group_ids,
+        )
+
 
 class MunicipioAdmin(admin.ModelAdmin):
     list_display = ("nome", "uf", "ativo")
@@ -409,14 +463,25 @@ class PermissaoFuncionalAdmin(admin.ModelAdmin):
 
     def save_related(self, request: HttpRequest, form: Any, formsets: Any, change: bool) -> None:
         """
-        Após persistir os m2m (`groups`), emite o AuditLog consolidado por
-        operação Admin. O signal `m2m_changed` em `signals.py` já cuidou
-        do cache bust e acumulou os deltas; aqui flushamos uma vez.
-        """
-        from apps.core.signals import flush_group_capability_audit
+        Emite o AuditLog `GROUP_CAPABILITY_CHANGED` desta operação Admin (#1672).
 
+        Captura o snapshot dos grupos ANTES de persistir os m2m e compara com o
+        DEPOIS, delegando ao serviço transacional (emite em `on_commit`). O
+        signal `m2m_changed` já cuidou do cache bust. Substitui o antigo
+        buffer global + `flush_group_capability_audit`, que só persistia daqui.
+        """
+        from apps.core.services.audit import auditar_group_capability_change
+
+        capability = form.instance
+        before_group_ids = set(capability.groups.values_list("pk", flat=True)) if capability.pk else set()
         super().save_related(request, form, formsets, change)
-        flush_group_capability_audit(actor_user=request.user)
+        after_group_ids = set(capability.groups.values_list("pk", flat=True))
+        auditar_group_capability_change(
+            actor=request.user,
+            capability=capability,
+            before_group_ids=before_group_ids,
+            after_group_ids=after_group_ids,
+        )
 
 
 # Registro funcional (evita problemas de importação circular com decoradores)

--- a/v2/backend/apps/core/models/auditoria.py
+++ b/v2/backend/apps/core/models/auditoria.py
@@ -91,6 +91,18 @@ class AuditLog(models.Model):
         GROUP_CAPABILITY_CHANGED = "GROUP_CAPABILITY_CHANGED", "Capability de grupo alterada"
         UPDATE_CONFIG = "UPDATE_CONFIG", "Atualizar configuracao"
 
+        # Usuarios / privilegio (#1672) — mutacoes de privilegio fora do Admin
+        # tambem precisam de trilha. Emitidas pelo servico transacional
+        # `apps.core.services.audit`.
+        RESET_PASSWORD = "RESET_PASSWORD", "Redefinir senha de usuario"
+        USER_DELETE = "USER_DELETE", "Excluir usuario"
+        ASSIGN_GROUPS = "ASSIGN_GROUPS", "Atribuir grupos a usuario"
+        USER_IMPORT = "USER_IMPORT", "Importar usuarios"
+        USER_PRIVILEGE_CHANGED = (
+            "USER_PRIVILEGE_CHANGED",
+            "Alterar flags de privilegio (is_superuser/is_staff/is_active)",
+        )
+
     usuario = models.ForeignKey(  # type: ignore[misc]
         "core.Usuario",
         on_delete=models.SET_NULL,

--- a/v2/backend/apps/core/serializers/auditoria.py
+++ b/v2/backend/apps/core/serializers/auditoria.py
@@ -19,7 +19,9 @@ from apps.core.models import AuditLog
 
 # SEC-AUDIT-01: PII fields to redact for non-superuser access
 _PII_KEYS_TO_REMOVE = {"user_agent"}
-_PII_KEYS_TO_MASK = {"ip_address", "google_email"}
+# `target_username` pode ser um CPF (username=cpf no import de usuarios) — mascarar
+# para nao-superuser na trilha de privilegio (#1672).
+_PII_KEYS_TO_MASK = {"ip_address", "google_email", "target_username"}
 
 
 def _mask_ip(ip: str) -> str:

--- a/v2/backend/apps/core/serializers/usuario.py
+++ b/v2/backend/apps/core/serializers/usuario.py
@@ -5,7 +5,7 @@ Serializers para Usuario e Group.
 Type-checked with Pyright (strict mode).
 """
 
-# pyright: reportUnknownMemberType=false, reportUnknownVariableType=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false
+# pyright: reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportAttributeAccessIssue=false, reportUntypedBaseClass=false
 
 from __future__ import annotations
 
@@ -19,6 +19,11 @@ from rest_framework import serializers  # type: ignore[attr-defined]
 
 from apps.core.constants import FUNCAO_GROUPS, RESERVED_GROUPS, SETOR_GROUPS
 from apps.core.models import GroupClassificacao, PermissaoFuncional
+from apps.core.services.audit import (
+    auditar_assign_groups,
+    auditar_group_capabilities_set,
+    auditar_reset_senha,
+)
 from apps.core.services.rbac_service import get_assignable_group_names
 
 
@@ -247,16 +252,22 @@ class UsuarioAdminSerializer(serializers.ModelSerializer):
         actor: Any = getattr(request, "user", None)
         return bool(actor and getattr(actor, "is_superuser", False))
 
+    def _actor(self) -> Any:
+        return getattr(self.context.get("request"), "user", None)
+
     def create(self, validated_data: dict[str, Any]) -> Any:
         """Create user with hashed password and groups."""
         groups = validated_data.pop("groups", [])
         password = validated_data.pop("password", None)
 
         user = super().create(validated_data)
+        actor = self._actor()
 
         if password:
             user.set_password(password)
             user.save()
+            # #1672: senha definida por um admin para outro usuario -> trilha.
+            auditar_reset_senha(actor=actor, target_user=user, contexto="create")
 
         # P0-1 Tier-0 (D-1=2a): membership é superuser-only. group_ids de
         # não-superuser é ignorado (o frontend já não envia — aqui é a
@@ -264,6 +275,13 @@ class UsuarioAdminSerializer(serializers.ModelSerializer):
         # cargo do superuser.
         if groups and self._actor_is_superuser():
             user.groups.set(groups)
+            # #1672: atribuicao de grupos (privilegio) auditada.
+            auditar_assign_groups(
+                actor=actor,
+                target_user=user,
+                before_group_ids=[],
+                after_group_ids=list(user.groups.values_list("pk", flat=True)),
+            )
 
         return user
 
@@ -271,17 +289,28 @@ class UsuarioAdminSerializer(serializers.ModelSerializer):
         """Update user and hash password if provided."""
         groups = validated_data.pop("groups", None)
         password = validated_data.pop("password", None)
+        actor = self._actor()
+        before_group_ids = set(instance.groups.values_list("pk", flat=True))
 
         user = super().update(instance, validated_data)
 
         if password:
             user.set_password(password)
             user.save()
+            # #1672: senha redefinida por um admin para outro usuario -> trilha.
+            auditar_reset_senha(actor=actor, target_user=user, contexto="update")
 
         # P0-1 Tier-0 (D-1=2a): membership é superuser-only (ver create()).
         # group_ids de não-superuser é ignorado.
         if groups is not None and self._actor_is_superuser():
             user.groups.set(groups)
+            # #1672: mudanca de membership (privilegio) auditada.
+            auditar_assign_groups(
+                actor=actor,
+                target_user=user,
+                before_group_ids=before_group_ids,
+                after_group_ids=set(user.groups.values_list("pk", flat=True)),
+            )
 
         return user
 
@@ -418,6 +447,9 @@ class GroupSerializer(serializers.ModelSerializer):
                 )
         return value
 
+    def _actor(self) -> Any:
+        return getattr(self.context.get("request"), "user", None)
+
     def create(self, validated_data: dict[str, Any]) -> Group:
         group_type = validated_data.pop("group_type_input", None)
         permissoes_funcionais = validated_data.pop("permissoes_funcionais", [])
@@ -426,16 +458,32 @@ class GroupSerializer(serializers.ModelSerializer):
             GroupClassificacao.objects.update_or_create(group=instance, defaults={"tipo": group_type})
         if permissoes_funcionais:
             instance.permissoes_funcionais.set(permissoes_funcionais)
+            # #1672: mudanca Group x Capability via REST tambem e auditada — este
+            # e o path que antes perdia o registro por nao passar pelo Admin.
+            auditar_group_capabilities_set(
+                actor=self._actor(),
+                group=instance,
+                before_cap_ids=[],
+                after_cap_ids=[c.pk for c in permissoes_funcionais],
+            )
         return instance
 
     def update(self, instance: Group, validated_data: dict[str, Any]) -> Group:
         group_type = validated_data.pop("group_type_input", None)
         permissoes_funcionais = validated_data.pop("permissoes_funcionais", None)
+        before_cap_ids = set(instance.permissoes_funcionais.values_list("pk", flat=True))
         instance = super().update(instance, validated_data)
         if group_type:
             GroupClassificacao.objects.update_or_create(group=instance, defaults={"tipo": group_type})
         if permissoes_funcionais is not None:
             instance.permissoes_funcionais.set(permissoes_funcionais)
+            # #1672: idem — REST auditado (antes so o Admin persistia a trilha).
+            auditar_group_capabilities_set(
+                actor=self._actor(),
+                group=instance,
+                before_cap_ids=before_cap_ids,
+                after_cap_ids=set(instance.permissoes_funcionais.values_list("pk", flat=True)),
+            )
         return instance
 
 

--- a/v2/backend/apps/core/services/audit.py
+++ b/v2/backend/apps/core/services/audit.py
@@ -1,0 +1,285 @@
+# pyright: reportAttributeAccessIssue=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false
+
+"""
+Servico central de auditoria transacional (#1672).
+
+Ponto UNICO de emissao de `AuditLog`. Por padrao adia a gravacao para
+`transaction.on_commit`, de modo que a trilha reflita exatamente o que foi
+commitado — nada de trilha-fantasma se a transacao der rollback, e (o bug que
+motivou o issue) nada perdido quando a mudanca de privilegio NAO vem do Django
+Admin (shell, script, REST, import).
+
+Substitui o buffer global `_PENDING_GROUP_CAP_DELTAS` de `signals.py`, que so
+persistia quando o Admin chamava `flush_group_capability_audit`. Agora o
+before/after e o ator sao capturados no proprio call-site (mesmo modelo que
+`sync_members` ja usa) e emitidos aqui.
+
+Semantica de `on_commit`:
+- Fora de qualquer transacao (autocommit): o callback roda IMEDIATAMENTE.
+- Dentro de um `atomic()`: roda apos o commit do bloco mais externo. Se o bloco
+  der rollback, o AuditLog nao e criado.
+- Em teste `django_db` (transacao externa que sempre da rollback), use o fixture
+  `django_capture_on_commit_callbacks(execute=True)` do pytest-django para
+  executar os callbacks e observar os registros.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+from django.contrib.auth.models import Group
+from django.db import transaction
+
+from apps.core.models import AuditLog, PermissaoFuncional
+
+# Sentinela para distinguir "nao passei usuario_id" de "passei usuario_id=None".
+_UNSET: Any = object()
+
+
+def _actor_id(actor: Any) -> int | None:
+    """ID do ator, ou None para anonimo/sistema.
+
+    Aceita `Usuario`, `None` e `AnonymousUser`. Anonimo tem
+    `is_authenticated=False` -> None. Sistema (shell/script sem ator) passa
+    `actor=None` -> None.
+    """
+    if actor is None:
+        return None
+    if not getattr(actor, "is_authenticated", False):
+        return None
+    return getattr(actor, "id", None)
+
+
+def _group_names(ids: Iterable[int]) -> list[str]:
+    """Nomes de grupos (ordenados) a partir de um iteravel de pks."""
+    id_list = list(ids)
+    if not id_list:
+        return []
+    return list(Group.objects.filter(pk__in=id_list).order_by("name").values_list("name", flat=True))
+
+
+def registrar_auditoria(
+    *,
+    actor: Any,
+    action: str,
+    model_name: str | None = None,
+    details: dict[str, Any] | None = None,
+    imediato: bool = False,
+    usuario_id: Any = _UNSET,
+) -> None:
+    """Emite um `AuditLog` de forma transacional.
+
+    Por padrao (`imediato=False`) adia a criacao para `transaction.on_commit`.
+    Passe `imediato=True` para criar sincronicamente (ex.: fora de transacao,
+    quando se quer garantir o insert na hora).
+
+    `details` e materializado por valor (copia rasa) no momento da chamada: o
+    call-site deve montar o snapshot before/after ANTES de chamar. O insert em
+    si e a unica parte adiada.
+
+    `usuario_id` (FK do ator) e derivado de `actor` por padrao. Passe explicito
+    quando o ator pode nao existir no momento do commit — ex.: auto-exclusao de
+    usuario, onde a FK precisa ser None mesmo com o ator preservado em `details`.
+    """
+    resolved_id = _actor_id(actor) if usuario_id is _UNSET else usuario_id
+    payload = {
+        "usuario_id": resolved_id,
+        "action": action,
+        "model_name": model_name,
+        "details": dict(details or {}),
+    }
+
+    def _emit() -> None:
+        AuditLog.objects.create(**payload)
+
+    if imediato:
+        _emit()
+    else:
+        transaction.on_commit(_emit)
+
+
+def auditar_group_capability_change(
+    *,
+    actor: Any,
+    capability: PermissaoFuncional,
+    before_group_ids: Iterable[int],
+    after_group_ids: Iterable[int],
+    imediato: bool = False,
+) -> bool:
+    """Auditoria de mudanca nos GRUPOS de UMA capability.
+
+    Path `perm.groups.set(...)` (Django Admin `filter_horizontal`, shell). O
+    call-site captura o snapshot dos group_ids ANTES e DEPOIS; aqui comparamos
+    e emitimos UM `GROUP_CAPABILITY_CHANGED` se houve delta liquido.
+
+    Mantem o contrato de `details` legado (actor_user_id, capability_id,
+    capability_codename, added_groups, removed_groups, groups_after) consumido
+    por `test_pr16` e pelo serializer de auditoria.
+
+    Retorna True se registrou, False se no-op (sem delta).
+    """
+    before = set(before_group_ids)
+    after = set(after_group_ids)
+    added = after - before
+    removed = before - after
+    if not added and not removed:
+        return False
+
+    registrar_auditoria(
+        actor=actor,
+        action=AuditLog.Action.GROUP_CAPABILITY_CHANGED,
+        model_name="PermissaoFuncional",
+        details={
+            "actor_user_id": _actor_id(actor),
+            "capability_id": capability.pk,
+            "capability_codename": capability.codename,
+            "added_groups": _group_names(added),
+            "removed_groups": _group_names(removed),
+            "groups_after": _group_names(after),
+        },
+        imediato=imediato,
+    )
+    return True
+
+
+def auditar_group_capabilities_set(
+    *,
+    actor: Any,
+    group: Group,
+    before_cap_ids: Iterable[int],
+    after_cap_ids: Iterable[int],
+    imediato: bool = False,
+) -> int:
+    """Auditoria quando o SET de capabilities de UM grupo muda (REST).
+
+    Path `group.permissoes_funcionais.set(...)` (GroupSerializer create/update).
+    Este e' o caminho que hoje PERDE o registro: o buffer acumulava mas ninguem
+    fazia flush fora do Admin. Emite um `GROUP_CAPABILITY_CHANGED` por capability
+    afetada, mantendo o contrato per-capability do path do Admin.
+
+    Deve ser chamado APOS o `.set()` (usa o estado atual de `cap.groups` para
+    `groups_after`). Retorna o numero de capabilities auditadas.
+    """
+    before = set(before_cap_ids)
+    after = set(after_cap_ids)
+    added_caps = after - before
+    removed_caps = before - after
+    affected = added_caps | removed_caps
+    if not affected:
+        return 0
+
+    count = 0
+    for cap in PermissaoFuncional.objects.filter(pk__in=affected):
+        gained = cap.pk in added_caps
+        registrar_auditoria(
+            actor=actor,
+            action=AuditLog.Action.GROUP_CAPABILITY_CHANGED,
+            model_name="PermissaoFuncional",
+            details={
+                "actor_user_id": _actor_id(actor),
+                "capability_id": cap.pk,
+                "capability_codename": cap.codename,
+                "added_groups": [group.name] if gained else [],
+                "removed_groups": [] if gained else [group.name],
+                "groups_after": _group_names(cap.groups.values_list("pk", flat=True)),
+                "via": "group_serializer",
+            },
+            imediato=imediato,
+        )
+        count += 1
+    return count
+
+
+def auditar_assign_groups(
+    *,
+    actor: Any,
+    target_user: Any,
+    before_group_ids: Iterable[int],
+    after_group_ids: Iterable[int],
+    imediato: bool = False,
+) -> bool:
+    """Auditoria de mudanca de MEMBERSHIP de um usuario (`user.groups.set`).
+
+    Path `assign_groups` (view) e UsuarioAdminSerializer.create/update. Compara
+    before/after e emite `ASSIGN_GROUPS` se houve delta liquido. Retorna True se
+    registrou, False se no-op.
+    """
+    before = set(before_group_ids)
+    after = set(after_group_ids)
+    added = after - before
+    removed = before - after
+    if not added and not removed:
+        return False
+
+    registrar_auditoria(
+        actor=actor,
+        action=AuditLog.Action.ASSIGN_GROUPS,
+        model_name="Usuario",
+        details={
+            "actor_user_id": _actor_id(actor),
+            "target_user_id": target_user.pk,
+            "target_username": getattr(target_user, "username", None),
+            "added_groups": _group_names(added),
+            "removed_groups": _group_names(removed),
+            "groups_after": _group_names(after),
+        },
+        imediato=imediato,
+    )
+    return True
+
+
+def auditar_reset_senha(
+    *,
+    actor: Any,
+    target_user: Any,
+    contexto: str = "update",
+    imediato: bool = False,
+) -> None:
+    """Auditoria de senha definida/redefinida por um ADMIN para OUTRO usuario.
+
+    A troca self-service (`/api/me/change-password/`) ja audita `CHANGE_PASSWORD`
+    no proprio endpoint — aqui e o caso do #1672: admin/DAT define a senha de um
+    terceiro (serializer create/update). NUNCA inclui a senha nos `details`.
+    """
+    registrar_auditoria(
+        actor=actor,
+        action=AuditLog.Action.RESET_PASSWORD,
+        model_name="Usuario",
+        details={
+            "actor_user_id": _actor_id(actor),
+            "target_user_id": target_user.pk,
+            "target_username": getattr(target_user, "username", None),
+            "contexto": contexto,
+        },
+        imediato=imediato,
+    )
+
+
+def auditar_user_delete(
+    *,
+    actor: Any,
+    target_user: Any,
+    imediato: bool = False,
+) -> None:
+    """Auditoria de exclusao de usuario.
+
+    Deve ser chamado ANTES de `target_user.delete()` (le pk/username enquanto
+    existem — os `details` sao materializados na hora da chamada). Auto-exclusao
+    e tratada aqui: a FK (`usuario_id`) vira None para nao referenciar a linha
+    que sera removida, mas o `actor_user_id` fica preservado em `details`.
+    """
+    actor_id = _actor_id(actor)
+    self_delete = actor_id is not None and actor_id == target_user.pk
+    registrar_auditoria(
+        actor=actor,
+        usuario_id=None if self_delete else _UNSET,
+        action=AuditLog.Action.USER_DELETE,
+        model_name="Usuario",
+        details={
+            "actor_user_id": actor_id,
+            "target_user_id": target_user.pk,
+            "target_username": getattr(target_user, "username", None),
+            "target_is_superuser": bool(getattr(target_user, "is_superuser", False)),
+        },
+        imediato=imediato,
+    )

--- a/v2/backend/apps/core/services/usuarios_import.py
+++ b/v2/backend/apps/core/services/usuarios_import.py
@@ -35,7 +35,8 @@ import pandas as pd
 
 from apps.core.imports.normalization import normalize_active_flag, normalize_blank, normalize_cpf_digits
 from apps.core.imports.row_errors import registrar_erro_import
-from apps.core.models import Usuario
+from apps.core.models import AuditLog, Usuario
+from apps.core.services.audit import registrar_auditoria
 from apps.core.validators import CPF_ABSENT, CPF_VALID, classify_cpf
 
 
@@ -102,6 +103,24 @@ def import_usuarios_from_file(*, path: str, dry_run: bool = True, actor: Any = N
 
         if dry_run:
             transaction.set_rollback(True)
+        else:
+            # #1672: import real (apply) deixa trilha de auditoria. Registrado
+            # dentro do outer atomic com on_commit -> so grava se o apply
+            # commitar; o rollback do dry_run descarta o callback naturalmente.
+            registrar_auditoria(
+                actor=actor,
+                action=AuditLog.Action.USER_IMPORT,
+                model_name="Usuario",
+                details={
+                    "file": path,
+                    "created": stats["created"],
+                    "updated": stats["updated"],
+                    "unchanged": stats["unchanged"],
+                    "grupos_ignorados": stats["grupos_ignorados"],
+                    "grupos_desconhecidos": stats["grupos_desconhecidos"],
+                    "skipped": dict(stats["skipped"]),
+                },
+            )
 
     return {
         "stats": stats,

--- a/v2/backend/apps/core/signals.py
+++ b/v2/backend/apps/core/signals.py
@@ -23,7 +23,6 @@ from django.db.models.signals import m2m_changed, post_delete, post_save
 from django.dispatch import receiver
 
 from apps.core.models import (
-    AuditLog,
     AvailabilityBlock,
     Config,
     Municipio,
@@ -38,13 +37,6 @@ from apps.core.services.rbac_permissions import (
     invalidate_group_functional_permissions_cache,
 )
 from apps.core.utils.cache_utils import invalidate_availability_cache, invalidate_static_cache
-
-# PR 16 hardening RBAC (2026-05-04): consolidação por operação Admin.
-# m2m_changed dispara `pre_*` e `post_*` para `add`/`remove`/`clear`.
-# Acumulamos os deltas durante uma operação (request thread-local) e
-# emitimos UM AuditLog ao final. Para signals fora de Admin (ex: shell ou
-# fixture), o consolidador ainda funciona: cada chamada gera 1 entry.
-_PENDING_GROUP_CAP_DELTAS: dict[int, dict[str, list[str]]] = {}
 
 
 @receiver(post_save, sender=Config)
@@ -179,23 +171,24 @@ def _invalidate_cache_on_tipo_evento_change(
 
 
 # ================================================================
-# PR 16 hardening RBAC (2026-05-04): Group × Capability changes
+# Group × Capability changes — cache bust (auditoria movida p/ #1672)
 # ================================================================
 #
-# Decisão D17: pós-PR 16, atribuição Group × Capability é admin-driven.
-# Toda mudança em `PermissaoFuncional.groups` (Admin, ETL interno, shell)
+# Decisão D17: atribuição Group × Capability é admin-driven e AUDITADA.
+# Toda mudança em `PermissaoFuncional.groups` (Admin, REST, shell, import)
 # precisa: (1) invalidar o cache funcional dos usuários afetados;
-# (2) registrar AuditLog `GROUP_CAPABILITY_CHANGED` consolidado.
+# (2) registrar AuditLog `GROUP_CAPABILITY_CHANGED`.
 #
-# Consolidação: m2m_changed dispara seis vezes por operação (`pre_*` /
-# `post_*` × `add`/`remove`/`clear`). Para emitir um único AuditLog por
-# operação Admin, acumulamos os group_ids adicionados/removidos em
-# `_PENDING_GROUP_CAP_DELTAS[capability_id]` durante os `post_*`, e o
-# consumidor (Admin `save_related` ou helper de teste) finaliza com
-# `flush_group_capability_audit(actor_user)`.
+# (2) NÃO é mais feito aqui. Um signal não tem acesso ao ator nem ao escopo
+# transacional do request — foi por isso que existia o buffer global
+# `_PENDING_GROUP_CAP_DELTAS`, que só persistia quando o Admin chamava
+# `flush_group_capability_audit`; qualquer outro caminho (REST/shell/import)
+# perdia o registro em silêncio (#1672). A auditoria passou para o serviço
+# transacional `apps.core.services.audit`, chamado no call-site com
+# before/after e ator explícitos.
 #
-# Cache bust roda a cada `post_*` — invalidação é cheap e não pode
-# atrasar (impacta `/api/me/policies/` em outros requests).
+# Aqui fica só o cache bust — barato, imediato e independente de ator
+# (impacta `/api/me/policies/` em outros requests).
 
 
 @receiver(m2m_changed, sender=PermissaoFuncional.groups.through)
@@ -208,123 +201,23 @@ def _on_permissao_funcional_groups_changed(  # pyright: ignore[reportUnusedFunct
     **kwargs: Any,
 ) -> None:
     """
-    Invalida cache funcional dos grupos afetados e acumula deltas para
-    o AuditLog consolidado.
+    Invalida o cache funcional dos grupos afetados quando
+    `PermissaoFuncional.groups` muda.
 
-    Django Admin (filter_horizontal) usa `clear() + add()` para set —
-    capturamos `pre_clear` para saber os pks ANTES de remoção, depois
-    `post_add` para os novos. Diferenciamos `pre_clear` (snapshot) de
-    `post_remove` (delta) para não duplicar contagens.
-
-    Reverse mode (`group.permissoes_funcionais.add(perm)`): `instance`
-    é o `Group`, `pk_set` contém ids de `PermissaoFuncional`. Cobrimos
-    ambos os sentidos para robustez.
+    Reverse mode (`group.permissoes_funcionais.{add,remove,clear}`): instance
+    é o `Group` — o grupo afetado é ele mesmo. Forward (`perm.groups.{...}`):
+    instance é a `PermissaoFuncional` e os grupos afetados vêm de `pk_set`
+    (ou snapshot dos atuais em `pre_clear`, antes da remoção).
     """
     if action not in {"pre_clear", "post_add", "post_remove"}:
         return
 
     if reverse:
-        # `group.permissoes_funcionais.{add,remove,clear}(...)` — instance=Group.
-        affected_perm_ids: set[int]
-        affected_group_ids: set[int]
-        if action == "pre_clear":
-            # Snapshot dos perms vinculados antes do clear.
-            affected_perm_ids = set(instance.permissoes_funcionais.values_list("pk", flat=True))
-            affected_group_ids = {int(instance.pk)}
-        else:
-            affected_perm_ids = set(pk_set or set())
-            affected_group_ids = {int(instance.pk)}
+        affected_group_ids = {int(instance.pk)}
+    elif action == "pre_clear":
+        affected_group_ids = set(instance.groups.values_list("pk", flat=True))
     else:
-        # `perm.groups.{add,remove,clear}(...)` — instance=PermissaoFuncional.
-        if action == "pre_clear":
-            # Snapshot dos grupos antes do clear.
-            affected_group_ids = set(instance.groups.values_list("pk", flat=True))
-        else:
-            affected_group_ids = set(pk_set or set())
-        affected_perm_ids = {int(instance.pk)}
+        affected_group_ids = set(pk_set or set())
 
-    # Cache bust: invalida os usuários dos grupos afetados imediatamente.
-    # Para `pre_clear`, os usuários ainda têm a relação no DB — invalidação
-    # cobre o flush iminente. Em `post_add`, cobre os recém-adicionados.
     if affected_group_ids:
         invalidate_group_functional_permissions_cache(affected_group_ids)
-
-    # Acumula delta por capability — finalizado por flush_group_capability_audit.
-    for perm_id in affected_perm_ids:
-        slot = _PENDING_GROUP_CAP_DELTAS.setdefault(perm_id, {"added_groups": [], "removed_groups": []})
-        if action == "post_add":
-            for gid in affected_group_ids:
-                if gid not in slot["added_groups"]:
-                    slot["added_groups"].append(gid)
-        elif action in {"post_remove", "pre_clear"}:
-            # Tanto `clear()` quanto `remove()` removem ids — registramos
-            # uma vez só. `pre_clear` snapshot já cobriu todos os atuais.
-            for gid in affected_group_ids:
-                if gid not in slot["removed_groups"]:
-                    slot["removed_groups"].append(gid)
-
-
-def flush_group_capability_audit(actor_user: Any) -> list[int]:
-    """
-    Emite AuditLog consolidado por capability afetada na operação corrente.
-
-    Chamado pelo `PermissaoFuncionalAdmin.save_related` (1 entry/capability
-    por operação Admin) e por testes que querem validar o registro.
-    Limpa o buffer em `_PENDING_GROUP_CAP_DELTAS` ao final.
-
-    Retorna a lista de IDs de AuditLog criados (testes asseram contra
-    isso). Em operações sem deltas (ex: salvar sem mudar groups),
-    retorna lista vazia.
-    """
-    from django.contrib.auth.models import Group
-
-    created_ids: list[int] = []
-    if not _PENDING_GROUP_CAP_DELTAS:
-        return created_ids
-
-    # Snapshot dos deltas e clear imediato para evitar dupla emissão.
-    pending = dict(_PENDING_GROUP_CAP_DELTAS)
-    _PENDING_GROUP_CAP_DELTAS.clear()
-
-    actor_id = getattr(actor_user, "id", None) if actor_user else None
-
-    for perm_id, delta in pending.items():
-        added_ids = list(delta.get("added_groups", []) or [])
-        removed_ids = list(delta.get("removed_groups", []) or [])
-
-        # Django Admin (filter_horizontal) executa `clear() + add()` mesmo
-        # quando o set final é igual ao inicial. O delta net (entradas que
-        # mudaram de fato) é (added \ removed) e (removed \ added).
-        net_added = [gid for gid in added_ids if gid not in removed_ids]
-        net_removed = [gid for gid in removed_ids if gid not in added_ids]
-
-        if not net_added and not net_removed:
-            continue
-
-        try:
-            perm = PermissaoFuncional.objects.get(pk=perm_id)
-        except PermissaoFuncional.DoesNotExist:
-            continue
-
-        added_names = list(Group.objects.filter(pk__in=net_added).order_by("name").values_list("name", flat=True))
-        removed_names = list(Group.objects.filter(pk__in=net_removed).order_by("name").values_list("name", flat=True))
-
-        # Snapshot final dos grupos atribuídos (após mudança).
-        after_names = list(perm.groups.order_by("name").values_list("name", flat=True))
-
-        log = AuditLog.objects.create(
-            usuario_id=actor_id,
-            action=AuditLog.Action.GROUP_CAPABILITY_CHANGED,
-            model_name="PermissaoFuncional",
-            details={
-                "actor_user_id": actor_id,
-                "capability_id": perm_id,
-                "capability_codename": perm.codename,
-                "added_groups": added_names,
-                "removed_groups": removed_names,
-                "groups_after": after_names,
-            },
-        )
-        created_ids.append(int(log.pk))
-
-    return created_ids

--- a/v2/backend/apps/core/tests/test_audit_privilege_sites.py
+++ b/v2/backend/apps/core/tests/test_audit_privilege_sites.py
@@ -1,0 +1,306 @@
+"""
+Integração dos pontos de mutação de privilégio com o serviço de auditoria (#1672).
+
+Prova que cada endpoint/serviço REALMENTE emite a trilha — não só o helper.
+Como a auditoria é emitida em `transaction.on_commit`, cada chamada mutante roda
+dentro de `django_capture_on_commit_callbacks(execute=True)`.
+
+Cobre os caminhos que ANTES perdiam o registro por não passar pelo Django Admin:
+- Group × Capability via REST (GroupSerializer create/update) — o bug do issue.
+- `assign_groups` (membership).
+- Reset de senha de outro usuário (admin).
+- Exclusão de usuário e de grupo.
+- Import de usuários (apply audita; dry-run não).
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportMissingTypeArgument=false, reportCallIssue=false, reportIndexIssue=false, reportOptionalMemberAccess=false
+
+from __future__ import annotations
+
+import itertools
+from unittest import mock
+
+from django.contrib.auth.models import Group
+from django.core.cache import cache
+from django.test import RequestFactory
+from rest_framework.test import APIClient
+
+import pytest
+
+from apps.core.admin import UsuarioAdmin, admin_site
+from apps.core.models import AuditLog, PermissaoFuncional, Usuario
+from apps.core.services.functional_permissions_seed import seed_functional_permissions
+from apps.core.services.usuarios_import import import_usuarios_from_file
+from apps.core.tests.factories import GroupFactory, UsuarioFactory
+
+pytestmark = pytest.mark.django_db
+
+_CPF = itertools.count(75000000000)
+
+
+def _mk(label: str, **kwargs) -> Usuario:
+    cpf = str(next(_CPF)).zfill(11)
+    return UsuarioFactory(username=f"{label}_{cpf}", email=f"{label}_{cpf}@t.com", cpf=cpf, **kwargs)
+
+
+@pytest.fixture
+def api_client() -> APIClient:
+    return APIClient()
+
+
+@pytest.fixture
+def superuser() -> Usuario:
+    return _mk("su", is_superuser=True, is_staff=True)
+
+
+@pytest.fixture
+def common_user() -> Usuario:
+    return _mk("common")
+
+
+@pytest.fixture
+def caps() -> list[PermissaoFuncional]:
+    seed_functional_permissions(assign_default_groups=False)
+    return list(PermissaoFuncional.objects.order_by("codename")[:2])
+
+
+# ============================================================================
+# Group × Capability via REST (o path do bug — antes só o Admin persistia)
+# ============================================================================
+
+
+class TestGroupCapabilityViaREST:
+    def test_create_group_com_caps_audita(self, api_client, superuser, caps, django_capture_on_commit_callbacks):
+        AuditLog.objects.filter(action="GROUP_CAPABILITY_CHANGED").delete()
+        api_client.force_authenticate(user=superuser)
+        with django_capture_on_commit_callbacks(execute=True):
+            resp = api_client.post(
+                "/api/grupos/",
+                {"name": "GrupoAudit", "permissao_funcional_ids": [caps[0].id]},
+                format="json",
+            )
+        assert resp.status_code == 201, resp.content
+        logs = AuditLog.objects.filter(action="GROUP_CAPABILITY_CHANGED")
+        assert logs.count() == 1
+        d = logs.first().details
+        assert d["via"] == "group_serializer"
+        assert d["capability_id"] == caps[0].id
+        assert d["added_groups"] == ["GrupoAudit"]
+        assert d["removed_groups"] == []
+
+    def test_update_group_caps_audita_uma_por_cap(
+        self, api_client, superuser, caps, django_capture_on_commit_callbacks
+    ):
+        group = GroupFactory(name="GrupoUpd")
+        api_client.force_authenticate(user=superuser)
+        AuditLog.objects.filter(action="GROUP_CAPABILITY_CHANGED").delete()
+        with django_capture_on_commit_callbacks(execute=True):
+            resp = api_client.patch(
+                f"/api/grupos/{group.id}/",
+                {"permissao_funcional_ids": [caps[0].id, caps[1].id]},
+                format="json",
+            )
+        assert resp.status_code == 200, resp.content
+        assert AuditLog.objects.filter(action="GROUP_CAPABILITY_CHANGED").count() == 2
+
+
+# ============================================================================
+# assign_groups (membership)
+# ============================================================================
+
+
+class TestAssignGroups:
+    def test_assign_groups_audita(self, api_client, superuser, common_user, caps, django_capture_on_commit_callbacks):
+        group = GroupFactory(name="GrupoAtrib")
+        # Vincular capability torna o grupo "atribuível" (whitelist dinâmica).
+        group.permissoes_funcionais.add(caps[0])
+        cache.clear()
+        api_client.force_authenticate(user=superuser)
+        AuditLog.objects.filter(action="ASSIGN_GROUPS").delete()
+        with django_capture_on_commit_callbacks(execute=True):
+            resp = api_client.post(
+                f"/api/usuarios-admin/{common_user.id}/assign_groups/",
+                {"group_ids": [group.id]},
+                format="json",
+            )
+        assert resp.status_code == 200, resp.content
+        log = AuditLog.objects.filter(action="ASSIGN_GROUPS").latest("created_at")
+        assert log.usuario_id == superuser.id
+        assert log.details["target_user_id"] == common_user.id
+        assert log.details["added_groups"] == ["GrupoAtrib"]
+
+
+# ============================================================================
+# Reset de senha (admin -> outro usuário)
+# ============================================================================
+
+
+class TestResetPassword:
+    def test_patch_senha_de_outro_audita(self, api_client, superuser, common_user, django_capture_on_commit_callbacks):
+        api_client.force_authenticate(user=superuser)
+        AuditLog.objects.filter(action="RESET_PASSWORD").delete()
+        with django_capture_on_commit_callbacks(execute=True):
+            resp = api_client.patch(
+                f"/api/usuarios-admin/{common_user.id}/",
+                {"password": "NovaSenhaForte123"},  # gitleaks:allow (literal de teste, nao e segredo)
+                format="json",
+            )
+        assert resp.status_code == 200, resp.content
+        log = AuditLog.objects.filter(action="RESET_PASSWORD").latest("created_at")
+        assert log.usuario_id == superuser.id
+        assert log.details["target_user_id"] == common_user.id
+        assert log.details["contexto"] == "update"
+        # Contrato de segurança: a senha nunca aparece na trilha.
+        assert "NovaSenhaForte123" not in str(log.details)
+
+
+# ============================================================================
+# Exclusão de usuário e de grupo
+# ============================================================================
+
+
+class TestDeletions:
+    def test_delete_usuario_audita(self, api_client, superuser, common_user, django_capture_on_commit_callbacks):
+        uid = common_user.id
+        api_client.force_authenticate(user=superuser)
+        AuditLog.objects.filter(action="USER_DELETE").delete()
+        with django_capture_on_commit_callbacks(execute=True):
+            resp = api_client.delete(f"/api/usuarios-admin/{uid}/")
+        assert resp.status_code == 204, resp.content
+        assert not Usuario.objects.filter(id=uid).exists()
+        log = AuditLog.objects.filter(action="USER_DELETE").latest("created_at")
+        assert log.usuario_id == superuser.id
+        assert log.details["target_user_id"] == uid
+
+    def test_delete_grupo_audita_com_capabilities(
+        self, api_client, superuser, caps, django_capture_on_commit_callbacks
+    ):
+        group = GroupFactory(name="GrupoDel")
+        group.permissoes_funcionais.add(caps[0])
+        gid = group.id
+        api_client.force_authenticate(user=superuser)
+        AuditLog.objects.filter(action="DELETE", model_name="Group").delete()
+        with django_capture_on_commit_callbacks(execute=True):
+            resp = api_client.delete(f"/api/grupos/{gid}/")
+        assert resp.status_code == 204, resp.content
+        log = AuditLog.objects.filter(action="DELETE", model_name="Group").latest("created_at")
+        assert log.details["group_id"] == gid
+        assert caps[0].codename in log.details["capabilities"]
+
+    def test_delete_usuario_falho_nao_deixa_trilha_fantasma(
+        self, superuser, common_user, django_capture_on_commit_callbacks
+    ):
+        # Regressão #1672 (achado adversarial P1): audit + delete no mesmo atomic.
+        # Se o delete falha (ex.: ProtectedError), o on_commit é descartado no
+        # rollback -> NENHUM USER_DELETE gravado (sem trilha de exclusão fantasma).
+        uid = common_user.id
+        client = APIClient(raise_request_exception=False)
+        client.force_authenticate(user=superuser)
+        AuditLog.objects.filter(action="USER_DELETE").delete()
+        with mock.patch.object(Usuario, "delete", side_effect=RuntimeError("PROTECT")):
+            with django_capture_on_commit_callbacks(execute=True):
+                resp = client.delete(f"/api/usuarios-admin/{uid}/")
+        assert resp.status_code == 500
+        assert Usuario.objects.filter(id=uid).exists()  # não removido
+        assert not AuditLog.objects.filter(action="USER_DELETE").exists()  # sem fantasma
+
+    def test_delete_grupo_falho_nao_deixa_trilha_fantasma(self, superuser, caps, django_capture_on_commit_callbacks):
+        group = GroupFactory(name="GrupoProt")
+        group.permissoes_funcionais.add(caps[0])
+        gid = group.id
+        client = APIClient(raise_request_exception=False)
+        client.force_authenticate(user=superuser)
+        AuditLog.objects.filter(action="DELETE", model_name="Group").delete()
+        with mock.patch.object(Group, "delete", side_effect=RuntimeError("PROTECT")):
+            with django_capture_on_commit_callbacks(execute=True):
+                resp = client.delete(f"/api/grupos/{gid}/")
+        assert resp.status_code == 500
+        assert Group.objects.filter(id=gid).exists()
+        assert not AuditLog.objects.filter(action="DELETE", model_name="Group").exists()
+
+
+# ============================================================================
+# Import de usuários (apply audita; dry-run não)
+# ============================================================================
+
+
+class TestImportAudit:
+    def _csv(self, tmp_path, name: str) -> str:
+        p = tmp_path / name
+        p.write_text("cpf,nome\n11144477735,Fulano De Tal\n", encoding="utf-8")
+        return str(p)
+
+    def test_apply_audita_user_import(self, tmp_path, superuser, django_capture_on_commit_callbacks):
+        path = self._csv(tmp_path, "u.csv")
+        AuditLog.objects.filter(action="USER_IMPORT").delete()
+        with django_capture_on_commit_callbacks(execute=True):
+            result = import_usuarios_from_file(path=path, dry_run=False, actor=superuser)
+        assert result["dry_run"] is False
+        log = AuditLog.objects.filter(action="USER_IMPORT").latest("created_at")
+        assert log.usuario_id == superuser.id
+        assert log.details["created"] >= 1
+        assert log.details["file"].endswith("u.csv")
+
+    def test_dry_run_nao_audita(self, tmp_path, superuser, django_capture_on_commit_callbacks):
+        path = self._csv(tmp_path, "u2.csv")
+        AuditLog.objects.filter(action="USER_IMPORT").delete()
+        with django_capture_on_commit_callbacks(execute=True):
+            import_usuarios_from_file(path=path, dry_run=True, actor=superuser)
+        assert not AuditLog.objects.filter(action="USER_IMPORT").exists()
+
+
+# ============================================================================
+# Django admin UsuarioAdmin (achado adversarial P1: mudar grupos/flags de
+# privilégio pelo admin web não deixava trilha)
+# ============================================================================
+
+
+class TestUsuarioAdminAudit:
+    def _admin(self) -> UsuarioAdmin:
+        return UsuarioAdmin(Usuario, admin_site)
+
+    def _request(self, actor: Usuario):
+        req = RequestFactory().post("/admin/core/usuario/")
+        req.user = actor
+        return req
+
+    def test_save_model_audita_concessao_de_superuser(self, superuser, common_user, django_capture_on_commit_callbacks):
+        AuditLog.objects.filter(action="USER_PRIVILEGE_CHANGED").delete()
+        admin_obj = self._admin()
+        req = self._request(superuser)
+        common_user.is_superuser = True  # concessão de superuser via admin
+        with django_capture_on_commit_callbacks(execute=True):
+            admin_obj.save_model(req, common_user, form=None, change=True)
+        log = AuditLog.objects.filter(action="USER_PRIVILEGE_CHANGED").latest("created_at")
+        assert log.usuario_id == superuser.id
+        assert log.details["target_user_id"] == common_user.id
+        assert log.details["changes"]["is_superuser"] == {"before": False, "after": True}
+        assert log.details["via"] == "django_admin"
+
+    def test_save_model_sem_flip_de_flag_nao_audita(self, superuser, common_user, django_capture_on_commit_callbacks):
+        AuditLog.objects.filter(action="USER_PRIVILEGE_CHANGED").delete()
+        admin_obj = self._admin()
+        req = self._request(superuser)
+        # Re-salva sem mudar flag -> sem trilha.
+        with django_capture_on_commit_callbacks(execute=True):
+            admin_obj.save_model(req, common_user, form=None, change=True)
+        assert not AuditLog.objects.filter(action="USER_PRIVILEGE_CHANGED").exists()
+
+    def test_save_related_audita_grupos(self, superuser, common_user, django_capture_on_commit_callbacks):
+        group = GroupFactory(name="DAT")
+        AuditLog.objects.filter(action="ASSIGN_GROUPS").delete()
+        admin_obj = self._admin()
+        req = self._request(superuser)
+
+        class _FakeForm:
+            instance = common_user
+
+            def save_m2m(self):
+                common_user.groups.set([group])
+
+        with django_capture_on_commit_callbacks(execute=True):
+            admin_obj.save_related(req, _FakeForm(), [], change=True)
+        log = AuditLog.objects.filter(action="ASSIGN_GROUPS").latest("created_at")
+        assert log.usuario_id == superuser.id
+        assert log.details["target_user_id"] == common_user.id
+        assert log.details["added_groups"] == ["DAT"]

--- a/v2/backend/apps/core/tests/test_audit_service.py
+++ b/v2/backend/apps/core/tests/test_audit_service.py
@@ -1,0 +1,295 @@
+"""
+Servico central de auditoria transacional — `apps.core.services.audit` (#1672).
+
+Cobre:
+- `registrar_auditoria`: adia p/ on_commit por padrao; `imediato=True` cria na hora.
+- `_actor_id`: None / AnonymousUser -> None; usuario real -> id.
+- `auditar_group_capability_change`: contrato de details + no-op sem delta.
+- `auditar_group_capabilities_set`: emite 1 entry por capability afetada (path REST).
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportMissingTypeArgument=false, reportCallIssue=false, reportIndexIssue=false
+
+from __future__ import annotations
+
+import itertools
+
+from django.contrib.auth.models import AnonymousUser, Group
+
+import pytest
+
+from apps.core.models import AuditLog, PermissaoFuncional
+from apps.core.services.audit import (
+    _actor_id,
+    auditar_assign_groups,
+    auditar_group_capabilities_set,
+    auditar_group_capability_change,
+    auditar_reset_senha,
+    auditar_user_delete,
+    registrar_auditoria,
+)
+from apps.core.services.functional_permissions_seed import seed_functional_permissions
+from apps.core.tests.factories import GroupFactory, UsuarioFactory
+
+pytestmark = pytest.mark.django_db
+
+_CPF_COUNTER = itertools.count(74000000000)
+
+
+def _make_user(label: str = "u"):
+    cpf = str(next(_CPF_COUNTER)).zfill(11)
+    return UsuarioFactory(username=f"{label}_{cpf}", email=f"{label}_{cpf}@t.com", cpf=cpf)
+
+
+@pytest.fixture
+def group_dat() -> Group:
+    return GroupFactory(name="DAT")
+
+
+@pytest.fixture
+def capability() -> PermissaoFuncional:
+    seed_functional_permissions(assign_default_groups=False)
+    AuditLog.objects.filter(action="GROUP_CAPABILITY_CHANGED").delete()
+    return PermissaoFuncional.objects.get(codename="view_compras_dashboard")
+
+
+# ============================================================================
+# registrar_auditoria — semantica on_commit
+# ============================================================================
+
+
+class TestRegistrarAuditoria:
+    def test_adia_ate_commit(self, django_capture_on_commit_callbacks):
+        with django_capture_on_commit_callbacks(execute=False) as callbacks:
+            registrar_auditoria(actor=None, action="TEST_DEFERRED", details={"x": 1})
+            # Ainda nao criou — insert adiado p/ on_commit.
+            assert not AuditLog.objects.filter(action="TEST_DEFERRED").exists()
+        assert len(callbacks) == 1
+        # execute=False -> callback nao rodou; nada gravado.
+        assert not AuditLog.objects.filter(action="TEST_DEFERRED").exists()
+
+    def test_cria_no_commit(self, django_capture_on_commit_callbacks):
+        with django_capture_on_commit_callbacks(execute=True):
+            registrar_auditoria(actor=None, action="TEST_COMMITTED", details={"x": 1})
+        assert AuditLog.objects.filter(action="TEST_COMMITTED").count() == 1
+
+    def test_imediato_cria_na_hora(self):
+        registrar_auditoria(actor=None, action="TEST_IMMEDIATE", imediato=True)
+        assert AuditLog.objects.filter(action="TEST_IMMEDIATE").count() == 1
+
+    def test_details_copiado_por_valor(self):
+        d = {"a": 1}
+        registrar_auditoria(actor=None, action="TEST_COPY", details=d, imediato=True)
+        d["a"] = 999  # mutacao pos-chamada nao deve afetar o registro
+        log = AuditLog.objects.filter(action="TEST_COPY").latest("created_at")
+        assert log.details["a"] == 1
+
+
+# ============================================================================
+# _actor_id
+# ============================================================================
+
+
+class TestActorId:
+    def test_none(self):
+        assert _actor_id(None) is None
+
+    def test_anonymous(self):
+        assert _actor_id(AnonymousUser()) is None
+
+    def test_usuario_real(self):
+        cpf = str(next(_CPF_COUNTER)).zfill(11)
+        user = UsuarioFactory(username=f"a_{cpf}", email=f"a_{cpf}@t.com", cpf=cpf)
+        assert _actor_id(user) == user.id
+
+    def test_actor_none_gera_log_sistema(self):
+        registrar_auditoria(actor=None, action="TEST_SYSTEM", imediato=True)
+        log = AuditLog.objects.filter(action="TEST_SYSTEM").latest("created_at")
+        assert log.usuario_id is None
+
+
+# ============================================================================
+# auditar_group_capability_change (path Admin/perm.groups)
+# ============================================================================
+
+
+class TestGroupCapabilityChange:
+    def test_contrato_de_details(self, capability, group_dat):
+        ok = auditar_group_capability_change(
+            actor=None,
+            capability=capability,
+            before_group_ids=[],
+            after_group_ids=[group_dat.pk],
+            imediato=True,
+        )
+        assert ok is True
+        log = AuditLog.objects.filter(action="GROUP_CAPABILITY_CHANGED").latest("created_at")
+        assert log.model_name == "PermissaoFuncional"
+        d = log.details
+        assert d["capability_codename"] == capability.codename
+        assert d["capability_id"] == capability.pk
+        assert d["added_groups"] == ["DAT"]
+        assert d["removed_groups"] == []
+        assert d["groups_after"] == ["DAT"]
+
+    def test_remocao(self, capability, group_dat):
+        ok = auditar_group_capability_change(
+            actor=None,
+            capability=capability,
+            before_group_ids=[group_dat.pk],
+            after_group_ids=[],
+            imediato=True,
+        )
+        assert ok is True
+        log = AuditLog.objects.filter(action="GROUP_CAPABILITY_CHANGED").latest("created_at")
+        d = log.details
+        assert d["added_groups"] == []
+        assert d["removed_groups"] == ["DAT"]
+        assert d["groups_after"] == []
+
+    def test_noop_sem_delta(self, capability, group_dat):
+        ok = auditar_group_capability_change(
+            actor=None,
+            capability=capability,
+            before_group_ids=[group_dat.pk],
+            after_group_ids=[group_dat.pk],
+            imediato=True,
+        )
+        assert ok is False
+        assert not AuditLog.objects.filter(action="GROUP_CAPABILITY_CHANGED").exists()
+
+
+# ============================================================================
+# auditar_group_capabilities_set (path REST group.permissoes_funcionais.set)
+# ============================================================================
+
+
+class TestGroupCapabilitiesSet:
+    def test_emite_um_por_capability(self, capability, group_dat):
+        seed_functional_permissions(assign_default_groups=False)
+        cap_a = capability
+        cap_b = PermissaoFuncional.objects.exclude(pk=cap_a.pk).first()
+        assert cap_b is not None
+
+        before = list(group_dat.permissoes_funcionais.values_list("pk", flat=True))
+        group_dat.permissoes_funcionais.set([cap_a.pk, cap_b.pk])
+        AuditLog.objects.filter(action="GROUP_CAPABILITY_CHANGED").delete()
+
+        n = auditar_group_capabilities_set(
+            actor=None,
+            group=group_dat,
+            before_cap_ids=before,
+            after_cap_ids=[cap_a.pk, cap_b.pk],
+            imediato=True,
+        )
+        assert n == 2
+        logs = AuditLog.objects.filter(action="GROUP_CAPABILITY_CHANGED")
+        assert logs.count() == 2
+        for log in logs:
+            assert log.details["added_groups"] == ["DAT"]
+            assert log.details["removed_groups"] == []
+            assert log.details["via"] == "group_serializer"
+            assert "DAT" in log.details["groups_after"]
+
+    def test_remocao_de_capability(self, capability, group_dat):
+        group_dat.permissoes_funcionais.set([capability.pk])
+        before = [capability.pk]
+        group_dat.permissoes_funcionais.set([])
+        AuditLog.objects.filter(action="GROUP_CAPABILITY_CHANGED").delete()
+
+        n = auditar_group_capabilities_set(
+            actor=None,
+            group=group_dat,
+            before_cap_ids=before,
+            after_cap_ids=[],
+            imediato=True,
+        )
+        assert n == 1
+        log = AuditLog.objects.filter(action="GROUP_CAPABILITY_CHANGED").latest("created_at")
+        assert log.details["removed_groups"] == ["DAT"]
+        assert log.details["added_groups"] == []
+        assert log.details["groups_after"] == []  # grupo removido -> cap sem esse grupo
+
+    def test_noop_sem_delta(self, capability, group_dat):
+        n = auditar_group_capabilities_set(
+            actor=None,
+            group=group_dat,
+            before_cap_ids=[capability.pk],
+            after_cap_ids=[capability.pk],
+            imediato=True,
+        )
+        assert n == 0
+        assert not AuditLog.objects.filter(action="GROUP_CAPABILITY_CHANGED").exists()
+
+
+# ============================================================================
+# Helpers de privilegio de usuario (ASSIGN_GROUPS / RESET_PASSWORD / USER_DELETE)
+# ============================================================================
+
+
+class TestUserPrivilegeHelpers:
+    def test_assign_groups_emite_com_delta(self, group_dat):
+        user = _make_user()
+        ok = auditar_assign_groups(
+            actor=None,
+            target_user=user,
+            before_group_ids=[],
+            after_group_ids=[group_dat.pk],
+            imediato=True,
+        )
+        assert ok is True
+        log = AuditLog.objects.filter(action="ASSIGN_GROUPS").latest("created_at")
+        assert log.model_name == "Usuario"
+        assert log.details["target_user_id"] == user.id
+        assert log.details["added_groups"] == ["DAT"]
+        assert log.details["removed_groups"] == []
+        assert log.details["groups_after"] == ["DAT"]
+
+    def test_assign_groups_noop(self, group_dat):
+        user = _make_user()
+        ok = auditar_assign_groups(
+            actor=None,
+            target_user=user,
+            before_group_ids=[group_dat.pk],
+            after_group_ids=[group_dat.pk],
+            imediato=True,
+        )
+        assert ok is False
+        assert not AuditLog.objects.filter(action="ASSIGN_GROUPS").exists()
+
+    def test_reset_senha_nunca_inclui_a_senha(self):
+        user = _make_user()
+        auditar_reset_senha(actor=None, target_user=user, contexto="update", imediato=True)
+        log = AuditLog.objects.filter(action="RESET_PASSWORD").latest("created_at")
+        assert log.model_name == "Usuario"
+        assert log.details["target_user_id"] == user.id
+        assert log.details["contexto"] == "update"
+        # Contrato de seguranca: senha NUNCA aparece nos details.
+        assert set(log.details.keys()) == {"actor_user_id", "target_user_id", "target_username", "contexto"}
+
+    def test_user_delete_captura_identidade_do_alvo(self):
+        user = _make_user()
+        uid = user.id
+        uname = user.username
+        auditar_user_delete(actor=None, target_user=user, imediato=True)
+        log = AuditLog.objects.filter(action="USER_DELETE").latest("created_at")
+        assert log.details["target_user_id"] == uid
+        assert log.details["target_username"] == uname
+
+    def test_user_delete_auto_exclusao_zera_fk_mas_preserva_ator(self):
+        # actor == target: a FK usuario_id precisa ser None (a linha some), mas
+        # o ator fica registrado em details.actor_user_id.
+        user = _make_user()
+        auditar_user_delete(actor=user, target_user=user, imediato=True)
+        log = AuditLog.objects.filter(action="USER_DELETE").latest("created_at")
+        assert log.usuario_id is None
+        assert log.details["actor_user_id"] == user.id
+        assert log.details["target_user_id"] == user.id
+
+    def test_user_delete_ator_distinto_mantem_fk(self):
+        actor = _make_user(label="actor")
+        target = _make_user(label="target")
+        auditar_user_delete(actor=actor, target_user=target, imediato=True)
+        log = AuditLog.objects.filter(action="USER_DELETE").latest("created_at")
+        assert log.usuario_id == actor.id
+        assert log.details["target_user_id"] == target.id

--- a/v2/backend/apps/core/tests/test_pr16_admin_group_capability.py
+++ b/v2/backend/apps/core/tests/test_pr16_admin_group_capability.py
@@ -1,6 +1,10 @@
 """
-PR 16 hardening RBAC (2026-05-04, último do programa): Admin UI
-superuser-only para atribuição Group × Capability.
+PR 16 hardening RBAC (2026-05-04): Admin UI superuser-only para atribuição
+Group × Capability. Atualizado no #1672: a auditoria não usa mais o buffer
+global `_PENDING_GROUP_CAP_DELTAS` — o Admin `save_related` captura before/after
+e delega ao serviço transacional `apps.core.services.audit`, que emite o
+AuditLog em `transaction.on_commit`. Por isso os POSTs que verificam AuditLog
+rodam dentro de `django_capture_on_commit_callbacks(execute=True)`.
 
 Cobre:
 - Guarda de acesso: superuser passa, staff puro nega, anonymous redireciona.
@@ -59,29 +63,10 @@ def staff_user() -> Usuario:
     return _make_user(is_staff=True, label="staff")
 
 
-@pytest.fixture(autouse=True)
-def _reset_rbac_audit_buffer():
-    """
-    O seed `seed_functional_permissions(assign_default_groups=False)`
-    dispara `m2m_changed.pre_clear` em todas as 16 capabilities, populando
-    `_PENDING_GROUP_CAP_DELTAS`. Sem reset entre testes, o `save_related`
-    do Admin flushaaria deltas vindos do seed — falsos positivos.
-    """
-    from apps.core.signals import _PENDING_GROUP_CAP_DELTAS
-
-    _PENDING_GROUP_CAP_DELTAS.clear()
-    yield
-    _PENDING_GROUP_CAP_DELTAS.clear()
-
-
 @pytest.fixture
 def capability() -> PermissaoFuncional:
     """Garante que `view_compras_dashboard` exista (do seed). Sem grupos."""
     seed_functional_permissions(assign_default_groups=False)
-    # Limpa o buffer poluído pelo seed antes do test rodar.
-    from apps.core.signals import _PENDING_GROUP_CAP_DELTAS
-
-    _PENDING_GROUP_CAP_DELTAS.clear()
     AuditLog.objects.filter(action="GROUP_CAPABILITY_CHANGED").delete()
     return PermissaoFuncional.objects.get(codename="view_compras_dashboard")
 
@@ -193,11 +178,6 @@ class TestAdminGroupEditing:
 
     def test_superuser_remove_grupo(self, superuser, capability, group_dat):
         capability.groups.add(group_dat)
-        # Limpa AuditLog gerado pelo signal m2m_changed direto (fora de Admin)
-        AuditLog.objects.filter(action="GROUP_CAPABILITY_CHANGED").delete()
-        from apps.core.signals import _PENDING_GROUP_CAP_DELTAS
-
-        _PENDING_GROUP_CAP_DELTAS.clear()
 
         c = Client()
         c.force_login(superuser)
@@ -242,21 +222,25 @@ class TestCacheInvalidation:
 
 # ============================================================================
 # AuditLog consolidado (GROUP_CAPABILITY_CHANGED)
+#
+# #1672: o AuditLog é emitido em `transaction.on_commit` pelo serviço de
+# auditoria. Em teste `django_db` (transação externa que dá rollback) os
+# callbacks só rodam sob `django_capture_on_commit_callbacks(execute=True)`.
 # ============================================================================
 
 
 class TestAuditLog:
-    def test_auditlog_criado_com_actor_e_deltas(self, superuser, capability, group_dat):
+    def test_auditlog_criado_com_actor_e_deltas(
+        self, superuser, capability, group_dat, django_capture_on_commit_callbacks
+    ):
         AuditLog.objects.filter(action="GROUP_CAPABILITY_CHANGED").delete()
-        from apps.core.signals import _PENDING_GROUP_CAP_DELTAS
-
-        _PENDING_GROUP_CAP_DELTAS.clear()
         c = Client()
         c.force_login(superuser)
-        c.post(
-            f"/admin/core/permissaofuncional/{capability.pk}/change/",
-            data={"groups": [str(group_dat.pk)], "_save": "Salvar"},
-        )
+        with django_capture_on_commit_callbacks(execute=True):
+            c.post(
+                f"/admin/core/permissaofuncional/{capability.pk}/change/",
+                data={"groups": [str(group_dat.pk)], "_save": "Salvar"},
+            )
         log = AuditLog.objects.filter(action="GROUP_CAPABILITY_CHANGED").latest("created_at")
         assert log.usuario_id == superuser.id
         assert log.model_name == "PermissaoFuncional"
@@ -267,19 +251,19 @@ class TestAuditLog:
         assert d["removed_groups"] == []
         assert d["groups_after"] == ["DAT"]
 
-    def test_remocao_explicita_lista_grupos_removidos(self, superuser, capability, group_dat, group_diretoria):
+    def test_remocao_explicita_lista_grupos_removidos(
+        self, superuser, capability, group_dat, group_diretoria, django_capture_on_commit_callbacks
+    ):
         capability.groups.add(group_dat, group_diretoria)
         AuditLog.objects.filter(action="GROUP_CAPABILITY_CHANGED").delete()
-        from apps.core.signals import _PENDING_GROUP_CAP_DELTAS
-
-        _PENDING_GROUP_CAP_DELTAS.clear()
 
         c = Client()
         c.force_login(superuser)
-        c.post(
-            f"/admin/core/permissaofuncional/{capability.pk}/change/",
-            data={"groups": [], "_save": "Salvar"},
-        )
+        with django_capture_on_commit_callbacks(execute=True):
+            c.post(
+                f"/admin/core/permissaofuncional/{capability.pk}/change/",
+                data={"groups": [], "_save": "Salvar"},
+            )
         log = AuditLog.objects.filter(action="GROUP_CAPABILITY_CHANGED").latest("created_at")
         d = log.details
         assert d["added_groups"] == []
@@ -288,21 +272,19 @@ class TestAuditLog:
         assert d["groups_after"] == []
 
     def test_uma_operacao_admin_gera_um_auditlog_por_capability(
-        self, superuser, capability, group_dat, group_diretoria
+        self, superuser, capability, group_dat, group_diretoria, django_capture_on_commit_callbacks
     ):
         capability.groups.add(group_dat)
         AuditLog.objects.filter(action="GROUP_CAPABILITY_CHANGED").delete()
-        from apps.core.signals import _PENDING_GROUP_CAP_DELTAS
-
-        _PENDING_GROUP_CAP_DELTAS.clear()
 
         c = Client()
         c.force_login(superuser)
         # Em uma única operação Admin: remove DAT + adiciona Diretoria.
-        c.post(
-            f"/admin/core/permissaofuncional/{capability.pk}/change/",
-            data={"groups": [str(group_diretoria.pk)], "_save": "Salvar"},
-        )
+        with django_capture_on_commit_callbacks(execute=True):
+            c.post(
+                f"/admin/core/permissaofuncional/{capability.pk}/change/",
+                data={"groups": [str(group_diretoria.pk)], "_save": "Salvar"},
+            )
         # Apenas UM AuditLog para essa capability nesta operação.
         logs = AuditLog.objects.filter(
             action="GROUP_CAPABILITY_CHANGED",
@@ -316,18 +298,18 @@ class TestAuditLog:
         assert d["removed_groups"] == ["DAT"]
         assert d["groups_after"] == ["Diretoria"]
 
-    def test_save_sem_mudanca_em_groups_nao_emite_auditlog(self, superuser, capability, group_dat):
+    def test_save_sem_mudanca_em_groups_nao_emite_auditlog(
+        self, superuser, capability, group_dat, django_capture_on_commit_callbacks
+    ):
         capability.groups.add(group_dat)
         AuditLog.objects.filter(action="GROUP_CAPABILITY_CHANGED").delete()
-        from apps.core.signals import _PENDING_GROUP_CAP_DELTAS
-
-        _PENDING_GROUP_CAP_DELTAS.clear()
 
         c = Client()
         c.force_login(superuser)
         # Re-salva com o mesmo set → sem delta.
-        c.post(
-            f"/admin/core/permissaofuncional/{capability.pk}/change/",
-            data={"groups": [str(group_dat.pk)], "_save": "Salvar"},
-        )
+        with django_capture_on_commit_callbacks(execute=True):
+            c.post(
+                f"/admin/core/permissaofuncional/{capability.pk}/change/",
+                data={"groups": [str(group_dat.pk)], "_save": "Salvar"},
+            )
         assert not AuditLog.objects.filter(action="GROUP_CAPABILITY_CHANGED").exists()

--- a/v2/backend/apps/core/tests/test_sec_enum_audit.py
+++ b/v2/backend/apps/core/tests/test_sec_enum_audit.py
@@ -189,6 +189,13 @@ class TestAuditLogPIIRedaction(TestCase):
         redacted = _redact_details(details)
         assert redacted["google_email"] == "u***@gmail.com"
 
+    def test_redact_masks_target_username(self):
+        # #1672: target_username pode ser um CPF (username=cpf no import) -> PII.
+        details = {"target_username": "11144477735", "target_user_id": 42}
+        redacted = _redact_details(details)
+        assert redacted["target_username"] == "***"
+        assert redacted["target_user_id"] == 42  # id nao e PII, preservado
+
     def test_redact_preserves_non_pii(self):
         details = {
             "username": "admin",

--- a/v2/backend/apps/core/views/admin.py
+++ b/v2/backend/apps/core/views/admin.py
@@ -48,6 +48,11 @@ from apps.core.serializers import (
     ProjetoSerializer,
     UsuarioAdminSerializer,
 )
+from apps.core.services.audit import (
+    auditar_assign_groups,
+    auditar_user_delete,
+    registrar_auditoria,
+)
 from apps.core.services.options_cache import invalidate_municipios_options_cache
 from apps.core.services.rbac_service import get_assignable_group_names
 
@@ -394,7 +399,14 @@ class UsuarioAdminViewSet(viewsets.ModelViewSet):
             )
             if not has_other_active_superuser:
                 raise ValidationError({"detail": "Não é possível remover o último superusuário ativo."})
-        instance.delete()
+        # #1672: auditoria + delete no MESMO atomic. Sem isso, em autocommit
+        # (ATOMIC_REQUESTS off) o on_commit dispararia ANTES do delete e um
+        # ProtectedError (Solicitacao/AvailabilityBlock/dat_* referenciam Usuario
+        # com PROTECT) deixaria trilha-fantasma de uma exclusao que nao ocorreu.
+        # O helper trata auto-exclusao (FK None, ator preservado em details).
+        with transaction.atomic():
+            auditar_user_delete(actor=self.request.user, target_user=instance)
+            instance.delete()
 
     @action(detail=True, methods=["post"], permission_classes=[SuperuserOnly])
     def assign_groups(self, request, pk=None):
@@ -462,7 +474,15 @@ class UsuarioAdminViewSet(viewsets.ModelViewSet):
                 )
 
         # Atribuir grupos (substitui grupos existentes)
+        before_group_ids = set(usuario.groups.values_list("id", flat=True))
         usuario.groups.set(groups)
+        # #1672: mudanca de membership (privilegio) auditada.
+        auditar_assign_groups(
+            actor=request.user,
+            target_user=usuario,
+            before_group_ids=before_group_ids,
+            after_group_ids=set(usuario.groups.values_list("id", flat=True)),
+        )
 
         # Retornar usuário atualizado com grupos
         serializer = self.get_serializer(usuario)
@@ -506,7 +526,22 @@ class GroupViewSet(viewsets.ModelViewSet):
             raise ValidationError(
                 {"detail": "Grupo reservado. Para excluir, use ?confirm_reserved=true na requisição."}
             )
-        super().perform_destroy(instance)
+        # #1672: auditoria + delete no MESMO atomic (ver perform_destroy de Usuario):
+        # o on_commit só grava se o delete commitar, evitando trilha-fantasma quando
+        # um ProtectedError (ex.: AcaoTemplateExecutor.group) impede a remoção.
+        # Registra as capabilities que o grupo carregava no momento da remoção.
+        with transaction.atomic():
+            registrar_auditoria(
+                actor=self.request.user,
+                action=AuditLog.Action.DELETE,
+                model_name="Group",
+                details={
+                    "group_id": instance.pk,
+                    "group_name": instance.name,
+                    "capabilities": list(instance.permissoes_funcionais.values_list("codename", flat=True)),
+                },
+            )
+            super().perform_destroy(instance)
 
     @action(
         detail=True,

--- a/v2/backend/conftest.py
+++ b/v2/backend/conftest.py
@@ -48,12 +48,8 @@ def ensure_rbac_seed(db):
     if not PermissaoFuncional.objects.filter(groups__isnull=False).exists():
         ensure_base_groups()
         seed_functional_permissions(assign_default_groups=True)
-        # O groups.set do seed dispara m2m_changed e popula o buffer de auditoria de
-        # capability; essas mudancas sao infraestrutura de teste (nao operacoes
-        # auditaveis) -> limpar para nao contaminar contagens de AuditLog.
-        from apps.core.signals import _PENDING_GROUP_CAP_DELTAS
-
-        _PENDING_GROUP_CAP_DELTAS.clear()
+        # #1672: a auditoria de capability nao usa mais buffer global — o
+        # `groups.set` do seed so dispara cache bust (nenhum AuditLog a limpar).
 
 
 @pytest.fixture(autouse=True, scope="function")


### PR DESCRIPTION
## Problema (#1672)

Mudança de **Group × Capability fora do Django Admin não gerava `AuditLog`**. O delta era acumulado num **buffer global de módulo** (`_PENDING_GROUP_CAP_DELTAS` em `signals.py`) que **só persistia** via `PermissaoFuncionalAdmin.save_related`. Qualquer outro caminho — REST, `manage.py shell`, import — acumulava e **perdia o registro quando o processo terminava**. Falha silenciosa: nada avisava que a auditoria não foi gravada. Reproduzido em prod em 2026-07-20 (concessão via shell não deixou trilha).

## Solução

Sai de **signal-reativo com buffer** para **serviço transacional explícito no call-site** (`apps/core/services/audit.py`), emitindo em `transaction.on_commit` — o mesmo modelo que o `sync_members` já usava, generalizado.

- **`registrar_auditoria(...)`** — ponto único de emissão; `on_commit` por padrão (a trilha reflete só o que commitou; em autocommit dispara na hora; `imediato=True` p/ síncrono). Override `usuario_id` para o caso de auto-exclusão.
- **Helpers before/after**: `auditar_group_capability_change` (Admin/`perm.groups`), `auditar_group_capabilities_set` (REST `group.permissoes_funcionais.set` — **o bug**), `auditar_assign_groups`, `auditar_reset_senha`, `auditar_user_delete`.
- **Buffer removido**: `_PENDING_GROUP_CAP_DELTAS` + `flush_group_capability_audit` deletados; o handler `m2m_changed` vira **só cache-bust** (imediato, independe de ator).

### Pontos de mutação agora auditados
| Caminho | Antes | Agora |
|---|---|---|
| Admin `PermissaoFuncional` (capability) | ✅ (via buffer) | ✅ before/after direto |
| REST `GroupSerializer` caps-set | ❌ **perdia** | ✅ `GROUP_CAPABILITY_CHANGED` |
| `assign_groups` (membership) | ❌ | ✅ `ASSIGN_GROUPS` |
| Reset de senha de outro (serializer) | ❌ | ✅ `RESET_PASSWORD` |
| Delete de usuário / grupo | ❌ | ✅ `USER_DELETE` / `DELETE` |
| **Django admin `UsuarioAdmin`** (groups + flags) | ❌ | ✅ `ASSIGN_GROUPS` + `USER_PRIVILEGE_CHANGED` |
| Import de usuários (`--apply`) | ❌ | ✅ `USER_IMPORT` (dry-run não audita) |

- **+5 Actions** (`RESET_PASSWORD`/`USER_DELETE`/`ASSIGN_GROUPS`/`USER_IMPORT`/`USER_PRIVILEGE_CHANGED`) — **sem migration** (`action` é `CharField` sem `choices`).
- **PII**: `target_username` (pode ser CPF via import) mascarado p/ não-superuser (SEC-AUDIT-01).

## Verificação adversarial (workflow 3 lentes) — achados corrigidos

- **P1 — trilha-fantasma no delete** (CONFIRMADO): o audit era emitido **antes** de `instance.delete()`; como o projeto **não seta `ATOMIC_REQUESTS`** (autocommit), `on_commit` sem transação ativa dispara **na hora** → um `ProtectedError` (Usuario/Group têm FKs PROTECT) deixaria trilha de exclusão que nunca ocorreu. **Fix**: audit + delete no **mesmo `transaction.atomic()`** (usuário e grupo) → rollback descarta o `on_commit`. Regressão coberta.
- **P1 — `UsuarioAdmin` sem trilha** (CONFIRMADO): admin web (superuser-only, alcançável em prod pós-#1671) editava groups/`is_superuser` sem auditoria. **Fix**: `save_model` + `save_related` instrumentados.
- **Auto-exclusão**: FK `usuario_id` nula (evita 500 no callback pós-delete); ator preservado em `details`.

## Testes
- **33 novos**: unit do serviço + integração de endpoint (GroupSerializer/assign_groups/reset/delete/import) + **regressão de phantom** (delete falho não audita) + `UsuarioAdmin`, todos via `django_capture_on_commit_callbacks` (prova o caminho `on_commit`, não um atalho).
- **Suíte core completa: 3074 passed, 37 skipped.** `manage.py check` limpo.

## Gaps conhecidos (follow-up, **documentados ≠ silenciosos**)
1. **`export_contract_importer._apply_usuario`** (`groups.add`) não audita — importer gated por allowlist do `--apply`, **nunca executou apply real**. Subsistema distinto; fora do escopo nomeado do #1672.
2. **`USER_IMPORT` granularidade**: hoje registra contadores por lote, não *quem recebeu quais grupos*. Suficiente para saber que um import ocorreu por quem; a reconstrução per-usuário é enhancement.
3. **Shell/`manage.py`** cru permanece não-auditável por natureza (break-glass) — o cache-bust segue, mas não há call-site p/ trilha.

Closes #1672
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `92242b46`, slot `0` / projeto `aprender_staging`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
