### PR TITLE
feat(frontend): botão "Redefinir senha" na admin de usuários (#1675)

### DIFF
--- a/v2/frontend/src/api/__tests__/adminDAT.test.ts
+++ b/v2/frontend/src/api/__tests__/adminDAT.test.ts
@@ -22,6 +22,7 @@ import {
   deleteGroup,
   getRBACMeta,
   listUsers,
+  resetUserPassword,
   syncGroupMembers,
   updateGroup,
 } from '../adminDAT';
@@ -63,6 +64,21 @@ describe('adminDAT API wrappers (MSW)', () => {
 
   beforeEach(() => {
     calls = [];
+  });
+
+  test('resetUserPassword PATCHes /usuarios-admin/:id/ with only the password', async () => {
+    server.use(
+      spyHandler(http.patch, apiUrl('/usuarios-admin/5/'), { json: { id: 5 } }, calls),
+    );
+
+    const senha = 'trocar-em-teste-123'; // gitleaks:allow (literal de teste, nao e segredo)
+    await resetUserPassword(5, senha);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].method).toBe('PATCH');
+    expect(calls[0].url).toContain('/usuarios-admin/5/');
+    // Só a senha vai no corpo — nenhum outro campo do usuário é tocado.
+    expect(calls[0].body).toEqual({ password: senha });
   });
 
   test('listUsers calls /usuarios-admin/ with params', async () => {

--- a/v2/frontend/src/api/adminDAT.ts
+++ b/v2/frontend/src/api/adminDAT.ts
@@ -191,6 +191,20 @@ export async function deleteUser(id: ID): Promise<void> {
   syncChannel.publish('usuarios', { action: 'deleted' });
 }
 
+/**
+ * Redefine a senha de OUTRO usuário (ação de admin/DAT). PATCH parcial só com
+ * `password` — o backend faz o hash e audita como `RESET_PASSWORD` (#1672).
+ * A senha nunca é retornada nem logada. Endpoint compartilhado com updateUser.
+ */
+export async function resetUserPassword(id: ID, password: string): Promise<void> {
+  await fetchWithErrorMapping(
+    `/usuarios-admin/${id}/`,
+    { method: 'PATCH', body: JSON.stringify({ password }) },
+    ADMIN_ERROR_MAP,
+  );
+  syncChannel.publish('usuarios', { action: 'updated' });
+}
+
 // ========== GRUPOS ==========
 
 export async function listGroups(params: ListParams = {}): Promise<PaginatedResponse<Group>> {

--- a/v2/frontend/src/pages/AdminDAT/UsuariosPage.tsx
+++ b/v2/frontend/src/pages/AdminDAT/UsuariosPage.tsx
@@ -29,10 +29,10 @@ import {
 import type { ColumnsType, TablePaginationConfig } from 'antd/es/table';
 import type { FilterValue, SorterResult } from 'antd/es/table/interface';
 import type { RadioChangeEvent } from 'antd/es/radio';
-import { ReloadOutlined, EditOutlined, PlusOutlined, DeleteOutlined } from '@ant-design/icons';
+import { ReloadOutlined, EditOutlined, PlusOutlined, DeleteOutlined, KeyOutlined } from '@ant-design/icons';
 import { Link } from 'react-router';
 import { checkAuth } from '../../api/auth';
-import { listUsers, createUser, updateUser, deleteUser, listGroups, getRBACMeta } from '../../api/adminDAT';
+import { listUsers, createUser, updateUser, deleteUser, resetUserPassword, listGroups, getRBACMeta } from '../../api/adminDAT';
 import { buildUsuarioPayload } from './usuario_form_helpers';
 import type { PermissaoFuncional, RBACMetaPayload } from '../../api/adminDAT';
 import { importUsuarios } from '../../api/ops';
@@ -155,6 +155,11 @@ export default function UsuariosPage(): JSX.Element {
   });
   const [modalVisible, setModalVisible] = useState(false);
   const [editingUser, setEditingUser] = useState<UserRecord | null>(null);
+  // #1675 follow-up: redefinição de senha de OUTRO usuário (ação de admin).
+  // Modal dedicado, separado do form de edição — intenção explícita e a
+  // auditoria RESET_PASSWORD (#1672) dispara só aqui.
+  const [resetPasswordUser, setResetPasswordUser] = useState<UserRecord | null>(null);
+  const [resetSaving, setResetSaving] = useState(false);
   // Bug 3 fix (2026-04-27): CPF é write-only por LGPD (serializer), então API
   // nunca retorna o CPF raw — apenas `cpf_masked`. No modo edit, manter o
   // campo disabled mostrando o mascarado, e exigir clique em "Alterar CPF"
@@ -166,6 +171,7 @@ export default function UsuariosPage(): JSX.Element {
   const [viewMode, setViewMode] = useState<ViewMode>('lista');
 
   const [form] = Form.useForm<UserFormValues>();
+  const [resetForm] = Form.useForm<{ nova_senha: string; confirmar_nova_senha: string }>();
   const selectedSetorIds = Form.useWatch('setor_ids', form) || [];
   const selectedFuncaoIds = Form.useWatch('funcao_ids', form) || [];
 
@@ -371,6 +377,26 @@ export default function UsuariosPage(): JSX.Element {
     }
   };
 
+  const handleOpenResetPassword = (user: UserRecord): void => {
+    setResetPasswordUser(user);
+    resetForm.resetFields();
+  };
+
+  const handleResetPassword = async (values: { nova_senha: string }): Promise<void> => {
+    if (!resetPasswordUser) return;
+    setResetSaving(true);
+    try {
+      await resetUserPassword(resetPasswordUser.id, values.nova_senha);
+      message.success(`Senha de "${resetPasswordUser.username}" redefinida com sucesso`);
+      setResetPasswordUser(null);
+      resetForm.resetFields();
+    } catch (error) {
+      message.error(`Erro ao redefinir senha: ${(error as Error).message}`);
+    } finally {
+      setResetSaving(false);
+    }
+  };
+
   const columns: ColumnsType<UserRecord> = [
     {
       title: 'ID',
@@ -465,7 +491,7 @@ export default function UsuariosPage(): JSX.Element {
     {
       title: 'Ações',
       key: 'acoes',
-      width: 200,
+      width: 280,
       render: (_, record) => (
         <Space size="small">
           <Button
@@ -475,6 +501,15 @@ export default function UsuariosPage(): JSX.Element {
             onClick={() => handleEdit(record)}
           >
             Editar
+          </Button>
+          <Button
+            type="link"
+            size="small"
+            icon={<KeyOutlined />}
+            onClick={() => handleOpenResetPassword(record)}
+            aria-label={`Redefinir senha de ${record.username}`}
+          >
+            Senha
           </Button>
           <Button
             type="link"
@@ -794,6 +829,61 @@ export default function UsuariosPage(): JSX.Element {
               <Input.Password placeholder="Senha inicial" />
             </Form.Item>
           )}
+        </Form>
+      </Modal>
+
+      {/* #1675: Modal dedicado de redefinição de senha (admin -> outro usuário).
+          O backend audita como RESET_PASSWORD (#1672); a senha nunca é exibida. */}
+      <Modal
+        title={resetPasswordUser ? `Redefinir senha — ${resetPasswordUser.username}` : 'Redefinir senha'}
+        open={resetPasswordUser !== null}
+        onCancel={() => { setResetPasswordUser(null); resetForm.resetFields(); }}
+        onOk={() => resetForm.submit()}
+        okText="Redefinir senha"
+        cancelText="Cancelar"
+        confirmLoading={resetSaving}
+        width={480}
+      >
+        <Alert
+          type="info"
+          showIcon
+          className="mb-4"
+          message="A nova senha entra em vigor imediatamente."
+        />
+        <Form
+          form={resetForm}
+          layout="vertical"
+          autoComplete="off"
+          onFinish={handleResetPassword}
+        >
+          <Form.Item
+            name="nova_senha"
+            label="Nova senha"
+            rules={[
+              { required: true, message: 'Informe a nova senha.' },
+              { min: 8, message: 'A senha deve ter no mínimo 8 caracteres.' },
+            ]}
+          >
+            <Input.Password placeholder="Nova senha" autoComplete="new-password" />
+          </Form.Item>
+          <Form.Item
+            name="confirmar_nova_senha"
+            label="Confirmar nova senha"
+            dependencies={['nova_senha']}
+            rules={[
+              { required: true, message: 'Confirme a nova senha.' },
+              ({ getFieldValue }) => ({
+                validator(_, value) {
+                  if (!value || getFieldValue('nova_senha') === value) {
+                    return Promise.resolve();
+                  }
+                  return Promise.reject(new Error('As senhas não coincidem.'));
+                },
+              }),
+            ]}
+          >
+            <Input.Password placeholder="Confirmar nova senha" autoComplete="new-password" />
+          </Form.Item>
         </Form>
       </Modal>
     </section>


### PR DESCRIPTION
## Lacuna que fecha

O backend já suportava **resetar a senha de OUTRO usuário** — `PATCH /usuarios-admin/{id}/` com `{password}`, **auditado como `RESET_PASSWORD`** (#1672). Mas a tela de **Usuários** só tinha campo de senha na **criação** (`{!editingUser && ...}`) — não havia como redefinir a senha de um usuário existente pela interface. Os únicos caminhos eram self-service (Perfil) ou `manage.py changepassword` no container.

## O que faz

- **`api/adminDAT.ts`** → `resetUserPassword(id, password)`: PATCH parcial só com a senha (nunca exibida/logada). Reusa o endpoint que já audita.
- **`UsuariosPage`** → botão **"Senha"** (`KeyOutlined`, com `aria-label`) na coluna Ações + **Modal dedicado** (nova senha + confirmação; validação mín. 8 e coincidência, espelhando o self-service do Perfil). Ação separada da edição → intenção explícita e a trilha `RESET_PASSWORD` dispara só aqui.

## Testes
- **API (MSW)**: `resetUserPassword` PATCHa `/usuarios-admin/:id/` só com `{password}`.
- **Componente (`fireEvent`)**: fluxo botão → modal → submit chama `resetUserPassword(id, senha)`; senhas divergentes bloqueiam o submit.
- `tsc` 0 · `lint` 0 erros · **vitest 544 pass**.

## Notas
- Sem gate extra no botão: mostra para o mesmo público de Editar/Excluir; o backend enforça permissão (não-superuser sequer vê superusers). 
- `react-router` (não `-dom`) e `fetchPriority` já no padrão React 19 (pós-#1687).

Ref #1675
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `841b5d8a`, slot `0` / projeto `aprender_staging`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
