### PR TITLE
fix(ci): retry no smoke [7/8] Frontend HTTP do staging gate

### DIFF
--- a/v2/infra/scripts/smoke_test_staging.sh
+++ b/v2/infra/scripts/smoke_test_staging.sh
@@ -226,22 +226,33 @@ fi
 echo ""
 
 # ── [7/8] Frontend HTTP ─────────────────────────────────────────
+# Retry como worker/beat: logo apos o `up`, o container nginx pode responder
+# antes de servir o index.html completo -> o check single-shot dava
+# "root div not found" transitorio (falso-negativo, index.html tem o root div).
 echo -n "[7/${TOTAL}] Frontend HTTP: "
-FE_BODY="$(curl -sf "${FRONTEND_URL}/" 2>/dev/null || true)"
-if echo "$FE_BODY" | grep -q '<div id="root"'; then
+frontend_root_check() {
+  local body
+  body="$(curl -sf "${FRONTEND_URL}/" 2>/dev/null)" || return 1
+  echo "$body" | grep -q '<div id="root"'
+}
+if retry 12 5 frontend_root_check; then
   pass "Frontend HTTP"
 else
-  fail "Frontend HTTP" "root div not found"
+  fail "Frontend HTTP" "root div not found after 12 attempts"
 fi
 echo ""
 
 # ── [8/8] Frontend health ────────────────────────────────────────
 echo -n "[8/${TOTAL}] Frontend health: "
-FE_HEALTH="$(curl -sf -o /dev/null -w '%{http_code}' "${FRONTEND_URL}/health" 2>/dev/null || echo "000")"
-if [ "$FE_HEALTH" = "200" ]; then
+frontend_health_check() {
+  local code
+  code="$(curl -sf -o /dev/null -w '%{http_code}' "${FRONTEND_URL}/health" 2>/dev/null || echo "000")"
+  [ "$code" = "200" ]
+}
+if retry 12 5 frontend_health_check; then
   pass "Frontend health"
 else
-  fail "Frontend health" "HTTP ${FE_HEALTH}"
+  fail "Frontend health" "not 200 after 12 attempts"
 fi
 echo ""
 


### PR DESCRIPTION
## Problema

No staging gate, o check **`[7/8] Frontend HTTP`** era **single-shot** (`curl` + grep do `<div id="root">`), ao contrário do `[5/8] worker` e `[6/8] beat` que usam `retry 12 5`. Logo após o `up`, o nginx do frontend pode responder **antes** de servir o `index.html` completo → **"root div not found" transitório** (falso-negativo — o `index.html` tem o root div e o prod monta normalmente).

Aconteceu ao rodar o staging gate do #1688: falhou o [7/8], **passou no re-run** sem nenhuma mudança de código.

## Fix

Envolve `[7/8]` e `[8/8]` no **mesmo `retry` helper** já usado pelos checks de Celery — 12 tentativas × 5s. Zero mudança de comportamento no caso feliz; elimina o falso-negativo transitório.

## Validação
- `bash -n` (sintaxe) ✅
- `retry` helper já definido antes (linha 102), provado pelo worker/beat.
- Validado de ponta a ponta rodando o próprio staging gate nesta branch (markers no corpo).
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `4dc5553b`, slot `0` / projeto `aprender_staging`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
