### PR TITLE
fix(backup): restore_db.sh verifica integridade de backup .age antes do gzip -t (#1611)

### DIFF
--- a/.github/workflows/staging-gate-bats.yml
+++ b/.github/workflows/staging-gate-bats.yml
@@ -15,6 +15,7 @@ on:
       - "v2/infra/scripts/staging-gate.sh"
       - "v2/infra/scripts/staging-gate-scope.sh"
       - "v2/infra/scripts/smoke_test_staging.sh"
+      - "v2/infra/scripts/restore_db.sh"
       - "v2/infra/scripts/tests/**"
       - ".github/workflows/staging-gate-bats.yml"
   push:
@@ -24,6 +25,7 @@ on:
       - "v2/infra/scripts/staging-gate.sh"
       - "v2/infra/scripts/staging-gate-scope.sh"
       - "v2/infra/scripts/smoke_test_staging.sh"
+      - "v2/infra/scripts/restore_db.sh"
       - "v2/infra/scripts/tests/**"
       - ".github/workflows/staging-gate-bats.yml"
   workflow_dispatch:

--- a/v2/infra/scripts/restore_db.sh
+++ b/v2/infra/scripts/restore_db.sh
@@ -12,9 +12,15 @@
 #   - Sufficient disk space
 #   - Application stopped (recommended)
 
+# NB: pipefail NAO e' global de proposito. As selecoes de backup usam `ls A B | head`,
+# e com so `.age` em prod o glob `*.sql.gz` nao casa -> `ls` sai 2 e, sob pipefail+set -e,
+# abortaria a selecao antes do guard de "nenhum backup". Onde a falha do pipe importa
+# (os pipes do `age`), habilitamos pipefail LOCALMENTE via subshell.
 set -e
 
-BACKUP_DIR="/var/backups/aprender"
+# BACKUP_DIR respeita a env var (o mount do container aponta /backups). Antes estava
+# hardcoded, entao `--latest` dentro do container nao achava os backups (#1611).
+BACKUP_DIR="${BACKUP_DIR:-/var/backups/aprender}"
 DB_NAME="${DB_NAME:-aprender_db}"
 DB_USER="${DB_USER:-aprender_user}"
 DB_HOST="${DB_HOST:-localhost}"
@@ -87,10 +93,31 @@ echo ""
 echo "[$(date)] Starting restore..."
 
 # Step 1: Verify backup integrity
+# SEC-017/#1611: a verificacao precisa ser CIENTE DO FORMATO. Producao grava so
+# `.sql.gz.age`, cujo cabecalho e' texto ("age-encryption.org/v1"), nao gzip. Rodar
+# `gzip -t` direto no .age falhava com "corrupted" (falso) e travava TODO restore de
+# prod. Espelhamos aqui o branch que a Step 4 ja tinha: decifrar e SO ENTAO testar o gzip.
 echo "[$(date)] Verifying backup integrity..."
-if ! gzip -t "$BACKUP_FILE"; then
-    echo -e "${RED}ERROR: Backup file is corrupted!${NC}"
-    exit 1
+if echo "$BACKUP_FILE" | grep -q '\.age$'; then
+    BACKUP_AGE_KEY="${BACKUP_AGE_KEY:-/etc/backup-key.txt}"
+    if ! command -v age > /dev/null 2>&1; then
+        echo -e "${RED}ERROR: 'age' nao esta no PATH — necessario para verificar/restaurar backup .age${NC}"
+        exit 1
+    fi
+    if [ ! -r "$BACKUP_AGE_KEY" ]; then
+        echo -e "${RED}ERROR: chave age nao legivel: $BACKUP_AGE_KEY${NC}"
+        exit 1
+    fi
+    # pipefail LOCAL (subshell): sem ele a falha do `age` seria mascarada pelo exit do gzip -t.
+    if ! ( set -o pipefail; age -d -i "$BACKUP_AGE_KEY" "$BACKUP_FILE" | gzip -t ); then
+        echo -e "${RED}ERROR: backup cifrado invalido (falha ao decifrar ou gzip corrompido)!${NC}"
+        exit 1
+    fi
+else
+    if ! gzip -t "$BACKUP_FILE"; then
+        echo -e "${RED}ERROR: Backup file is corrupted!${NC}"
+        exit 1
+    fi
 fi
 echo -e "${GREEN}Backup integrity OK${NC}"
 
@@ -113,7 +140,9 @@ echo "[$(date)] Restoring backup (this may take a while)..."
 if echo "$BACKUP_FILE" | grep -q '\.age$'; then
     BACKUP_AGE_KEY="${BACKUP_AGE_KEY:-/etc/backup-key.txt}"
     echo "[$(date)] Decrypting encrypted backup with age..."
-    age -d -i "$BACKUP_AGE_KEY" "$BACKUP_FILE" | gunzip | psql -h $DB_HOST -U postgres -d $DB_NAME -q
+    # pipefail LOCAL: uma falha do `age` (chave errada, arquivo truncado) deve abortar o
+    # restore — sem isso, o psql receberia stream vazio e "restauraria" um banco incompleto.
+    ( set -o pipefail; age -d -i "$BACKUP_AGE_KEY" "$BACKUP_FILE" | gunzip | psql -h $DB_HOST -U postgres -d $DB_NAME -q )
 else
     gunzip -c "$BACKUP_FILE" | psql -h $DB_HOST -U postgres -d $DB_NAME -q
 fi

--- a/v2/infra/scripts/tests/restore_db.bats
+++ b/v2/infra/scripts/tests/restore_db.bats
@@ -1,0 +1,124 @@
+#!/usr/bin/env bats
+# restore_db.bats — cobertura do restore_db.sh (issue #1611 / M26-01).
+#
+# O bug: a Step 1 (verificacao de integridade) rodava `gzip -t` INCONDICIONALMENTE,
+# antes do branch que decifra `.age`. Producao grava SO `.sql.gz.age` (SEC-017), cujo
+# cabecalho e' texto (`age-encryption.org/v1`), nao gzip -> `gzip -t` falhava e o unico
+# formato de backup de prod nao restaurava ("Backup file is corrupted!" — factualmente falso).
+#
+# Estes testes sao HERMETICOS: stubam `age` e `psql` no PATH (bats e `age` nem sempre
+# existem no runner). Validam o FLUXO DE CONTROLE do script — que e' onde o bug vive.
+# O ensaio de DR real (age de verdade + Postgres) fica no test_dr.sh / staging.
+#
+# Rodar:  bats v2/infra/scripts/tests/restore_db.bats
+#     ou:  docker run --rm -v "$PWD:/code" -w /code bats/bats v2/infra/scripts/tests/
+
+setup() {
+  SCRIPT="${BATS_TEST_DIRNAME}/../restore_db.sh"
+  STUB_BIN="${BATS_TEST_TMPDIR}/bin"
+  mkdir -p "$STUB_BIN"
+
+  # Registro das chamadas ao psql (p/ assertar se o DROP DATABASE chegou a ser emitido).
+  PSQL_LOG="${BATS_TEST_TMPDIR}/psql.log"
+  : > "$PSQL_LOG"
+  export PSQL_LOG
+
+  # Stub `psql`: nunca toca banco real. Loga os argumentos, dreno o stdin do pipe de
+  # restore e devolve um numero para as queries de contagem (Step 5).
+  cat > "$STUB_BIN/psql" <<'STUB'
+#!/usr/bin/env bash
+echo "psql $*" >> "$PSQL_LOG"
+cat >/dev/null 2>&1 || true   # dreno do pipe (age|gunzip|psql); EOF imediato nos -c
+for a in "$@"; do
+  case "$a" in
+    *information_schema*|*"count("*|*"COUNT("*) echo 42 ;;
+  esac
+done
+exit 0
+STUB
+  chmod +x "$STUB_BIN/psql"
+
+  # Stub `age`: ignora cripto; ao ser chamado como `age -d -i KEY FILE`, emite o
+  # conteudo "decifrado" apontado por AGE_PAYLOAD (um .gz real nos testes de sucesso,
+  # ou lixo nao-gzip nos testes de corrupcao). Assim o cabecalho on-disk do .age pode
+  # ser nao-gzip (como um .age de verdade) enquanto o age -d entrega o gzip.
+  cat > "$STUB_BIN/age" <<'STUB'
+#!/usr/bin/env bash
+cat "$AGE_PAYLOAD"
+STUB
+  chmod +x "$STUB_BIN/age"
+
+  export PATH="$STUB_BIN:$PATH"
+
+  # Chave age dummy (o fix exige que ela seja legivel antes de decifrar).
+  export BACKUP_AGE_KEY="${BATS_TEST_TMPDIR}/backup-key.txt"
+  echo "AGE-SECRET-KEY-STUB" > "$BACKUP_AGE_KEY"
+
+  # Payload "decifrado" valido: um gzip real de um SQL minimo.
+  VALID_GZ="${BATS_TEST_TMPDIR}/payload.sql.gz"
+  printf 'CREATE TABLE t(id int);\n' | gzip > "$VALID_GZ"
+
+  # Fixture .age on-disk: bytes NAO-gzip (cabecalho age real) — e' o que a Step 1
+  # antiga passava direto p/ `gzip -t`.
+  AGE_BACKUP="${BATS_TEST_TMPDIR}/backup_full_20260720_010000.sql.gz.age"
+  { printf 'age-encryption.org/v1\n'; head -c 64 /dev/urandom; } > "$AGE_BACKUP"
+
+  # Fixture .sql.gz simples (nao cifrado) p/ nao-regressao.
+  PLAIN_GZ="${BATS_TEST_TMPDIR}/backup_plain_20260101_000000.sql.gz"
+  printf 'CREATE TABLE u(id int);\n' | gzip > "$PLAIN_GZ"
+}
+
+# Invoca o script confirmando o prompt "yes" via stdin.
+run_restore() { printf 'yes\n' | bash "$SCRIPT" "$@"; }
+
+# 1) .age VALIDO passa na verificacao de integridade (o coracao do #1611).
+@test "restore .age valido passa na verificacao de integridade" {
+  export AGE_PAYLOAD="$VALID_GZ"
+  run run_restore "$AGE_BACKUP"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Backup integrity OK"* ]]
+  [[ "$output" != *"Backup file is corrupted"* ]]
+}
+
+# 2) .age realmente corrompido FALHA — e falha ANTES do DROP DATABASE (fail-closed).
+@test "restore .age corrompido falha antes do DROP DATABASE" {
+  # age -d "decifra" para lixo nao-gzip -> gzip -t do stream deve falhar.
+  GARBAGE="${BATS_TEST_TMPDIR}/garbage.bin"
+  printf 'isto nao e gzip valido' > "$GARBAGE"
+  export AGE_PAYLOAD="$GARBAGE"
+  run run_restore "$AGE_BACKUP"
+  [ "$status" -ne 0 ]
+  # Nenhum DROP DATABASE pode ter sido emitido (parou na Step 1).
+  ! grep -q "DROP DATABASE" "$PSQL_LOG"
+}
+
+# 3) .sql.gz simples (nao cifrado) continua funcionando — nao-regressao.
+@test "restore .sql.gz simples continua passando na integridade" {
+  run run_restore "$PLAIN_GZ"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Backup integrity OK"* ]]
+}
+
+# 4) BACKUP_DIR respeita a env var (hoje esta hardcoded em :17) — --latest seleciona de la.
+@test "--latest respeita BACKUP_DIR da env var" {
+  export BACKUP_DIR="${BATS_TEST_TMPDIR}"
+  export AGE_PAYLOAD="$VALID_GZ"
+  run run_restore --latest
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"${BATS_TEST_TMPDIR}/"* ]]
+  [[ "$output" == *"Backup integrity OK"* ]]
+}
+
+# 5) REGRESSAO: prod tem SO `.age` no BACKUP_DIR, entao o glob `*.sql.gz` nao casa e `ls`
+# sai 2. Se pipefail fosse GLOBAL, `BACKUP_FILE=$(ls A B | head)` herdaria o 2 e `set -e`
+# abortaria a selecao antes do guard. Este teste trava esse comportamento (pipefail e' local).
+@test "--latest com SO .age no diretorio nao aborta na selecao" {
+  local onlydir="${BATS_TEST_TMPDIR}/onlyage"
+  mkdir -p "$onlydir"
+  cp "$AGE_BACKUP" "$onlydir/backup_full_20260720_010000.sql.gz.age"
+  export BACKUP_DIR="$onlydir"
+  export AGE_PAYLOAD="$VALID_GZ"
+  run run_restore --latest
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Backup integrity OK"* ]]
+}


### PR DESCRIPTION
## Contexto

`restore_db.sh` Step 1 rodava `gzip -t "$BACKUP_FILE"` **incondicionalmente**, antes do branch que decifra `.age` (Step 4). Produção grava **só** `.sql.gz.age` (SEC-017), cujo cabeçalho é texto (`age-encryption.org/v1`), não gzip → `gzip -t` falhava com **`Backup file is corrupted!`** (factualmente falso) e **o único formato de backup de prod não restaurava** pela ferramenta oficial. Confirmado vivo em prod na issue #1611.

Atenuante: era **fail-closed** (parava antes do `DROP DATABASE`, sem perda de dados). O dano era RTO estourado + DR não exercitado + mensagem enganosa sob incidente.

## Correção

- **Step 1 ciente do formato**: se `.age`, decifra com `age` e **só então** testa o gzip do stream decifrado (espelha o branch que a Step 4 já tinha). `.sql.gz` simples segue idêntico.
- **`pipefail` LOCAL (subshell), não global**: garante que uma falha do `age` não seja mascarada pelo exit do `gzip -t`. **Não** global de propósito — com pipefail global, a seleção `ls A B | head` herdaria o exit 2 do glob `*.sql.gz` que não casa (prod só tem `.age`) e o `set -e` abortaria a seleção antes do guard de "nenhum backup". Guardado por teste de regressão (#5).
- **Guards**: `age` no PATH + chave age legível, antes de decifrar.
- **`BACKUP_DIR` respeita a env var** (era hardcoded `/var/backups/aprender`; dentro do container o mount é `/backups`, então `--latest` não achava nada — bug secundário da #1611).

## Testes

Primeira cobertura do script: `v2/infra/scripts/tests/restore_db.bats` (herméticos — stubam `age`/`psql` no PATH; rodam no CI `staging-gate-bats.yml`). **RED→GREEN provado localmente** (bats 1.14):

1. `.age` válido passa na integridade ✅ *(era RED antes do fix)*
2. `.age` corrompido falha **antes** do `DROP DATABASE` (fail-closed) ✅
3. `.sql.gz` simples continua passando (não-regressão) ✅
4. `--latest` respeita `BACKUP_DIR` da env ✅ *(era RED antes do fix)*
5. `--latest` com só `.age` no diretório não aborta na seleção (regressão pipefail) ✅

## Follow-up (não neste PR)

Ensaio de DR **real** (age de verdade + Postgres em staging): `backup_db.sh` gera `.age` → `restore_db.sh --latest` → conferir `TABLE_COUNT` + linhas de `core_usuario`/`core_solicitacao`. Registrar a data em `DISASTER_RECOVERY.md`. Requer a stack de staging up.

Closes #1611