### PR TITLE
feat(lgpd): anonimização de usuário (direito ao esquecimento, art. 18-VI)

### DIFF
--- a/v2/backend/apps/core/models/auditoria.py
+++ b/v2/backend/apps/core/models/auditoria.py
@@ -102,6 +102,9 @@ class AuditLog(models.Model):
             "USER_PRIVILEGE_CHANGED",
             "Alterar flags de privilegio (is_superuser/is_staff/is_active)",
         )
+        # LGPD art. 18-VI (direito ao esquecimento). Anonimizacao preserva a linha
+        # (FKs PROTECT) e remove a PII — ver apps.core.services.anonimizacao.
+        USER_ANONYMIZE = "USER_ANONYMIZE", "Anonimizar usuario (LGPD art. 18-VI)"
 
     usuario = models.ForeignKey(  # type: ignore[misc]
         "core.Usuario",

--- a/v2/backend/apps/core/services/anonimizacao.py
+++ b/v2/backend/apps/core/services/anonimizacao.py
@@ -1,0 +1,108 @@
+# pyright: reportAttributeAccessIssue=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false
+
+"""LGPD art. 18-VI — anonimizacao de Usuario (direito ao esquecimento).
+
+O hard-delete de Usuario e' barrado por FKs PROTECT (Solicitacao,
+AvailabilityBlock, dat_*): qualquer titular com historico dispara
+`ProtectedError`. A via LGPD-correta nesse caso e' ANONIMIZAR — remover a PII e
+MANTER a linha, preservando a integridade referencial dos registros de negocio.
+
+Idempotente. Audita `USER_ANONYMIZE` no MESMO `atomic()` da mutacao — padrao do
+servico transacional de auditoria (#1672): em autocommit (o projeto nao seta
+`ATOMIC_REQUESTS`) o `on_commit` dispararia ANTES do save e deixaria
+trilha-fantasma se a mutacao falhasse. Ver `apps.core.services.audit`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from django.db import transaction
+
+from apps.core.models import AuditLog, GoogleOAuthCredential, Usuario
+from apps.core.services.audit import registrar_auditoria
+
+# PII scrubbada — SSOT p/ o `details` da auditoria e p/ os testes.
+CAMPOS_ANONIMIZADOS: tuple[str, ...] = (
+    "cpf",
+    "username",
+    "first_name",
+    "last_name",
+    "email",
+    "telefone",
+    "cargo",
+)
+
+# Prefixo do username anonimo; serve tambem de sentinela de idempotencia.
+_ANON_USERNAME_PREFIX = "anon_"
+
+
+def usuario_anonimizado(usuario: Usuario) -> bool:
+    """True se `usuario` ja foi anonimizado (para tornar a operacao idempotente)."""
+    return usuario.username.startswith(_ANON_USERNAME_PREFIX) and not usuario.is_active
+
+
+def _cpf_tombstone(pk: int) -> str:
+    """Marcador unico p/ o campo `cpf` (unique + NOT NULL, max_length=11).
+
+    Nao pode ser NULL nem colidir com um CPF real (11 digitos). `ANON` + pk
+    zero-paddeado cabe em 11 chars ate ~10M usuarios e nunca casa o regex de CPF.
+    """
+    return f"ANON{pk:07d}"[:11]
+
+
+def anonimizar_usuario(*, usuario: Usuario, actor: Any) -> bool:
+    """Anonimiza a PII de `usuario`, preservando a linha e as FKs.
+
+    - Scrubba os campos de `CAMPOS_ANONIMIZADOS`, desativa a conta e torna a
+      senha inutilizavel.
+    - Remove a credencial Google OAuth (google_email + tokens = PII do titular).
+    - Audita `USER_ANONYMIZE` (o FATO — NUNCA os valores antigos de PII, para nao
+      re-introduzir dado pessoal na trilha).
+
+    Retorna True se anonimizou; False se ja estava anonimizado (idempotente).
+    """
+    if usuario_anonimizado(usuario):
+        return False
+
+    target_pk: int = usuario.pk
+
+    with transaction.atomic():
+        deleted_oauth, _ = GoogleOAuthCredential.objects.filter(user=usuario).delete()
+
+        usuario.cpf = _cpf_tombstone(target_pk)
+        usuario.username = f"{_ANON_USERNAME_PREFIX}{target_pk}"
+        usuario.first_name = ""
+        usuario.last_name = ""
+        usuario.email = ""
+        usuario.telefone = ""
+        usuario.cargo = ""
+        usuario.is_active = False
+        usuario.set_unusable_password()
+        usuario.save(
+            update_fields=[
+                "cpf",
+                "username",
+                "first_name",
+                "last_name",
+                "email",
+                "telefone",
+                "cargo",
+                "is_active",
+                "password",
+            ]
+        )
+
+        actor_id = getattr(actor, "id", None) if getattr(actor, "is_authenticated", False) else None
+        registrar_auditoria(
+            actor=actor,
+            action=AuditLog.Action.USER_ANONYMIZE,
+            model_name="Usuario",
+            details={
+                "actor_user_id": actor_id,
+                "target_user_id": target_pk,
+                "campos_anonimizados": list(CAMPOS_ANONIMIZADOS),
+                "oauth_removido": deleted_oauth > 0,
+            },
+        )
+    return True

--- a/v2/backend/apps/core/tests/test_anonimizacao_usuario.py
+++ b/v2/backend/apps/core/tests/test_anonimizacao_usuario.py
@@ -1,0 +1,161 @@
+"""LGPD art. 18-VI — testes da anonimizacao de Usuario (servico + endpoint).
+
+Cobre a via de "direito ao esquecimento" que preserva a linha (FKs PROTECT):
+scrub de PII, idempotencia, funcionamento onde o hard-delete falha com
+ProtectedError, auditoria do FATO sem PII, e o endpoint admin com RBAC/anti-lockout.
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportOptionalMemberAccess=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportCallIssue=false, reportIndexIssue=false
+
+from __future__ import annotations
+
+from django.db.models import ProtectedError
+from rest_framework import status
+from rest_framework.test import APIClient
+
+import pytest
+
+from apps.core.models import AuditLog, Usuario
+from apps.core.services.anonimizacao import CAMPOS_ANONIMIZADOS, anonimizar_usuario
+from apps.core.tests.factories import SolicitacaoFactory, UsuarioFactory
+
+pytestmark = pytest.mark.django_db
+
+ANON_URL = "/api/usuarios-admin/{pk}/anonimizar/"
+
+_CPF_TITULAR = "11144477735"
+_EMAIL_TITULAR = "maria@example.com"
+_TEL_TITULAR = "85999998888"
+
+
+def _titular(**kw):
+    """Titular com PII conhecida (para assertar que sumiu)."""
+    defaults = dict(
+        cpf=_CPF_TITULAR,
+        first_name="Maria",
+        last_name="Silva",
+        email=_EMAIL_TITULAR,
+        telefone=_TEL_TITULAR,
+        cargo="Coordenadora",
+    )
+    defaults.update(kw)
+    return UsuarioFactory(**defaults)
+
+
+# ------------------------------- servico -------------------------------
+
+
+def test_anonimiza_scrubba_pii_e_preserva_linha(django_capture_on_commit_callbacks):
+    user = _titular()
+    pk = user.pk
+    with django_capture_on_commit_callbacks(execute=True):
+        changed = anonimizar_usuario(usuario=user, actor=None)
+
+    assert changed is True
+    assert Usuario.objects.filter(pk=pk).exists()  # linha preservada (FK PROTECT)
+    user.refresh_from_db()
+    assert user.cpf != _CPF_TITULAR
+    assert user.username == f"anon_{pk}"
+    assert user.first_name == ""
+    assert user.last_name == ""
+    assert user.email == ""
+    assert user.telefone == ""
+    assert user.cargo == ""
+    assert user.is_active is False
+    assert user.has_usable_password() is False
+
+
+def test_anonimiza_e_idempotente(django_capture_on_commit_callbacks):
+    user = _titular()
+    with django_capture_on_commit_callbacks(execute=True):
+        assert anonimizar_usuario(usuario=user, actor=None) is True
+    user.refresh_from_db()
+    # 2a chamada nao muda nada e sinaliza no-op
+    assert anonimizar_usuario(usuario=user, actor=None) is False
+
+
+def test_anonimiza_funciona_onde_hard_delete_falha(django_capture_on_commit_callbacks):
+    """FK PROTECT (Solicitacao) barra o delete; a anonimizacao preserva a linha."""
+    user = _titular()
+    SolicitacaoFactory(usuario=user)  # cria referencia PROTECT ao titular
+
+    with pytest.raises(ProtectedError):
+        user.delete()
+
+    with django_capture_on_commit_callbacks(execute=True):
+        assert anonimizar_usuario(usuario=user, actor=None) is True
+    user.refresh_from_db()
+    assert user.is_active is False
+    assert user.cpf != _CPF_TITULAR
+
+
+def test_auditoria_registra_o_fato_sem_pii(django_capture_on_commit_callbacks):
+    actor = UsuarioFactory(superuser=True)
+    user = _titular()
+
+    with django_capture_on_commit_callbacks(execute=True):
+        anonimizar_usuario(usuario=user, actor=actor)
+
+    log = AuditLog.objects.filter(action=AuditLog.Action.USER_ANONYMIZE).latest("created_at")
+    assert log.details["target_user_id"] == user.pk
+    assert log.details["actor_user_id"] == actor.pk
+    assert set(log.details["campos_anonimizados"]) == set(CAMPOS_ANONIMIZADOS)
+    # o details NAO pode re-introduzir PII do titular
+    blob = str(log.details)
+    assert _CPF_TITULAR not in blob
+    assert _EMAIL_TITULAR not in blob
+    assert _TEL_TITULAR not in blob
+
+
+# ------------------------------- endpoint -------------------------------
+
+
+def test_endpoint_anonimiza_com_permissao():
+    dat = UsuarioFactory(groups=["DAT"])
+    alvo = _titular()
+    client = APIClient()
+    client.force_authenticate(user=dat)
+
+    resp = client.post(ANON_URL.format(pk=alvo.pk))
+
+    assert resp.status_code == status.HTTP_200_OK
+    alvo.refresh_from_db()
+    assert alvo.is_active is False
+    assert alvo.cpf != _CPF_TITULAR
+
+
+def test_endpoint_sem_permissao_403():
+    formador = UsuarioFactory(groups=["Formador"])
+    alvo = _titular()
+    client = APIClient()
+    client.force_authenticate(user=formador)
+
+    resp = client.post(ANON_URL.format(pk=alvo.pk))
+
+    assert resp.status_code == status.HTTP_403_FORBIDDEN
+    alvo.refresh_from_db()
+    assert alvo.is_active is True  # inalterado
+
+
+def test_endpoint_superuser_alvo_404_para_nao_superuser():
+    """P0-0: contas superuser sao invisiveis/inalcancaveis para nao-superusers."""
+    dat = UsuarioFactory(groups=["DAT"])
+    alvo_super = UsuarioFactory(superuser=True)
+    client = APIClient()
+    client.force_authenticate(user=dat)
+
+    resp = client.post(ANON_URL.format(pk=alvo_super.pk))
+
+    assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_endpoint_ultimo_superuser_ativo_bloqueado():
+    root = UsuarioFactory(superuser=True)
+    client = APIClient()
+    client.force_authenticate(user=root)
+
+    resp = client.post(ANON_URL.format(pk=root.pk))
+
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST
+    root.refresh_from_db()
+    assert root.is_active is True

--- a/v2/backend/apps/core/views/admin.py
+++ b/v2/backend/apps/core/views/admin.py
@@ -48,6 +48,7 @@ from apps.core.serializers import (
     ProjetoSerializer,
     UsuarioAdminSerializer,
 )
+from apps.core.services.anonimizacao import anonimizar_usuario
 from apps.core.services.audit import (
     auditar_assign_groups,
     auditar_user_delete,
@@ -407,6 +408,35 @@ class UsuarioAdminViewSet(viewsets.ModelViewSet):
         with transaction.atomic():
             auditar_user_delete(actor=self.request.user, target_user=instance)
             instance.delete()
+
+    @action(detail=True, methods=["post"], permission_classes=[HasPerm("manage_admin_registries")])
+    def anonimizar(self, request: Request, pk: str | None = None) -> Response:
+        """
+        LGPD art. 18-VI (direito ao esquecimento) — anonimiza a PII do usuário,
+        preservando o histórico.
+
+        Alternativa ao hard-delete (`perform_destroy`) quando FKs PROTECT
+        (Solicitacao/AvailabilityBlock/dat_*) barram a exclusão: em vez de falhar
+        com ProtectedError, remove a PII e mantém a linha. Idempotente.
+
+        Segurança: superuser-alvo já recebe 404 via `get_queryset` (P0-0); além
+        disso o último superusuário ativo não pode ser anonimizado (anti-lockout,
+        espelha `perform_destroy`).
+
+        Endpoint: POST /api/usuarios-admin/{id}/anonimizar/
+        """
+        usuario = self.get_object()
+        if usuario.is_superuser:
+            has_other_active_superuser = (
+                Usuario.objects.filter(is_superuser=True, is_active=True).exclude(pk=usuario.pk).exists()
+            )
+            if not has_other_active_superuser:
+                raise ValidationError({"detail": "Não é possível anonimizar o último superusuário ativo."})
+        anonimizado = anonimizar_usuario(usuario=usuario, actor=request.user)
+        return Response(
+            {"detail": "Usuário anonimizado.", "id": usuario.pk, "anonimizado": anonimizado},
+            status=status.HTTP_200_OK,
+        )
 
     @action(detail=True, methods=["post"], permission_classes=[SuperuserOnly])
     def assign_groups(self, request, pk=None):


### PR DESCRIPTION
## Contexto (auditoria de risco jurídico)

Achado P1 da auditoria LGPD: **direito ao esquecimento não acionável**. O `perform_destroy` do admin faz **hard-delete**, mas as FKs são `PROTECT` (Solicitacao/AvailabilityBlock/dat_*) → qualquer titular com histórico dispara `ProtectedError`, e não há anonimização. Na prática a PII fica retida sem caminho de remoção (LGPD art. 18-VI).

## Solução — anonimizar preservando a linha

Como o `cpf` é `unique`+NOT NULL e as FKs são PROTECT, a via LGPD-correta é **anonimizar** (não deletar): remover a PII e manter a linha para preservar a integridade referencial dos registros de negócio.

- **`services/anonimizacao.py`** — `anonimizar_usuario(usuario, actor)`:
  - Scrubba `cpf` (marcador único `ANON…`), `username` (`anon_<pk>`), `first_name`, `last_name`, `email`, `telefone`, `cargo`.
  - `is_active=False` + `set_unusable_password()`.
  - Remove a credencial **Google OAuth** (`google_email` + tokens Fernet = PII do titular).
  - **Idempotente**.
- **Auditoria** — `USER_ANONYMIZE` emitido no **mesmo `atomic()`** da mutação (padrão #1672: em autocommit o `on_commit` dispararia antes do save → trilha-fantasma). O `details` registra só o **fato** (ids + lista de campos), **nunca os valores de PII** (não re-introduz dado pessoal na trilha).
- **Enum** — `USER_ANONYMIZE` em `AuditLog.Action`, **sem migration** (o field não aplica `choices`).
- **Endpoint** — `POST /api/usuarios-admin/{id}/anonimizar/`: `HasPerm("manage_admin_registries")`, **anti-lockout** do último superuser ativo, e P0-0 (superuser-alvo → 404 via `get_queryset`).

## Testes

`apps/core/tests/test_anonimizacao_usuario.py` — 8 testes, **RED→GREEN provado** (neutralizei o scrub → 5 comportamentais vermelhos; restaurei → 8/8 verdes):

- serviço: scrub + **preserva a linha**, idempotência, **funciona onde o hard-delete falha com `ProtectedError`** (cria `Solicitacao` referenciando o titular), auditoria sem PII.
- endpoint: 200 (DAT), 403 (sem perm), 404 (superuser-alvo p/ não-superuser), 400 (último superuser).

**Regressão** (enum + viewset são compartilhados): `test_audit_service` + `test_audit_privilege_sites` + `test_admin_api` = **79/79** verdes.

## Escopo / follow-up

Fecha a **capacidade** de exclusão/anonimização (backend). O fluxo **self-service** do titular (solicitar a própria anonimização pela UI) e a anonimização de dossiês paralelos (`DATCoordenador`) são follow-ups separados da mesma auditoria.

Parte do sweep de P1 técnicos da auditoria de risco jurídico (sem depender do jurídico).
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `ab0876d8`, slot `0` / projeto `aprender_staging`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
