### PR TITLE
feat(lgpd): retenção/expurgo dos artefatos de PII dos ImportJobs (arts. 6/16)

### DIFF
--- a/v2/backend/apps/core/models/auditoria.py
+++ b/v2/backend/apps/core/models/auditoria.py
@@ -71,6 +71,9 @@ class AuditLog(models.Model):
         # Import jobs
         IMPORT_JOB_COMPLETED = "IMPORT_JOB_COMPLETED", "Import job concluido"
         IMPORT_JOB_FAILED = "IMPORT_JOB_FAILED", "Import job falhou"
+        # LGPD retencao (arts. 6/16): expurgo dos artefatos de PII de jobs antigos
+        # (arquivo submetido + pendencias + traceback). Ver apps.core.tasks.
+        IMPORT_ARTIFACT_PURGE = "IMPORT_ARTIFACT_PURGE", "Expurgo de artefatos de import (retencao LGPD)"
 
         # Deslocamento
         CREATE_DESLOCAMENTO = "CREATE_DESLOCAMENTO", "Criar deslocamento"

--- a/v2/backend/apps/core/tasks.py
+++ b/v2/backend/apps/core/tasks.py
@@ -45,6 +45,53 @@ def debug_task(self: Any) -> str:
 
 
 @shared_task
+def purge_import_job_artifacts() -> dict[str, Any]:
+    """LGPD retencao/minimizacao (arts. 6-III/16): expurga os artefatos de PII de
+    ImportJobs antigos.
+
+    Apos `IMPORT_JOB_ARTIFACT_RETENTION_DAYS` (default 90), remove do storage o
+    arquivo submetido e limpa `pendencias` + `error_traceback` (que podem carregar
+    CPF/e-mail/nome de linhas rejeitadas), MANTENDO a linha do job — a metadata
+    operacional (quem/quando/status/contagens) fica para a trilha (art. 37).
+    Idempotente. Registrada no CELERY_BEAT_SCHEDULE (diaria, 03:00).
+    """
+    from datetime import timedelta
+
+    from django.conf import settings
+    from django.utils import timezone
+
+    from apps.core.models import AuditLog, ImportJob
+    from apps.core.services.audit import registrar_auditoria
+
+    days = int(getattr(settings, "IMPORT_JOB_ARTIFACT_RETENTION_DAYS", 90))
+    cutoff = timezone.now() - timedelta(days=days)
+
+    purged = 0
+    for job in ImportJob.objects.filter(created_at__lt=cutoff).iterator():
+        tem_pii = bool(job.file) or bool(job.pendencias) or bool(job.error_traceback)
+        if not tem_pii:
+            continue  # ja expurgado — idempotente
+        if job.file:
+            job.file.delete(save=False)  # apaga do storage e limpa o FileField
+        job.pendencias = {}
+        job.error_traceback = ""
+        job.save(update_fields=["file", "pendencias", "error_traceback", "updated_at"])
+        purged += 1
+
+    if purged:
+        registrar_auditoria(
+            actor=None,
+            action=AuditLog.Action.IMPORT_ARTIFACT_PURGE,
+            model_name="ImportJob",
+            details={"purged": purged, "retention_days": days, "cutoff": cutoff.isoformat()},
+            imediato=True,
+        )
+
+    logger.info("purge_import_job_artifacts: %d job(s) expurgado(s) (retencao=%dd)", purged, days)
+    return {"purged": purged, "retention_days": days}
+
+
+@shared_task
 def gcal_sync_task() -> None:
     """
     DEPRECATED: Tarefa stub para sincronização com Google Calendar.

--- a/v2/backend/apps/core/tests/test_purge_import_artifacts.py
+++ b/v2/backend/apps/core/tests/test_purge_import_artifacts.py
@@ -1,0 +1,88 @@
+"""LGPD retencao/minimizacao (arts. 6/16) — testes da task purge_import_job_artifacts.
+
+Verifica que, apos a janela de retencao, os artefatos de PII do ImportJob (arquivo
+submetido + pendencias + traceback) sao expurgados, MANTENDO a linha operacional,
+de forma idempotente e auditada.
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportAttributeAccessIssue=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportIndexIssue=false
+
+from __future__ import annotations
+
+import os
+from datetime import timedelta
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.utils import timezone
+
+import pytest
+
+from apps.core.models import AuditLog, ImportJob
+from apps.core.tasks import purge_import_job_artifacts
+from apps.core.tests.factories import UsuarioFactory
+
+pytestmark = pytest.mark.django_db
+
+_PII_CSV = b"cpf,nome,email\n11144477735,Maria,maria@example.com\n"
+
+
+def _import_job(*, dias_atras: int):
+    job = ImportJob.objects.create(
+        user=UsuarioFactory(),
+        import_type=ImportJob.ImportType.BLOQUEIOS,
+        file=SimpleUploadedFile("planilha.csv", _PII_CSV),
+        pendencias={"usuarios": [{"cpf": "11144477735"}]},
+        error_traceback="Traceback: valor invalido na linha do CPF 11144477735",
+    )
+    # created_at tem default=now; backdate via update p/ nao brigar com o default.
+    ImportJob.objects.filter(pk=job.pk).update(created_at=timezone.now() - timedelta(days=dias_atras))
+    job.refresh_from_db()
+    return job
+
+
+def test_purga_artefatos_de_job_antigo(settings, tmp_path):
+    settings.MEDIA_ROOT = str(tmp_path)
+    job = _import_job(dias_atras=200)
+    file_path = job.file.path
+    assert os.path.exists(file_path)
+
+    result = purge_import_job_artifacts()
+
+    assert result["purged"] == 1
+    job.refresh_from_db()
+    assert ImportJob.objects.filter(pk=job.pk).exists()  # linha preservada (metadata)
+    assert not job.file
+    assert job.pendencias == {}
+    assert job.error_traceback == ""
+    assert not os.path.exists(file_path)  # arquivo removido do storage
+    assert job.import_type == ImportJob.ImportType.BLOQUEIOS  # metadata operacional intacta
+
+
+def test_nao_toca_job_dentro_da_retencao(settings, tmp_path):
+    settings.MEDIA_ROOT = str(tmp_path)
+    job = _import_job(dias_atras=10)  # < 90 dias
+
+    purge_import_job_artifacts()
+
+    job.refresh_from_db()
+    assert bool(job.file) is True
+    assert job.pendencias != {}
+
+
+def test_idempotente(settings, tmp_path):
+    settings.MEDIA_ROOT = str(tmp_path)
+    _import_job(dias_atras=200)
+
+    assert purge_import_job_artifacts()["purged"] == 1
+    assert purge_import_job_artifacts()["purged"] == 0  # nada mais a expurgar
+
+
+def test_audita_o_purge(settings, tmp_path):
+    settings.MEDIA_ROOT = str(tmp_path)
+    _import_job(dias_atras=200)
+
+    purge_import_job_artifacts()
+
+    log = AuditLog.objects.filter(action=AuditLog.Action.IMPORT_ARTIFACT_PURGE).latest("created_at")
+    assert log.details["purged"] == 1
+    assert log.details["retention_days"] == 90

--- a/v2/backend/config/settings.py
+++ b/v2/backend/config/settings.py
@@ -612,19 +612,23 @@ CELERY_TASK_TIME_LIMIT = 30 * 60  # 30 minutes
 FEATURE_AUTO_APPLY_ENABLED = os.getenv("FEATURE_AUTO_APPLY_ENABLED", "0") == "1"
 
 # Celery Beat Schedule (tarefas periódicas)
-# Governança Fase 3: schedule só é registrado quando FEATURE_AUTO_APPLY_ENABLED=True
+from celery.schedules import crontab  # noqa: E402 — usado só pelo beat schedule abaixo
+
+# LGPD retenção/minimização (arts. 6/16): o expurgo diário dos artefatos de PII de
+# ImportJobs antigos é SEMPRE registrado — não depende de FEATURE_AUTO_APPLY_ENABLED.
+CELERY_BEAT_SCHEDULE = {
+    "purge-import-artifacts-daily": {
+        "task": "apps.core.tasks.purge_import_job_artifacts",
+        "schedule": crontab(hour=3, minute=0),  # 03:00 (off-peak)
+    },
+}
+# Governança Fase 3: o gcal-sync só é registrado quando FEATURE_AUTO_APPLY_ENABLED=True.
 if FEATURE_AUTO_APPLY_ENABLED:
-    CELERY_BEAT_SCHEDULE = {
-        "gcal-sync-every-5-minutes": {
-            "task": "apps.core.tasks.preview_then_apply_gcal",
-            "schedule": 300.0,  # 5 minutos (em segundos)
-            "options": {
-                "expires": 60.0,  # Tarefa expira após 60s se não iniciar
-            },
-        },
+    CELERY_BEAT_SCHEDULE["gcal-sync-every-5-minutes"] = {
+        "task": "apps.core.tasks.preview_then_apply_gcal",
+        "schedule": 300.0,  # 5 minutos (em segundos)
+        "options": {"expires": 60.0},  # Tarefa expira após 60s se não iniciar
     }
-else:
-    CELERY_BEAT_SCHEDULE = {}
 
 # ================================================================
 # LOGGING (MP2: Structured Logging)
@@ -804,6 +808,10 @@ DATA_IMPORT_DIR = os.getenv("DATA_IMPORT_DIR", "/app/data/csv-import")
 # ================================================================
 BACKUP_DIR = os.getenv("BACKUP_DIR", "/backups")
 BACKUP_RETENTION_DAYS = int(os.getenv("BACKUP_RETENTION_DAYS", "7"))
+# LGPD retencao/minimizacao (arts. 6-III/16): apos N dias, os artefatos de PII dos
+# ImportJobs (arquivo submetido + pendencias + traceback) sao expurgados pela task
+# `purge_import_job_artifacts`, preservando a metadata operacional. Default 90 dias.
+IMPORT_JOB_ARTIFACT_RETENTION_DAYS = int(os.getenv("IMPORT_JOB_ARTIFACT_RETENTION_DAYS", "90"))
 # S3 bucket name (without s3://). Use empty string to disable uploads.
 BACKUP_S3_BUCKET = os.getenv("BACKUP_S3_BUCKET", "")
 

--- a/v2/backend/config/settings.py
+++ b/v2/backend/config/settings.py
@@ -616,7 +616,10 @@ from celery.schedules import crontab  # noqa: E402 — usado só pelo beat sched
 
 # LGPD retenção/minimização (arts. 6/16): o expurgo diário dos artefatos de PII de
 # ImportJobs antigos é SEMPRE registrado — não depende de FEATURE_AUTO_APPLY_ENABLED.
-CELERY_BEAT_SCHEDULE = {
+# Anotacao explicita: as entradas sao heterogeneas (crontab vs float + options),
+# entao sem o tipo declarado o pyright estreita o valor pela 1a entrada e reprova o
+# __setitem__ da entrada do gcal. `dict[str, object]` por entrada aceita ambas.
+CELERY_BEAT_SCHEDULE: dict[str, dict[str, object]] = {
     "purge-import-artifacts-daily": {
         "task": "apps.core.tasks.purge_import_job_artifacts",
         "schedule": crontab(hour=3, minute=0),  # 03:00 (off-peak)


### PR DESCRIPTION
## Contexto (auditoria de risco jurídico)

Achado P1: **planilhas de import com PII em massa retidas indefinidamente**. O `ImportJob` mantém o **arquivo submetido** (`FileField`) + **`pendencias`** + **`error_traceback`** "para auditoria" **sem prazo nem expurgo**. Esses artefatos carregam CPF/nome/e-mail de linhas rejeitadas — tensiona minimização/retenção (LGPD art. 6‑III/16).

## Solução — retenção com preservação da metadata

Task Celery diária que, após a janela de retenção, **remove os artefatos de PII mantendo a linha operacional** (a via correta: minimiza o dado sensível, preserva a trilha de accountability do art. 37).

- **`purge_import_job_artifacts`** (`apps/core/tasks.py`): para jobs com `created_at` além de `IMPORT_JOB_ARTIFACT_RETENTION_DAYS` (default **90**), apaga o `file` do storage e zera `pendencias`/`error_traceback`, **mantendo** `user`/`import_type`/`status`/`stats`/timestamps. **Idempotente**. Audita `IMPORT_ARTIFACT_PURGE`.
- **`CELERY_BEAT_SCHEDULE`**: purge **diário às 03:00**, **sempre registrado** (não depende de `FEATURE_AUTO_APPLY_ENABLED`, que só gateia o gcal-sync). Restruturei o bloco para o purge ser incondicional e o gcal-sync continuar condicional.
- **`IMPORT_JOB_ARTIFACT_RETENTION_DAYS`** — novo setting (env-configurável).
- **`IMPORT_ARTIFACT_PURGE`** no enum `AuditLog.Action` — **sem migration** (o field não aplica `choices`).

## Testes

`apps/core/tests/test_purge_import_artifacts.py` — 4 testes, **RED→GREEN provado** (neutralizei o purge → 3 vermelhos; restaurei → 4/4):

- purga o arquivo + `pendencias`/`traceback` de job antigo e **preserva a linha**;
- **não toca** job dentro da janela de retenção;
- **idempotência** (2ª execução expurga 0);
- **audita** `IMPORT_ARTIFACT_PURGE`.

**Verificação de integração**: `manage.py check` limpo · task **autodiscoberta por celery** (`True`) · **7/7** dos testes de beat registration/schedule (inclui "toda task agendada está registrada" + "mantém backup/notificações") · **67** de regressão import_job/tasks.

Parte do sweep de P1 técnicos da auditoria de risco jurídico.
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `81826f22`, slot `0` / projeto `aprender_staging`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
