### PR TITLE
docs(security): spec de cifra at-rest do CPF/PII — decisão = cifra de disco VM02

### DIFF
--- a/v2/docs/specs/INDEX_SDD.md
+++ b/v2/docs/specs/INDEX_SDD.md
@@ -98,6 +98,7 @@ related: []                   # links a specs/ADRs relacionados
 | [deploy.spec.md](./infra/deploy.spec.md) | deploy pull-based (ADR-018): promote → ponteiro assinado → agente na VM01 | canonical |
 | [environments.spec.md](./infra/environments.spec.md) | dev / staging / prod-like | canonical |
 | [ci.spec.md](./infra/ci.spec.md) | GitHub Actions, gates, deploy | canonical |
+| [at-rest-encryption.spec.md](./infra/at-rest-encryption.spec.md) | cifra de dados em repouso (CPF/PII): decisão = cifra de disco VM02 | draft |
 
 > READMEs de área: [`domain/`](./domain/README.md) · [`backend/`](./backend/README.md) ·
 > [`frontend/`](./frontend/README.md) · [`infra/`](./infra/README.md).

--- a/v2/docs/specs/infra/README.md
+++ b/v2/docs/specs/infra/README.md
@@ -18,6 +18,7 @@ Voltar ao [índice SDD](../INDEX_SDD.md).
 | [`deploy.spec.md`](./deploy.spec.md) | ✅ escrita | `docker-compose.prod.yml`, `deploy.yaml`, `promote.yml`, `v2/infra/deployer/`, ADR-018 |
 | [`environments.spec.md`](./environments.spec.md) | ✅ escrita | `v2/infra/ENVIRONMENTS.md`, `docker-compose*.yml` |
 | [`ci.spec.md`](./ci.spec.md) | ✅ escrita | `.github/workflows/`, `docs/operations/ci-*.md` |
+| [`at-rest-encryption.spec.md`](./at-rest-encryption.spec.md) | 📝 draft | `docker-compose.prod.yml`, `usuario.py`, `backup_db.sh` (decisão: cifra de disco VM02) |
 
 > **Modelo de deploy: pull-based** ([ADR-018](../../../../docs/architecture/project-decisions/ADR-018-pull-based-deploy.md),
 > que **supersede** o ADR-010). **Merge na `main` NÃO deploya** — ele só faz build, scan,

--- a/v2/docs/specs/infra/at-rest-encryption.spec.md
+++ b/v2/docs/specs/infra/at-rest-encryption.spec.md
@@ -1,0 +1,96 @@
+---
+title: Criptografia de dados em repouso (at-rest) — CPF/PII
+status: draft
+last_verified: 2026-08-10
+sources_of_truth:
+  - v2/infra/docker-compose.prod.yml
+  - v2/infra/scripts/backup_db.sh
+  - v2/backend/apps/core/models/usuario.py
+  - v2/backend/apps/core/models/integracao.py
+  - v2/backend/config/settings.py
+owner: infra
+supersedes: []
+related:
+  - ./deploy.spec.md
+  - ./environments.spec.md
+  - ../../BACKUP_OPERATIONS.md
+  - ../../DISASTER_RECOVERY.md
+  - ../INDEX_SDD.md
+---
+
+# Criptografia de dados em repouso (at-rest) — CPF/PII
+
+> **Decisão de arquitetura** (auditoria de risco jurídico, 2026-08-10). Define **como** o
+> CPF e a PII operacional são protegidos **em repouso** e **por que** a cifra é feita no
+> **disco/volume da VM02**, não campo-a-campo no aplicativo. A verificação/ativação na VM02
+> é ação de infra (runbook abaixo) — por isso `status: draft` até a evidência ser registrada.
+
+## Contexto / risco
+
+`core_usuario.cpf` é **texto puro** no PostgreSQL: `CharField(max_length=11, unique=True)`, **NOT
+NULL**, e é a **chave de login** (autenticação por CPF). Nome, e-mail e telefone idem
+([`usuario.py`](../../../backend/apps/core/models/usuario.py)). O `DATCoordenador` mantém um
+dossiê paralelo de PII. O risco é a exposição desse dado **em repouso** — um cenário de **roubo
+de disco, snapshot ou dump não-autorizado** do volume do banco.
+
+O que **já** protege (por isso o risco é "em repouso", não vazamento iminente):
+
+| Camada | Estado | Onde |
+|---|---|---|
+| TLS em trânsito (app↔DB `sslmode=require`, HSTS, cookies seguros) | ✅ | [`settings.py`](../../../backend/config/settings.py) (SEC-016) |
+| Backups cifrados com `age` (fail-closed, chave fora do repo) | ✅ | [`backup_db.sh`](../../../infra/scripts/backup_db.sh) |
+| Tokens OAuth cifrados com Fernet | ✅ | [`integracao.py`](../../../backend/apps/core/models/integracao.py) |
+| Controle de acesso (RBAC + admin superuser-only) | ✅ | `apps/core/rbac/` |
+| **Cifra do volume do PostgreSQL (VM02)** | ⚠️ **não evidenciado** | infra/provedor |
+
+A última linha é o furo: o PGDATA na **VM02** (Postgres externo — [`docker-compose.prod.yml`](../../../infra/docker-compose.prod.yml)
+**não** tem serviço de DB; o app conecta na VM02) precisa de cifra em repouso.
+
+## Decisão
+
+**O controle de at-rest é a criptografia de disco/volume da VM02** (LUKS no host **ou** cifra de
+volume gerenciada pelo provedor). É transparente para o app e para o PostgreSQL, protege **toda**
+a PII (não só o CPF), e não exige mudança de código.
+
+### Rejeitado: cifra de campo (Fernet) do CPF
+
+Considerada e **descartada como over-engineering** para este *threat model*:
+
+1. **Quebra o login-por-CPF.** A autenticação faz `WHERE cpf = X`; um valor cifrado não é
+   buscável. Exigiria cifra **determinística** ou um **HMAC/hash paralelo** só para a busca, mais
+   **migração de dados** e mudanças em `auth_backends`, serializers, importadores e na busca do
+   admin — superfície grande e sensível (auth).
+2. **Ganho marginal sobre a cifra de disco.** Um adversário com acesso ao processo Django tem a
+   chave Fernet de qualquer forma; a cifra de campo só ajuda contra **dump de disco frio** — que a
+   **cifra de disco já cobre**, para toda a PII e sem código.
+3. **Custo de gestão + rotação de chave** para esse ganho marginal.
+
+> **Por que os tokens OAuth *são* cifrados com Fernet e o CPF não deve ser:** o token é **segredo de
+> altíssimo valor e NÃO é chave de busca** — cifra de campo é adequada. O CPF é **identificador de
+> busca** (login) — categoria diferente; para ele o controle certo é a cifra de disco.
+
+## Runbook — verificar / ativar (VM02)
+
+1. **Verificar** se o volume do PGDATA já é cifrado:
+   - LUKS: `lsblk -o NAME,FSTYPE,MOUNTPOINT` e `cryptsetup status <device>` (esperar `crypto_LUKS`
+     no device que monta o PGDATA).
+   - Provedor (cloud): confirmar "**encryption at rest**" habilitado no disco/volume no console.
+2. **Se não cifrado**, planejar a migração: cifrar exige recriar o volume ou migrar o PGDATA para um
+   volume cifrado — **janela de manutenção** + restore a partir do backup `age`
+   ([`restore_db.sh`](../../../infra/scripts/restore_db.sh); ver [`DISASTER_RECOVERY.md`](../../DISASTER_RECOVERY.md)).
+3. **Confirmar** que os **snapshots do volume** (se o provedor os faz) também são cifrados.
+4. **Registrar** a evidência e atualizar o `last_verified` + `status` desta spec.
+
+## Critério de aceite
+
+- Volume do PGDATA na VM02 **cifrado em repouso** (LUKS ou gerenciado pelo provedor), com evidência.
+- Snapshots do volume cifrados.
+- Esta spec atualizada (`status: canonical`, `last_verified` com a data da verificação, evidência).
+
+## Estado atual
+
+⚠️ **Pendente de verificação de infra.** A cifra de disco da VM02 é configuração de infra/provedor,
+**fora do código** — não é observável neste repositório. Achado da auditoria de risco jurídico
+(2026-08-10): *"o at-rest do CPF/PII depende da cifra de disco da VM02, não evidenciada no repo"*.
+**Ação do dono/infra:** rodar o runbook acima e registrar a evidência aqui. Enquanto isso, os
+controles compensatórios da tabela de contexto (TLS, backups `age`, RBAC) permanecem ativos.


### PR DESCRIPTION
## Contexto (auditoria de risco jurídico)

Achado P1: **CPF em texto puro** no PostgreSQL (`core_usuario.cpf`, `unique`+NOT NULL, chave de login), sem cifra **em repouso** evidenciada. Risco = roubo de disco/snapshot/dump da VM02.

Diferente dos outros P1 do sweep, este é uma **decisão de arquitetura**, não código mecânico — então o entregável é uma **spec viva** (SDD) que fixa a decisão + o runbook.

## Decisão

**Cifra de disco/volume na VM02** (LUKS ou gerenciada pelo provedor) como o controle de at-rest: transparente para o app e o Postgres, protege **toda** a PII, sem mudança de código.

**Rejeita cifra de campo (Fernet) do CPF** como over-engineering:
- Quebra o **login-por-CPF** (`WHERE cpf = X`) → exigiria HMAC/determinística + migração + mudanças em auth/serializers/imports/admin.
- Ganho marginal sobre a cifra de disco (quem tem o processo Django tem a chave Fernet; a cifra de campo só ajuda contra dump frio, que o disco já cobre).
- Contrasta com os **tokens OAuth** (segredo, não chave de busca → Fernet justificado e já em uso).

## Entregável

`v2/docs/specs/infra/at-rest-encryption.spec.md` — contexto/risco (com tabela dos controles já ativos: TLS, backups `age`, RBAC), decisão + justificativa, **runbook de verificação/ativação na VM02**, e critério de aceite. `status: draft` até a evidência de infra ser registrada. Indexada no `INDEX_SDD` + README de infra.

## Verificação

Gates de docs locais **verdes**: `check_doc_frontmatter.py` (OK) + `check_doc_links.py` (0 links quebrados).

## Ação pendente (fora deste PR)

A cifra de disco da VM02 é config de infra/provedor — **ação do dono/infra**: rodar o runbook e registrar a evidência (aí a spec vira `canonical`).

Fecha o **sweep de P1 técnicos** da auditoria (junto de #1691/#1692/#1693).