### PR TITLE
feat(lgpd): retenção do AuditLog + trilha de exportação; conserta lgpd_export quebrado (arts. 6/16/37)

### DIFF
--- a/v2/backend/apps/core/management/commands/lgpd_export.py
+++ b/v2/backend/apps/core/management/commands/lgpd_export.py
@@ -114,18 +114,19 @@ class Command(BaseCommand):
             },
         }
 
-        # Solicitations created by user
-        solicitations = Solicitacao.objects.filter(solicitante=user)
+        # Solicitations created by user. NB: os campos reais sao usuario/inicio/fim — o
+        # command usava solicitante/data_inicio/data_fim/titulo/fluxo (inexistentes), entao
+        # a ferramenta de portabilidade LGPD estourava FieldError em qualquer invocacao real.
+        solicitations = Solicitacao.objects.filter(usuario=user)
         data["solicitations_created"] = list(
             solicitations.values(
                 "id",
-                "titulo",
                 "status",
-                "fluxo",
-                "data_inicio",
-                "data_fim",
+                "inicio",
+                "fim",
                 "municipio__nome",
                 "projeto__nome",
+                "tipo_evento__nome",
                 "created_at",
                 "updated_at",
             )
@@ -136,22 +137,21 @@ class Command(BaseCommand):
         data["events_as_formador"] = list(
             formador_events.values(
                 "id",
-                "titulo",
                 "status",
-                "data_inicio",
-                "data_fim",
+                "inicio",
+                "fim",
                 "municipio__nome",
             )
         )
 
-        # Availability blocks for user
-        blocks = AvailabilityBlock.objects.filter(formador=user)
+        # Availability blocks for user (o dono do bloco e' `usuario`, nao `formador`)
+        blocks = AvailabilityBlock.objects.filter(usuario=user)
         data["availability_blocks"] = list(
             blocks.values(
                 "id",
                 "tipo",
-                "data_inicio",
-                "data_fim",
+                "inicio",
+                "fim",
                 "motivo",
                 "created_at",
             )
@@ -211,6 +211,29 @@ class Command(BaseCommand):
             json.dump(data, f, indent=2, ensure_ascii=False, default=str)
 
         self.stdout.write(self.style.SUCCESS(f"Data exported to: {output_path}"))
+
+        # LGPD art. 18 (acesso/portabilidade): a exportacao do dossie de um titular e'
+        # operacao sensivel e precisa de trilha (art. 37). Registra o FATO — alvo, destino,
+        # contagens — NUNCA os valores de PII exportados.
+        from apps.core.services.audit import registrar_auditoria
+
+        registrar_auditoria(
+            actor=None,  # comando CLI de admin; sem request user
+            action=AuditLog.Action.EXPORT,
+            model_name="Usuario",
+            details={
+                "target_user_id": user.pk,
+                "output_path": str(output_path),
+                "include_audit": bool(include_audit),
+                "counts": {
+                    "solicitations_created": len(data["solicitations_created"]),
+                    "events_as_formador": len(data["events_as_formador"]),
+                    "availability_blocks": len(data["availability_blocks"]),
+                    "approvals_made": len(data["approvals_made"]),
+                },
+            },
+            imediato=True,
+        )
 
         # Summary
         self.stdout.write("  - Personal data: exported")

--- a/v2/backend/apps/core/models/auditoria.py
+++ b/v2/backend/apps/core/models/auditoria.py
@@ -108,6 +108,9 @@ class AuditLog(models.Model):
         # LGPD art. 18-VI (direito ao esquecimento). Anonimizacao preserva a linha
         # (FKs PROTECT) e remove a PII — ver apps.core.services.anonimizacao.
         USER_ANONYMIZE = "USER_ANONYMIZE", "Anonimizar usuario (LGPD art. 18-VI)"
+        # LGPD art. 18 (acesso/portabilidade): exportacao do dossie de um titular
+        # (management command lgpd_export). Registra o FATO, nunca os valores de PII.
+        EXPORT = "EXPORT", "Exportar dados de usuario (LGPD art. 18)"
 
     usuario = models.ForeignKey(  # type: ignore[misc]
         "core.Usuario",

--- a/v2/backend/apps/core/tasks.py
+++ b/v2/backend/apps/core/tasks.py
@@ -92,6 +92,30 @@ def purge_import_job_artifacts() -> dict[str, Any]:
 
 
 @shared_task
+def purge_old_audit_logs() -> dict[str, Any]:
+    """LGPD retencao/minimizacao (arts. 6-III/16): expurga entradas de AuditLog mais
+    antigas que AUDITLOG_RETENTION_DAYS.
+
+    A trilha acumula ip_address/user_agent/CPF-as-username indefinidamente; manter para
+    sempre tensiona a minimizacao. O prazo (default 5 anos; Marco Civil exige >= 6 meses
+    p/ logs de acesso) equilibra accountability e minimizacao. NAO se auto-audita (seria
+    recursivo) — registra o resultado no log do servidor. Agendada semanalmente.
+    """
+    from datetime import timedelta
+
+    from django.conf import settings
+    from django.utils import timezone
+
+    from apps.core.models import AuditLog
+
+    days = int(getattr(settings, "AUDITLOG_RETENTION_DAYS", 1825))
+    cutoff = timezone.now() - timedelta(days=days)
+    deleted, _ = AuditLog.objects.filter(created_at__lt=cutoff).delete()
+    logger.info("purge_old_audit_logs: %d registro(s) expurgado(s) (retencao=%dd)", deleted, days)
+    return {"deleted": deleted, "retention_days": days}
+
+
+@shared_task
 def gcal_sync_task() -> None:
     """
     DEPRECATED: Tarefa stub para sincronização com Google Calendar.

--- a/v2/backend/apps/core/tests/test_auditlog_retention_export.py
+++ b/v2/backend/apps/core/tests/test_auditlog_retention_export.py
@@ -1,0 +1,76 @@
+"""LGPD arts. 6/16/37 — retenção do AuditLog (#1) + trilha de exportação (#7).
+
+- Retencao: `purge_old_audit_logs` expurga entradas alem de AUDITLOG_RETENTION_DAYS.
+- Export audit: `lgpd_export` grava um AuditLog EXPORT do FATO, sem valores de PII.
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportAttributeAccessIssue=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportIndexIssue=false
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from django.core.management import call_command
+from django.utils import timezone
+
+import pytest
+
+from apps.core.models import AuditLog
+from apps.core.tasks import purge_old_audit_logs
+from apps.core.tests.factories import UsuarioFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def _audit(*, dias_atras: int, action: str = "LOGIN"):
+    log = AuditLog.objects.create(action=action, details={"ip_address": "1.2.3.4"})
+    AuditLog.objects.filter(pk=log.pk).update(created_at=timezone.now() - timedelta(days=dias_atras))
+    return log
+
+
+# ------------------------- retenção (#1) -------------------------
+
+
+def test_purge_expurga_logs_antigos(settings):
+    settings.AUDITLOG_RETENTION_DAYS = 1825
+    old = _audit(dias_atras=2000)  # > 5 anos
+    recent = _audit(dias_atras=30)  # dentro da janela
+
+    result = purge_old_audit_logs()
+
+    assert result["deleted"] == 1
+    assert not AuditLog.objects.filter(pk=old.pk).exists()
+    assert AuditLog.objects.filter(pk=recent.pk).exists()
+
+
+def test_purge_idempotente(settings):
+    settings.AUDITLOG_RETENTION_DAYS = 1825
+    _audit(dias_atras=2000)
+    assert purge_old_audit_logs()["deleted"] == 1
+    assert purge_old_audit_logs()["deleted"] == 0
+
+
+def test_purge_respeita_retention_configuravel(settings):
+    settings.AUDITLOG_RETENTION_DAYS = 10
+    _audit(dias_atras=20)  # fora
+    _audit(dias_atras=5)  # dentro
+    assert purge_old_audit_logs()["deleted"] == 1
+
+
+# ------------------------- trilha de export (#7) -------------------------
+
+
+def test_lgpd_export_registra_trilha_sem_pii(tmp_path):
+    user = UsuarioFactory(cpf="11144477735", email="maria@example.com")
+    out = tmp_path / "export.json"
+
+    call_command("lgpd_export", cpf="11144477735", output=str(out))
+
+    log = AuditLog.objects.filter(action=AuditLog.Action.EXPORT).latest("created_at")
+    assert log.details["target_user_id"] == user.pk
+    assert "counts" in log.details
+    # o FATO e' auditado, mas os valores de PII do titular NAO entram na trilha
+    blob = str(log.details)
+    assert "11144477735" not in blob
+    assert "maria@example.com" not in blob
+    assert out.exists()

--- a/v2/backend/config/settings.py
+++ b/v2/backend/config/settings.py
@@ -624,6 +624,11 @@ CELERY_BEAT_SCHEDULE: dict[str, dict[str, object]] = {
         "task": "apps.core.tasks.purge_import_job_artifacts",
         "schedule": crontab(hour=3, minute=0),  # 03:00 (off-peak)
     },
+    # Retencao LGPD da trilha de auditoria (arts. 6/16). Semanal (domingo 04:00).
+    "purge-audit-logs-weekly": {
+        "task": "apps.core.tasks.purge_old_audit_logs",
+        "schedule": crontab(hour=4, minute=0, day_of_week=0),
+    },
 }
 # Governança Fase 3: o gcal-sync só é registrado quando FEATURE_AUTO_APPLY_ENABLED=True.
 if FEATURE_AUTO_APPLY_ENABLED:
@@ -815,6 +820,11 @@ BACKUP_RETENTION_DAYS = int(os.getenv("BACKUP_RETENTION_DAYS", "7"))
 # ImportJobs (arquivo submetido + pendencias + traceback) sao expurgados pela task
 # `purge_import_job_artifacts`, preservando a metadata operacional. Default 90 dias.
 IMPORT_JOB_ARTIFACT_RETENTION_DAYS = int(os.getenv("IMPORT_JOB_ARTIFACT_RETENTION_DAYS", "90"))
+# LGPD retencao/minimizacao (arts. 6-III/16) da trilha de auditoria: o AuditLog acumula
+# ip_address/user_agent/CPF-as-username indefinidamente. Apos N dias os registros sao
+# expurgados por `purge_old_audit_logs`. Default 5 anos: Marco Civil art. 15 exige >= 6
+# meses para logs de acesso, e 5 anos cobre com folga a prescricao usual.
+AUDITLOG_RETENTION_DAYS = int(os.getenv("AUDITLOG_RETENTION_DAYS", "1825"))
 # S3 bucket name (without s3://). Use empty string to disable uploads.
 BACKUP_S3_BUCKET = os.getenv("BACKUP_S3_BUCKET", "")
 


### PR DESCRIPTION
Batch **A** dos achados técnicos restantes da auditoria de risco jurídico (#1 + #7), + um bug real destravado no caminho.

## #1 — Retenção da trilha de auditoria (arts. 6-III/16)
`AuditLog` acumulava `ip_address`/`user_agent`/CPF-as-username **indefinidamente**. Nova task **`purge_old_audit_logs`** expurga entradas além de `AUDITLOG_RETENTION_DAYS` (default **5 anos** — Marco Civil art. 15 exige ≥ 6 meses p/ logs de acesso; equilibra accountability × minimização). Beat **semanal** (domingo 04:00). Não se auto-audita (evita recursão); loga o resultado no servidor.

## #7 — Trilha de exportação (art. 37)
`lgpd_export` agora grava um `AuditLog` **EXPORT** do **FATO** (alvo, destino, contagens) — **nunca os valores de PII** exportados. Ação `EXPORT` no enum (sem migration).

## 🐛 Bug destravado pelo teste — a portabilidade nunca funcionou
Ao testar #7, o `lgpd_export` (ferramenta de **portabilidade/acesso**, art. 18-V) estourou `FieldError`: usava `solicitante` / `data_inicio` / `data_fim` / `titulo` / `fluxo` — **campos inexistentes**. A ferramenta **crashava em qualquer invocação real** (nunca foi rodada). Corrigido para os campos reais (`usuario`/`inicio`/`fim` em Solicitacao; `usuario`/`inicio`/`fim` em AvailabilityBlock — o dono do bloco é `usuario`, não `formador`).

## Testes (4, GREEN)
purga logs antigos + preserva recentes · idempotência · retenção configurável · export grava trilha **sem PII**. **Regressão**: `test_celery_beat_registration` (valida a task nova registrada) + `test_audit_service` + `test_purge_import_artifacts` = **26/26**. `manage.py check` limpo.

Próximos batches: B (PII em log + CPF/username), C (minimização GCal), D (DATCoordenador+Sentry+DB_PASSWORD), E (self-service do titular).
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `098088d7`, slot `0` / projeto `aprender_staging`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
