### PR TITLE
feat(lgpd): redação central de PII no log + Usuario.__str__ sem CPF (art. 46)

### DIFF
--- a/v2/backend/apps/core/logging_filters.py
+++ b/v2/backend/apps/core/logging_filters.py
@@ -7,7 +7,12 @@ Refs: MP2 - Structured Logging (Issue #166)
 from __future__ import annotations
 
 import logging
+import re
 import threading
+
+# PII patterns para o PIIRedactionFilter.
+_EMAIL_RE = re.compile(r"[\w.+-]+@[\w-]+\.[\w.-]+")
+_CPF_RE = re.compile(r"\b\d{11}\b")
 
 
 class RequestIDFilter(logging.Filter):
@@ -48,4 +53,35 @@ class ContextFilter(logging.Filter):
     def filter(self, record: logging.LogRecord) -> bool:
         record.environment = self.environment  # type: ignore[attr-defined]
         record.service = self.service  # type: ignore[attr-defined]
+        return True
+
+
+class PIIRedactionFilter(logging.Filter):
+    """Mascara PII na mensagem do log ANTES da formatacao (LGPD art. 46).
+
+    Camada de defesa central: em vez de confiar que cada call-site nao loga PII, o
+    pipeline scrubba de QUALQUER mensagem:
+    - e-mail (ex.: google_email de OAuth) -> mantem o dominio, mascara o local:
+      `***@dominio` (observabilidade sem identificar a pessoa).
+    - sequencia de 11 digitos (CPF, tambem username de usuarios importados) -> `<cpf>`.
+
+    Aplicado a todos os handlers em `LOGGING`. Nao substitui a disciplina de nao logar
+    PII no call-site, mas garante o piso mesmo quando alguem esquece.
+    """
+
+    @staticmethod
+    def _mask_email(m: re.Match[str]) -> str:
+        dom = m.group(0).split("@", 1)[1]
+        return f"***@{dom}"
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        try:
+            msg = record.getMessage()
+        except Exception:
+            return True
+        redacted = _EMAIL_RE.sub(self._mask_email, msg)
+        redacted = _CPF_RE.sub("<cpf>", redacted)
+        if redacted != msg:
+            record.msg = redacted
+            record.args = ()
         return True

--- a/v2/backend/apps/core/models/usuario.py
+++ b/v2/backend/apps/core/models/usuario.py
@@ -38,4 +38,6 @@ class Usuario(AbstractUser):
         verbose_name_plural = "Usuarios"
 
     def __str__(self) -> str:
-        return f"{self.get_full_name() or self.username} ({self.cpf})"
+        # LGPD: nao expor CPF (nem o username, que == CPF para importados) no __str__,
+        # que vaza em logs/reprs/mensagens de erro do DRF. Nome, ou um id nao-PII.
+        return self.get_full_name() or f"Usuario #{self.pk}"

--- a/v2/backend/apps/core/tests/test_pii_log_redaction.py
+++ b/v2/backend/apps/core/tests/test_pii_log_redaction.py
@@ -1,0 +1,71 @@
+"""LGPD art. 46 — redação de PII no pipeline de log (#3) + Usuario.__str__ sem CPF (#2)."""
+
+# pyright: reportPrivateUsage=false, reportUnknownMemberType=false, reportUnknownArgumentType=false, reportAttributeAccessIssue=false
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from apps.core.logging_filters import PIIRedactionFilter
+from apps.core.tests.factories import UsuarioFactory
+
+
+def _record(msg: str, *args: object) -> logging.LogRecord:
+    return logging.LogRecord("t", logging.INFO, __file__, 1, msg, args, None)
+
+
+# ------------------------- filtro de redação (#3) -------------------------
+
+
+def test_filtro_mascara_email_mantendo_dominio():
+    rec = _record("Refresh token para maria@aprendereditora.com.br ok")
+    PIIRedactionFilter().filter(rec)
+    out = rec.getMessage()
+    assert "maria@" not in out
+    assert "***@aprendereditora.com.br" in out
+
+
+def test_filtro_mascara_cpf_de_11_digitos():
+    rec = _record("login username=11144477735 bloqueado")
+    PIIRedactionFilter().filter(rec)
+    out = rec.getMessage()
+    assert "11144477735" not in out
+    assert "<cpf>" in out
+
+
+def test_filtro_redige_apos_interpolar_args_lazy():
+    # `logger.info("email %s cpf %s", email, cpf)` — a PII so aparece apos o %.
+    rec = _record("email %s cpf %s", "x@y.com", "11144477735")
+    PIIRedactionFilter().filter(rec)
+    out = rec.getMessage()
+    assert "x@y.com" not in out
+    assert "11144477735" not in out
+    assert "***@y.com" in out and "<cpf>" in out
+
+
+def test_filtro_nao_altera_mensagem_sem_pii():
+    rec = _record("processado 42 registros com sucesso")
+    PIIRedactionFilter().filter(rec)
+    assert rec.getMessage() == "processado 42 registros com sucesso"
+
+
+# ------------------------- Usuario.__str__ (#2) -------------------------
+
+
+@pytest.mark.django_db
+def test_usuario_str_nao_vaza_cpf_nem_username():
+    # Usuario importado: username == CPF, sem nome.
+    u = UsuarioFactory(cpf="11144477735", username="11144477735", first_name="", last_name="")
+    s = str(u)
+    assert "11144477735" not in s
+    assert s == f"Usuario #{u.pk}"
+
+
+@pytest.mark.django_db
+def test_usuario_str_usa_nome_quando_existe():
+    u = UsuarioFactory(first_name="Maria", last_name="Silva", cpf="22255588846")
+    s = str(u)
+    assert s == "Maria Silva"
+    assert "22255588846" not in s

--- a/v2/backend/config/settings.py
+++ b/v2/backend/config/settings.py
@@ -675,18 +675,23 @@ LOGGING = {
             "environment": ENVIRONMENT,
             "service": os.getenv("SERVICE_NAME", "web"),  # web/worker/beat
         },
+        # LGPD art. 46: mascara e-mail/CPF de QUALQUER mensagem antes de formatar.
+        "pii_redaction": {
+            "()": "apps.core.logging_filters.PIIRedactionFilter",
+        },
     },
     "handlers": {
         # Handler JSON para stdout (production/staging)
         "console_json": {
             "class": "logging.StreamHandler",
             "formatter": "json",
-            "filters": ["request_id", "context"],
+            "filters": ["request_id", "context", "pii_redaction"],
         },
         # Handler human-readable para development
         "console": {
             "class": "logging.StreamHandler",
             "formatter": "verbose",
+            "filters": ["pii_redaction"],
         },
     },
     "root": {


### PR DESCRIPTION
Batch **B** dos achados técnicos da auditoria: PII em log (#3) e via `__str__`/`username` (#2).

## #3 — Filtro central de redação de PII no log
Novo **`PIIRedactionFilter`** (`logging_filters.py`, plugado no `LOGGING`) mascara, de **qualquer** mensagem e **antes** de formatar:
- **e-mail** (ex.: `google_email` dos ~11 call-sites OAuth) → `***@dominio` (mantém o domínio p/ observabilidade, esconde a pessoa);
- **sequência de 11 dígitos** (CPF — e o `username` que é CPF nos importados) → `<cpf>`.

Camada **central** em vez de editar os ~11 sites: garante o piso mesmo quando alguém esquece. Aplicado aos dois handlers (`console_json` prod/staging + `console` dev). Redige inclusive quando a PII só aparece após interpolar `%`-args (`logger.info("... %s", email)`).

## #2 — `Usuario.__str__` não vaza CPF
Retornava `"Nome (cpf)"` → vazava o CPF em logs/reprs/mensagens de erro do DRF. Agora retorna o **nome**, ou **`Usuario #<pk>`** (não-PII) quando não há nome — o que também evita o `username`-que-é-CPF dos importados.

## Testes (6, GREEN)
Filtro mascara email/CPF (inclusive após `%`-args) e não altera mensagem limpa; `__str__` sem CPF/username, com nome quando existe. **Regressão** admin/models/rbac = **59/60** (1 skip). `manage.py check` limpo.

Próximos: C (minimização GCal), D (DATCoordenador+Sentry+DB_PASSWORD), E (self-service do titular).
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `6f526753`, slot `0` / projeto `aprender_staging`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
