### PR TITLE
feat(lgpd): redige PII incidental de observacoes no payload GCal (arts. 6-III/33)

### DIFF
--- a/v2/backend/apps/core/services/gcal/minimize.py
+++ b/v2/backend/apps/core/services/gcal/minimize.py
@@ -1,0 +1,33 @@
+"""AS v2 — Minimização de PII em texto livre transferido ao Google Calendar.
+
+LGPD arts. 6-III (necessidade) e 33 (transferência internacional): a descrição do evento
+é transferida ao Google (processador nos EUA). Campos estruturados (município, projeto,
+equipe, attendees) são necessários ao agendamento/notificação e permanecem. Já o texto
+livre `observacoes` pode conter PII *incidental* — um CPF ou e-mail digitado nas notas —
+que não é necessário ao agendamento. Redigimos apenas esses padrões, preservando o resto.
+
+Deliberadamente independente de `apps.core.logging_filters` (redação de log é outro
+contexto): mantém este PR self-contained e o placeholder é legível para quem lê a agenda.
+"""
+
+from __future__ import annotations
+
+import re
+
+_EMAIL_RE = re.compile(r"[\w.+-]+@[\w-]+\.[\w.-]+")
+# CPF formatado (000.000.000-00) OU sequência crua de 11 dígitos (CPF ou telefone móvel).
+_CPF_RE = re.compile(r"\b(?:\d{3}\.\d{3}\.\d{3}-\d{2}|\d{11})\b")
+
+_PLACEHOLDER = "[dado pessoal removido]"
+
+
+def minimize_free_text(text: str | None) -> str:
+    """Redige CPF/e-mail de um texto livre antes de transferi-lo ao Google.
+
+    Preserva todo o restante do conteúdo. Idempotente e seguro para None/vazio.
+    """
+    if not text:
+        return ""
+    redacted = _EMAIL_RE.sub(_PLACEHOLDER, text)
+    redacted = _CPF_RE.sub(_PLACEHOLDER, redacted)
+    return redacted

--- a/v2/backend/apps/core/services/gcal/payload.py
+++ b/v2/backend/apps/core/services/gcal/payload.py
@@ -16,6 +16,7 @@ from django.conf import settings
 from apps.core.models import Solicitacao
 from apps.core.types import JsonDict, PayloadHash
 
+from .minimize import minimize_free_text
 from .utils import _payload_hash
 from .validation import GCAL_EVENT_ID_PREFIX, _event_id_for, _request_id_for
 
@@ -200,7 +201,9 @@ def _build_payload(s: Solicitacao, *, enable_meet: bool = False) -> JsonDict:
             description_lines.append(f"  • {equipe_line}")
 
     # Seção 7: Links e Observações
-    observacoes = getattr(s, "observacoes", "")
+    # LGPD arts. 6-III/33: `observacoes` é texto livre transferido ao Google — redige
+    # PII incidental (CPF/e-mail) antes da transferência, preservando o restante da nota.
+    observacoes = minimize_free_text(getattr(s, "observacoes", ""))
     if observacoes:
         description_lines.append("")
         description_lines.append("📝 Observações:")

--- a/v2/backend/apps/core/tests/test_gcal_observacoes_minimize.py
+++ b/v2/backend/apps/core/tests/test_gcal_observacoes_minimize.py
@@ -1,0 +1,73 @@
+"""LGPD arts. 6-III/33 — minimização de PII incidental em `observacoes` no payload GCal.
+
+O texto livre `observacoes` (autoria do coordenador) vai verbatim para a descrição do
+evento transferida ao Google. Nomes da equipe e attendees são NECESSÁRIOS (visibilidade
+na agenda + notificação) e permanecem. Mas CPF/e-mail digitados incidentalmente nas notas
+NÃO são necessários ao agendamento — este teste TRAVA a redação desses padrões antes da
+transferência, preservando o restante da nota.
+"""
+
+# pyright: reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportAttributeAccessIssue=false, reportMissingParameterType=false, reportUnknownParameterType=false
+
+from __future__ import annotations
+
+import pytest
+
+from apps.core.services.gcal.minimize import minimize_free_text
+from apps.core.services.gcal.payload import build_event_payload
+from apps.core.tests.factories import SolicitacaoFactory
+
+# ------------------------- unidade: minimize_free_text -------------------------
+
+
+def test_minimize_redige_cpf_raw_11_digitos():
+    out = minimize_free_text("Responsavel CPF 11144477735 confirmar presenca")
+    assert "11144477735" not in out
+    assert "Responsavel CPF" in out and "confirmar presenca" in out
+
+
+def test_minimize_redige_cpf_formatado():
+    out = minimize_free_text("doc 111.444.777-35 do participante")
+    assert "111.444.777-35" not in out
+    assert "do participante" in out
+
+
+def test_minimize_redige_email():
+    out = minimize_free_text("contato joao@gmail.com para ajustes")
+    assert "joao@gmail.com" not in out
+    assert "para ajustes" in out
+
+
+def test_minimize_preserva_texto_sem_pii():
+    txt = "Trazer materiais de apoio e chegar 30 min antes"
+    assert minimize_free_text(txt) == txt
+
+
+def test_minimize_trata_none_e_vazio():
+    assert minimize_free_text("") == ""
+    assert minimize_free_text(None) == ""
+
+
+# ------------------------- integração: payload GCal -------------------------
+
+
+@pytest.mark.django_db
+def test_payload_description_nao_vaza_cpf_nem_email_de_observacoes():
+    sol = SolicitacaoFactory(
+        status="aprovado",
+        observacoes="Substituto joao.pessoal@gmail.com, CPF 11144477735. Levar material.",
+    )
+    payload = build_event_payload(sol)
+    desc = payload["description"]
+
+    assert "11144477735" not in desc, "CPF vazou na descrição transferida ao Google"
+    assert "joao.pessoal@gmail.com" not in desc, "e-mail vazou na descrição transferida ao Google"
+    # O conteúdo operacional legítimo permanece.
+    assert "Levar material" in desc
+
+
+@pytest.mark.django_db
+def test_payload_preserva_observacoes_sem_pii():
+    sol = SolicitacaoFactory(status="aprovado", observacoes="Reuniao de alinhamento previa")
+    payload = build_event_payload(sol)
+    assert "Reuniao de alinhamento previa" in payload["description"]


### PR DESCRIPTION
## Contexto — batch C do sweep LGPD (minimização GCal)

Parte do sweep técnico pós-auditoria de risco jurídico. **O achado original do batch C
(omitir attendees quando `sendUpdates=none`) foi REFUTADO** pela realidade do deploy: o
criador (@aprendereditora.com.br), coordenadores e formadores (e-mails pessoais)
**precisam** ver o evento na agenda do Google e ser notificados por e-mail. Pelo art. 6-III
(necessidade) os attendees e os nomes na descrição são **adequados e necessários** ao
propósito → permanecem intactos.

Resta o resíduo real: **`observacoes` é texto livre** (autoria do coordenador) que vai
verbatim para a descrição do evento transferida ao Google (processador nos EUA). Um CPF ou
e-mail digitado incidentalmente ali **não é necessário** ao agendamento.

## Mudança

- Novo `apps/core/services/gcal/minimize.py` → `minimize_free_text(text)`: redige e-mail e
  CPF (formatado ou 11 dígitos crus) para `[dado pessoal removido]`, preservando o restante
  da nota. Self-contained (não depende do #1698), pyright-strict-clean.
- `_build_payload` aplica a redação **apenas** em `observacoes`. Título, local, projeto,
  equipe (nomes) e attendees **inalterados**.

## Base legal
- **art. 6-III (necessidade / minimização)** — só transfere o necessário ao propósito.
- **art. 33 (transferência internacional)** — reduz PII incidental enviado a processador nos EUA.

## Testes
- 7 testes (`test_gcal_observacoes_minimize.py`): unidade de `minimize_free_text` + integração no payload.
- Suíte GCal completa (template fase3, sync dryrun, preagenda publish, insert-log-lgpd, modular service): **62 passed, 2 skipped**, sem regressão. Attendees e `observacoes` sem PII preservados.
- TDD: RED provado antes do GREEN. `manage.py check` limpo.

## ⚠️ Achado de configuração (fora do escopo deste PR, requer verificação em prod)
Se formadores **precisam ser notificados por e-mail** (confirmado pelo dono), então
`GCAL_SEND_UPDATES` em produção deve ser `all` (ou `externalOnly`), **não** o default `none`
— com `none` nenhum e-mail de convite/atualização é enviado. Vale conferir a env de prod.
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `c66b18a2`, slot `0` / projeto `aprender_staging`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
