### PR TITLE
feat(lgpd): guard fail-closed do DB_PASSWORD em prod + Sentry sem locais de frame (art. 46)

### DIFF
--- a/v2/backend/apps/core/tests/test_prod_guard_rails.py
+++ b/v2/backend/apps/core/tests/test_prod_guard_rails.py
@@ -333,3 +333,60 @@ class RedisPasswordProductionGuardTests(TestCase):
         result = self._run_check(REDIS_PASSWORD="uma-senha-forte-de-redis")
 
         self.assertNotEqual(result.returncode, 1, f"stderr: {result.stderr}")
+
+
+class DbPasswordProductionGuardTests(TestCase):
+    """
+    LGPD art. 46 / SEC — DB_PASSWORD vazio/ausente aborta o boot em produção.
+
+    `DATABASES["default"]["PASSWORD"]` usa `os.getenv("DB_PASSWORD", "aprender_password")`:
+    se o operador esquece o secret, o app tenta conectar com a senha pública de dev, em
+    silêncio. Fail-closed no mesmo espírito do guard de REDIS_PASSWORD. Como o guard de
+    Redis roda antes, aqui sempre fornecemos um REDIS_PASSWORD válido para isolar o cenário
+    de DB_PASSWORD sob teste.
+    """
+
+    def _run_check(self, **overrides: str) -> subprocess.CompletedProcess[str]:
+        env = os.environ.copy()
+        env["ENVIRONMENT"] = "production"
+        env["DEBUG"] = "0"
+        env["ALLOWED_HOSTS"] = "example.com"
+        env["SECRET_KEY"] = "a" * 64
+        env["REDIS_PASSWORD"] = "uma-senha-forte-de-redis"  # passa o guard anterior
+        env["DB_NAME"] = "test_db"
+        env["DB_USER"] = "test_user"
+        env["DB_HOST"] = "localhost"
+        env["DB_PORT"] = "5434"
+        # Herdar DB_PASSWORD do ambiente mascararia o cenário sob teste.
+        env.pop("DB_PASSWORD", None)
+        env.update(overrides)
+
+        return subprocess.run(
+            [sys.executable, "manage.py", "check", "--deploy"],
+            cwd=str(Path(settings.BASE_DIR)),
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+
+    def test_startup_fails_when_db_password_missing_in_production(self):
+        """DB_PASSWORD ausente em produção -> sys.exit(1)."""
+        result = self._run_check()
+
+        self.assertEqual(result.returncode, 1, f"stdout: {result.stdout}")
+        self.assertIn("DB_PASSWORD", result.stderr)
+        self.assertIn("ERRO CRÍTICO", result.stderr)
+
+    def test_startup_fails_when_db_password_empty_in_production(self):
+        """DB_PASSWORD='' (o que os templates entregam) -> sys.exit(1)."""
+        result = self._run_check(DB_PASSWORD="")
+
+        self.assertEqual(result.returncode, 1, f"stdout: {result.stdout}")
+        self.assertIn("DB_PASSWORD", result.stderr)
+
+    def test_startup_succeeds_when_db_password_set_in_production(self):
+        """Com senha definida o boot segue normal (sem regressão)."""
+        result = self._run_check(DB_PASSWORD="uma-senha-forte-de-postgres")
+
+        self.assertNotEqual(result.returncode, 1, f"stderr: {result.stderr}")

--- a/v2/backend/apps/core/tests/test_sentry.py
+++ b/v2/backend/apps/core/tests/test_sentry.py
@@ -53,6 +53,8 @@ class TestSentryConfiguration:
 
                 # Verificar configurações de privacidade (LGPD/GDPR)
                 assert call_kwargs.get("send_default_pii") is False
+                # LGPD art. 46: locais de frame (senha/CPF/token) NÃO vão ao Sentry.
+                assert call_kwargs.get("include_local_variables") is False
 
                 # Verificar sample rates
                 assert 0.0 <= call_kwargs.get("traces_sample_rate", 0.1) <= 1.0

--- a/v2/backend/config/settings.py
+++ b/v2/backend/config/settings.py
@@ -105,6 +105,17 @@ if ENVIRONMENT == "production":
         print("   Defina REDIS_PASSWORD com um secret forte.", file=sys.stderr)
         sys.exit(1)
 
+    # LGPD art. 46 / SEC: DB_PASSWORD ausente em produção cai no default de dev.
+    # DATABASES["default"]["PASSWORD"] usa os.getenv("DB_PASSWORD", "aprender_password"):
+    # se o operador esquecer o secret, o app tenta conectar com a senha pública bem
+    # conhecida — credencial fraca em silêncio. Fail-closed, mesmo padrão do guard de
+    # REDIS_PASSWORD acima. (O default "aprender_password" jamais deve ser usado em prod.)
+    if not os.getenv("DB_PASSWORD", "").strip():
+        print("❌ ERRO CRÍTICO: DB_PASSWORD vazio ou ausente em produção", file=sys.stderr)
+        print("   O app cairia no default de desenvolvimento ('aprender_password').", file=sys.stderr)
+        print("   Defina DB_PASSWORD com um secret forte.", file=sys.stderr)
+        sys.exit(1)
+
     # WARNING: GCAL_CLIENT=fake em produção
     if os.getenv("GCAL_CLIENT", "fake") == "fake":
         print("⚠️  WARNING: GCAL_CLIENT=fake em produção", file=sys.stderr)
@@ -928,6 +939,11 @@ if SENTRY_DSN:
         release=os.getenv("GIT_COMMIT_SHA", "unknown"),  # Track deployments
         # Additional context
         send_default_pii=False,  # Don't send PII (LGPD/GDPR compliance)
+        # LGPD art. 46: por padrão o SDK captura as variáveis locais de cada frame do
+        # stack trace — que podem conter senha, CPF, token OAuth (ex.: `password` numa
+        # view de login, `cpf` num serializer). Desligamos para não vazar PII a um
+        # processador externo (Sentry). send_default_pii=False não cobre locais de frame.
+        include_local_variables=False,
         attach_stacktrace=True,  # Include stack traces for breadcrumbs
         # Performance options
         profiles_sample_rate=float(os.getenv("SENTRY_PROFILES_SAMPLE_RATE", "0.0")),  # Profiling (disabled by default)


### PR DESCRIPTION
## Contexto — batch D do sweep LGPD (secrets/observabilidade)

Dois hardenings de **segurança do tratamento (LGPD art. 46)**, mesmo tema.

### 1. `DB_PASSWORD` fail-closed em produção
`DATABASES["default"]["PASSWORD"]` usa `os.getenv("DB_PASSWORD", "aprender_password")`.
Se o operador **esquece o secret**, o app tenta conectar com a senha pública de
desenvolvimento (`aprender_password`), em silêncio — credencial fraca sem aviso.
Guard `sys.exit(1)` no boot de produção, **mesmo padrão do guard de `REDIS_PASSWORD`** (#1457).
- 3 testes em `DbPasswordProductionGuardTests` (subprocess `check --deploy`): falha se ausente/vazio, sucesso se definido.

### 2. Sentry `include_local_variables=False`
Por padrão o sentry-sdk captura as **variáveis locais de cada frame** do stack trace —
que podem conter `password`, `cpf`, token OAuth (ex.: numa view de login ou serializer).
`send_default_pii=False` (já existente) **não cobre** locais de frame. Desligado.
- Asserção em `test_sentry.py`.
- ⚠️ Sentry hoje **dorme** (SENTRY_DSN vazio em prod) — isto é defense-in-depth para quando for ligado.

## Base legal
- **art. 46 (segurança do tratamento)** — evita credencial fraca silenciosa e vazamento de PII em telemetria de erro.

## Achado REFUTADO na verificação (transparência)
O 3º item planejado do batch D — "**DATCoordenador dossiê sem máscara**" — foi **refutado**:
o serializer só é acessível via `HasPerm("manage_admin_registries") | HasPerm("run_daily_operations")`
(gestores DAT/Controle, que precisam do contato do coordenador para alocações/operação diária).
Não há exposição ampla (nenhum Coordenador comum lê o dossiê); mascarar quebraria a função
operacional legítima. **Sem mudança** — igual ao caso dos attendees no #1699.

## Testes
- `test_prod_guard_rails.py`: **13 passed** (novo DB guard + Redis sem regressão).
- `test_sentry.py`: **5 passed**.
- `manage.py check` limpo. TDD (asserções falham sem o código).
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `2c627c69`, slot `0` / projeto `aprender_staging`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
