### PR TITLE
feat(lgpd): self-service do titular em /api/me/ (acesso + correcao de contato, art. 18 II/III)

### DIFF
--- a/v2/backend/apps/core/models/auditoria.py
+++ b/v2/backend/apps/core/models/auditoria.py
@@ -108,6 +108,9 @@ class AuditLog(models.Model):
         # LGPD art. 18-VI (direito ao esquecimento). Anonimizacao preserva a linha
         # (FKs PROTECT) e remove a PII — ver apps.core.services.anonimizacao.
         USER_ANONYMIZE = "USER_ANONYMIZE", "Anonimizar usuario (LGPD art. 18-VI)"
+        # LGPD art. 18-III (correcao). O proprio titular corrige seus dados de
+        # contato em /api/me/ (PATCH). Auditamos o FATO, nunca o valor de PII.
+        USER_SELF_UPDATE = "USER_SELF_UPDATE", "Autocorrecao de dados pelo titular (LGPD art. 18-III)"
 
     usuario = models.ForeignKey(  # type: ignore[misc]
         "core.Usuario",

--- a/v2/backend/apps/core/serializers/__init__.py
+++ b/v2/backend/apps/core/serializers/__init__.py
@@ -74,6 +74,7 @@ from apps.core.serializers.solicitacao import (
 from apps.core.serializers.usuario import (
     CurrentUserSerializer,
     GroupSerializer,
+    MeContactUpdateSerializer,
     PermissaoFuncionalSerializer,
     UserSlimSerializer,
     UsuarioAdminSerializer,
@@ -95,6 +96,7 @@ __all__ = [
     "NotificacaoInternaSerializer",
     # Usuario
     "CurrentUserSerializer",
+    "MeContactUpdateSerializer",
     "UserSlimSerializer",
     "UsuarioOptionSerializer",
     "UsuarioAdminSerializer",

--- a/v2/backend/apps/core/serializers/usuario.py
+++ b/v2/backend/apps/core/serializers/usuario.py
@@ -49,6 +49,10 @@ class CurrentUserSerializer(serializers.Serializer):  # type: ignore[misc]
     first_name = serializers.CharField(allow_blank=True, required=False)
     last_name = serializers.CharField(allow_blank=True, required=False)
     name = serializers.CharField()
+    # LGPD art. 18-II (acesso): o titular confirma os proprios dados de cadastro.
+    cpf = serializers.CharField()
+    telefone = serializers.CharField(allow_blank=True, required=False)
+    cargo = serializers.CharField(allow_blank=True, required=False)
     groups = serializers.ListField(child=serializers.CharField())
     setores = serializers.ListField(child=serializers.CharField())
     funcoes = serializers.ListField(child=serializers.CharField())
@@ -56,6 +60,17 @@ class CurrentUserSerializer(serializers.Serializer):  # type: ignore[misc]
     is_superintendencia = serializers.BooleanField()
     can_approve_super = serializers.BooleanField()
     permissions = serializers.ListField(child=serializers.CharField())
+
+
+class MeContactUpdateSerializer(serializers.Serializer):  # type: ignore[misc]
+    """PATCH /api/me/ — autocorreção de contato pelo titular (LGPD art. 18-III).
+
+    Apenas `telefone` é autocorrigível. Identidade (cpf), organização (cargo, groups)
+    e privilégio (is_superuser/is_staff) ficam de fora: são dados que o titular não
+    define sozinho. Campos não declarados aqui são simplesmente ignorados no PATCH.
+    """
+
+    telefone = serializers.CharField(max_length=20, allow_blank=True, trim_whitespace=True)
 
 
 class UsuarioOptionSerializer(serializers.ModelSerializer):

--- a/v2/backend/apps/core/tests/test_me_self_service.py
+++ b/v2/backend/apps/core/tests/test_me_self_service.py
@@ -1,0 +1,103 @@
+"""LGPD art. 18 II/III — self-service do titular em /api/me/.
+
+- II (acesso/confirmação): o titular vê os próprios cpf/telefone/cargo.
+- III (correção): o titular corrige o próprio telefone (dado de contato), auditado.
+
+Campos de identidade/organização (cpf, cargo, is_superuser, groups) NÃO são
+autocorrigíveis pelo titular — o PATCH os ignora.
+"""
+
+# pyright: reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportAttributeAccessIssue=false, reportMissingParameterType=false, reportUnknownParameterType=false
+
+from __future__ import annotations
+
+from rest_framework.test import APIClient
+
+import pytest
+
+from apps.core.models import AuditLog
+from apps.core.tests.factories import UsuarioFactory
+
+ME_URL = "/api/me/"
+
+
+@pytest.fixture
+def titular():
+    return UsuarioFactory(
+        cpf="11144477735",
+        username="11144477735",
+        first_name="Maria",
+        last_name="Souza",
+        email="maria@aprendereditora.com.br",
+        telefone="",
+        cargo="Coordenadora",
+    )
+
+
+# ------------------------- art. 18-II: acesso -------------------------
+
+
+@pytest.mark.django_db
+def test_get_me_expoe_cpf_telefone_cargo_do_proprio_titular(titular):
+    client = APIClient()
+    client.force_authenticate(user=titular)
+
+    resp = client.get(ME_URL)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["cpf"] == "11144477735"
+    assert data["telefone"] == ""
+    assert data["cargo"] == "Coordenadora"
+
+
+@pytest.mark.django_db
+def test_get_me_exige_autenticacao():
+    resp = APIClient().get(ME_URL)
+    assert resp.status_code in (401, 403)
+
+
+# ------------------------- art. 18-III: correção -------------------------
+
+
+@pytest.mark.django_db
+def test_patch_me_corrige_telefone_e_audita(titular, django_capture_on_commit_callbacks):
+    client = APIClient()
+    client.force_authenticate(user=titular)
+
+    # A trilha é emitida via transaction.on_commit (audita só se a mutação commitar —
+    # sem trilha-fantasma). Capturamos + executamos os callbacks para vê-la no teste.
+    with django_capture_on_commit_callbacks(execute=True):
+        resp = client.patch(ME_URL, {"telefone": "(85) 99999-1234"}, format="json")
+
+    assert resp.status_code == 200
+    titular.refresh_from_db()
+    assert titular.telefone == "(85) 99999-1234"
+    # Trilha: o FATO da autocorreção é auditado (art. 18-III / accountability).
+    assert AuditLog.objects.filter(usuario=titular, action=AuditLog.Action.USER_SELF_UPDATE).exists()
+
+
+@pytest.mark.django_db
+def test_patch_me_nao_altera_cpf_cargo_nem_privilegio(titular):
+    client = APIClient()
+    client.force_authenticate(user=titular)
+
+    resp = client.patch(
+        ME_URL,
+        {"cpf": "00000000000", "cargo": "Diretora", "is_superuser": True, "telefone": "1199"},
+        format="json",
+    )
+
+    assert resp.status_code == 200
+    titular.refresh_from_db()
+    # Só telefone muda; identidade/organização/privilégio ficam intactos.
+    assert titular.telefone == "1199"
+    assert titular.cpf == "11144477735"
+    assert titular.cargo == "Coordenadora"
+    assert titular.is_superuser is False
+
+
+@pytest.mark.django_db
+def test_patch_me_exige_autenticacao():
+    resp = APIClient().patch(ME_URL, {"telefone": "1199"}, format="json")
+    assert resp.status_code in (401, 403)

--- a/v2/backend/apps/core/views_basic.py
+++ b/v2/backend/apps/core/views_basic.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from django.db import transaction
 from django.http import HttpRequest, JsonResponse
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
@@ -19,8 +20,9 @@ from drf_spectacular.utils import extend_schema
 
 from .api_schemas import COMMON_ERROR_RESPONSES
 from .constants import FUNCAO_GROUPS, SETOR_GROUPS
-from .models import GroupClassificacao
-from .serializers import CurrentUserSerializer
+from .models import AuditLog, GroupClassificacao
+from .serializers import CurrentUserSerializer, MeContactUpdateSerializer
+from .services.audit import registrar_auditoria
 from .services.rbac_permissions import get_user_functional_permissions
 
 
@@ -121,6 +123,10 @@ class CurrentUserView(APIView):
                 "first_name": user.first_name,
                 "last_name": user.last_name,
                 "name": name,
+                # LGPD art. 18-II (acesso): o titular confirma os próprios dados de cadastro.
+                "cpf": user.cpf,
+                "telefone": user.telefone,
+                "cargo": user.cargo,
                 "groups": groups,
                 "setores": setores,
                 "funcoes": funcoes,
@@ -131,3 +137,39 @@ class CurrentUserView(APIView):
             },
             status=status.HTTP_200_OK,
         )
+
+    @extend_schema(
+        summary="Corrigir os próprios dados de contato",
+        description=(
+            "LGPD art. 18-III (correção). O titular corrige o próprio telefone. "
+            "Campos de identidade (cpf), organização (cargo/grupos) e privilégio não "
+            "são autocorrigíveis e são ignorados."
+        ),
+        request=MeContactUpdateSerializer,
+        responses={
+            200: CurrentUserSerializer,
+            400: COMMON_ERROR_RESPONSES[400],
+            401: COMMON_ERROR_RESPONSES[401],
+        },
+        tags=["me"],
+    )
+    def patch(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        serializer = MeContactUpdateSerializer(data=request.data, partial=True)
+        serializer.is_valid(raise_exception=True)
+        telefone = serializer.validated_data.get("telefone")
+        if telefone is None:
+            return self.get(request, *args, **kwargs)
+
+        user = request.user
+        # LGPD [[feedback-on-commit-needs-atomic-or-phantom]]: mutação + auditoria no
+        # mesmo atomic(). Auditamos o FATO (campo alterado), nunca o valor de PII.
+        with transaction.atomic():
+            user.telefone = telefone
+            user.save(update_fields=["telefone"])
+            registrar_auditoria(
+                actor=user,
+                action=AuditLog.Action.USER_SELF_UPDATE,
+                model_name="Usuario",
+                details={"campos": ["telefone"]},
+            )
+        return self.get(request, *args, **kwargs)

--- a/v2/frontend/src/api/me.ts
+++ b/v2/frontend/src/api/me.ts
@@ -7,6 +7,7 @@
 
 import { fetchAPI, buildUrl, type QueryParams } from './config';
 import type { ID, PaginatedResponse } from '../types';
+import type { CurrentUser } from '../types/usuario';
 
 /**
  * Evento na visão do participante (saída de `GET /api/me/events/`).
@@ -96,6 +97,24 @@ export async function changeMyPassword(
 ): Promise<{ detail: string }> {
   return await fetchAPI<{ detail: string }>('/me/change-password/', {
     method: 'POST',
+    body: JSON.stringify(payload),
+  });
+}
+
+/**
+ * Corrige os próprios dados de contato (`PATCH /api/me/`) — LGPD art. 18-III.
+ *
+ * Só `telefone` é autocorrigível pelo titular; cpf/cargo/grupos/privilégio são
+ * ignorados pelo backend. A resposta é o payload completo de `/api/me/` atualizado.
+ *
+ * @param payload - novo telefone
+ * @returns o `CurrentUser` atualizado
+ */
+export async function updateMyContact(
+  payload: { telefone: string }
+): Promise<CurrentUser> {
+  return await fetchAPI<CurrentUser>('/me/', {
+    method: 'PATCH',
     body: JSON.stringify(payload),
   });
 }

--- a/v2/frontend/src/pages/Perfil/PerfilPage.tsx
+++ b/v2/frontend/src/pages/Perfil/PerfilPage.tsx
@@ -10,10 +10,10 @@
 
 import { useState } from 'react';
 import { Button, Card, Descriptions, Form, Input, Space, Tag, Typography, message } from 'antd';
-import { LockOutlined, UserOutlined } from '@ant-design/icons';
+import { LockOutlined, PhoneOutlined, UserOutlined } from '@ant-design/icons';
 
 import type { CurrentUser } from '../../types/usuario';
-import { changeMyPassword } from '../../api/me';
+import { changeMyPassword, updateMyContact } from '../../api/me';
 
 const { Title } = Typography;
 
@@ -21,6 +21,10 @@ interface ChangePasswordForm {
   senha_atual: string;
   nova_senha: string;
   confirmar: string;
+}
+
+interface ContatoForm {
+  telefone: string;
 }
 
 /** Mascara o CPF (LGPD): mostra só os 3 primeiros e os 2 últimos dígitos. */
@@ -43,7 +47,11 @@ function TagList({ items }: { items: readonly string[] }) {
 
 export default function PerfilPage({ user }: { user: CurrentUser }) {
   const [form] = Form.useForm<ChangePasswordForm>();
+  const [contatoForm] = Form.useForm<ContatoForm>();
   const [saving, setSaving] = useState(false);
+  const [savingContato, setSavingContato] = useState(false);
+  // Telefone exibido: estado local para refletir a correção sem recarregar a página.
+  const [telefone, setTelefone] = useState(user.telefone ?? '');
 
   const onFinish = async (values: ChangePasswordForm) => {
     setSaving(true);
@@ -61,6 +69,20 @@ export default function PerfilPage({ user }: { user: CurrentUser }) {
     }
   };
 
+  // LGPD art. 18-III: o titular corrige o próprio telefone.
+  const onFinishContato = async (values: ContatoForm) => {
+    setSavingContato(true);
+    try {
+      const atualizado = await updateMyContact({ telefone: values.telefone.trim() });
+      setTelefone(atualizado.telefone ?? values.telefone.trim());
+      message.success('Telefone atualizado com sucesso.');
+    } catch (error) {
+      message.error((error as Error).message || 'Não foi possível atualizar o telefone.');
+    } finally {
+      setSavingContato(false);
+    }
+  };
+
   return (
     <section className="p-6 bg-gray-100 min-h-full" aria-labelledby="perfil-title">
       <Space direction="vertical" size="large" style={{ width: '100%', maxWidth: 640 }}>
@@ -75,8 +97,10 @@ export default function PerfilPage({ user }: { user: CurrentUser }) {
         }>
           <Descriptions column={1} size="small">
             <Descriptions.Item label="Nome">{user.name || user.username}</Descriptions.Item>
-            <Descriptions.Item label="CPF">{maskCpf(user.username)}</Descriptions.Item>
+            <Descriptions.Item label="CPF">{maskCpf(user.cpf ?? user.username)}</Descriptions.Item>
             <Descriptions.Item label="E-mail">{user.email || '—'}</Descriptions.Item>
+            <Descriptions.Item label="Telefone">{telefone || '—'}</Descriptions.Item>
+            <Descriptions.Item label="Cargo">{user.cargo || '—'}</Descriptions.Item>
             <Descriptions.Item label="Setores">
               <TagList items={user.setores} />
             </Descriptions.Item>
@@ -84,6 +108,34 @@ export default function PerfilPage({ user }: { user: CurrentUser }) {
               <TagList items={user.funcoes} />
             </Descriptions.Item>
           </Descriptions>
+        </Card>
+
+        <Card title={
+          <span>
+            <PhoneOutlined /> Atualizar telefone
+          </span>
+        }>
+          <Form<ContatoForm>
+            form={contatoForm}
+            layout="vertical"
+            autoComplete="off"
+            initialValues={{ telefone }}
+            onFinish={onFinishContato}
+          >
+            <Form.Item
+              name="telefone"
+              label="Telefone"
+              rules={[{ max: 20, message: 'O telefone deve ter no máximo 20 caracteres.' }]}
+            >
+              <Input placeholder="(85) 99999-0000" allowClear />
+            </Form.Item>
+
+            <Form.Item>
+              <Button type="primary" htmlType="submit" icon={<PhoneOutlined />} loading={savingContato}>
+                Salvar telefone
+              </Button>
+            </Form.Item>
+          </Form>
         </Card>
 
         <Card title={

--- a/v2/frontend/src/pages/Perfil/__tests__/PerfilPage.test.tsx
+++ b/v2/frontend/src/pages/Perfil/__tests__/PerfilPage.test.tsx
@@ -3,12 +3,14 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { MemoryRouter } from 'react-router';
 import { message } from 'antd';
 
-const { changeMyPasswordMock } = vi.hoisted(() => ({
+const { changeMyPasswordMock, updateMyContactMock } = vi.hoisted(() => ({
   changeMyPasswordMock: vi.fn(),
+  updateMyContactMock: vi.fn(),
 }));
 
 vi.mock('../../../api/me', () => ({
   changeMyPassword: changeMyPasswordMock,
+  updateMyContact: updateMyContactMock,
 }));
 
 import PerfilPage from '../PerfilPage';
@@ -48,6 +50,7 @@ function fill(placeholder: string, value: string) {
 describe('PerfilPage', () => {
   beforeEach(() => {
     changeMyPasswordMock.mockReset();
+    updateMyContactMock.mockReset();
     vi.restoreAllMocks();
   });
 
@@ -57,6 +60,35 @@ describe('PerfilPage', () => {
     // CPF mascarado (LGPD): 3 primeiros + 2 últimos.
     expect(screen.getByText('049.***.***-05')).toBeInTheDocument();
     expect(screen.getByText('coord@aprendereditora.com.br')).toBeInTheDocument();
+  });
+
+  test('mascara o CPF do campo cpf (não do username) e mostra telefone/cargo', async () => {
+    renderPage(
+      makeUser({
+        username: 'amanda.rodrigues', // username != cpf
+        cpf: '11144477735',
+        telefone: '(85) 98888-1111',
+        cargo: 'Coordenadora',
+      })
+    );
+    // Mascara o CPF real, não o username.
+    expect(await screen.findByText('111.***.***-35')).toBeInTheDocument();
+    expect(screen.getByText('(85) 98888-1111')).toBeInTheDocument();
+    expect(screen.getByText('Coordenadora')).toBeInTheDocument();
+  });
+
+  test('salvar telefone chama updateMyContact e avisa sucesso (art. 18-III)', async () => {
+    updateMyContactMock.mockResolvedValueOnce(makeUser({ telefone: '(85) 97777-2222' }));
+    const successSpy = vi.spyOn(message, 'success');
+    renderPage();
+
+    fill('(85) 99999-0000', '(85) 97777-2222');
+    fireEvent.click(screen.getByRole('button', { name: /salvar telefone/i }));
+
+    await waitFor(() =>
+      expect(updateMyContactMock).toHaveBeenCalledWith({ telefone: '(85) 97777-2222' })
+    );
+    await waitFor(() => expect(successSpy).toHaveBeenCalled());
   });
 
   test('submit válido chama changeMyPassword e avisa sucesso', async () => {

--- a/v2/frontend/src/types/usuario.ts
+++ b/v2/frontend/src/types/usuario.ts
@@ -41,6 +41,10 @@ export interface CurrentUser {
   first_name: string;
   last_name: string;
   name: string;
+  /** LGPD art. 18-II: dados de cadastro do próprio titular (backend sempre envia). */
+  cpf?: string;
+  telefone?: string;
+  cargo?: string;
   groups: string[];
   setores: string[];
   funcoes: string[];


### PR DESCRIPTION
## Contexto — batch E do sweep LGPD (self-service do titular)

Fortalece os direitos do titular. O achado #8 da auditoria era: *"self-service fraco —
correção só de senha, export só via CLI"*. Este PR entrega **acesso** e **correção**.

### art. 18-II (acesso / confirmação)
`GET /api/me/` passa a expor **cpf / telefone / cargo** do **próprio** titular (dados de
cadastro que ele confirma). Antes só nome/email/grupos — o titular não via os próprios
dados de contato.

### art. 18-III (correção)
Novo **`PATCH /api/me/`** deixa o titular **corrigir o próprio telefone**. Só `telefone`
é autocorrigível — `cpf` (identidade), `cargo`/grupos (organização) e privilégio
(`is_superuser`) são **ignorados**. A correção é **auditada** (`USER_SELF_UPDATE`) no
**mesmo `atomic()`** da mutação; audita o **FATO** (campo alterado), nunca o valor de PII.

## Mudança
**Backend**
- `MeContactUpdateSerializer` (só `telefone`).
- `CurrentUserSerializer` + dict de `/api/me/` ganham `cpf/telefone/cargo`.
- `CurrentUserView.patch` — valida, salva `update_fields=["telefone"]`, audita, retorna o payload atualizado.
- `Action.USER_SELF_UPDATE` — **sem migration** (o field `action` não tem `choices`).

**Frontend**
- `PerfilPage` mostra cpf(real, mascarado)/telefone/cargo + card **"Atualizar telefone"** (`updateMyContact`).
- Corrige a máscara de CPF, que era derivada do `username` (proxy que falha quando `username != cpf`).
- `CurrentUser` ganha `cpf?/telefone?/cargo?` (opcionais → não quebra mocks); `api/me.ts` ganha `updateMyContact`.

## Testes
- Backend `test_me_self_service.py` (5): acesso expõe cpf/telefone/cargo; correção + trilha (via `django_capture_on_commit_callbacks`); PATCH não altera cpf/cargo/privilégio; 401 sem auth.
- Frontend `PerfilPage.test.tsx` (6): +máscara-do-cpf-real, +salvar-telefone.
- Regressão me/serializers/openapi: **77 passed**. `tsc --noEmit`: **0**. `makemigrations --check`: limpo. TDD (RED provado).

## Follow-up (art. 18-V portabilidade)
Botão de **exportação** self-service — o CLI `lgpd_export` já existe (foi consertado no #1697); a UI fica para um próximo PR.
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `adff370f`, slot `0` / projeto `aprender_staging`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
