### PR TITLE
fix(compliance): compliance_audit crashava com jsonb=bigint no AUDIT-01

### DIFF
--- a/v2/backend/apps/core/management/commands/compliance_audit.py
+++ b/v2/backend/apps/core/management/commands/compliance_audit.py
@@ -191,17 +191,20 @@ class Command(BaseCommand):
         # ================================================================
         # Audit Log Completeness
         # ================================================================
+        # `details__solicitacao_id` é um valor JSONB (o campo `details` é JSONField).
+        # Usá-lo direto em `id__in=<subquery>` faz o Postgres comparar bigint = jsonb
+        # -> ProgrammingError. Materializamos os ids em Python, coagindo para int
+        # (o details pode gravar o id como número ou string), e então excluímos.
+        audited_ids = {
+            int(sid)
+            for sid in AuditLog.objects.filter(
+                model_name="Solicitacao",
+                action__in=["CREATE", "CRIAR_SOLICITACAO"],
+            ).values_list("details__solicitacao_id", flat=True)
+            if sid is not None and str(sid).isdigit()
+        }
         solicitations_without_audit = (
-            Solicitacao.objects.filter(
-                created_at__gte=since,
-            )
-            .exclude(
-                id__in=AuditLog.objects.filter(
-                    model_name="Solicitacao",
-                    action__in=["CREATE", "CRIAR_SOLICITACAO"],
-                ).values_list("details__solicitacao_id", flat=True)
-            )
-            .count()
+            Solicitacao.objects.filter(created_at__gte=since).exclude(id__in=audited_ids).count()
         )
 
         report["checks"].append(

--- a/v2/backend/apps/core/tests/test_compliance_audit_command.py
+++ b/v2/backend/apps/core/tests/test_compliance_audit_command.py
@@ -1,0 +1,47 @@
+"""Exercita o command `compliance_audit` end-to-end.
+
+Este era o teste AUSENTE que deixou o AUDIT-01 apodrecer: a subquery
+`values_list("details__solicitacao_id")` retorna jsonb e o `id__in=<jsonb>` compara
+com o `id` (bigint) -> `ProgrammingError: operator does not exist: bigint = jsonb`.
+O comando crashava em qualquer execução real com dados no período. Aqui garantimos que
+ele roda de ponta a ponta (inclusive AUDIT-01 e o GCAL-01 que vinha depois do crash).
+"""
+
+# pyright: reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportAttributeAccessIssue=false, reportMissingParameterType=false, reportUnknownParameterType=false
+
+from __future__ import annotations
+
+import json
+from io import StringIO
+
+from django.core.management import call_command
+
+import pytest
+
+from apps.core.models import AuditLog
+from apps.core.tests.factories import SolicitacaoFactory
+
+
+@pytest.mark.django_db
+def test_compliance_audit_roda_sem_crashar_e_emite_json():
+    sol = SolicitacaoFactory(status="aprovado")
+    # Um log de CREATE com o id no details exercita o ramo do AUDIT-01 (id no set).
+    AuditLog.objects.create(
+        usuario=sol.usuario,
+        action="CREATE",
+        model_name="Solicitacao",
+        details={"solicitacao_id": sol.id},
+    )
+
+    out = StringIO()
+    call_command("compliance_audit", "--days=30", "--format=json", stdout=out)
+
+    report = json.loads(out.getvalue())
+    rules = {c["rule"] for c in report["checks"]}
+    # AUDIT-01 (crashava) e GCAL-01 (vinha depois do crash) precisam constar.
+    assert "AUDIT-01" in rules
+    assert "GCAL-01" in rules
+    assert report["summary"]["total_checks"] == len(report["checks"])
+    # A solicitacao tem trilha de CREATE -> nao entra na contagem "sem audit".
+    audit01 = next(c for c in report["checks"] if c["rule"] == "AUDIT-01")
+    assert audit01["violations"] == 0


### PR DESCRIPTION
## Bug (verificado empiricamente rodando o comando)

`manage.py compliance_audit` **crashava em qualquer execução real** com dados no período:

```
django.db.utils.ProgrammingError: operator does not exist: bigint = jsonb
LINE 1: ...AND NOT ("core_solicitacao"."id" IN (SELECT ...
```

O check **AUDIT-01** fazia:
```python
.exclude(id__in=AuditLog.objects.filter(...).values_list("details__solicitacao_id", flat=True))
```
`details` é `JSONField`, então `details__solicitacao_id` é um valor **jsonb**; compará-lo
com `id` (**bigint**) explode no Postgres. Como **GCAL-01** vinha depois, também nunca rodava.
A ferramenta de compliance/accountability (regras PA/RD) estava **morta sem ninguém ver** —
não havia teste que a exercitasse (o mesmo padrão do `lgpd_export` que estava quebrado no #1697).

## Fix
Materializa os ids auditados em Python (coagindo para `int` — o `details` pode gravar número
ou string), depois `.exclude(id__in=<set de int>)`. Sem comparação jsonb.

## Teste
`test_compliance_audit_command.py` — **o teste ausente** que exercita o comando end-to-end
(roda AUDIT-01 + GCAL-01, valida o JSON e a contagem `total_checks == len(checks)`).
**TDD:** RED (mesmo `ProgrammingError`) → GREEN. Comando agora emite os **7 checks + summary**.

`manage.py check` limpo. Sem migration.
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `367635c9`, slot `0` / projeto `aprender_staging`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
