### PR TITLE
feat(lgpd): endpoint self-service de exportacao de dados do titular (art. 18-V)

### DIFF
--- a/v2/backend/apps/core/management/commands/lgpd_export.py
+++ b/v2/backend/apps/core/management/commands/lgpd_export.py
@@ -16,7 +16,6 @@ import json
 from typing import TYPE_CHECKING, Any
 
 from django.core.management.base import BaseCommand, CommandError
-from django.utils import timezone
 
 if TYPE_CHECKING:
     from argparse import ArgumentParser
@@ -60,7 +59,8 @@ class Command(BaseCommand):
 
     def handle(self, *args: Any, **options: Any) -> None:
         """Execute LGPD data export."""
-        from apps.core.models import AuditLog, AvailabilityBlock, GoogleOAuthCredential, Solicitacao, Usuario
+        from apps.core.models import AuditLog, Usuario
+        from apps.core.services.lgpd_export_service import build_lgpd_export_data, export_counts
 
         cpf = options.get("cpf")
         email = options.get("email")
@@ -86,125 +86,9 @@ class Command(BaseCommand):
 
         self.stdout.write(f"Exporting data for user: {user.username} (ID: {user.id})")
 
-        # Build export data
-        data: dict[str, Any] = {
-            "export_info": {
-                "generated_at": timezone.now().isoformat(),
-                "system": "Aprender Sistema v2",
-                "purpose": "LGPD Data Portability (Art. 18, V)",
-            },
-            "personal_data": {
-                "id": user.id,
-                "username": user.username,
-                "cpf": user.cpf,
-                "first_name": user.first_name,
-                "last_name": user.last_name,
-                "email": user.email,
-                "cargo": getattr(user, "cargo", None),
-                "matricula": getattr(user, "matricula", None),
-                "telefone": getattr(user, "telefone", None),
-                "setores": list(user.setores) if hasattr(user, "setores") else [],
-                "funcoes": list(user.funcoes) if hasattr(user, "funcoes") else [],
-                "groups": list(user.groups.values_list("name", flat=True)),
-                "is_active": user.is_active,
-                "is_staff": user.is_staff,
-                "is_superuser": user.is_superuser,
-                "date_joined": user.date_joined.isoformat(),
-                "last_login": user.last_login.isoformat() if user.last_login else None,
-            },
-        }
-
-        # Solicitations created by user. NB: os campos reais sao usuario/inicio/fim — o
-        # command usava solicitante/data_inicio/data_fim/titulo/fluxo (inexistentes), entao
-        # a ferramenta de portabilidade LGPD estourava FieldError em qualquer invocacao real.
-        solicitations = Solicitacao.objects.filter(usuario=user)
-        data["solicitations_created"] = list(
-            solicitations.values(
-                "id",
-                "status",
-                "inicio",
-                "fim",
-                "municipio__nome",
-                "projeto__nome",
-                "tipo_evento__nome",
-                "created_at",
-                "updated_at",
-            )
-        )
-
-        # Solicitations where user is a formador (formadores is M2M to Usuario)
-        formador_events = Solicitacao.objects.filter(formadores=user)
-        data["events_as_formador"] = list(
-            formador_events.values(
-                "id",
-                "status",
-                "inicio",
-                "fim",
-                "municipio__nome",
-            )
-        )
-
-        # Availability blocks for user (o dono do bloco e' `usuario`, nao `formador`)
-        blocks = AvailabilityBlock.objects.filter(usuario=user)
-        data["availability_blocks"] = list(
-            blocks.values(
-                "id",
-                "tipo",
-                "inicio",
-                "fim",
-                "motivo",
-                "created_at",
-            )
-        )
-
-        # Approvals made by user (from AuditLog)
-        approval_logs = AuditLog.objects.filter(
-            usuario=user,
-            action__in=["APROVAR", "APPROVE", "REPROVAR", "REJECT"],
-        ).order_by("-created_at")[:50]
-        data["approvals_made"] = list(
-            approval_logs.values(
-                "id",
-                "action",
-                "details",
-                "created_at",
-            )
-        )
-
-        # Audit logs (if requested)
-        if include_audit:
-            audit_logs = AuditLog.objects.filter(usuario=user).order_by("-created_at")[:100]
-            data["audit_logs"] = list(
-                audit_logs.values(
-                    "id",
-                    "action",
-                    "model_name",
-                    "details",
-                    "created_at",
-                )
-            )
-        else:
-            data["audit_logs"] = "(excluded from export)"
-
-        # GCal credentials (if requested)
-        if include_gcal:
-            gcal_cred = GoogleOAuthCredential.objects.filter(user=user).first()
-            if gcal_cred:
-                data["gcal_credentials"] = {
-                    "has_credential": True,
-                    "google_email": gcal_cred.google_email,
-                    "created_at": gcal_cred.created_at.isoformat(),
-                    "last_used_at": (gcal_cred.last_used_at.isoformat() if gcal_cred.last_used_at else None),
-                    # Note: We don't export actual tokens for security
-                    "tokens": "(excluded for security)",
-                }
-            else:
-                data["gcal_credentials"] = None
-        else:
-            data["gcal_credentials"] = "(excluded from export)"
-
-        # Convert all datetime objects to ISO format strings
-        data = self._serialize_data(data)
+        # Dossiê montado pelo serviço compartilhado (SSOT — mesma lógica do endpoint
+        # self-service `GET /api/me/export/`). Já vem JSON-serializável.
+        data = build_lgpd_export_data(user, include_audit=include_audit, include_gcal=include_gcal)
 
         # Write to file
         with open(output_path, "w", encoding="utf-8") as f:
@@ -225,41 +109,17 @@ class Command(BaseCommand):
                 "target_user_id": user.pk,
                 "output_path": str(output_path),
                 "include_audit": bool(include_audit),
-                "counts": {
-                    "solicitations_created": len(data["solicitations_created"]),
-                    "events_as_formador": len(data["events_as_formador"]),
-                    "availability_blocks": len(data["availability_blocks"]),
-                    "approvals_made": len(data["approvals_made"]),
-                },
+                "counts": export_counts(data),
             },
             imediato=True,
         )
 
         # Summary
+        counts = export_counts(data)
         self.stdout.write("  - Personal data: exported")
-        self.stdout.write(f"  - Solicitations created: {len(data['solicitations_created'])}")
-        self.stdout.write(f"  - Events as formador: {len(data['events_as_formador'])}")
-        self.stdout.write(f"  - Availability blocks: {len(data['availability_blocks'])}")
-        self.stdout.write(f"  - Approvals made: {len(data['approvals_made'])}")
-        if include_audit:
+        self.stdout.write(f"  - Solicitations created: {counts['solicitations_created']}")
+        self.stdout.write(f"  - Events as formador: {counts['events_as_formador']}")
+        self.stdout.write(f"  - Availability blocks: {counts['availability_blocks']}")
+        self.stdout.write(f"  - Approvals made: {counts['approvals_made']}")
+        if include_audit and isinstance(data["audit_logs"], list):
             self.stdout.write(f"  - Audit logs: {len(data['audit_logs'])}")
-
-    def _serialize_data(self, obj: Any) -> Any:
-        """Recursively convert datetime objects to ISO format strings."""
-        import datetime
-        from decimal import Decimal
-
-        if isinstance(obj, dict):
-            return {k: self._serialize_data(v) for k, v in obj.items()}
-        elif isinstance(obj, list):
-            return [self._serialize_data(item) for item in obj]
-        elif isinstance(obj, datetime.datetime):
-            return obj.isoformat()
-        elif isinstance(obj, datetime.date):
-            return obj.isoformat()
-        elif isinstance(obj, datetime.time):
-            return obj.isoformat()
-        elif isinstance(obj, Decimal):
-            return float(obj)
-        else:
-            return obj

--- a/v2/backend/apps/core/services/lgpd_export_service.py
+++ b/v2/backend/apps/core/services/lgpd_export_service.py
@@ -1,0 +1,154 @@
+"""AS v2 — Serviço de exportação de dados do titular (LGPD art. 18-V, portabilidade).
+
+SSOT do "dossiê de um titular": tanto o command `lgpd_export` (ferramenta de admin/DPO)
+quanto o endpoint self-service `GET /api/me/export/` chamam `build_lgpd_export_data`. Um
+único lugar evita o field-drift que já matou o `lgpd_export` (duas cópias divergem e
+apodrecem). O serviço só MONTA o dossiê — I/O (arquivo/HTTP) e a trilha de auditoria são
+responsabilidade do caller (contexto diferente: admin CLI vs. titular autenticado).
+"""
+
+# pyright: reportUnknownMemberType=false, reportUnknownVariableType=false, reportAttributeAccessIssue=false, reportUnknownArgumentType=false, reportArgumentType=false
+
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+from typing import Any
+
+from django.utils import timezone
+
+# Chaves de contagem expostas na trilha de auditoria (o FATO, nunca a PII).
+COUNT_KEYS = (
+    "solicitations_created",
+    "events_as_formador",
+    "availability_blocks",
+    "approvals_made",
+)
+
+
+def _serialize(obj: Any) -> Any:
+    """Converte recursivamente datetime/date/time/Decimal para tipos JSON."""
+    if isinstance(obj, dict):
+        return {k: _serialize(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_serialize(item) for item in obj]
+    if isinstance(obj, (datetime.datetime, datetime.date, datetime.time)):
+        return obj.isoformat()
+    if isinstance(obj, Decimal):
+        return float(obj)
+    return obj
+
+
+def build_lgpd_export_data(user: Any, *, include_audit: bool = True, include_gcal: bool = False) -> dict[str, Any]:
+    """Monta o dossiê LGPD de `user` (JSON-serializável).
+
+    `include_audit`: inclui as últimas 100 entradas de AuditLog do usuário.
+    `include_gcal`: inclui METADADOS da credencial Google (nunca os tokens).
+    """
+    from apps.core.models import AuditLog, AvailabilityBlock, GoogleOAuthCredential, Solicitacao
+
+    data: dict[str, Any] = {
+        "export_info": {
+            "generated_at": timezone.now().isoformat(),
+            "system": "Aprender Sistema v2",
+            "purpose": "LGPD Data Portability (Art. 18, V)",
+        },
+        "personal_data": {
+            "id": user.id,
+            "username": user.username,
+            "cpf": user.cpf,
+            "first_name": user.first_name,
+            "last_name": user.last_name,
+            "email": user.email,
+            "cargo": getattr(user, "cargo", None),
+            "matricula": getattr(user, "matricula", None),
+            "telefone": getattr(user, "telefone", None),
+            "setores": list(user.setores) if hasattr(user, "setores") else [],
+            "funcoes": list(user.funcoes) if hasattr(user, "funcoes") else [],
+            "groups": list(user.groups.values_list("name", flat=True)),
+            "is_active": user.is_active,
+            "is_staff": user.is_staff,
+            "is_superuser": user.is_superuser,
+            "date_joined": user.date_joined.isoformat(),
+            "last_login": user.last_login.isoformat() if user.last_login else None,
+        },
+    }
+
+    # Solicitacoes criadas pelo titular. Campos reais: usuario/inicio/fim.
+    data["solicitations_created"] = list(
+        Solicitacao.objects.filter(usuario=user).values(
+            "id",
+            "status",
+            "inicio",
+            "fim",
+            "municipio__nome",
+            "projeto__nome",
+            "tipo_evento__nome",
+            "created_at",
+            "updated_at",
+        )
+    )
+
+    # Eventos onde o titular e' formador (formadores = M2M com Usuario).
+    data["events_as_formador"] = list(
+        Solicitacao.objects.filter(formadores=user).values(
+            "id",
+            "status",
+            "inicio",
+            "fim",
+            "municipio__nome",
+        )
+    )
+
+    # Blocos de disponibilidade (dono = `usuario`, nao `formador`).
+    data["availability_blocks"] = list(
+        AvailabilityBlock.objects.filter(usuario=user).values(
+            "id",
+            "tipo",
+            "inicio",
+            "fim",
+            "motivo",
+            "created_at",
+        )
+    )
+
+    # Aprovacoes feitas pelo titular (do AuditLog).
+    data["approvals_made"] = list(
+        AuditLog.objects.filter(
+            usuario=user,
+            action__in=["APROVAR", "APPROVE", "REPROVAR", "REJECT"],
+        )
+        .order_by("-created_at")[:50]
+        .values("id", "action", "details", "created_at")
+    )
+
+    if include_audit:
+        data["audit_logs"] = list(
+            AuditLog.objects.filter(usuario=user)
+            .order_by("-created_at")[:100]
+            .values("id", "action", "model_name", "details", "created_at")
+        )
+    else:
+        data["audit_logs"] = "(excluded from export)"
+
+    if include_gcal:
+        gcal_cred = GoogleOAuthCredential.objects.filter(user=user).first()
+        if gcal_cred:
+            data["gcal_credentials"] = {
+                "has_credential": True,
+                "google_email": gcal_cred.google_email,
+                "created_at": gcal_cred.created_at.isoformat(),
+                "last_used_at": (gcal_cred.last_used_at.isoformat() if gcal_cred.last_used_at else None),
+                "tokens": "(excluded for security)",
+            }
+        else:
+            data["gcal_credentials"] = None
+    else:
+        data["gcal_credentials"] = "(excluded from export)"
+
+    return _serialize(data)
+
+
+def export_counts(data: dict[str, Any]) -> dict[str, int]:
+    """Contagens por seção para a trilha de auditoria (o FATO, nunca a PII)."""
+    return {key: len(data[key]) for key in COUNT_KEYS if isinstance(data.get(key), list)}

--- a/v2/backend/apps/core/tests/test_me_export.py
+++ b/v2/backend/apps/core/tests/test_me_export.py
@@ -1,0 +1,80 @@
+"""LGPD art. 18-V (portabilidade) — export self-service em GET /api/me/export/.
+
+O titular baixa o próprio dossiê; o escopo é sempre `request.user` (não há como
+exportar dados de outro). A exportação é auditada (EXPORT, o FATO). O serviço
+`build_lgpd_export_data` é o SSOT compartilhado com o command `lgpd_export`.
+"""
+
+# pyright: reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportAttributeAccessIssue=false, reportMissingParameterType=false, reportUnknownParameterType=false, reportIndexIssue=false
+
+from __future__ import annotations
+
+import json
+
+from rest_framework.test import APIClient
+
+import pytest
+
+from apps.core.models import AuditLog
+from apps.core.services.lgpd_export_service import build_lgpd_export_data
+from apps.core.tests.factories import UsuarioFactory
+
+ME_EXPORT_URL = "/api/me/export/"
+
+
+# ------------------------- serviço (SSOT) -------------------------
+
+
+@pytest.mark.django_db
+def test_build_lgpd_export_data_traz_dados_do_titular():
+    user = UsuarioFactory(cpf="11144477735", telefone="(85) 90000-0000", cargo="Coordenadora")
+    data = build_lgpd_export_data(user)
+
+    assert data["personal_data"]["cpf"] == "11144477735"
+    assert data["personal_data"]["telefone"] == "(85) 90000-0000"
+    assert data["export_info"]["purpose"].startswith("LGPD Data Portability")
+    # Seções esperadas presentes (listas mesmo que vazias).
+    for key in ("solicitations_created", "events_as_formador", "availability_blocks", "approvals_made"):
+        assert isinstance(data[key], list)
+
+
+# ------------------------- endpoint self-service -------------------------
+
+
+@pytest.mark.django_db
+def test_get_export_baixa_json_do_proprio_titular_e_audita():
+    user = UsuarioFactory(cpf="11144477735")
+    client = APIClient()
+    client.force_authenticate(user=user)
+
+    resp = client.get(ME_EXPORT_URL)
+
+    assert resp.status_code == 200
+    assert resp["Content-Disposition"] == 'attachment; filename="meus-dados-aprender.json"'
+    body = json.loads(resp.content)
+    assert body["personal_data"]["cpf"] == "11144477735"
+    # Trilha do FATO (art. 37): EXPORT self-service, sem valores de PII no details.
+    log = AuditLog.objects.filter(usuario=user, action=AuditLog.Action.EXPORT).first()
+    assert log is not None
+    assert log.details["channel"] == "self-service"
+    assert log.details["target_user_id"] == user.pk
+    assert "cpf" not in json.dumps(log.details)
+
+
+@pytest.mark.django_db
+def test_export_e_escopado_ao_proprio_usuario():
+    eu = UsuarioFactory(cpf="11144477735")
+    outro = UsuarioFactory(cpf="22255588846")
+    client = APIClient()
+    client.force_authenticate(user=eu)
+
+    body = json.loads(client.get(ME_EXPORT_URL).content)
+
+    assert body["personal_data"]["cpf"] == "11144477735"
+    assert outro.cpf not in json.dumps(body)
+
+
+@pytest.mark.django_db
+def test_export_exige_autenticacao():
+    resp = APIClient().get(ME_EXPORT_URL)
+    assert resp.status_code in (401, 403)

--- a/v2/backend/apps/core/urls.py
+++ b/v2/backend/apps/core/urls.py
@@ -40,7 +40,7 @@ from .views import (  # ASQ-005: async imports; DAT Module ViewSets; Plano Forma
 )
 
 # Imports de módulos isolados (GAP-001 fix)
-from .views.me import ChangePasswordView, MeEventsListView, MePoliciesView
+from .views.me import ChangePasswordView, MeEventsListView, MeExportView, MePoliciesView
 from .views.stats import HomeStatsView
 from .views_auth import csrf_token, login, logout, ping
 from .views_availability import AvailabilityBlockViewSet, AvailabilityCheckManyView, AvailabilityCheckView
@@ -164,6 +164,7 @@ urlpatterns = [
     path("me/events/", MeEventsListView.as_view(), name="me-events"),
     path("me/policies/", MePoliciesView.as_view(), name="me-policies"),
     path("me/change-password/", ChangePasswordView.as_view(), name="me-change-password"),
+    path("me/export/", MeExportView.as_view(), name="me-export"),
     path("rbac/meta/", RBACMetaView.as_view(), name="rbac-meta"),
     path("stats/home/", HomeStatsView.as_view(), name="stats-home"),
     # CSRF Token (Issue #135)

--- a/v2/backend/apps/core/views/me.py
+++ b/v2/backend/apps/core/views/me.py
@@ -23,12 +23,14 @@ from typing import cast
 
 from django.contrib.auth import update_session_auth_hash
 from django.db.models import QuerySet
+from django.http import JsonResponse
 from rest_framework import generics, serializers
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema, extend_schema_view, inline_serializer
 
 from apps.core.api_schemas import COMMON_ERROR_RESPONSES
@@ -36,6 +38,8 @@ from apps.core.models import AuditLog, Solicitacao, Usuario
 from apps.core.rbac.policies import resolve_public_policies
 from apps.core.serializers.me import MeEventSerializer
 from apps.core.serializers.usuario import ChangePasswordSerializer
+from apps.core.services.audit import registrar_auditoria
+from apps.core.services.lgpd_export_service import build_lgpd_export_data, export_counts
 
 
 @extend_schema_view(
@@ -180,3 +184,49 @@ class ChangePasswordView(APIView):
             },
         )
         return Response({"detail": "Senha alterada com sucesso."})
+
+
+class MeExportView(APIView):
+    """Exportação self-service dos próprios dados (LGPD art. 18-V, portabilidade).
+
+    GET /api/me/export/
+
+    Baixa o dossiê do titular autenticado como JSON (mesmo SSOT do command
+    `lgpd_export`, via `build_lgpd_export_data`). Escopo é sempre `request.user` —
+    não há como um titular exportar dados de outro. Audita o FATO (EXPORT: alvo=self,
+    canal, contagens), nunca os valores de PII exportados.
+    """
+
+    permission_classes = [IsAuthenticated]
+
+    @extend_schema(
+        summary="Exportar os próprios dados (portabilidade LGPD)",
+        description="Baixa o dossiê do titular autenticado como arquivo JSON (art. 18-V).",
+        responses={
+            (200, "application/json"): OpenApiTypes.BINARY,
+            401: COMMON_ERROR_RESPONSES[401],
+        },
+        tags=["me"],
+    )
+    def get(self, request: Request) -> JsonResponse:
+        user = cast(Usuario, request.user)
+        # Metadados da credencial GCal (sem tokens) fazem parte do dossiê do titular.
+        data = build_lgpd_export_data(user, include_audit=True, include_gcal=True)
+
+        # LGPD art. 37 (accountability): a exportação é operação sensível -> trilha do
+        # FATO. Leitura pura (sem mutação) -> imediato=True (não há commit a atrelar).
+        registrar_auditoria(
+            actor=user,
+            action=AuditLog.Action.EXPORT,
+            model_name="Usuario",
+            details={
+                "target_user_id": user.pk,
+                "channel": "self-service",
+                "counts": export_counts(data),
+            },
+            imediato=True,
+        )
+
+        response = JsonResponse(data, json_dumps_params={"ensure_ascii": False, "indent": 2})
+        response["Content-Disposition"] = 'attachment; filename="meus-dados-aprender.json"'
+        return response


### PR DESCRIPTION
## Contexto — portabilidade do titular (LGPD art. 18-V)

Fecha o direito de **portabilidade**: o #1701 entregou **acesso** (18-II) e **correção**
(18-III); faltava o **export self-service** — antes só via CLI de admin (`lgpd_export`).

## Mudança (backend)
- **Novo serviço `lgpd_export_service.build_lgpd_export_data(user)`** — **SSOT** do "dossiê
  de um titular" (personal_data + solicitações + eventos-formador + blocos + aprovações +
  audit_logs + metadados GCal **sem tokens**), já JSON-serializável. Um único lugar evita o
  **field-drift** que matou o `lgpd_export` (duas cópias divergem e apodrecem — a lição do #1697/#1702).
- **Command `lgpd_export` repontado para o serviço** (DRY; comportamento idêntico, coberto
  pelos testes do #1697). Remove a cópia inline + `_serialize_data`.
- **Novo `GET /api/me/export/`** (`MeExportView`): baixa o dossiê do titular autenticado
  como JSON (`Content-Disposition: attachment`). Escopo **sempre `request.user`** — não há
  como exportar dados de outro. Audita o **FATO** (`EXPORT`: alvo=self, canal, contagens), nunca a PII.

## Testes
- `test_me_export.py` (4): serviço traz os dados do titular; endpoint baixa JSON + audita; **escopo self** (outro CPF não aparece); 401 sem auth.
- `test_auditlog_retention_export.py` (#1697) **segue verde** → refactor **sem regressão** no command.
- OpenAPI + me endpoints verdes. `manage.py check` limpo. **Sem migration.**

## Sem conflito com os PRs abertos
Toca `views/me.py` + `urls.py` + serviço/command — **nenhum overlap** com #1698/#1699/#1700/#1701.

## Follow-up
Botão **"Exportar meus dados"** na PerfilPage (usa `GET /api/me/export/` via `fetchBlob`) —
sai **após o #1701 mergear** (ele já mexe em `PerfilPage`/`api/me`; separar evita conflito).
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `1f224746`, slot `0` / projeto `aprender_staging`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
