### PR TITLE
feat(lgpd): botao Exportar meus dados na PerfilPage (portabilidade, art. 18-V)

### DIFF
--- a/v2/frontend/src/api/me.ts
+++ b/v2/frontend/src/api/me.ts
@@ -5,7 +5,7 @@
  * Issue #1225 (Epic 2): página `/meus-eventos` (caso primário: Formador).
  */
 
-import { fetchAPI, buildUrl, type QueryParams } from './config';
+import { fetchAPI, fetchBlob, buildUrl, type QueryParams } from './config';
 import type { ID, PaginatedResponse } from '../types';
 import type { CurrentUser } from '../types/usuario';
 
@@ -117,4 +117,16 @@ export async function updateMyContact(
     method: 'PATCH',
     body: JSON.stringify(payload),
   });
+}
+
+/**
+ * Exporta os próprios dados (`GET /api/me/export/`) — portabilidade LGPD art. 18-V.
+ *
+ * Retorna o dossiê do titular como Blob JSON (backend responde com
+ * `Content-Disposition: attachment`). A exportação é auditada no backend.
+ *
+ * @returns Blob com o JSON dos dados do titular
+ */
+export async function exportMyData(): Promise<Blob> {
+  return await fetchBlob('/me/export/');
 }

--- a/v2/frontend/src/pages/Perfil/PerfilPage.tsx
+++ b/v2/frontend/src/pages/Perfil/PerfilPage.tsx
@@ -10,10 +10,10 @@
 
 import { useState } from 'react';
 import { Button, Card, Descriptions, Form, Input, Space, Tag, Typography, message } from 'antd';
-import { LockOutlined, PhoneOutlined, UserOutlined } from '@ant-design/icons';
+import { DownloadOutlined, LockOutlined, PhoneOutlined, UserOutlined } from '@ant-design/icons';
 
 import type { CurrentUser } from '../../types/usuario';
-import { changeMyPassword, updateMyContact } from '../../api/me';
+import { changeMyPassword, exportMyData, updateMyContact } from '../../api/me';
 
 const { Title } = Typography;
 
@@ -50,8 +50,30 @@ export default function PerfilPage({ user }: { user: CurrentUser }) {
   const [contatoForm] = Form.useForm<ContatoForm>();
   const [saving, setSaving] = useState(false);
   const [savingContato, setSavingContato] = useState(false);
+  const [exporting, setExporting] = useState(false);
   // Telefone exibido: estado local para refletir a correção sem recarregar a página.
   const [telefone, setTelefone] = useState(user.telefone ?? '');
+
+  // LGPD art. 18-V (portabilidade): baixa o dossiê do titular como JSON.
+  const onExport = async () => {
+    setExporting(true);
+    try {
+      const blob = await exportMyData();
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = 'meus-dados-aprender.json';
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      URL.revokeObjectURL(url);
+      message.success('Seus dados foram exportados.');
+    } catch (error) {
+      message.error((error as Error).message || 'Não foi possível exportar seus dados.');
+    } finally {
+      setExporting(false);
+    }
+  };
 
   const onFinish = async (values: ChangePasswordForm) => {
     setSaving(true);
@@ -108,6 +130,15 @@ export default function PerfilPage({ user }: { user: CurrentUser }) {
               <TagList items={user.funcoes} />
             </Descriptions.Item>
           </Descriptions>
+
+          <div className="mt-4">
+            <Button icon={<DownloadOutlined />} loading={exporting} onClick={onExport}>
+              Exportar meus dados
+            </Button>
+            <Typography.Text type="secondary" className="ml-2">
+              Baixa uma cópia dos seus dados (portabilidade — LGPD art. 18-V).
+            </Typography.Text>
+          </div>
         </Card>
 
         <Card title={

--- a/v2/frontend/src/pages/Perfil/__tests__/PerfilPage.test.tsx
+++ b/v2/frontend/src/pages/Perfil/__tests__/PerfilPage.test.tsx
@@ -3,14 +3,16 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { MemoryRouter } from 'react-router';
 import { message } from 'antd';
 
-const { changeMyPasswordMock, updateMyContactMock } = vi.hoisted(() => ({
+const { changeMyPasswordMock, updateMyContactMock, exportMyDataMock } = vi.hoisted(() => ({
   changeMyPasswordMock: vi.fn(),
   updateMyContactMock: vi.fn(),
+  exportMyDataMock: vi.fn(),
 }));
 
 vi.mock('../../../api/me', () => ({
   changeMyPassword: changeMyPasswordMock,
   updateMyContact: updateMyContactMock,
+  exportMyData: exportMyDataMock,
 }));
 
 import PerfilPage from '../PerfilPage';
@@ -51,7 +53,26 @@ describe('PerfilPage', () => {
   beforeEach(() => {
     changeMyPasswordMock.mockReset();
     updateMyContactMock.mockReset();
+    exportMyDataMock.mockReset();
     vi.restoreAllMocks();
+  });
+
+  test('exportar meus dados chama exportMyData e dispara o download (art. 18-V)', async () => {
+    const blob = new Blob(['{"personal_data":{}}'], { type: 'application/json' });
+    exportMyDataMock.mockResolvedValueOnce(blob);
+    const createObjectURL = vi.fn(() => 'blob:fake');
+    const revokeObjectURL = vi.fn();
+    (URL as unknown as { createObjectURL: unknown }).createObjectURL = createObjectURL;
+    (URL as unknown as { revokeObjectURL: unknown }).revokeObjectURL = revokeObjectURL;
+    const successSpy = vi.spyOn(message, 'success');
+    renderPage();
+
+    fireEvent.click(screen.getByRole('button', { name: /exportar meus dados/i }));
+
+    await waitFor(() => expect(exportMyDataMock).toHaveBeenCalled());
+    await waitFor(() => expect(successSpy).toHaveBeenCalled());
+    expect(createObjectURL).toHaveBeenCalledWith(blob);
+    expect(revokeObjectURL).toHaveBeenCalled();
   });
 
   test('mostra os dados do usuário com CPF mascarado', async () => {


### PR DESCRIPTION
## Contexto — fecha o art. 18-V no frontend

O endpoint self-service `GET /api/me/export/` (backend, #1703) agora ganha **UI**. Junto com
**acesso** (18-II) e **correção** (18-III) do #1701, o titular exerce os **três direitos**
pela tela de Perfil (`/perfil`).

## Mudança
- `api/me.ts`: **`exportMyData()`** via `fetchBlob('/me/export/')`.
- `PerfilPage`: botão **"Exportar meus dados"** no card "Meus dados" — baixa o dossiê JSON
  (`createObjectURL` → âncora `download` → `revokeObjectURL`) com aviso de sucesso/erro.

## Testes
- `PerfilPage.test.tsx`: clique → `exportMyData` chamado + download disparado (assert em `createObjectURL`/`revokeObjectURL`). **7/7** na PerfilPage; `tsc --noEmit` **0**.

## Escopo
Só frontend (`api/me.ts` + `PerfilPage` + teste). Depende do endpoint do #1703 (já na main).
Com este PR, o programa LGPD de direitos do titular fica completo: acesso + correção + portabilidade + (exclusão via anonimização #1692).
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `48ee2295`, slot `0` / projeto `aprender_staging`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
