### PR TITLE
test(a11y): cobertura axe em pagina autenticada (/perfil) + bootstrap mockado

### DIFF
--- a/v2/frontend/e2e/checklist/accessibility.spec.ts
+++ b/v2/frontend/e2e/checklist/accessibility.spec.ts
@@ -14,7 +14,7 @@
  */
 import { test, expect, Page } from '@playwright/test';
 import AxeBuilder from '@axe-core/playwright';
-import { mockChecklistAuthBootstrap } from './checklist-network-mocks';
+import { mockChecklistAuthBootstrap, mockChecklistAuthenticated } from './checklist-network-mocks';
 
 test.beforeEach(async ({ page }) => {
   await mockChecklistAuthBootstrap(page);
@@ -403,4 +403,61 @@ test.describe('Checklist: Formulários Acessíveis', () => {
     // Não falha - é recomendação
     expect(true).toBeTruthy();
   });
+});
+
+test.describe('Checklist: Acessibilidade — páginas autenticadas (axe-core)', () => {
+  // O bootstrap padrão (beforeEach) mocka /api/me como 401 -> tela anônima. Aqui
+  // sobrescrevemos com um titular autenticado (a rota registrada por último vence no
+  // Playwright) para rodar o axe em páginas LOGADAS — antes o gate só cobria a home
+  // anônima. Foco em /perfil: renderiza só do prop `user`, sem dados extras a mockar.
+  const AUTH_PAGES = [{ path: '/perfil', name: 'Perfil' }];
+
+  for (const { path, name } of AUTH_PAGES) {
+    test(`🔴 ${name} (${path}) sem violações críticas de acessibilidade (autenticado)`, async ({
+      page,
+    }) => {
+      await mockChecklistAuthenticated(page);
+      await page.goto(path);
+      await page.waitForLoadState('networkidle');
+      await waitForLoadingOverlayToDisappear(page);
+
+      const results = await new AxeBuilder({ page })
+        .withTags(['wcag2a', 'wcag2aa', 'wcag21aa'])
+        .exclude('.ant-spin-fullscreen')
+        .exclude('.ant-spin-text')
+        .analyze();
+
+      const critical = results.violations.filter(
+        (v) => v.impact === 'critical' || v.impact === 'serious'
+      );
+
+      // `color-contrast` é reportado mas NÃO falha: os gaps atuais (label #8c8c8c do
+      // Descriptions, botão danger #ff4d4f) são dos TOKENS GLOBAIS do tema Antd — afetam
+      // o app inteiro, então corrigi-los é uma decisão de tema à parte (ConfigProvider),
+      // não desta cobertura. Aqui travamos os críticos ESTRUTURAIS (label, *-name, alt,
+      // aria) em páginas autenticadas — antes o gate só via a home anônima.
+      const contrast = critical.filter((v) => v.id === 'color-contrast');
+      const structural = critical.filter((v) => v.id !== 'color-contrast');
+
+      if (contrast.length > 0) {
+        console.log(
+          `[report-only] ${contrast.length} violação(ões) de contraste em ${path} ` +
+            `(tokens globais do tema Antd — decisão de tema à parte).`
+        );
+      }
+      if (structural.length > 0) {
+        console.log(
+          `Violações estruturais de acessibilidade em ${path}:\n` +
+            structural
+              .map((v) => `[${v.impact}] ${v.id}: ${v.help} — ${v.nodes.length} elemento(s)`)
+              .join('\n')
+        );
+      }
+
+      expect(
+        structural,
+        `${structural.length} violações críticas estruturais de acessibilidade em ${path}`
+      ).toHaveLength(0);
+    });
+  }
 });

--- a/v2/frontend/e2e/checklist/checklist-network-mocks.ts
+++ b/v2/frontend/e2e/checklist/checklist-network-mocks.ts
@@ -36,3 +36,53 @@ export async function mockChecklistAuthBootstrap(
     });
   }
 }
+
+/** Payload de `/api/me/` para um titular autenticado (shape de `isCurrentUserPayload`). */
+export const CHECKLIST_AUTH_USER = {
+  id: 42,
+  username: '04944374305',
+  email: 'coord@aprendereditora.com.br',
+  first_name: 'Amanda',
+  last_name: 'Rodrigues',
+  name: 'Amanda Rodrigues',
+  cpf: '04944374305',
+  telefone: '(85) 90000-0000',
+  cargo: 'Coordenadora',
+  groups: ['Coordenador', 'Vidas'],
+  setores: ['Vidas'],
+  funcoes: ['Coordenador'],
+  is_superuser: false,
+  is_superintendencia: false,
+  can_approve_super: false,
+  permissions: [],
+};
+
+/**
+ * Bootstrap de um usuário AUTENTICADO para os checklists (a11y de páginas logadas).
+ *
+ * Mocka csrf + `/api/me/` (200, titular) + `/api/me/policies/` ([]) — o suficiente para
+ * o App carregar `user`/policies e renderizar rotas protegidas (ex.: /perfil). Páginas com
+ * dados próprios exigem mockar seus endpoints à parte.
+ */
+export async function mockChecklistAuthenticated(
+  page: Page,
+  user: Record<string, unknown> = CHECKLIST_AUTH_USER
+): Promise<void> {
+  await page.route(/\/api\/csrf\/?(\?.*)?$/, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ csrfToken: 'checklist-test-csrf-token' }),
+    });
+  });
+  await page.route(/\/api\/me\/policies\/?(\?.*)?$/, async (route) => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: '[]' });
+  });
+  await page.route(/\/api\/me\/?(\?.*)?$/, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(user),
+    });
+  });
+}


### PR DESCRIPTION
## Contexto — o gate a11y só via a home anônima

O `accessibility.spec.ts` (axe-core no checklist) só testava `/` com **`/api/me` mockado como 401** → tela **anônima**. Este PR estende a cobertura a **páginas autenticadas**.

## Mudança
- **`mockChecklistAuthenticated`**: bootstrap de um titular logado (csrf + `/api/me` 200 + `/api/me/policies` `[]`). No Playwright a rota registrada por último vence, então sobrescreve o `401` do `beforeEach`.
- **Novo bloco axe em `/perfil`** (renderiza só do prop `user` — sem dados extras a mockar, baixo risco de flake). Trava os **críticos estruturais** (`label`, `*-name`, `image-alt`, `aria`) → /perfil passa (**0 estruturais**).

## ⚠️ Achado real: 2 gaps de contraste (report-only)
A cobertura **encontrou** 2 violações `color-contrast` (serious), mas são **tokens GLOBAIS do tema Antd** (afetam o app inteiro, não só /perfil):
- Botão **danger "Sair"**: branco em `#ff4d4f` → **3.26** (< 4.5:1)
- **Labels do Descriptions** (Nome/CPF/E-mail/…): `#8c8c8c` em branco → **3.36**

Corrigi-los é **decisão de tema** (ConfigProvider) com impacto visual app-wide → deixei `color-contrast` **report-only** aqui (logado no console), não bloqueando. **Posso fazer o fix de tema num PR separado se você quiser** (darkening dos tokens; é mudança visual em toda parte).

## Verificação
Rodei o spec no host (Playwright/chromium contra o dev server 5173): **1 passed**, contraste reportado. `tsc` limpo; e2e não é lintado.
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `38a92720`, slot `0` / projeto `aprender_staging`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
