### PR TITLE
fix(a11y): contraste WCAG AA — texto terciario do tema + logout nao-danger

### DIFF
--- a/v2/frontend/e2e/checklist/accessibility.spec.ts
+++ b/v2/frontend/e2e/checklist/accessibility.spec.ts
@@ -431,32 +431,22 @@ test.describe('Checklist: Acessibilidade — páginas autenticadas (axe-core)', 
         (v) => v.impact === 'critical' || v.impact === 'serious'
       );
 
-      // `color-contrast` é reportado mas NÃO falha: os gaps atuais (label #8c8c8c do
-      // Descriptions, botão danger #ff4d4f) são dos TOKENS GLOBAIS do tema Antd — afetam
-      // o app inteiro, então corrigi-los é uma decisão de tema à parte (ConfigProvider),
-      // não desta cobertura. Aqui travamos os críticos ESTRUTURAIS (label, *-name, alt,
-      // aria) em páginas autenticadas — antes o gate só via a home anônima.
-      const contrast = critical.filter((v) => v.id === 'color-contrast');
-      const structural = critical.filter((v) => v.id !== 'color-contrast');
-
-      if (contrast.length > 0) {
+      // Inclui `color-contrast`: os 2 gaps globais do tema Antd (label #8c8c8c do
+      // Descriptions e botão danger #ff4d4f) foram corrigidos no tema (colorTextTertiary
+      // mais escuro + logout des-danger). Agora o contraste fica GUARDADO nas páginas
+      // autenticadas, além dos críticos estruturais (label, *-name, alt, aria).
+      if (critical.length > 0) {
         console.log(
-          `[report-only] ${contrast.length} violação(ões) de contraste em ${path} ` +
-            `(tokens globais do tema Antd — decisão de tema à parte).`
-        );
-      }
-      if (structural.length > 0) {
-        console.log(
-          `Violações estruturais de acessibilidade em ${path}:\n` +
-            structural
+          `Violações críticas de acessibilidade em ${path}:\n` +
+            critical
               .map((v) => `[${v.impact}] ${v.id}: ${v.help} — ${v.nodes.length} elemento(s)`)
               .join('\n')
         );
       }
 
       expect(
-        structural,
-        `${structural.length} violações críticas estruturais de acessibilidade em ${path}`
+        critical,
+        `${critical.length} violações críticas de acessibilidade em ${path}`
       ).toHaveLength(0);
     });
   }

--- a/v2/frontend/src/components/AppHeader.tsx
+++ b/v2/frontend/src/components/AppHeader.tsx
@@ -182,8 +182,6 @@ export function AppHeader({
           </Popover>
         )}
         <Button
-          type="primary"
-          danger
           icon={<LogoutOutlined />}
           onClick={onLogout}
         >

--- a/v2/frontend/src/contexts/ThemeContext.tsx
+++ b/v2/frontend/src/contexts/ThemeContext.tsx
@@ -104,6 +104,10 @@ const darkThemeTokens = {
 const lightThemeTokens = {
   colorPrimary: '#006B52',
   borderRadius: 6,
+  // A11y (WCAG AA): o default do Antd para texto terciário é rgba(0,0,0,0.45)=#8c8c8c,
+  // que dá só 3.36:1 em branco (ex.: labels do Descriptions) e reprova 4.5:1. Escurecemos
+  // para rgba(0,0,0,0.55)≈#737373 (~4.8:1). Só aumenta contraste — mudança sutil.
+  colorTextTertiary: 'rgba(0, 0, 0, 0.55)',
 };
 
 export function ThemeProvider({ children }: ThemeProviderProps): JSX.Element {


### PR DESCRIPTION
## Contexto — fecha os 2 gaps de contraste que o #1706 achou

A cobertura a11y autenticada (#1706) encontrou 2 violações `color-contrast` (serious) que eram **tokens globais do tema Antd** (afetam o app inteiro, não só /perfil). Este PR corrige e volta o contraste a **bloquear** no teste.

## Mudança
- **`ThemeContext` (lightThemeTokens)**: `colorTextTertiary` de `rgba(0,0,0,0.45)` (#8c8c8c, **3.36:1**, reprova AA) → `rgba(0,0,0,0.55)` (~#737373, **~4.8:1**). Escurece **sutilmente** o texto terciário app-wide (ex.: labels do Descriptions) — só aumenta contraste.
- **`AppHeader`**: botão **"Sair"** deixa de ser `type="primary" danger` (branco em `#ff4d4f` = **3.26:1**) e vira botão **default** (texto escuro, passa AA). Logout não é destrutivo → não precisa de vermelho.
- **`accessibility.spec.ts`**: `color-contrast` volta a **bloquear** nas páginas autenticadas (era report-only no #1706).

## Escopo / risco
- **Não** mexe no `colorError` global (o vermelho de erro/validação fica intacto) — só o token de texto terciário + 1 botão.
- Mudança visual: labels terciários um tico mais escuros; botão de logout deixa de ser vermelho. Baixo risco.

## Verificação
Playwright/axe no dev server: **suíte a11y completa 13 passed** — home **sem regressão** (o token global só aumenta contraste) + `/perfil` passa com `color-contrast` **enforced**. `tsc` limpo; sem teste de AppHeader afetado.
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `361e0eff`, slot `0` / projeto `aprender_staging`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
