### PR TITLE
feat(lgpd): scaffold organizacional — Politica de Privacidade + aviso no login + runbook ANPD

### DIFF
--- a/v2/docs/lgpd/README.md
+++ b/v2/docs/lgpd/README.md
@@ -1,0 +1,43 @@
+# Governança LGPD — Aprender Sistema v2
+
+Reúne a parte **organizacional** da conformidade LGPD. Veredito da auditoria de risco
+(2026-08): **engenharia de segurança forte, conformidade formal a completar** — o risco real
+é reclamação de titular à ANPD sobre transparência/governança, não vazamento.
+
+## O que este scaffold entrega (estrutura + placeholders)
+
+| Item | Onde | Estado |
+|------|------|--------|
+| Política de Privacidade | `components/lgpd/PoliticaPrivacidadeContent.tsx` + rota `/politica-privacidade` + link na PerfilPage | conteúdo técnico real; jurídico completa os `[A PREENCHER]` |
+| Aviso de transparência no login (art. 9º) | `components/lgpd/AvisoTransparenciaLGPD.tsx` (na LoginPage) | pronto; falta base legal + contato do DPO |
+| Runbook de incidente (art. 48) | `RUNBOOK_INCIDENTE_ANPD.md` | template; falta contatos/prazos internos |
+
+## O que depende do controlador + advogado (preencher os `[A PREENCHER]`)
+
+1. **Identificação do controlador**: razão social, CNPJ, endereço.
+2. **Encarregado (DPO)**: nome + e-mail/canal de contato (usado na Política, no aviso e no runbook).
+3. **Base legal** por categoria de dado (arts. 7º/11). Para sistema interno de colaboradores,
+   tipicamente **não é consentimento** — execução de contrato / obrigação legal / legítimo interesse.
+4. **Prazos de retenção** oficiais por categoria.
+5. **Versão e data de vigência** da Política.
+6. **Canal/procedimento vigente da ANPD** para comunicação de incidente.
+
+## Base TÉCNICA já implementada (dá suporte à governança)
+
+- **Direitos do titular (art. 18)** self-service em *Meu perfil*: acesso, correção de contato,
+  exportação (portabilidade). Exclusão via **anonimização** (`apps/core/services/anonimizacao.py`).
+- **Retenção/expurgo** automático: AuditLog e artefatos de importação (tasks Celery beat).
+- **Trilha de auditoria** transacional (ator + fato, sem PII); export do titular auditado.
+- **Segurança do tratamento (art. 46)**: TLS/HSTS, backups cifrados (`age`), RBAC + row-level,
+  segredos fail-closed, redação de PII no log, minimização de PII na transferência ao Google.
+- **Atribuição de licenças**: `frontend/public/THIRD-PARTY-NOTICES.txt`.
+
+## Achado operacional pendente (fora deste scaffold)
+
+- Em produção, `GCAL_SEND_UPDATES` deve ser `all`/`externalOnly` (formadores precisam ser
+  notificados por e-mail), não o default `none`.
+
+## Referências
+
+- Auditoria + sweep técnico: memória `project_lgpd_audit_and_sweep_2026_08`.
+- Specs de segurança: `v2/docs/specs/backend/` (rbac, backup-dr) e `specs/infra/at-rest-encryption.spec.md`.

--- a/v2/docs/lgpd/RUNBOOK_INCIDENTE_ANPD.md
+++ b/v2/docs/lgpd/RUNBOOK_INCIDENTE_ANPD.md
@@ -1,0 +1,61 @@
+# Runbook — Resposta a Incidente de Dados Pessoais (LGPD art. 48) — SCAFFOLD
+
+> ⚠️ **Andaime.** Preencha os campos `[A PREENCHER]` (contatos, prazos internos, autoridade
+> de decisão) com o Encarregado (DPO) e o jurídico. A LGPD não fixa um prazo numérico único;
+> a comunicação à ANPD e aos titulares deve ser feita **em prazo razoável** — trate como
+> **urgente** (referência operacional: iniciar em até **2 dias úteis** da ciência).
+
+## Papéis
+
+| Papel | Quem | Contato |
+|-------|------|---------|
+| Encarregado (DPO) | `[A PREENCHER]` | `[A PREENCHER]` |
+| Responsável técnico (on-call) | `[A PREENCHER]` | `[A PREENCHER]` |
+| Decisão/porta-voz (jurídico/diretoria) | `[A PREENCHER]` | `[A PREENCHER]` |
+
+## Fluxo
+
+### 1. Detecção e registro (imediato)
+- Registrar: quem detectou, data/hora, como foi detectado, sistemas/dados aparentemente afetados.
+- Abrir um registro do incidente (ticket/planilha de incidentes — `[A PREENCHER: onde]`).
+- Acionar o Encarregado e o responsável técnico.
+
+### 2. Contenção (horas)
+- Estancar o vazamento/acesso indevido: revogar credenciais, isolar host, rotacionar segredos
+  (`REDIS_PASSWORD`, `DB_PASSWORD`, chaves OAuth/Fernet), bloquear IP, etc.
+- **Não** destruir evidências — preservar logs (AuditLog, logs de app, acesso do servidor).
+
+### 3. Avaliação (1–2 dias)
+- Quais **categorias de dados** e quantos **titulares**? (CPF, e-mail, telefone, cargo, agenda…)
+- Houve **exposição efetiva** ou apenas risco? Dados estavam cifrados?
+- **Risco aos titulares** (fraude, discriminação, dano). Isso define a extensão da comunicação.
+
+### 4. Comunicação (prazo razoável — tratar como urgente)
+- **À ANPD**: comunicar quando houver risco/dano relevante aos titulares. Canal e formulário
+  oficiais da ANPD: `[A PREENCHER: link/procedimento vigente]`. Conteúdo mínimo: natureza dos
+  dados, titulares envolvidos, medidas técnicas/de segurança, riscos e medidas adotadas/​propostas.
+- **Aos titulares afetados**: comunicar quando houver risco/dano relevante, em linguagem clara.
+  Canal: `[A PREENCHER]`.
+- Aprovar o texto com jurídico/porta-voz antes de enviar.
+
+### 5. Registro e prestação de contas (art. 37)
+- Consolidar o registro do incidente: linha do tempo, decisão sobre notificar (com justificativa
+  se **não** notificar), comunicações enviadas, evidências.
+- Guardar por `[A PREENCHER: prazo de retenção do registro]`.
+
+### 6. Pós-incidente (dias/semanas)
+- Causa-raiz + ações corretivas (fechar a falha, não só o sintoma).
+- Revisar controles: acesso, segredos, backup/restore, monitoramento.
+- Lições aprendidas → atualizar este runbook e a base técnica.
+
+## Comandos úteis (referência técnica)
+
+- Trilha de auditoria: `AuditLog` (por usuário/ação/período). Export de um titular:
+  `python manage.py lgpd_export --cpf=<cpf> --output=<arquivo>`.
+- Rotação de segredos: via Portainer (produção) — ver `v2/docs/DEPLOY_CHECKLIST` / `project_prod_secrets`.
+- Auditoria de compliance PA/RD: `python manage.py compliance_audit --days=<n> --format=json`.
+
+## Referências
+
+- LGPD arts. 46 (segurança), 48 (comunicação de incidente), 37 (registro), 18 (direitos).
+- Base técnica de suporte: backups cifrados (`age`), TLS, RBAC, retenção automática, anonimização.

--- a/v2/frontend/src/components/AppRoutes.tsx
+++ b/v2/frontend/src/components/AppRoutes.tsx
@@ -12,6 +12,7 @@ const MonthlyPage = lazy(() => import('../pages/Disponibilidade/MonthlyPage'));
 const ControlePage = lazy(() => import('../pages/Controle/ControlePage'));
 const DATImportacoesPage = lazy(() => import('../pages/DAT/ImportacoesPage'));
 const PerfilPage = lazy(() => import('../pages/Perfil/PerfilPage'));
+const PoliticaPrivacidadePage = lazy(() => import('../pages/Politica/PoliticaPrivacidadePage'));
 const NewSolicitacaoWizard = lazy(() => import('../pages/Solicitacoes/NewSolicitacaoWizard'));
 const EditSolicitacaoPage = lazy(() => import('../pages/Solicitacoes/EditSolicitacaoPage'));
 const MySolicitacoesPage = lazy(() => import('../pages/Solicitacoes/MySolicitacoesPage'));
@@ -104,6 +105,7 @@ export function AppRoutes({ user, permissions, policies }: AppRoutesProps): JSX.
         <Route path="/solicitacoes/deslocamentos" element={<RequirePolicy allow={access.can('view_all_availability') || canControle || canCoordenador || canDAT}><DeslocamentosPage /></RequirePolicy>} />
         <Route path="/solicitacoes/meus-eventos" element={<RequirePolicy allow={!!user}><MeusEventosPage /></RequirePolicy>} />
         <Route path="/perfil" element={<RequirePolicy allow={!!user}><PerfilPage user={user} /></RequirePolicy>} />
+        <Route path="/politica-privacidade" element={<RequirePolicy allow={!!user}><PoliticaPrivacidadePage /></RequirePolicy>} />
 
         {/* Redirects de URLs legadas → novas (preserva deep-links/bookmarks) */}
         <Route path="/aprovacoes" element={<Navigate to="/solicitacoes/aprovacoes" replace />} />

--- a/v2/frontend/src/components/lgpd/AvisoTransparenciaLGPD.tsx
+++ b/v2/frontend/src/components/lgpd/AvisoTransparenciaLGPD.tsx
@@ -1,0 +1,55 @@
+/**
+ * Aviso de transparência LGPD (art. 9º) para a tela de login — SCAFFOLD.
+ *
+ * NÃO é um portão de consentimento: para um sistema interno de colaboradores a base legal
+ * tipicamente não é consentimento (ver Política). É apenas informação ao titular no momento
+ * da coleta. Self-contained (gerencia o próprio Drawer) para funcionar no login, que roda
+ * fora do react-router. Os trechos [A PREENCHER] dependem do jurídico/Encarregado.
+ */
+import { useState, type JSX } from 'react';
+import { Alert, Button, Drawer, Typography } from 'antd';
+import PoliticaPrivacidadeContent from './PoliticaPrivacidadeContent';
+import { BRAND_COLORS } from '../../contexts/ThemeContext';
+
+const { Text } = Typography;
+
+export default function AvisoTransparenciaLGPD(): JSX.Element {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <Alert
+        type="info"
+        showIcon
+        style={{ width: '100%', maxWidth: 420, marginTop: 24 }}
+        message="Tratamento dos seus dados"
+        description={
+          <span>
+            Ao acessar, seus dados de cadastro (CPF, nome e contato) são tratados para a
+            gestão de formações e da agenda. Base legal:{' '}
+            <Text mark>[A PREENCHER pelo jurídico]</Text>. Encarregado (DPO):{' '}
+            <Text mark>[A PREENCHER]</Text>.{' '}
+            <Button
+              type="link"
+              size="small"
+              style={{ padding: 0, color: BRAND_COLORS.primaryDark, textDecoration: 'underline' }}
+              onClick={() => setOpen(true)}
+            >
+              Ler a Política de Privacidade
+            </Button>
+            .
+          </span>
+        }
+      />
+      <Drawer
+        title="Política de Privacidade"
+        placement="right"
+        width={Math.min(720, typeof window !== 'undefined' ? window.innerWidth : 720)}
+        open={open}
+        onClose={() => setOpen(false)}
+      >
+        <PoliticaPrivacidadeContent />
+      </Drawer>
+    </>
+  );
+}

--- a/v2/frontend/src/components/lgpd/PoliticaPrivacidadeContent.tsx
+++ b/v2/frontend/src/components/lgpd/PoliticaPrivacidadeContent.tsx
@@ -1,0 +1,141 @@
+/**
+ * Conteúdo da Política de Privacidade (LGPD) — SCAFFOLD.
+ *
+ * ⚠️ Este é um ANDAIME para o Encarregado (DPO) + jurídico revisarem e completarem.
+ * O conteúdo técnico (quais dados, finalidade, compartilhamento com Google, retenção,
+ * segurança, como exercer direitos) reflete o sistema REAL e pode ser mantido. Os trechos
+ * marcados com <Pendente> exigem decisão do controlador/advogado (identificação legal,
+ * contato do Encarregado, base legal específica, data de vigência) — NÃO são texto
+ * jurídico vinculante gerado automaticamente.
+ *
+ * Reutilizado na rota autenticada `/politica-privacidade` e no Drawer do aviso no login.
+ */
+import type { JSX, ReactNode } from 'react';
+import { Typography, Divider } from 'antd';
+
+const { Title, Paragraph, Text } = Typography;
+
+/** Realça um trecho que o controlador/advogado precisa preencher. */
+function Pendente({ children }: { children: ReactNode }): JSX.Element {
+  return (
+    <Text
+      mark
+      style={{ padding: '0 4px' }}
+      aria-label="Trecho pendente de preenchimento pelo jurídico"
+    >
+      [A PREENCHER] {children}
+    </Text>
+  );
+}
+
+export default function PoliticaPrivacidadeContent(): JSX.Element {
+  return (
+    <Typography>
+      <Title level={2}>Política de Privacidade</Title>
+      <Paragraph type="secondary">
+        Versão: <Pendente>vX.Y</Pendente> · Vigência a partir de <Pendente>dd/mm/aaaa</Pendente>.
+        Este documento explica como o Aprender Sistema trata seus dados pessoais, conforme a
+        Lei nº 13.709/2018 (LGPD).
+      </Paragraph>
+
+      <Title level={3}>1. Quem é o controlador</Title>
+      <Paragraph>
+        O controlador dos dados é <Pendente>razão social, CNPJ e endereço</Pendente>. Para
+        assuntos de privacidade, fale com o Encarregado (DPO): <Pendente>nome, e-mail e
+        canal de contato do Encarregado</Pendente>.
+      </Paragraph>
+
+      <Title level={3}>2. Quais dados tratamos</Title>
+      <Paragraph>Para operar a plataforma, tratamos:</Paragraph>
+      <ul>
+        <li><Text strong>Cadastro:</Text> CPF, nome, e-mail, telefone e cargo.</li>
+        <li><Text strong>Organização:</Text> setores e funções (perfil de acesso).</li>
+        <li>
+          <Text strong>Operação:</Text> solicitações e eventos de formação, disponibilidade
+          e bloqueios de agenda, aprovações.
+        </li>
+        <li>
+          <Text strong>Registros de acesso e auditoria:</Text> data/hora, ação realizada e,
+          quando aplicável, endereço IP e navegador — para segurança e prestação de contas.
+        </li>
+      </ul>
+
+      <Title level={3}>3. Para que tratamos (finalidade)</Title>
+      <Paragraph>
+        Gestão das formações e da agenda dos formadores/coordenadores, verificação de
+        disponibilidade e conflitos, fluxo de aprovação, publicação de eventos no calendário
+        e comunicação com os envolvidos. O acesso é de colaboradores da organização.
+      </Paragraph>
+
+      <Title level={3}>4. Com que base legal</Title>
+      <Paragraph>
+        <Pendente>
+          base legal específica a confirmar pelo jurídico. Por ser um sistema interno de
+          colaboradores, tipicamente NÃO é consentimento — costuma ser execução de contrato,
+          cumprimento de obrigação legal/regulatória e/ou legítimo interesse (arts. 7º e 11
+          da LGPD). Confirmar o enquadramento por tipo de dado.
+        </Pendente>
+      </Paragraph>
+
+      <Title level={3}>5. Com quem compartilhamos</Title>
+      <Paragraph>
+        Não vendemos seus dados. Compartilhamos com <Text strong>Google Calendar</Text> os
+        dados necessários para publicar e notificar eventos de agenda (título, local, data e
+        os e-mails dos participantes convidados). Não há outros compartilhamentos além dos
+        estritamente necessários à operação e às obrigações legais.
+      </Paragraph>
+
+      <Title level={3}>6. Transferência internacional</Title>
+      <Paragraph>
+        A integração de calendário usa o Google, que pode processar dados fora do Brasil
+        (art. 33 da LGPD), sob as salvaguardas contratuais e de segurança do próprio Google.
+      </Paragraph>
+
+      <Title level={3}>7. Por quanto tempo guardamos</Title>
+      <ul>
+        <li>Dados de cadastro: enquanto durar o vínculo/uso do sistema.</li>
+        <li>Registros de auditoria/acesso: retenção alinhada à obrigação legal (Marco Civil, mínimo de 6 meses).</li>
+        <li>Arquivos de importação com dados pessoais: expurgados automaticamente após o período de processamento.</li>
+      </ul>
+      <Paragraph type="secondary">
+        Prazos exatos: <Pendente>confirmar/oficializar os prazos de retenção por categoria</Pendente>.
+      </Paragraph>
+
+      <Title level={3}>8. Como protegemos</Title>
+      <Paragraph>
+        Comunicação cifrada (TLS/HTTPS), backups criptografados, controle de acesso por papel
+        (cada pessoa vê apenas o necessário), senhas armazenadas com hash e trilha de auditoria
+        das operações sensíveis.
+      </Paragraph>
+
+      <Title level={3}>9. Seus direitos e como exercê-los</Title>
+      <Paragraph>
+        A LGPD (art. 18) garante, entre outros, os direitos de acesso, correção,
+        portabilidade e eliminação. No próprio sistema, em <Text strong>“Meu perfil”</Text>,
+        você pode:
+      </Paragraph>
+      <ul>
+        <li><Text strong>Acessar</Text> seus dados de cadastro (CPF, e-mail, telefone, cargo).</li>
+        <li><Text strong>Corrigir</Text> seu telefone de contato.</li>
+        <li><Text strong>Exportar</Text> uma cópia dos seus dados (portabilidade), em JSON.</li>
+      </ul>
+      <Paragraph>
+        Para <Text strong>exclusão/anonimização</Text> ou qualquer outra solicitação, procure
+        o Encarregado: <Pendente>canal de contato do Encarregado</Pendente>. Responderemos nos
+        prazos da LGPD.
+      </Paragraph>
+
+      <Title level={3}>10. Alterações</Title>
+      <Paragraph>
+        Esta política pode ser atualizada. Publicaremos a nova versão aqui, com a data de
+        vigência. Dúvidas: <Pendente>canal de contato do Encarregado</Pendente>.
+      </Paragraph>
+
+      <Divider />
+      <Paragraph type="secondary" style={{ fontSize: 12 }}>
+        Documento em preenchimento pelo controlador e pelo Encarregado (DPO). Os trechos
+        realçados como [A PREENCHER] ainda não têm valor jurídico definitivo.
+      </Paragraph>
+    </Typography>
+  );
+}

--- a/v2/frontend/src/pages/Auth/LoginPage.tsx
+++ b/v2/frontend/src/pages/Auth/LoginPage.tsx
@@ -14,6 +14,7 @@ import { login } from '../../api/auth';
 import logoLogin from '../../assets/logo-login.webp';
 import logger from '../../utils/logger';
 import { BRAND_COLORS } from '../../contexts/ThemeContext';
+import AvisoTransparenciaLGPD from '../../components/lgpd/AvisoTransparenciaLGPD';
 
 /**
  * Login form values interface
@@ -145,6 +146,9 @@ export default function LoginPage({ onLoginSuccess }: LoginPageProps): JSX.Eleme
           </Form.Item>
         </Form>
       </article>
+
+      {/* LGPD art. 9º: aviso de transparência no momento da coleta (não é consentimento). */}
+      <AvisoTransparenciaLGPD />
       </main>
     </>
   );

--- a/v2/frontend/src/pages/Perfil/PerfilPage.tsx
+++ b/v2/frontend/src/pages/Perfil/PerfilPage.tsx
@@ -11,6 +11,7 @@
 import { useState } from 'react';
 import { Button, Card, Descriptions, Form, Input, Space, Tag, Typography, message } from 'antd';
 import { DownloadOutlined, LockOutlined, PhoneOutlined, UserOutlined } from '@ant-design/icons';
+import { Link } from 'react-router';
 
 import type { CurrentUser } from '../../types/usuario';
 import { changeMyPassword, exportMyData, updateMyContact } from '../../api/me';
@@ -138,6 +139,9 @@ export default function PerfilPage({ user }: { user: CurrentUser }) {
             <Typography.Text type="secondary" className="ml-2">
               Baixa uma cópia dos seus dados (portabilidade — LGPD art. 18-V).
             </Typography.Text>
+          </div>
+          <div className="mt-3">
+            <Link to="/politica-privacidade">Política de Privacidade</Link>
           </div>
         </Card>
 

--- a/v2/frontend/src/pages/Politica/PoliticaPrivacidadePage.tsx
+++ b/v2/frontend/src/pages/Politica/PoliticaPrivacidadePage.tsx
@@ -1,0 +1,23 @@
+/**
+ * Página de Política de Privacidade (`/politica-privacidade`) — SCAFFOLD.
+ *
+ * Rota autenticada; o mesmo conteúdo aparece no Drawer do aviso de transparência no login
+ * (acessível ao anônimo). Ver `components/lgpd/PoliticaPrivacidadeContent`.
+ */
+import type { JSX } from 'react';
+import { Card, Space } from 'antd';
+import PoliticaPrivacidadeContent from '../../components/lgpd/PoliticaPrivacidadeContent';
+
+export default function PoliticaPrivacidadePage(): JSX.Element {
+  return (
+    <section className="p-6 bg-gray-100 min-h-full" aria-labelledby="politica-title">
+      <Space direction="vertical" size="large" style={{ width: '100%', maxWidth: 820 }}>
+        <Card>
+          <div id="politica-title">
+            <PoliticaPrivacidadeContent />
+          </div>
+        </Card>
+      </Space>
+    </section>
+  );
+}


### PR DESCRIPTION
## Contexto — a parte organizacional da LGPD (o que faltava)

A auditoria concluiu **engenharia forte, conformidade formal a completar**. A base técnica
(direitos do titular, retenção, anonimização, segurança) já foi entregue (#1697–#1707).
Este PR **scaffolda a parte organizacional** — estrutura + placeholders para o **Encarregado
(DPO) + jurídico** completarem. **Não invento texto jurídico vinculante.**

## O que entrega
**Frontend**
- **Política de Privacidade** (`PoliticaPrivacidadeContent`) — corpo com **conteúdo técnico real** (quais dados, finalidade, compartilhamento com Google/art. 33, retenção, segurança/art. 46, como exercer os direitos do art. 18) + `[A PREENCHER]` só nos campos jurídicos. Reutilizado na **rota `/politica-privacidade`** e no **Drawer do aviso no login** (acessível ao anônimo, que roda fora do react-router).
- **Aviso de transparência (art. 9º)** na LoginPage — **não é portão de consentimento** (sistema interno → base legal ≠ consentimento; é informação ao titular na coleta).
- Link "Política de Privacidade" na PerfilPage.

**Docs**
- `v2/docs/lgpd/RUNBOOK_INCIDENTE_ANPD.md` — resposta a incidente (art. 48), com papéis/fluxo/comandos.
- `v2/docs/lgpd/README.md` — índice + **o que depende de você/advogado** (identificação legal, DPO, base legal, prazos, vigência, canal ANPD) + base técnica já pronta.

## a11y (a própria cobertura pegou)
O link do aviso usava o azul default do Antd (`#1677ff`) sobre o fundo do Alert info → **3.66:1** (reprova AA). O teste axe autenticado **falhou e me avisou** → corrigido para o verde da marca `#004B3D` + sublinhado.

## O que VOCÊ + advogado precisam preencher
Ver `v2/docs/lgpd/README.md`: identificação do controlador (razão social/CNPJ), contato do Encarregado, **base legal** por categoria (arts. 7º/11), prazos de retenção oficiais, versão/vigência, canal ANPD.

## Verificação
`tsc` 0; PerfilPage vitest **7/7**; suíte a11y **13 passed** (home + /perfil, contraste ok); gate de links de docs OK. (Frontmatter gate só cobre `specs/` → docs em `lgpd/` isentos.)
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `615b88bf`, slot `0` / projeto `aprender_staging`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
