### PR TITLE
ci(sign): retry+verify no cosign sign contra 409 transitorio do Rekor

### DIFF
--- a/.github/workflows/slsa-provenance.yml
+++ b/.github/workflows/slsa-provenance.yml
@@ -183,10 +183,40 @@ jobs:
           FRONTEND_IMAGE: ${{ env.FRONTEND_IMAGE }}
           BACKEND_DIGEST: ${{ steps.digests.outputs.backend_digest }}
           FRONTEND_DIGEST: ${{ steps.digests.outputs.frontend_digest }}
+          CERT_IDENTITY_REGEX: ^https://github.com/${{ github.repository }}/.github/workflows/slsa-provenance.yml@refs/(heads/main|tags/.+)$
         run: |
           set -euo pipefail
-          cosign sign --yes "${BACKEND_IMAGE}@${BACKEND_DIGEST}"
-          cosign sign --yes "${FRONTEND_IMAGE}@${FRONTEND_DIGEST}"
+
+          # `cosign sign` pega 409 transitorio do Rekor ("an equivalent entry already
+          # exists in the transparency log") quando o retry INTERNO do cosign re-submete
+          # ao tlog a entrada que o 1o POST ja criou (rede engasgou). Mesma classe de flake
+          # que o resolve_digest acima ja trata para o exit-255 do Docker Hub — mesmo idioma
+          # de retry com backoff. Keyless usa cert efemero NOVO a cada tentativa, entao um
+          # sign fresco nao colide. Se, apos um erro, a assinatura ja verificar, o 409 foi
+          # benigno (a entrada equivalente E' a assinatura valida) -> sucesso. Fail-closed ao
+          # esgotar; o step "Verify Cosign signatures" abaixo segue como gate duro autoritativo.
+          sign_with_retry() {
+            local ref="$1" attempt
+            for attempt in 1 2 3; do
+              if cosign sign --yes "$ref"; then
+                return 0
+              fi
+              if cosign verify "$ref" \
+                   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+                   --certificate-identity-regexp "${CERT_IDENTITY_REGEX}" \
+                   >/dev/null 2>&1; then
+                echo "aviso: ${ref}: cosign sign retornou erro, mas a assinatura verifica (Rekor 409 benigno)" >&2
+                return 0
+              fi
+              echo "aviso: ${ref}: cosign sign falhou (tentativa ${attempt}/3)" >&2
+              if [ "$attempt" -lt 3 ]; then sleep "$(( attempt * 5 ))"; fi
+            done
+            echo "${ref}: cosign sign nao concluiu apos 3 tentativas" >&2
+            return 1
+          }
+
+          sign_with_retry "${BACKEND_IMAGE}@${BACKEND_DIGEST}"
+          sign_with_retry "${FRONTEND_IMAGE}@${FRONTEND_DIGEST}"
 
       - name: Verify Cosign signatures
         env:


### PR DESCRIPTION
## Contexto

A release `v2026.08.11-d9b8330` (merge do scaffold LGPD #1708) quebrou no job **Sign images (cosign keyless + SLSA)** com:

```
Error: signing [norjosamatheus/aprender-backend@sha256:f6ca9fed...]: signing bundle:
error signing bundle: [POST /api/v1/log/entries][409] createLogEntryConflict
{"code":409,"message":"an equivalent entry already exists in the transparency log ..."}
```

## Diagnóstico

Flake **transitório** do cosign/Rekor, não problema de código:

- As **2 atestações SLSA subiram ao Rekor com sucesso** no mesmo run → Rekor estava acessível.
- O `cosign sign` do backend pegou 409 porque o **retry interno do cosign** re-submeteu ao tlog a entrada que o 1º POST já havia criado (rede engasgou).
- O digest `f6ca9fed` é inédito (backend leva cache-bust por `GIT_SHA`) → não é "digest já assinado numa release anterior".
- **Re-run do job passou verde** e a release ficou assinada — confirmando o caráter transitório.

`needs: [prepare, build_and_push]` + `concurrency` já impedem execução concorrente/dupla do job — o 409 não veio de assinar duas vezes.

## Fix

`sign_with_retry()`: 3 tentativas com backoff (5s, 10s), **mesmo idioma do `resolve_digest`** que já existe neste arquivo para o exit-255 do Docker Hub.

- Keyless usa **cert efêmero novo a cada tentativa** → um sign fresco não colide com o tlog.
- Se, após um erro, a assinatura **já verificar**, o 409 foi benigno (entrada equivalente = assinatura válida) → sucesso.
- **Fail-closed** ao esgotar; o step `Verify Cosign signatures` segue como gate duro autoritativo.

Lógica validada localmente com `cosign` stubado (sign-ok / 409-benigno / recupera-na-3ª / fail-closed — 4/4).

## Escopo

Só `.github/workflows/slsa-provenance.yml` (passo de assinatura). Sem mudança de app. A validação real do caminho de assinatura é o próximo release na main.
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `c2f31541`, slot `0` / projeto `aprender_staging`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
