### PR TITLE
fix(dat): recalcular_ch agrega no banco — CH nao fica um PATCH atrasada (#1642)

### DIFF
--- a/v2/backend/apps/core/models/plano_formacoes.py
+++ b/v2/backend/apps/core/models/plano_formacoes.py
@@ -14,6 +14,7 @@ from decimal import Decimal
 from typing import TYPE_CHECKING
 
 from django.db import models
+from django.db.models.functions import Coalesce
 from django.utils import timezone
 
 if TYPE_CHECKING:
@@ -110,10 +111,24 @@ class PlanoFormacoes(models.Model):
         return f"{self.municipio} - {self.projeto}"
 
     def recalcular_ch(self) -> None:
-        """Recalcula CH total e anual baseado nas formacoes."""
+        """Recalcula CH total e anual baseado nas formacoes.
+
+        Agrega no banco (nao itera `self.formacoes.all()` em Python) para nao ler um
+        cache de prefetch obsoleto: `update_formacao` carrega o prefetch em get_object()
+        ANTES de gravar a formacao, entao iterar o cache deixaria a CH um PATCH atrasada
+        (M19-01). `.filter().aggregate()` sempre emite SQL fresco, imune ao cache.
+        """
         from decimal import Decimal
 
-        total = sum((f.carga_horaria for f in self.formacoes.all() if f.data_formacao), Decimal("0.00"))
+        # Coalesce -> a soma ja vem 0.00 do proprio SQL quando nao ha formacao com data,
+        # dispensando guard em Python; `total` permanece o resultado do ORM (nunca None).
+        total = self.formacoes.filter(data_formacao__isnull=False).aggregate(
+            total=Coalesce(
+                models.Sum("carga_horaria"),
+                Decimal("0.00"),
+                output_field=models.DecimalField(max_digits=6, decimal_places=2),
+            )
+        )["total"]
         self.ch_total = total
         self.ch_anual = total + self.ch_estudo
 

--- a/v2/backend/apps/core/tests/test_plano_formacoes.py
+++ b/v2/backend/apps/core/tests/test_plano_formacoes.py
@@ -439,6 +439,61 @@ class TestPlanoFormacoesAPI:
         assert str(formacao.data_formacao) == "2025-05-01"
         assert formacao.realizada is True
 
+    def test_update_formacao_recalcula_ch_no_primeiro_patch(self, client, user, plano):
+        """RED (M19-01): a CH deve ser recalculada JA no 1o PATCH, nao uma edicao atrasada.
+
+        O endpoint carrega o prefetch de `formacoes` em get_object() ANTES da escrita;
+        recalcular_ch() nao pode ler esse cache obsoleto (senao ch_total/ch_anual ficam
+        um PATCH atras). Este teste passa pelo viewset de proposito — o unitario
+        test_recalcular_ch opera num objeto sem prefetch e por isso nao pega o bug.
+        """
+        # Formacao de 4h SEM data -> ainda nao conta na CH (ch_total deve ser 0 antes).
+        Formacao.objects.create(
+            plano=plano,
+            numero_formacao=1,
+            carga_horaria=Decimal("4.00"),
+        )
+
+        client.force_login(user)
+        response = client.patch(
+            f"/api/dat/plano-formacoes/{plano.id}/formacao/1/",
+            data={"data_formacao": "2026-03-10"},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 200
+        plano.refresh_from_db()
+        # Antes do fix: ch_total=0.00 / ch_anual=10.00 (cache de prefetch obsoleto).
+        assert plano.ch_total == Decimal("4.00")
+        assert plano.ch_anual == Decimal("14.00")  # 4 + ch_estudo(10)
+
+    def test_update_formacao_ch_acompanha_edicoes_sequenciais(self, client, user, plano):
+        """RED (M19-01): duas edicoes em sequencia — cada PATCH deve refletir na CH
+        imediatamente, travando a regressao de 'um PATCH atrasado'."""
+        Formacao.objects.create(plano=plano, numero_formacao=1, carga_horaria=Decimal("4.00"))
+        Formacao.objects.create(plano=plano, numero_formacao=2, carga_horaria=Decimal("6.00"))
+        client.force_login(user)
+
+        r1 = client.patch(
+            f"/api/dat/plano-formacoes/{plano.id}/formacao/1/",
+            data={"data_formacao": "2026-03-10"},
+            content_type="application/json",
+        )
+        assert r1.status_code == 200
+        plano.refresh_from_db()
+        assert plano.ch_total == Decimal("4.00")  # so a formacao 1 tem data
+        assert plano.ch_anual == Decimal("14.00")
+
+        r2 = client.patch(
+            f"/api/dat/plano-formacoes/{plano.id}/formacao/2/",
+            data={"data_formacao": "2026-04-10"},
+            content_type="application/json",
+        )
+        assert r2.status_code == 200
+        plano.refresh_from_db()
+        assert plano.ch_total == Decimal("10.00")  # 4 + 6
+        assert plano.ch_anual == Decimal("20.00")  # 10 + ch_estudo(10)
+
     def test_calendario_endpoint(self, client, user, plano):
         """Test calendario endpoint."""
         # Create formacao with date


### PR DESCRIPTION
Closes #1642

## Bug (M19-01)

A action `update_formacao` (`PATCH /api/dat/plano-formacoes/{id}/formacao/{numero}/`) recalculava a CH lendo o **cache de prefetch obsoleto**:

1. `get_object()` (queryset com `.prefetch_related("formacoes")`) popula o cache com o estado **antigo**.
2. `serializer.save()` grava `data_formacao` numa instância **nova** (fora do cache).
3. `recalcular_ch()` iterava `self.formacoes.all()` → devolve o **cache do passo 1**, onde `data_formacao` ainda é `None` → soma sai `0.00`.

Resultado: `ch_total`/`ch_anual` ficavam **um PATCH atrasados**. Um 2º PATCH idêntico "alcançava" o valor. A UI chegou a mascarar o sintoma exibindo `CH Total = "—"`. **Vivo em prod** (`v2026.07.18`), operado diariamente pela equipe DAT (3 membros ativos).

## Fix

`recalcular_ch()` passa a **agregar no banco** em vez de iterar em Python:

```python
total = self.formacoes.filter(data_formacao__isnull=False).aggregate(
    total=Coalesce(models.Sum("carga_horaria"), Decimal("0.00"),
                   output_field=models.DecimalField(max_digits=6, decimal_places=2)),
)["total"]
```

`.filter()/.aggregate()` sempre emitem SQL fresco — **imunes ao prefetch cache**, eliminando a classe inteira do bug em qualquer call site. `Coalesce` traz `0.00` do próprio SQL (sem guard em Python). Único call site em prod → blast radius pequeno.

## Testes (TDD)

Dois testes de **integração via endpoint** (o unitário `test_recalcular_ch` não pega o bug porque opera num objeto **sem prefetch**):

- `test_update_formacao_recalcula_ch_no_primeiro_patch` — CH correta já no 1º PATCH.
- `test_update_formacao_ch_acompanha_edicoes_sequenciais` — trava a regressão de "um PATCH atrasado".

**RED provado** antes do fix (`ch_total=0.00` vs `4.00`). Depois do fix: **36/36** verdes em `test_plano_formacoes.py` (inclui o `test_recalcular_ch` existente — sem regressão). `pyright apps/core/models/plano_formacoes.py` não introduz erro novo (o único erro remanescente, `default=True` na linha 82, é pré-existente / limitação de django-stubs).

## Follow-up (fora deste PR)

**Passivo já corrompido:** planos editados antes deste fix podem ter `ch_total`/`ch_anual` defasados no banco. Cada plano **auto-corrige na próxima edição** (recalcular_ch roda no PATCH). Um datafix idempotente (preflight → dry-run → apply, snapshot + postcheck) aceleraria a correção do passivo — proponho como tarefa separada, com autorização, seguindo a disciplina de datafix do projeto.
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `a8913d86`, slot `0` / projeto `aprender_staging`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
