### PR TITLE
fix(dat): datas do formulario /dat/registros chegam ao banco (#1638)

### DIFF
--- a/v2/frontend/src/pages/DATModule/DATRegistrosPage.tsx
+++ b/v2/frontend/src/pages/DATModule/DATRegistrosPage.tsx
@@ -54,7 +54,7 @@ import {
   getMunicipiosOptions,
   getProjetosOptions,
 } from '../../api/datModule';
-import dayjs from 'dayjs';
+import dayjs, { type Dayjs } from 'dayjs';
 import {
   STATUS_OPTIONS,
   UF_OPTIONS,
@@ -83,7 +83,62 @@ interface DATRegistroFormValues {
   municipio: number;
   projeto_geral: number;
   projeto: number;
-  [key: string]: any;
+  aluno_qtde?: number | null;
+  professor_qtde?: number | null;
+  // FORMAR
+  reuniao_dat?: Dayjs | null;
+  turma_formar_id?: string | null;
+  turma_formar_status?: string | null;
+  nr_codigos?: number | null;
+  chaves_inscricao_status?: string | null;
+  chaves_inscricao_data?: Dayjs | null;
+  instrucoes_status?: string | null;
+  instrucoes_data?: Dayjs | null;
+  envio_codigos_status?: string | null;
+  envio_codigos_data?: Dayjs | null;
+  obs_formar?: string | null;
+  // AVALIAR (a UI usa nome singular; o serializer usa o plural — ver buildDATRegistroPayload)
+  usa_avaliar?: boolean;
+  alunos_recebidos_status?: string | null;
+  alunos_recebidos_data?: Dayjs | null;
+  alunos_validados_status?: string | null;
+  alunos_validados_data?: Dayjs | null;
+  alunos_importados_status?: string | null;
+  alunos_importados_data?: Dayjs | null;
+  obs_avaliar?: string | null;
+}
+
+// Mapeia o nome singular do DatePicker AVALIAR (form) para o campo plural do serializer (JSONField).
+const AVALIAR_DATE_FIELDS = [
+  ['alunos_recebidos_data', 'alunos_recebidos_datas'],
+  ['alunos_validados_data', 'alunos_validados_datas'],
+  ['alunos_importados_data', 'alunos_importados_datas'],
+] as const;
+
+const toISODate = (d?: Dayjs | null): string | null => (d ? d.format('YYYY-MM-DD') : null);
+const toISODateList = (d?: Dayjs | null): string[] => (d ? [d.format('YYYY-MM-DD')] : []);
+
+/**
+ * Converte os valores do formulário no payload que os serializers DRF aceitam (M16-07):
+ * - datas FORMAR (DateField) viram `YYYY-MM-DD`; sem isso o Dayjs cru vira datetime ISO
+ *   (`2026-07-20T03:00:00.000Z`) e o DateField rejeita com 400, perdendo o formulário inteiro;
+ * - datas AVALIAR migram do nome singular do form para o plural do serializer (JSONField
+ *   multivalorado), como array de um elemento; sem isso o backend responde 200/201 e
+ *   descarta as datas em silêncio.
+ */
+export function buildDATRegistroPayload(values: DATRegistroFormValues): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    ...values,
+    reuniao_dat: toISODate(values.reuniao_dat),
+    chaves_inscricao_data: toISODate(values.chaves_inscricao_data),
+    instrucoes_data: toISODate(values.instrucoes_data),
+    envio_codigos_data: toISODate(values.envio_codigos_data),
+  };
+  for (const [singular, plural] of AVALIAR_DATE_FIELDS) {
+    payload[plural] = toISODateList(values[singular]);
+    delete payload[singular];
+  }
+  return payload;
 }
 
 interface ProjetoGeralOption {
@@ -214,19 +269,43 @@ export default function DATRegistrosPage(): JSX.Element {
 
   const handleEdit = (record: DATRegistroRecord) => {
     setEditingRegistro(record);
+    // Reconstrução explícita (record é frouxo, `[key: string]: unknown`): hidrata os 7
+    // DatePickers e mapeia as datas AVALIAR do plural persistido de volta ao singular do form.
+    const r = record as Record<string, unknown>;
+    const asDate = (v: unknown): Dayjs | null => (v ? dayjs(v as string) : null);
+    const firstOf = (v: unknown): Dayjs | null => asDate((v as string[] | undefined)?.[0]);
     form.setFieldsValue({
-      ...record,
-      reuniao_dat: record.reuniao_dat ? dayjs(record.reuniao_dat) : null,
+      municipio: record.municipio,
+      projeto_geral: record.projeto_geral,
+      projeto: record.projeto,
+      aluno_qtde: record.aluno_qtde,
+      professor_qtde: record.professor_qtde,
+      reuniao_dat: asDate(record.reuniao_dat),
+      turma_formar_id: record.turma_formar_id,
+      turma_formar_status: r.turma_formar_status as string | null | undefined,
+      nr_codigos: record.nr_codigos,
+      chaves_inscricao_status: record.chaves_inscricao_status,
+      chaves_inscricao_data: asDate(r.chaves_inscricao_data),
+      instrucoes_status: r.instrucoes_status as string | null | undefined,
+      instrucoes_data: asDate(r.instrucoes_data),
+      envio_codigos_status: record.envio_codigos_status,
+      envio_codigos_data: asDate(r.envio_codigos_data),
+      obs_formar: record.obs_formar,
+      usa_avaliar: record.usa_avaliar,
+      alunos_recebidos_status: record.alunos_recebidos_status,
+      alunos_recebidos_data: firstOf(r.alunos_recebidos_datas),
+      alunos_validados_status: record.alunos_validados_status,
+      alunos_validados_data: firstOf(r.alunos_validados_datas),
+      alunos_importados_status: record.alunos_importados_status,
+      alunos_importados_data: firstOf(r.alunos_importados_datas),
+      obs_avaliar: record.obs_avaliar,
     });
     setModalVisible(true);
   };
 
   const handleSave = async (values: DATRegistroFormValues) => {
     try {
-      const payload = {
-        ...values,
-        reuniao_dat: values.reuniao_dat ? values.reuniao_dat.format('YYYY-MM-DD') : null,
-      };
+      const payload = buildDATRegistroPayload(values);
 
       if (editingRegistro) {
         await updateDATRegistro(editingRegistro.id, payload);

--- a/v2/frontend/src/pages/DATModule/__tests__/buildDATRegistroPayload.test.ts
+++ b/v2/frontend/src/pages/DATModule/__tests__/buildDATRegistroPayload.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import dayjs from 'dayjs';
+
+import { buildDATRegistroPayload } from '../DATRegistrosPage';
+
+/**
+ * M16-07: o formulário de /dat/registros perdia datas em silêncio.
+ * Estas asserções codificam o contrato que o payload precisa cumprir — exatamente o
+ * que a lógica inline anterior violava (só `reuniao_dat` era adaptada; as demais iam
+ * como Dayjs cru -> datetime ISO -> 400; as datas AVALIAR iam no nome singular ->
+ * ignoradas pelo serializer -> 201/200 sem persistir).
+ */
+describe('buildDATRegistroPayload (M16-07)', () => {
+  const base = { municipio: 1, projeto_geral: 2, projeto: 3 } as const;
+
+  it('converte todas as datas FORMAR para YYYY-MM-DD (nunca datetime ISO)', () => {
+    const payload = buildDATRegistroPayload({
+      ...base,
+      reuniao_dat: dayjs('2026-07-20'),
+      chaves_inscricao_data: dayjs('2026-07-21'),
+      instrucoes_data: dayjs('2026-07-22'),
+      envio_codigos_data: dayjs('2026-07-23'),
+    });
+
+    expect(payload.reuniao_dat).toBe('2026-07-20');
+    expect(payload.chaves_inscricao_data).toBe('2026-07-21');
+    expect(payload.instrucoes_data).toBe('2026-07-22');
+    expect(payload.envio_codigos_data).toBe('2026-07-23');
+
+    for (const k of ['reuniao_dat', 'chaves_inscricao_data', 'instrucoes_data', 'envio_codigos_data']) {
+      expect(String(payload[k])).not.toMatch(/T\d{2}:/); // nenhum datetime ISO
+    }
+  });
+
+  it('mapeia datas AVALIAR do singular do form para o plural do serializer (array), removendo o singular', () => {
+    const payload = buildDATRegistroPayload({
+      ...base,
+      alunos_recebidos_data: dayjs('2026-07-20'),
+      alunos_validados_data: dayjs('2026-07-21'),
+      alunos_importados_data: dayjs('2026-07-22'),
+    });
+
+    expect(payload.alunos_recebidos_datas).toEqual(['2026-07-20']);
+    expect(payload.alunos_validados_datas).toEqual(['2026-07-21']);
+    expect(payload.alunos_importados_datas).toEqual(['2026-07-22']);
+
+    // O nome singular NÃO pode vazar no payload (é o campo que o serializer ignora hoje
+    // e que passaria a dar 400 quando a rejeição de campo desconhecido for ligada).
+    expect(payload).not.toHaveProperty('alunos_recebidos_data');
+    expect(payload).not.toHaveProperty('alunos_validados_data');
+    expect(payload).not.toHaveProperty('alunos_importados_data');
+  });
+
+  it('datas ausentes: FORMAR viram null e AVALIAR viram lista vazia', () => {
+    const payload = buildDATRegistroPayload({ ...base });
+
+    expect(payload.reuniao_dat).toBeNull();
+    expect(payload.chaves_inscricao_data).toBeNull();
+    expect(payload.instrucoes_data).toBeNull();
+    expect(payload.envio_codigos_data).toBeNull();
+    expect(payload.alunos_recebidos_datas).toEqual([]);
+    expect(payload.alunos_validados_datas).toEqual([]);
+    expect(payload.alunos_importados_datas).toEqual([]);
+  });
+
+  it('preserva os demais campos do formulário (status, ids, observações)', () => {
+    const payload = buildDATRegistroPayload({
+      ...base,
+      aluno_qtde: 30,
+      turma_formar_status: 'criada',
+      chaves_inscricao_status: 'concluido',
+      obs_formar: 'ok',
+    });
+
+    expect(payload.municipio).toBe(1);
+    expect(payload.aluno_qtde).toBe(30);
+    expect(payload.turma_formar_status).toBe('criada');
+    expect(payload.chaves_inscricao_status).toBe('concluido');
+    expect(payload.obs_formar).toBe('ok');
+  });
+});


### PR DESCRIPTION
Refs #1638

## Bug (M16-07) — perda silenciosa de datas em `/dat/registros`

O formulário grava **7 DatePickers**, mas só `reuniao_dat` era adaptada:

- **FORMAR** (`chaves_inscricao_data`, `instrucoes_data`, `envio_codigos_data`): iam como objeto **Dayjs cru** → `JSON.stringify` → datetime ISO (`2026-07-20T03:00:00.000Z`). O `DateField` do DRF rejeita → **HTTP 400**, perdendo o formulário inteiro na submissão.
- **AVALIAR** (`alunos_recebidos_data`, `alunos_validados_data`, `alunos_importados_data`): a UI usa o nome **singular**; o serializer aceita só o **plural** (`*_datas`, `JSONField`). Campo desconhecido é ignorado pelo ModelSerializer → **201/200 "sucesso"** e as datas **nunca persistiam**. O operador não tinha como perceber.

Vivo em prod, operado diariamente pela equipe DAT (3 membros + superuser).

## Fix (frontend)

`buildDATRegistroPayload(values)` (pura, exportada e testada):
- converte as 4 datas FORMAR para `YYYY-MM-DD`;
- mapeia as 3 datas AVALIAR do singular do form para o **plural** do serializer, como **array de um elemento** (caminho conservador);
- `handleEdit` hidrata os 7 pickers no caminho inverso (AVALIAR a partir do 1º item do array).

**Type hole fechado:** removido `[key: string]: any` de `DATRegistroFormValues` (era ele que mascarava o drift no typecheck) e tipados os campos; `handleEdit` reconstruído explicitamente (o `record` é frouxo). `tsc --noEmit` limpo.

## Testes

`buildDATRegistroPayload.test.ts` (4) — datas FORMAR viram `YYYY-MM-DD` (nenhum datetime ISO); AVALIAR viram plural-array e o singular é removido; ausentes viram `null`/`[]`; demais campos preservados. As asserções codificam exatamente o contrato que a lógica inline anterior violava.

## Decisão de domínio (aberta, não fechada aqui)

Os campos AVALIAR são `JSONField` **multivalorados**, mas a UI oferece **um** DatePicker. O adapter assume o caminho conservador (array de 1). Fechar isso — UI multivalor **ou** migrar o modelo para `DateField` único (expand/contract) — fica para o desenho de DTOs (M16-14).

## Follow-up (fora deste PR, deliberado)

A parte (3) da issue — backend **rejeitar campo desconhecido** (`to_internal_value`) — é **mais disruptiva do que o corpo da issue indica**: o form envia `usa_avaliar` (read-only computado) e, no update, `municipio/projeto/projeto_geral` (imutáveis, ausentes do UpdateSerializer). Ligá-la **sem antes limpar o payload** faria a tela tomar 400 em create **e** update. Como este PR resolve a perda de dado inteiramente no frontend, deixo a rejeição de desconhecido (+ o teste de contrato backend + M16-06) como fast-follow com o payload já saneado.
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `4553e9aa`, slot `0` / projeto `aprender_staging`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
