### PR TITLE
fix(dat): status de /dat/registros bate com os choices do backend (#1639)

### DIFF
--- a/v2/frontend/src/pages/DATModule/DATRegistros/__tests__/statusContract.test.tsx
+++ b/v2/frontend/src/pages/DATModule/DATRegistros/__tests__/statusContract.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+
+import { TURMA_STATUS_OPTIONS, ETAPA_STATUS_OPTIONS } from '../constants';
+import { renderStatusIcon } from '../helpers';
+
+/**
+ * M16-08: a UI usava uma única lista (`pendente/em_andamento/concluido`) para dois enums
+ * distintos do backend. Ofereciam-se valores que o serializer rejeitava (400) e escondiam-se
+ * valores válidos (`criada`, `erro`, `nao_aplicavel`). Estes valores espelham
+ * DATRegistro.TURMA_STATUS_CHOICES e DATRegistro.STATUS_CHOICES.
+ */
+const TURMA_BACKEND = ['criada', 'pendente', 'erro'];
+const ETAPA_BACKEND = ['concluido', 'pendente', 'em_andamento', 'nao_aplicavel', 'erro'];
+
+describe('DATRegistros status options — contrato com o backend (M16-08)', () => {
+  it('TURMA_STATUS_OPTIONS bate exatamente com TURMA_STATUS_CHOICES', () => {
+    expect(TURMA_STATUS_OPTIONS.map((o) => o.value).sort()).toEqual([...TURMA_BACKEND].sort());
+  });
+
+  it('ETAPA_STATUS_OPTIONS bate exatamente com STATUS_CHOICES', () => {
+    expect(ETAPA_STATUS_OPTIONS.map((o) => o.value).sort()).toEqual([...ETAPA_BACKEND].sort());
+  });
+
+  it('nenhuma opção oferece valor fora dos choices do backend (nada dá 400)', () => {
+    for (const o of TURMA_STATUS_OPTIONS) expect(TURMA_BACKEND).toContain(o.value);
+    for (const o of ETAPA_STATUS_OPTIONS) expect(ETAPA_BACKEND).toContain(o.value);
+  });
+});
+
+describe('renderStatusIcon — erro distinto de nao_aplicavel (M16-08)', () => {
+  it('erro e nao_aplicavel renderizam ícones distintos (antes ambos caíam no cinza)', () => {
+    const erro = renderStatusIcon('erro');
+    const na = renderStatusIcon('nao_aplicavel');
+    expect(erro.type).not.toBe(na.type);
+    expect(erro.props.className).not.toEqual(na.props.className);
+  });
+
+  it('erro é vermelho e nao_aplicavel é cinza', () => {
+    expect(renderStatusIcon('erro').props.className).toContain('text-red');
+    expect(renderStatusIcon('nao_aplicavel').props.className).toContain('text-gray');
+  });
+
+  it('valor desconhecido não é renderizado como nao_aplicavel', () => {
+    expect(renderStatusIcon('xpto').type).not.toBe(renderStatusIcon('nao_aplicavel').type);
+  });
+});

--- a/v2/frontend/src/pages/DATModule/DATRegistros/columns.tsx
+++ b/v2/frontend/src/pages/DATModule/DATRegistros/columns.tsx
@@ -7,7 +7,7 @@ import { Space, Tag, Typography, Tooltip, Button } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
 import { EditOutlined, DeleteOutlined } from '@ant-design/icons';
 import dayjs from 'dayjs';
-import { STATUS_OPTIONS } from './constants';
+import { ETAPA_STATUS_OPTIONS } from './constants';
 import { renderStatusIcon } from './helpers';
 import type { ID } from '../../../types';
 
@@ -119,6 +119,22 @@ export function getColumns({ onEdit, onDelete }: ColumnHandlers): ColumnsType<DA
         ),
     },
     {
+      title: 'Status Turma',
+      dataIndex: 'turma_formar_status',
+      key: 'turma_formar_status',
+      width: 100,
+      render: (status: string | undefined) => {
+        if (!status) return <Text type="secondary">-</Text>;
+        const map: Record<string, { color: string; label: string }> = {
+          criada: { color: 'green', label: 'Criada' },
+          pendente: { color: 'default', label: 'Pendente' },
+          erro: { color: 'red', label: 'Erro' },
+        };
+        const it = map[status];
+        return <Tag color={it?.color ?? 'default'}>{it?.label ?? status}</Tag>;
+      },
+    },
+    {
       title: 'Códs',
       dataIndex: 'nr_codigos',
       key: 'nr_codigos',
@@ -132,17 +148,24 @@ export function getColumns({ onEdit, onDelete }: ColumnHandlers): ColumnsType<DA
       key: 'chaves',
       width: 100,
       render: (status: string | undefined) => {
+        if (!status) return <Text type="secondary">-</Text>;
+        // M16-08: `erro` e `nao_aplicavel` faltavam nos mapas -> Tag vazia. Fallback mostra o
+        // valor cru em vez de sumir com o dado.
         const colors: Record<string, string> = {
           concluido: 'green',
           em_andamento: 'gold',
           pendente: 'default',
+          nao_aplicavel: 'default',
+          erro: 'red',
         };
         const labels: Record<string, string> = {
           concluido: 'Geradas',
           em_andamento: 'Pend.',
           pendente: 'Pend.',
+          nao_aplicavel: 'N/A',
+          erro: 'Erro',
         };
-        return <Tag color={status ? colors[status] : 'default'}>{status ? labels[status] : status}</Tag>;
+        return <Tag color={colors[status] ?? 'default'}>{labels[status] ?? status}</Tag>;
       },
     },
     {
@@ -152,7 +175,7 @@ export function getColumns({ onEdit, onDelete }: ColumnHandlers): ColumnsType<DA
       width: 70,
       align: 'center',
       render: (status: string | undefined) => (
-        <Tooltip title={STATUS_OPTIONS.find((s) => s.value === status)?.label || status}>
+        <Tooltip title={ETAPA_STATUS_OPTIONS.find((s) => s.value === status)?.label || status}>
           {renderStatusIcon(status)}
         </Tooltip>
       ),

--- a/v2/frontend/src/pages/DATModule/DATRegistros/constants.tsx
+++ b/v2/frontend/src/pages/DATModule/DATRegistros/constants.tsx
@@ -39,11 +39,26 @@ export interface DATRegistrosFilters {
   status_formar: string | undefined;
 }
 
-// Status options for workflow steps
-export const STATUS_OPTIONS: StatusOption[] = [
+// Opções de status. Espelham os choices do backend (M16-08):
+// DATRegistro.TURMA_STATUS_CHOICES e DATRegistro.STATUS_CHOICES. Divergir daqui faz
+// o Select oferecer valores que o serializer rejeita com 400 (perdendo o formulário
+// inteiro) ou esconder valores válidos. O contrato é travado por
+// __tests__/statusOptionsContract.test.ts.
+
+// turma_formar_status -> DATRegistro.TURMA_STATUS_CHOICES
+export const TURMA_STATUS_OPTIONS: StatusOption[] = [
+  { label: 'Criada', value: 'criada' },
+  { label: 'Pendente', value: 'pendente' },
+  { label: 'Erro', value: 'erro' },
+];
+
+// etapas FORMAR/AVALIAR (*_status) -> DATRegistro.STATUS_CHOICES
+export const ETAPA_STATUS_OPTIONS: StatusOption[] = [
+  { label: 'Concluído', value: 'concluido' },
   { label: 'Pendente', value: 'pendente' },
   { label: 'Em Andamento', value: 'em_andamento' },
-  { label: 'Concluído', value: 'concluido' },
+  { label: 'Não Aplicável', value: 'nao_aplicavel' },
+  { label: 'Erro', value: 'erro' },
 ];
 
 // Brazilian states

--- a/v2/frontend/src/pages/DATModule/DATRegistros/helpers.tsx
+++ b/v2/frontend/src/pages/DATModule/DATRegistros/helpers.tsx
@@ -8,29 +8,45 @@ import {
   ClockCircleFilled,
   ExclamationCircleFilled,
   MinusCircleFilled,
+  CloseCircleFilled,
+  QuestionCircleFilled,
 } from '@ant-design/icons';
 
 import type { JSX } from "react";
 
 /**
- * Status type for workflow steps
+ * Status type for workflow steps (espelha DATRegistro.STATUS_CHOICES + TURMA_STATUS_CHOICES).
  */
-export type WorkflowStatus = 'concluido' | 'em_andamento' | 'pendente';
+export type WorkflowStatus =
+  | 'concluido'
+  | 'em_andamento'
+  | 'pendente'
+  | 'nao_aplicavel'
+  | 'erro'
+  | 'criada';
 
 /**
- * Renders status icon based on status value
- * @param status - Status value (concluido, em_andamento, pendente)
- * @returns Icon component with appropriate color
+ * Renders status icon based on status value.
+ *
+ * M16-08: `erro` DEVE ser visualmente distinto de `nao_aplicavel` — antes ambos caíam no
+ * default (minus cinza) e a legenda rotulava o cinza como "Não Aplicável", exibindo uma
+ * etapa em ERRO como se não se aplicasse. O default passa a ser um "?" (valor desconhecido),
+ * separado do cinza de `nao_aplicavel`.
  */
 export function renderStatusIcon(status: string | undefined): JSX.Element {
   switch (status) {
     case 'concluido':
+    case 'criada':
       return <CheckCircleFilled className="text-green-500 text-lg" />;
     case 'em_andamento':
       return <ClockCircleFilled className="text-yellow-500 text-lg" />;
     case 'pendente':
       return <ExclamationCircleFilled className="text-red-500 text-lg" />;
-    default:
+    case 'erro':
+      return <CloseCircleFilled className="text-red-600 text-lg" />;
+    case 'nao_aplicavel':
       return <MinusCircleFilled className="text-gray-400 text-lg" />;
+    default:
+      return <QuestionCircleFilled className="text-gray-400 text-lg" />;
   }
 }

--- a/v2/frontend/src/pages/DATModule/DATRegistrosPage.tsx
+++ b/v2/frontend/src/pages/DATModule/DATRegistrosPage.tsx
@@ -39,6 +39,7 @@ import {
   ClockCircleFilled,
   ExclamationCircleFilled,
   MinusCircleFilled,
+  CloseCircleFilled,
   DatabaseOutlined,
   BookOutlined,
   BarChartOutlined,
@@ -56,7 +57,8 @@ import {
 } from '../../api/datModule';
 import dayjs, { type Dayjs } from 'dayjs';
 import {
-  STATUS_OPTIONS,
+  TURMA_STATUS_OPTIONS,
+  ETAPA_STATUS_OPTIONS,
   UF_OPTIONS,
   REGIAO_UFS,
   REGIAO_OPTIONS,
@@ -567,6 +569,10 @@ export default function DATRegistrosPage(): JSX.Element {
             <MinusCircleFilled className="text-gray-400" />
             <Text type="secondary">Não Aplicável</Text>
           </Space>
+          <Space>
+            <CloseCircleFilled className="text-red-600" />
+            <Text type="secondary">Erro</Text>
+          </Space>
           <Divider type="vertical" />
           <Space>
             <Tag color="green">Chaves Geradas</Tag>
@@ -706,8 +712,8 @@ export default function DATRegistrosPage(): JSX.Element {
                     </Form.Item>
                   </Col>
                   <Col span={12}>
-                    <Form.Item name="turma_formar_status" label="Status Turma">
-                      <Select placeholder="Selecione..." options={STATUS_OPTIONS} allowClear />
+                    <Form.Item name="turma_formar_status" label="Status Turma (Criada / Pendente / Erro)">
+                      <Select placeholder="Selecione..." options={TURMA_STATUS_OPTIONS} allowClear />
                     </Form.Item>
                   </Col>
                 </Row>
@@ -732,7 +738,7 @@ export default function DATRegistrosPage(): JSX.Element {
                     <Form.Item name="chaves_inscricao_status" noStyle>
                       <Select
                         placeholder="Status"
-                        options={STATUS_OPTIONS}
+                        options={ETAPA_STATUS_OPTIONS}
                         style={{ width: '100%', maxWidth: 140 }}
                         allowClear
                       />
@@ -747,7 +753,7 @@ export default function DATRegistrosPage(): JSX.Element {
                     <Form.Item name="instrucoes_status" noStyle>
                       <Select
                         placeholder="Status"
-                        options={STATUS_OPTIONS}
+                        options={ETAPA_STATUS_OPTIONS}
                         style={{ width: '100%', maxWidth: 140 }}
                         allowClear
                       />
@@ -762,7 +768,7 @@ export default function DATRegistrosPage(): JSX.Element {
                     <Form.Item name="envio_codigos_status" noStyle>
                       <Select
                         placeholder="Status"
-                        options={STATUS_OPTIONS}
+                        options={ETAPA_STATUS_OPTIONS}
                         style={{ width: '100%', maxWidth: 140 }}
                         allowClear
                       />
@@ -807,7 +813,7 @@ export default function DATRegistrosPage(): JSX.Element {
                         <Form.Item name="alunos_recebidos_status" noStyle>
                           <Select
                             placeholder="Status"
-                            options={STATUS_OPTIONS}
+                            options={ETAPA_STATUS_OPTIONS}
                             style={{ width: '100%', maxWidth: 140 }}
                             allowClear
                           />
@@ -827,7 +833,7 @@ export default function DATRegistrosPage(): JSX.Element {
                         <Form.Item name="alunos_validados_status" noStyle>
                           <Select
                             placeholder="Status"
-                            options={STATUS_OPTIONS}
+                            options={ETAPA_STATUS_OPTIONS}
                             style={{ width: '100%', maxWidth: 140 }}
                             allowClear
                           />
@@ -847,7 +853,7 @@ export default function DATRegistrosPage(): JSX.Element {
                         <Form.Item name="alunos_importados_status" noStyle>
                           <Select
                             placeholder="Status"
-                            options={STATUS_OPTIONS}
+                            options={ETAPA_STATUS_OPTIONS}
                             style={{ width: '100%', maxWidth: 140 }}
                             allowClear
                           />


### PR DESCRIPTION
Refs #1639

## Bug (M16-08) — status da UI diverge dos `choices` do backend em `/dat/registros`

Uma única lista (`STATUS_OPTIONS = pendente/em_andamento/concluido`) servia **dois enums** diferentes:

1. **`turma_formar_status`** (`TURMA_STATUS_CHOICES = criada/pendente/erro`): escolher "Em Andamento" ou "Concluído" → **HTTP 400**, perdendo o formulário inteiro. E `criada` (o valor de sucesso) **não era ofertado** — não havia como marcar uma turma como criada.
2. **Etapas** (`STATUS_CHOICES`): a lista escondia `erro` e `nao_aplicavel` (este é o **default** dos 3 campos AVALIAR). Pior: `erro` caía no ícone cinza que a legenda rotula **"Não Aplicável"** → uma etapa em **erro** era exibida como se não se aplicasse. Na coluna "Chaves", `erro`/`nao_aplicavel` saíam como **Tag vazia**.

## Fix (frontend)

Confinado ao `DATRegistros/` (cada página DAT tem o seu próprio `STATUS_OPTIONS`):

- **`constants.tsx`**: `TURMA_STATUS_OPTIONS` + `ETAPA_STATUS_OPTIONS` espelhando os choices do backend.
- **`DATRegistrosPage.tsx`**: Select da turma usa `TURMA_*`; as 6 etapas usam `ETAPA_*`; legenda ganha **Erro** (X vermelho).
- **`helpers.tsx`** (`renderStatusIcon`): `erro` (vermelho, `CloseCircleFilled`) distinto de `nao_aplicavel` (cinza) e `criada` (verde); `default` vira **"?"** (desconhecido), separado do cinza.
- **`columns.tsx`**: mapas de cor/label completos para `erro`/`nao_aplicavel` + fallback pro valor cru (não mais Tag vazia); nova coluna **"Status Turma"**.

## Testes (`statusContract.test.tsx`)

- `TURMA_STATUS_OPTIONS`/`ETAPA_STATUS_OPTIONS` batem **exatamente** com `TURMA_STATUS_CHOICES`/`STATUS_CHOICES` (guarda o drift; nenhum valor fora dos choices → nada dá 400).
- `renderStatusIcon('erro')` ≠ `renderStatusIcon('nao_aplicavel')` — **RED provado** no código antigo (ambos caíam no default cinza), 6/6 verde após o fix. `tsc --noEmit` limpo.

## Follow-up

SSOT de enum backend→frontend (constante gerada ou endpoint de metadata) em vez de duas listas mantidas à mão — issue item 1.

## Nota de sequência

Toca `DATRegistrosPage.tsx` como o #1638 (#1711), mas em **regiões diferentes** (Selects/legenda vs handlers/tipos). Se #1638 mergear antes, atualizo esta branch via `git merge origin/main` (conflito trivial se houver).
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `e2d7a053`, slot `0` / projeto `aprender_staging`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
