### PR TITLE
fix(dat): editar Acoes/Cadastros busca o detail — nao apaga datas (#1641)

### DIFF
--- a/v2/frontend/src/pages/DATModule/AcoesPage.tsx
+++ b/v2/frontend/src/pages/DATModule/AcoesPage.tsx
@@ -51,6 +51,7 @@ import {
 } from '@ant-design/icons';
 import {
   listAcoes,
+  getAcao,
   createAcao,
   updateAcao,
   deleteAcao,
@@ -207,16 +208,25 @@ export default function AcoesPage(): JSX.Element {
   };
 
   // Memoized handlers (§3 Epic #459)
-  const handleEdit = useCallback((record: AcaoRecord) => {
-    setEditingAcao(record);
-    form.setFieldsValue({
-      ...record,
-      data_carta: record.data_carta ? dayjs(record.data_carta) : null,
-      data_contato: record.data_contato ? dayjs(record.data_contato) : null,
-      data_reuniao: record.data_reuniao ? dayjs(record.data_reuniao) : null,
-      data_entrega: record.data_entrega ? dayjs(record.data_entrega) : null,
-    });
-    setModalVisible(true);
+  // M17-02: a linha da LISTA nao expoe as datas; alimentar o form com ela gravaria `null`
+  // e o PATCH apagaria as datas em silencio. Buscar o DETAIL antes de abrir o modal.
+  const handleEdit = useCallback(async (record: AcaoRecord) => {
+    try {
+      const detail = await getAcao(record.id);
+      form.resetFields(); // evita vazar valores do registro anterior (setFieldsValue faz merge)
+      form.setFieldsValue({
+        ...detail,
+        data_carta: detail.data_carta ? dayjs(detail.data_carta as string) : null,
+        data_contato: detail.data_contato ? dayjs(detail.data_contato as string) : null,
+        data_reuniao: detail.data_reuniao ? dayjs(detail.data_reuniao as string) : null,
+        data_entrega: detail.data_entrega ? dayjs(detail.data_entrega as string) : null,
+      });
+      setEditingAcao(record);
+      setModalVisible(true);
+    } catch (error) {
+      // Nao abrir o modal com form vazio: recriaria o bug por outro caminho.
+      message.error(`Erro ao carregar a acao para edicao: ${(error as Error).message}`);
+    }
   }, [form]);
 
   const handleSave = async (values: AcaoFormValues) => {

--- a/v2/frontend/src/pages/DATModule/CadastrosPage.tsx
+++ b/v2/frontend/src/pages/DATModule/CadastrosPage.tsx
@@ -48,6 +48,7 @@ import {
 } from '@ant-design/icons';
 import {
   listCadastros,
+  getCadastro,
   createCadastro,
   updateCadastro,
   deleteCadastro,
@@ -192,19 +193,28 @@ export default function CadastrosPage(): JSX.Element {
     setModalVisible(true);
   };
 
-  const handleEdit = (record: CadastroRecord) => {
-    setEditingCadastro(record);
-    form.setFieldsValue({
-      ...record,
-      data_criacao_curso: record.data_criacao_curso ? dayjs(record.data_criacao_curso) : null,
-      data_chaves: record.data_chaves ? dayjs(record.data_chaves) : null,
-      data_instrucoes: record.data_instrucoes ? dayjs(record.data_instrucoes) : null,
-      data_envio: record.data_envio ? dayjs(record.data_envio) : null,
-      data_recebidos: record.data_recebidos ? dayjs(record.data_recebidos) : null,
-      data_validados: record.data_validados ? dayjs(record.data_validados) : null,
-      data_importados: record.data_importados ? dayjs(record.data_importados) : null,
-    });
-    setModalVisible(true);
+  // M17-02: a linha da LISTA nao expoe as datas; alimentar o form com ela gravaria `null`
+  // e o PATCH apagaria as 7 datas em silencio. Buscar o DETAIL antes de abrir o modal.
+  const handleEdit = async (record: CadastroRecord) => {
+    try {
+      const detail = await getCadastro(record.id);
+      form.resetFields(); // evita vazar valores do registro anterior (setFieldsValue faz merge)
+      form.setFieldsValue({
+        ...detail,
+        data_criacao_curso: detail.data_criacao_curso ? dayjs(detail.data_criacao_curso as string) : null,
+        data_chaves: detail.data_chaves ? dayjs(detail.data_chaves as string) : null,
+        data_instrucoes: detail.data_instrucoes ? dayjs(detail.data_instrucoes as string) : null,
+        data_envio: detail.data_envio ? dayjs(detail.data_envio as string) : null,
+        data_recebidos: detail.data_recebidos ? dayjs(detail.data_recebidos as string) : null,
+        data_validados: detail.data_validados ? dayjs(detail.data_validados as string) : null,
+        data_importados: detail.data_importados ? dayjs(detail.data_importados as string) : null,
+      });
+      setEditingCadastro(record);
+      setModalVisible(true);
+    } catch (error) {
+      // Nao abrir o modal com form vazio: recriaria o bug por outro caminho.
+      message.error(`Erro ao carregar o cadastro para edicao: ${(error as Error).message}`);
+    }
   };
 
   const handleSave = async (values: CadastroFormValues) => {

--- a/v2/frontend/src/pages/DATModule/__tests__/editFetchesDetail.test.tsx
+++ b/v2/frontend/src/pages/DATModule/__tests__/editFetchesDetail.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * M17-02: editar pelo modal apagava as datas em silêncio, porque o form era alimentado com
+ * a LINHA DA LISTA (serializer de lista não expõe as datas) e o PATCH reenviava `data_*: null`.
+ *
+ * O fix: `handleEdit` busca o DETAIL (getAcao/getCadastro) antes de abrir o modal. Este teste
+ * trava exatamente isso — clicar em Editar dispara a busca do detail. RED no código antigo
+ * (handleEdit usava o record da lista e nunca chamava getAcao/getCadastro).
+ */
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router';
+
+// vi.hoisted: o factory do vi.mock é içado pro topo; as fixtures precisam ser içadas junto.
+const { acaoRow, cadastroRow } = vi.hoisted(() => ({
+  acaoRow: {
+    id: 7,
+    municipio_nome: 'Fortaleza',
+    municipio_uf: 'CE',
+    projeto_geral_nome: 'Projeto X',
+    projeto_nome: 'Sub X',
+    tipo_acao: 'carta',
+    prioridade: 'alta',
+    status: 'em_andamento',
+    progresso: 50,
+    observacoes: 'obs',
+  },
+  cadastroRow: {
+    id: 9,
+    municipio_nome: 'Sobral',
+    municipio_uf: 'CE',
+    projeto_geral_nome: 'Projeto Y',
+    status: 'em_andamento',
+    progresso: 40,
+  },
+}));
+
+vi.mock('../../../api/datModule', () => ({
+  listAcoes: vi.fn().mockResolvedValue({ results: [acaoRow], count: 1, next: null, previous: null }),
+  getAcao: vi.fn().mockResolvedValue({
+    ...acaoRow,
+    data_carta: '2026-03-10',
+    data_contato: null,
+    data_reuniao: null,
+    data_entrega: null,
+  }),
+  createAcao: vi.fn(),
+  updateAcao: vi.fn().mockResolvedValue({}),
+  deleteAcao: vi.fn(),
+  getAcoesStats: vi.fn().mockResolvedValue({}),
+  listCadastros: vi.fn().mockResolvedValue({ results: [cadastroRow], count: 1, next: null, previous: null }),
+  getCadastro: vi.fn().mockResolvedValue({
+    ...cadastroRow,
+    data_criacao_curso: '2026-03-10',
+    data_chaves: null,
+    data_instrucoes: null,
+    data_envio: null,
+    data_recebidos: null,
+    data_validados: null,
+    data_importados: null,
+  }),
+  createCadastro: vi.fn(),
+  updateCadastro: vi.fn().mockResolvedValue({}),
+  deleteCadastro: vi.fn(),
+  updateCadastroEtapa: vi.fn(),
+  getCadastrosStats: vi.fn().mockResolvedValue({}),
+  getMunicipiosOptions: vi.fn().mockResolvedValue({ results: [] }),
+  getProjetosOptions: vi.fn().mockResolvedValue({ results: [] }),
+  getProjetosGeraisOptions: vi.fn().mockResolvedValue({ results: [] }),
+  getCoordenadoresOptions: vi.fn().mockResolvedValue({ results: [] }),
+}));
+
+import AcoesPage from '../AcoesPage';
+import CadastrosPage from '../CadastrosPage';
+import { getAcao, getCadastro } from '../../../api/datModule';
+
+describe('M17-02: editar busca o DETAIL antes de abrir o modal', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  test('AcoesPage: clicar em Editar dispara getAcao(id) (não usa a linha da lista)', async () => {
+    render(
+      <MemoryRouter>
+        <AcoesPage />
+      </MemoryRouter>,
+    );
+    const btn = await screen.findByLabelText('Editar ação');
+    await userEvent.click(btn);
+    await waitFor(() => expect(getAcao).toHaveBeenCalledWith(7));
+  });
+
+  test('CadastrosPage: clicar em Editar dispara getCadastro(id)', async () => {
+    render(
+      <MemoryRouter>
+        <CadastrosPage />
+      </MemoryRouter>,
+    );
+    const btn = await screen.findByLabelText('Editar cadastro');
+    await userEvent.click(btn);
+    await waitFor(() => expect(getCadastro).toHaveBeenCalledWith(9));
+  });
+});


### PR DESCRIPTION
Refs #1641

## Bug (M17-02) — editar pelo modal apaga as datas em silêncio

Os modais de edição de `/controle/acoes` (DATAcao) e `/dat/cadastros` (DATCadastro) eram alimentados com a **linha da listagem**. Os serializers de lista **não expõem** os campos de data, então:

1. `handleEdit` convertia cada data ausente em `null`;
2. `handleSave` reenviava esse `null` **explicitamente** no corpo do PATCH (ser PATCH parcial não protege — a chave vai no payload com valor nulo).

→ Toda edição pelo modal **destruía as datas** do registro (4 no DATAcao, 7 no DATCadastro). Backend `200`, UI "atualizado com sucesso", nada indica a perda. Efeito colateral: `status_* = concluido` com a data correspondente nula → registro inconsistente.

Alcance real: **5 atores** em produção (DAT 3, Controle 1, Assist. Admin 1, superuser).

## Fix (frontend)

`handleEdit` passa a **buscar o DETAIL** (`getAcao`/`getCadastro`, que já existiam) antes de abrir o modal e só então hidrata o form:

- em **erro** no GET, **não abre** o modal (abrir vazio recriaria o bug por outro caminho);
- `resetFields()` antes do `setFieldsValue` evita **vazamento** de valores entre registros (`setFieldsValue` faz merge).

Sem mudança de contrato de API nem de schema — só frontend, revertível por deploy.

## Testes (`editFetchesDetail.test.tsx`)

Clicar em **Editar** dispara `getAcao(id)` / `getCadastro(id)`. **RED provado** no código antigo (usava a linha da lista e **nunca** buscava o detail → `waitFor` timeout); **2/2** verde após o fix; **12/12** na suíte `DATModule`. `tsc --noEmit` limpo.

## Follow-up (fora deste PR, deliberado)

- (a) Enviar **apenas campos sujos** no PATCH (item 2 da issue) — robustez extra contra TOCTOU.
- (b) Tipos `List`/`Detail`/`Patch` separados (item 4) — o typecheck acusaria quem editar a partir de um DTO de lista.
- (c) **Datafix do passivo**: registros já salvos com `status_* = concluido` e `data_*` nula (padrão que o bug deixou). Levantamento read-only + datafix separado, com autorização.

## Nota de sequência

Arquivos **diferentes** dos PRs #1638/#1639 (já mergeados) — sem conflito.
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `abdf43a1`, slot `0` / projeto `aprender_staging`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
