### PR TITLE
fix(dat): Nova Compra — valor_unitario + ano_uso obrigatorio + erro por campo (#1637 parte A)

### DIFF
--- a/v2/frontend/src/pages/DATModule/ComprasPage.tsx
+++ b/v2/frontend/src/pages/DATModule/ComprasPage.tsx
@@ -88,6 +88,24 @@ interface CompraFormValues {
   [key: string]: any;
 }
 
+/**
+ * Monta o payload de compra a partir dos valores do form (M15-10):
+ * - datas viram `YYYY-MM-DD`;
+ * - `uf` NÃO vai (é só filtro de UI; o `municipio` já carrega a UF);
+ * - `status_uso` NÃO vai (é read-only, recalculado no `save()` do backend — enviar
+ *   `esgotado` gravava `em_uso`).
+ */
+export function buildCompraPayload(values: CompraFormValues): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    ...values,
+    data_compra: values.data_compra ? values.data_compra.format('YYYY-MM-DD') : null,
+    data_entrega: values.data_entrega ? values.data_entrega.format('YYYY-MM-DD') : null,
+  };
+  delete payload.uf;
+  delete payload.status_uso;
+  return payload;
+}
+
 interface ComprasFilters {
   search: string;
   uf: string | undefined;
@@ -225,11 +243,7 @@ export default function ComprasPage(): JSX.Element {
   };
 
   const handleSave = async (values: CompraFormValues) => {
-    const payload = {
-      ...values,
-      data_compra: values.data_compra ? values.data_compra.format('YYYY-MM-DD') : null,
-      data_entrega: values.data_entrega ? values.data_entrega.format('YYYY-MM-DD') : null,
-    };
+    const payload = buildCompraPayload(values);
 
     try {
       if (editingCompra) {
@@ -243,7 +257,21 @@ export default function ComprasPage(): JSX.Element {
       form.resetFields();
       void refresh();
     } catch (error) {
-      message.error(`Erro: ${(error as Error).message}`);
+      // M15-10: o backend manda `errors: {campo: [...]}`; exibir inline no proprio campo em
+      // vez do toast generico que engolia a orientacao (ex.: ano_uso obrigatorio virava 400 mudo).
+      const err = error as Error & { response?: { data?: { errors?: Record<string, unknown>; detail?: string } } };
+      const fieldErrors = err.response?.data?.errors;
+      if (fieldErrors && typeof fieldErrors === 'object') {
+        form.setFields(
+          Object.entries(fieldErrors).map(([name, msgs]) => ({
+            name,
+            errors: Array.isArray(msgs) ? msgs.map(String) : [String(msgs)],
+          })),
+        );
+        message.error('Corrija os campos destacados.');
+      } else {
+        message.error(`Erro: ${err.message}`);
+      }
     }
   };
 
@@ -837,13 +865,24 @@ export default function ComprasPage(): JSX.Element {
                 </Form.Item>
               </Col>
               <Col xs={12} sm={6}>
-                <Form.Item name="ano_uso" label="Ano de Uso">
+                <Form.Item
+                  name="ano_uso"
+                  label="Ano de Uso"
+                  rules={[{ required: true, message: 'Selecione o ano de uso' }]}
+                >
                   <Select placeholder="Selecione..." options={ANO_OPTIONS} allowClear />
                 </Form.Item>
               </Col>
               <Col xs={12} sm={6}>
-                <Form.Item name="status_uso" label="Status">
-                  <Select placeholder="Automático..." options={STATUS_OPTIONS} allowClear />
+                {/* M15-10: valor_unitario existe no serializer mas nao tinha campo -> toda compra
+                    nascia com valor 0.00 e zerava o dashboard financeiro. status_uso saiu daqui
+                    (era read-only, recalculado no backend). */}
+                <Form.Item
+                  name="valor_unitario"
+                  label="Valor Unitário (R$)"
+                  rules={[{ required: true, message: 'Informe o valor unitário' }]}
+                >
+                  <InputNumber min={0} precision={2} style={{ width: '100%' }} placeholder="0,00" />
                 </Form.Item>
               </Col>
             </Row>

--- a/v2/frontend/src/pages/DATModule/__tests__/buildCompraPayload.test.ts
+++ b/v2/frontend/src/pages/DATModule/__tests__/buildCompraPayload.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import dayjs from 'dayjs';
+
+import { buildCompraPayload } from '../ComprasPage';
+
+/**
+ * M15-10: o form de Nova Compra enviava `uf` (inexistente no serializer) e `status_uso`
+ * (read-only, recalculado no backend — enviar 'esgotado' gravava 'em_uso'), e nunca
+ * mandava `valor_unitario` de forma confiável. Estas asserções travam o contrato do payload.
+ */
+describe('buildCompraPayload (M15-10)', () => {
+  const base = { projeto: 1, produto: 2, municipio: 3, quantidade: 10, uf: 'CE' };
+
+  it('não envia uf (o municipio já carrega a UF)', () => {
+    expect(buildCompraPayload({ ...base })).not.toHaveProperty('uf');
+  });
+
+  it('não envia status_uso (read-only, recalculado no backend)', () => {
+    expect(buildCompraPayload({ ...base, status_uso: 'esgotado' })).not.toHaveProperty('status_uso');
+  });
+
+  it('envia valor_unitario (destrava o dashboard financeiro)', () => {
+    expect(buildCompraPayload({ ...base, valor_unitario: 12.5 }).valor_unitario).toBe(12.5);
+  });
+
+  it('formata datas para YYYY-MM-DD (nunca datetime ISO)', () => {
+    const p = buildCompraPayload({
+      ...base,
+      data_compra: dayjs('2026-03-10'),
+      data_entrega: dayjs('2026-04-01'),
+    });
+    expect(p.data_compra).toBe('2026-03-10');
+    expect(p.data_entrega).toBe('2026-04-01');
+    expect(String(p.data_compra)).not.toMatch(/T\d{2}:/);
+  });
+
+  it('preserva os demais campos (projeto, produto, municipio, quantidade)', () => {
+    const p = buildCompraPayload({ ...base });
+    expect(p.projeto).toBe(1);
+    expect(p.produto).toBe(2);
+    expect(p.municipio).toBe(3);
+    expect(p.quantidade).toBe(10);
+  });
+});


### PR DESCRIPTION
Refs #1637 (parte A — integridade do form, sem migration)

## Bug (M15-10) — Nova Compra grava valor zero, esconde 400 e oferta campo read-only

Este PR resolve os 3 defeitos de **integridade** do modal (a decisão de persistir campos novos é a **parte B**, abaixo):

1. **Dashboard financeiro zerado.** `valor_unitario` existe no serializer, mas **não havia Form.Item** → toda compra nascia com `valor_unitario=0.00`/`valor_total=0.00`, zerando os KPIs de valor.
2. **400 mudo.** `ano_uso` é obrigatório no model, mas o Form.Item não tinha `required` → o usuário salvava, tomava 400 e via só "Erro de validação" genérico (o backend **manda** `errors:{ano_uso:[...]}`, o cliente jogava fora).
3. **Campo read-only ofertado.** `status_uso` é read-only (recalculado no `save()`); enviar `esgotado` gravava `em_uso`.

## Fix (frontend)

- **`valor_unitario`**: novo `Form.Item` (`InputNumber`, `required`, `precision 2`) → o dashboard para de mentir.
- **`ano_uso`**: `rules` `required` + o `catch` do `handleSave` mapeia `err.response.data.errors` (que o `config.ts` **já preserva** em `data: error`) para `form.setFields(...)`, exibindo o erro **no campo**. Fallback pro toast quando não há mapa.
- **`status_uso`**: `Select` removido do modal; **não vai** mais no payload.
- **`uf`**: continua como filtro de UI, mas **não vai** no payload (o `municipio` já carrega a UF).

`buildCompraPayload()` extraída e testada (**5**): não envia `uf`/`status_uso`, envia `valor_unitario`, formata datas. `tsc --noEmit` limpo. **Sem migration, sem mudança de contrato de API.**

## Parte B (follow-up — precisa design, NÃO neste PR)

Persistir `codigo_produto`, `data_entrega`, `numero_nota_fiscal`, `fornecedor` (hoje coletados e descartados em silêncio). O dono confirmou que **quem insere a compra é o setor Controle** e o dado flui pro DAT de lá (**DAT só visualiza**). Isso levanta a questão arquitetural: esses campos vivem no **`DATCompra`** (operacional, que o DAT vê) ou no modelo **`Compra`** do Controle que o alimenta? Precisa Entender o fluxo Compra↔DATCompra↔import antes de cravar a migration — por isso fica fora deste PR (que já para a perda de dado de valor/ano/status agora).
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `e89a05b5`, slot `0` / projeto `aprender_staging`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
