### PR TITLE
fix(dat): #1637 Fase A — codigo_produto read-only + tira procurement do modal

### DIFF
--- a/v2/backend/apps/core/serializers/dat_module/dat_compra.py
+++ b/v2/backend/apps/core/serializers/dat_module/dat_compra.py
@@ -22,6 +22,8 @@ class DATCompraSerializer(serializers.ModelSerializer["DATCompra"]):
     municipio_uf = serializers.CharField(source="municipio.uf", read_only=True)
     projeto_nome = serializers.CharField(source="projeto.nome", read_only=True)
     produto_nome = serializers.CharField(source="produto.nome", read_only=True, allow_null=True)
+    # #1637: codigo e' do Produto (SSOT), nao por-compra. Espelho read-only.
+    codigo_produto = serializers.CharField(source="produto.codigo", read_only=True, allow_null=True)
 
     # Computed
     disponivel = serializers.IntegerField(read_only=True)
@@ -42,6 +44,7 @@ class DATCompraSerializer(serializers.ModelSerializer["DATCompra"]):
             "projeto_nome",
             "produto",
             "produto_nome",
+            "codigo_produto",
             "descricao_produto",
             "tipo_compra",
             # Quantidades
@@ -74,6 +77,7 @@ class DATCompraListSerializer(serializers.ModelSerializer["DATCompra"]):
     municipio_uf = serializers.CharField(source="municipio.uf", read_only=True)
     projeto_nome = serializers.CharField(source="projeto.nome", read_only=True)
     produto_nome = serializers.CharField(source="produto.nome", read_only=True, allow_null=True)
+    codigo_produto = serializers.CharField(source="produto.codigo", read_only=True, allow_null=True)
     disponivel = serializers.IntegerField(read_only=True)
     valor_total = serializers.DecimalField(max_digits=12, decimal_places=2, read_only=True)
 
@@ -85,6 +89,7 @@ class DATCompraListSerializer(serializers.ModelSerializer["DATCompra"]):
             "municipio_uf",
             "projeto_nome",
             "produto_nome",
+            "codigo_produto",
             "descricao_produto",
             "tipo_compra",
             "quantidade",

--- a/v2/backend/apps/core/tests/test_compras_domain_boundary.py
+++ b/v2/backend/apps/core/tests/test_compras_domain_boundary.py
@@ -118,6 +118,9 @@ def test_dat_endpoint_exposes_dat_compra_contract(
 
     assert dat_record["quantidade"] == 20
     assert "valor_unitario" in dat_record
+    # #1637: codigo do produto e' espelho read-only (source="produto.codigo"), nao coluna
+    # gravavel por-compra. Deve estar no contrato do DAT (a coluna "Cod:" da tabela o consome).
+    assert "codigo_produto" in dat_record
     assert dat_record["municipio_nome"] == compra_dat.municipio.nome
 
 

--- a/v2/frontend/src/pages/DATModule/ComprasPage.tsx
+++ b/v2/frontend/src/pages/DATModule/ComprasPage.tsx
@@ -99,10 +99,13 @@ export function buildCompraPayload(values: CompraFormValues): Record<string, unk
   const payload: Record<string, unknown> = {
     ...values,
     data_compra: values.data_compra ? values.data_compra.format('YYYY-MM-DD') : null,
-    data_entrega: values.data_entrega ? values.data_entrega.format('YYYY-MM-DD') : null,
   };
-  delete payload.uf;
-  delete payload.status_uso;
+  // O DAT nao envia: uf/status_uso (read-only/derivado) + os campos de procurement
+  // (fornecedor/NF/data_entrega, que sao do CONTROLE — #1637) + codigo_produto (derivado
+  // de Produto, read-only). Colocar ownership no lado errado = perda silenciosa de dado.
+  for (const k of ['uf', 'status_uso', 'codigo_produto', 'fornecedor', 'numero_nota_fiscal', 'data_entrega']) {
+    delete payload[k];
+  }
   return payload;
 }
 
@@ -237,7 +240,6 @@ export default function ComprasPage(): JSX.Element {
     form.setFieldsValue({
       ...record,
       data_compra: record.data_compra ? dayjs(record.data_compra) : null,
-      data_entrega: record.data_entrega ? dayjs(record.data_entrega) : null,
     });
     setModalVisible(true);
   };
@@ -801,12 +803,9 @@ export default function ComprasPage(): JSX.Element {
               </Col>
             </Row>
             <Row gutter={16}>
-              <Col xs={24} sm={12}>
-                <Form.Item name="codigo_produto" label="Código do Produto">
-                  <Input placeholder="Ex: KIT-001" />
-                </Form.Item>
-              </Col>
-              <Col xs={24} sm={12}>
+              {/* #1637: codigo_produto saiu do form — e derivado do Produto (read-only,
+                  exposto pelo serializer via produto.codigo). A tabela ja mostra "Cod:". */}
+              <Col xs={24}>
                 <Form.Item name="descricao_produto" label="Descrição">
                   <Input placeholder="Descrição adicional..." />
                 </Form.Item>
@@ -888,38 +887,23 @@ export default function ComprasPage(): JSX.Element {
             </Row>
           </Card>
 
-          {/* Dados da Compra */}
+          {/* Dados da Compra. #1637: fornecedor / nota fiscal / data de entrega saíram do
+              modal do DAT — são fatos de PROCUREMENT do setor Controle (o DAT só visualiza).
+              Enquanto o Controle não os registra na fonte, coletá-los aqui só perdia dado. */}
           <Card size="small" title="Dados da Compra" className="mb-4">
             <Row gutter={16}>
-              <Col xs={12} sm={6}>
+              <Col xs={24} sm={12}>
                 <Form.Item name="data_compra" label="Data Compra">
                   <DatePicker style={{ width: '100%' }} format="DD/MM/YYYY" />
                 </Form.Item>
               </Col>
-              <Col xs={12} sm={6}>
+              <Col xs={24} sm={12}>
                 <Form.Item
                   name="tipo_compra"
                   label="Tipo de Compra"
                   rules={[{ required: true, message: 'Selecione o tipo de compra' }]}
                 >
                   <Select placeholder="Selecione..." options={TIPO_COMPRA_OPTIONS} />
-                </Form.Item>
-              </Col>
-              <Col xs={12} sm={6}>
-                <Form.Item name="data_entrega" label="Data Entrega">
-                  <DatePicker style={{ width: '100%' }} format="DD/MM/YYYY" />
-                </Form.Item>
-              </Col>
-              <Col xs={12} sm={6}>
-                <Form.Item name="numero_nota_fiscal" label="Nota Fiscal">
-                  <Input placeholder="NF-12345" />
-                </Form.Item>
-              </Col>
-            </Row>
-            <Row gutter={16}>
-              <Col xs={24}>
-                <Form.Item name="fornecedor" label="Fornecedor">
-                  <Input placeholder="Nome do fornecedor..." />
                 </Form.Item>
               </Col>
             </Row>

--- a/v2/frontend/src/pages/DATModule/__tests__/buildCompraPayload.test.ts
+++ b/v2/frontend/src/pages/DATModule/__tests__/buildCompraPayload.test.ts
@@ -23,15 +23,24 @@ describe('buildCompraPayload (M15-10)', () => {
     expect(buildCompraPayload({ ...base, valor_unitario: 12.5 }).valor_unitario).toBe(12.5);
   });
 
-  it('formata datas para YYYY-MM-DD (nunca datetime ISO)', () => {
+  it('formata data_compra para YYYY-MM-DD (nunca datetime ISO)', () => {
+    const p = buildCompraPayload({ ...base, data_compra: dayjs('2026-03-10') });
+    expect(p.data_compra).toBe('2026-03-10');
+    expect(String(p.data_compra)).not.toMatch(/T\d{2}:/);
+  });
+
+  it('#1637: nao envia procurement (do Controle) nem codigo_produto (derivado do Produto)', () => {
     const p = buildCompraPayload({
       ...base,
-      data_compra: dayjs('2026-03-10'),
+      codigo_produto: 'KIT-001',
+      fornecedor: 'Editora X',
+      numero_nota_fiscal: 'NF-123',
       data_entrega: dayjs('2026-04-01'),
     });
-    expect(p.data_compra).toBe('2026-03-10');
-    expect(p.data_entrega).toBe('2026-04-01');
-    expect(String(p.data_compra)).not.toMatch(/T\d{2}:/);
+    expect(p).not.toHaveProperty('codigo_produto');
+    expect(p).not.toHaveProperty('fornecedor');
+    expect(p).not.toHaveProperty('numero_nota_fiscal');
+    expect(p).not.toHaveProperty('data_entrega');
   });
 
   it('preserva os demais campos (projeto, produto, municipio, quantidade)', () => {


### PR DESCRIPTION
Refs #1637 — completa a **Fase A** (integridade do form, sem migration). Onda 0 do programa `v2/docs/plans/PLANO_IMPORTS_ORFAOS.md`.

Respeita a fronteira **Controle × DAT** (dono: "quem insere a compra é o Controle; o DAT só visualiza").

## Fix

- **`codigo_produto`**: era `Input` de texto livre que **não persistia** (código é do `Produto`, SSOT). Vira **espelho read-only** no serializer (`source="produto.codigo"`, em `DATCompraSerializer` + List). Com isso a coluna **"Cód:"** da tabela — que lia `record.codigo_produto` e **nunca renderizava** (o campo nem existia no serializer) — passa a funcionar. `Input` removido do modal.
- **Procurement** (`fornecedor` / `numero_nota_fiscal` / `data_entrega`): são fatos do **Controle**, não do DAT. Removidos do modal + do `buildCompraPayload` (que agora faz **strip explícito**). Coletar dado que não tem casa = perda silenciosa; parar de coletar é a correção mínima honesta.

Persistir esses 3 (no lado do **Controle**) é a **Fase B**, quando a fonte do Controle passar a registrá-los (ver o plano).

## Testes

- `buildCompraPayload` não envia procurement nem `codigo_produto` — **RED provado** (código antigo só tirava `uf`/`status_uso`).
- `test_compras_domain_boundary`: o contrato do DAT expõe `codigo_produto`.
- `tsc`/`pyright` limpos; **18/18** DATModule; **4/4** boundary.

Sem migration, sem mudança de contrato de API (só adiciona um campo read-only).
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `bfe5395e`, slot `0` / projeto `aprender_staging`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
