### PR TITLE
test(dat): editFetchesDetail com timeout folgado (render flakava a 5s)

### DIFF
--- a/v2/frontend/src/pages/DATModule/__tests__/editFetchesDetail.test.tsx
+++ b/v2/frontend/src/pages/DATModule/__tests__/editFetchesDetail.test.tsx
@@ -77,25 +77,36 @@ import { getAcao, getCadastro } from '../../../api/datModule';
 describe('M17-02: editar busca o DETAIL antes de abrir o modal', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  test('AcoesPage: clicar em Editar dispara getAcao(id) (não usa a linha da lista)', async () => {
-    render(
-      <MemoryRouter>
-        <AcoesPage />
-      </MemoryRouter>,
-    );
-    const btn = await screen.findByLabelText('Editar ação');
-    await userEvent.click(btn);
-    await waitFor(() => expect(getAcao).toHaveBeenCalledWith(7));
-  });
+  // Timeouts folgados: renderizar a pagina inteira (Table + useTableFilters + options) em
+  // jsdom sob carga do CI passa dos 5s default e estoura flaky. O comportamento testado
+  // (handleEdit busca o detail) e' rapido; o que e' lento e' o render — dai a margem.
+  test(
+    'AcoesPage: clicar em Editar dispara getAcao(id) (não usa a linha da lista)',
+    async () => {
+      render(
+        <MemoryRouter>
+          <AcoesPage />
+        </MemoryRouter>,
+      );
+      const btn = await screen.findByLabelText('Editar ação', {}, { timeout: 15000 });
+      await userEvent.click(btn);
+      await waitFor(() => expect(getAcao).toHaveBeenCalledWith(7), { timeout: 10000 });
+    },
+    20000,
+  );
 
-  test('CadastrosPage: clicar em Editar dispara getCadastro(id)', async () => {
-    render(
-      <MemoryRouter>
-        <CadastrosPage />
-      </MemoryRouter>,
-    );
-    const btn = await screen.findByLabelText('Editar cadastro');
-    await userEvent.click(btn);
-    await waitFor(() => expect(getCadastro).toHaveBeenCalledWith(9));
-  });
+  test(
+    'CadastrosPage: clicar em Editar dispara getCadastro(id)',
+    async () => {
+      render(
+        <MemoryRouter>
+          <CadastrosPage />
+        </MemoryRouter>,
+      );
+      const btn = await screen.findByLabelText('Editar cadastro', {}, { timeout: 15000 });
+      await userEvent.click(btn);
+      await waitFor(() => expect(getCadastro).toHaveBeenCalledWith(9), { timeout: 10000 });
+    },
+    20000,
+  );
 });


### PR DESCRIPTION
## O erro que você viu

O CI de main pós-merge do #1716 falhou no `[required] build/lint do frontend`: **`Error: Test timed out in 5000ms`** no teste `editFetchesDetail.test.tsx > AcoesPage` (do #1641), retried 3x, todos timeout. **1 failed | 562 passed.**

**Não é regressão do #1716** (que mexeu só no `ComprasPage`, não no AcoesPage/CadastrosPage). É o **meu teste de render do #1641 sendo lento na fronteira dos 5s**: ele renderiza a página inteira (Table + `useTableFilters` + options) em jsdom; sob carga do CI passa dos 5000ms default do vitest. Já tinha pedido "retry x1" no CI do #1713 — flake latente que o novo scheduling do suite (após #1716) expôs.

## Fix (test-only)

Timeouts folgados nos 2 testes: **test-level 20s** + `findByLabelText` 15s + `waitFor` 10s. O comportamento testado (`handleEdit` busca o detail via `getAcao`/`getCadastro`) é rápido; o que é lento é o render — a margem cobre isso sem afrouxar a asserção.

Local: **2/2** verde, `tsc` limpo.

## Nota

O run de main que falhou é do commit anterior (sem este fix), então pode continuar vermelho num re-run — o **remédio real é este PR**. Não bloqueia deploy (ADR-018: prod só muda via promote; o CI de push na main não gateia). Test-only, sem staging gate necessário.

Follow-up opcional: aliviar o teste (não renderizar a página inteira) — mas `handleEdit` é closure inline, exigiria refactor; o timeout resolve o flake já.
