### PR TITLE
test(google): mock fetchAPI — mata EnvironmentTeardownError que reprova o CI

### DIFF
--- a/v2/frontend/src/components/google/__tests__/GoogleIntegrationCard.test.tsx
+++ b/v2/frontend/src/components/google/__tests__/GoogleIntegrationCard.test.tsx
@@ -17,6 +17,16 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, test, expect, vi } from 'vitest';
 import GoogleIntegrationCard, { type GoogleIntegrationStatus } from '../GoogleIntegrationCard';
 
+// Quando `connected`, o componente dispara loadCalendars() ->
+// fetchAPI('/integrations/google/calendars/') num useEffect. Sem mock, esse fetch REJEITA
+// no jsdom e loga async DEPOIS do teste -> "onUserConsoleLog pending" no teardown do worker
+// -> EnvironmentTeardownError, que reprovava o CI (exit 1) mesmo com todos os testes passando.
+// Mockar fetchAPI resolvendo elimina o fetch pendente e o log no teardown.
+vi.mock('../../../api/config', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../api/config')>();
+  return { ...actual, fetchAPI: vi.fn().mockResolvedValue({ calendars: [] }) };
+});
+
 describe('GoogleIntegrationCard', () => {
   // ============================================================================
   // TESTES DE RENDERIZAÇÃO CONDICIONAL


### PR DESCRIPTION
## O erro (recorrente) que você viu

O CI de main (`build/lint do frontend`) passou a **falhar consistentemente** com exit 1 **mesmo com 563/563 testes passando** — inclusive num re-run. A causa:

```
Tests  563 passed (563)   ← tudo passa
Errors 3 errors
EnvironmentTeardownError: Closing rpc while "onUserConsoleLog" was pending
  → originated in GoogleIntegrationCard.test.tsx
```

Não é falha de teste — é o **flake de teardown do vitest** (memória `feedback_vitest_teardown_rpc_flake`). Ficou **determinístico** depois que #1716/#1717 mudaram o scheduling do suite (antes era intermitente → re-run resolvia; agora não).

## Causa raiz (achada, não só re-run)

Com `status.connected=true`, o `GoogleIntegrationCard` dispara `loadCalendars()` num `useEffect` → `fetchAPI('/integrations/google/calendars/')`. O teste **não mockava** → o fetch **rejeita** no jsdom e loga **async, depois** do teste → `console` pendente quando o worker fecha o rpc → `EnvironmentTeardownError`, que o vitest conta como "unhandled error" e vira **exit 1**.

## Fix (test-only)

`vi.mock('../../../api/config', ...)` resolvendo `fetchAPI` (`{ calendars: [] }`), preservando os demais exports via `importOriginal`. Sem fetch pendente → sem log no teardown → sem erro.

- `GoogleIntegrationCard.test.tsx`: **13/13** verde.
- **Suíte inteira: exit 0** local (antes exit 1). `tsc` limpo.
- A prova real é o CI deste PR (o ambiente onde o flake aparecia).

Test-only, sem staging gate. Elimina a maior fonte de main-vermelho recorrente em PRs de frontend.
