### PR TITLE
fix(frontend): exibe horário de evento em America/Fortaleza (RD-06)

### DIFF
--- a/v2/frontend/src/pages/Aprovacoes/ApprovalsPage.tsx
+++ b/v2/frontend/src/pages/Aprovacoes/ApprovalsPage.tsx
@@ -56,6 +56,7 @@ import { computeAccess } from '../../hooks/useCanAccess';
 import { TIMING } from '../../constants/timing';
 import { usePolling } from '../../hooks/usePolling';
 import { syncChannel } from '../../services/syncChannel';
+import { formatFortaleza, FORTALEZA_TZ } from '../../utils/datetime';
 import logger from '../../utils/logger';
 import type { ID, Solicitacao, SolicitacaoStatus, PaginatedResponse, Participation, BatchOperationResult } from '../../types';
 
@@ -298,9 +299,9 @@ export default function ApprovalsPage(): JSX.Element {
       width: 140,
       render: (_, record) => (
         <div>
-          <div>{dayjs(record.inicio).format('DD/MM/YYYY')}</div>
+          <div>{formatFortaleza(record.inicio, 'DD/MM/YYYY')}</div>
           <small className="text-gray-500">
-            {dayjs(record.inicio).format('HH:mm')} - {dayjs(record.fim).format('HH:mm')}
+            {formatFortaleza(record.inicio, 'HH:mm')} - {formatFortaleza(record.fim, 'HH:mm')}
           </small>
         </div>
       ),
@@ -519,8 +520,8 @@ export default function ApprovalsPage(): JSX.Element {
       >
         {previewData?.preview?.payload && (() => {
           const payload = previewData.preview.payload;
-          const start = payload.start?.dateTime ? dayjs(payload.start.dateTime) : null;
-          const end = payload.end?.dateTime ? dayjs(payload.end.dateTime) : null;
+          const start = payload.start?.dateTime ? dayjs(payload.start.dateTime).tz(FORTALEZA_TZ) : null;
+          const end = payload.end?.dateTime ? dayjs(payload.end.dateTime).tz(FORTALEZA_TZ) : null;
 
           return (
             <div style={{ maxHeight: 500, overflow: 'auto' }}>

--- a/v2/frontend/src/pages/PreAgenda/PreAgendaPage.tsx
+++ b/v2/frontend/src/pages/PreAgenda/PreAgendaPage.tsx
@@ -55,7 +55,6 @@ import {
   CodeOutlined,
   UnorderedListOutlined,
 } from '@ant-design/icons';
-import dayjs from 'dayjs';
 
 import { fetchAPI } from '../../api/config';
 import {
@@ -75,6 +74,7 @@ import GoogleIntegrationCard from '../../components/google/GoogleIntegrationCard
 import { TIMING } from '../../constants/timing';
 import { usePolling } from '../../hooks/usePolling';
 import { syncChannel } from '../../services/syncChannel';
+import { formatFortaleza } from '../../utils/datetime';
 import logger from '../../utils/logger';
 import type { ID, Solicitacao, GCalStatus, CurrentUser, PaginatedResponse } from '../../types';
 
@@ -431,7 +431,7 @@ export default function PreAgendaPage(): JSX.Element {
       title: 'Data/Hora',
       dataIndex: 'inicio',
       key: 'inicio',
-      render: (inicio: string) => dayjs(inicio).format('DD/MM/YYYY HH:mm'),
+      render: (inicio: string) => formatFortaleza(inicio),
       width: 150,
     },
     {
@@ -555,7 +555,7 @@ export default function PreAgendaPage(): JSX.Element {
   const formatGcalDate = (dateStr: string): string => {
     if (!dateStr) return '-';
     try {
-      return dayjs(dateStr).format('DD/MM/YYYY HH:mm');
+      return formatFortaleza(dateStr);
     } catch {
       return dateStr;
     }
@@ -927,13 +927,13 @@ export default function PreAgendaPage(): JSX.Element {
                 {previewData.preview.payload?.start?.dateTime && (
                   <Space>
                     <Tag color="blue">
-                      {dayjs(previewData.preview.payload.start.dateTime).format('DD/MM/YYYY')}
+                      {formatFortaleza(previewData.preview.payload.start.dateTime, 'DD/MM/YYYY')}
                     </Tag>
                     <Text>
-                      {dayjs(previewData.preview.payload.start.dateTime).format('HH:mm')}
+                      {formatFortaleza(previewData.preview.payload.start.dateTime, 'HH:mm')}
                       {' - '}
                       {previewData.preview.payload?.end?.dateTime &&
-                        dayjs(previewData.preview.payload.end.dateTime).format('HH:mm')}
+                        formatFortaleza(previewData.preview.payload.end.dateTime, 'HH:mm')}
                     </Text>
                   </Space>
                 )}

--- a/v2/frontend/src/pages/Solicitacoes/MySolicitacoesPage.tsx
+++ b/v2/frontend/src/pages/Solicitacoes/MySolicitacoesPage.tsx
@@ -28,11 +28,11 @@ import PlusOutlined from '@ant-design/icons/PlusOutlined';
 import SearchOutlined from '@ant-design/icons/SearchOutlined';
 import EditOutlined from '@ant-design/icons/EditOutlined';
 import DeleteOutlined from '@ant-design/icons/DeleteOutlined';
-import dayjs from 'dayjs';
 
 import { listSolicitacoes, deleteSolicitacao } from '../../api/solicitacoes';
 import { MeetLink } from '../../components/MeetLink';
 import type { ID, Solicitacao, SolicitacaoStatus, FluxoType, GCalStatus, Participation, PaginatedResponse } from '../../types';
+import { formatFortaleza } from '../../utils/datetime';
 
 const { Title } = Typography;
 
@@ -135,7 +135,7 @@ export default function MySolicitacoesPage(): JSX.Element {
       title: 'Data/Hora',
       dataIndex: 'inicio',
       key: 'inicio',
-      render: (inicio: string) => dayjs(inicio).format('DD/MM/YYYY HH:mm'),
+      render: (inicio: string) => formatFortaleza(inicio),
       width: 150,
     },
     {

--- a/v2/frontend/src/utils/__tests__/datetime.test.ts
+++ b/v2/frontend/src/utils/__tests__/datetime.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+
+import { formatFortaleza } from '../datetime';
+
+/**
+ * RD-06 / CP-03: eventos são armazenados em UTC e DEVEM ser exibidos em
+ * America/Fortaleza (UTC−3, sem DST). O teste é independente do fuso do
+ * runner justamente porque o util fixa o fuso — é essa a garantia.
+ */
+describe('formatFortaleza (RD-06: exibe em America/Fortaleza)', () => {
+  it('converte um instante UTC para o horário de Fortaleza (UTC−3)', () => {
+    // 12:00Z = 09:00 em Fortaleza
+    expect(formatFortaleza('2026-09-15T12:00:00Z')).toBe('15/09/2026 09:00');
+  });
+
+  it('aceita formato customizado', () => {
+    expect(formatFortaleza('2026-09-15T12:00:00Z', 'HH:mm')).toBe('09:00');
+  });
+
+  it('vira o dia corretamente perto da meia-noite UTC', () => {
+    // 01:00Z do dia 16 = 22:00 do dia 15 em Fortaleza
+    expect(formatFortaleza('2026-09-16T01:00:00Z', 'DD/MM/YYYY HH:mm')).toBe('15/09/2026 22:00');
+  });
+
+  it('preserva o instante quando a origem já traz offset −03:00', () => {
+    expect(formatFortaleza('2026-09-15T09:00:00-03:00', 'HH:mm')).toBe('09:00');
+  });
+
+  it('não quebra com valor nulo/vazio', () => {
+    expect(formatFortaleza(null)).toBe('');
+    expect(formatFortaleza(undefined)).toBe('');
+    expect(formatFortaleza('')).toBe('');
+  });
+});

--- a/v2/frontend/src/utils/datetime.ts
+++ b/v2/frontend/src/utils/datetime.ts
@@ -1,0 +1,31 @@
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
+
+// Plugins necessários para converter instantes UTC em um fuso IANA fixo.
+// (mesmo par usado em DateTimeRange / NewSolicitacaoWizard)
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+/**
+ * Fuso de exibição do sistema.
+ *
+ * RD-06 / CP-03: eventos são armazenados em UTC e exibidos em America/Fortaleza.
+ */
+export const FORTALEZA_TZ = 'America/Fortaleza';
+
+/**
+ * Formata um instante (string ISO/UTC vinda do backend, `Date`, epoch ou `Dayjs`)
+ * no fuso `America/Fortaleza`.
+ *
+ * Independe do fuso do navegador — essa é justamente a garantia do RD-06: dois
+ * usuários em fusos diferentes veem o MESMO horário (o de Fortaleza).
+ *
+ * @param value  instante a formatar; `null`/`undefined`/`''` retornam `''`.
+ * @param format máscara dayjs (padrão `DD/MM/YYYY HH:mm`).
+ */
+export function formatFortaleza(value: dayjs.ConfigType, format = 'DD/MM/YYYY HH:mm'): string {
+  if (value === null || value === undefined || value === '') return '';
+  const d = dayjs(value);
+  return d.isValid() ? d.tz(FORTALEZA_TZ).format(format) : '';
+}


### PR DESCRIPTION
## O que
Corrige a exibição do horário de eventos para **America/Fortaleza** (RD-06 / CP-03). Fecha #1719.

As telas de leitura mostravam o horário no fuso do **navegador** (`dayjs(inicio).format()` ingênuo). Num viewer fora de UTC−3, um evento 09:00 (Fortaleza) aparecia com o horário errado (ex.: 12:00 num browser em UTC).

## Como
- Novo util `utils/datetime.ts` → `formatFortaleza()` fixa `America/Fortaleza` (plugins `utc`+`timezone`, mesmo padrão de `DateTimeRange`/`NewSolicitacaoWizard`).
- Aplicado em `MySolicitacoesPage`, `PreAgendaPage` (coluna Data/Hora, eventos GCal, preview) e `ApprovalsPage` (coluna + preview).

## Test plan
- **TDD**: teste RED→GREEN do util, **independente do fuso do runner** (`12:00Z → 09:00`, virada de dia, offset `−03:00`, nulos). ✅ 5/5
- `PreAgendaPage.gcal.test.tsx` sem regressão ✅ 3/3
- `npm run typecheck` ✅ · `eslint` nos arquivos ✅
- **Verificação viva (Playwright, browser em UTC)**: `/solicitacoes/minhas` passou a exibir **09:00** (antes 12:00) para o mesmo evento.

Sem mudança de contrato de API — só formatação de exibição.
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `1559a2ef`, slot `0` / projeto `aprender_staging`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
