### PR TITLE
fix(notificacoes): pula escalonamento em dia não-útil (#1721)

### DIFF
--- a/v2/backend/apps/core/services/notificacoes_acoes_service.py
+++ b/v2/backend/apps/core/services/notificacoes_acoes_service.py
@@ -271,6 +271,32 @@ class AcoesNotificacaoDailyService:
     ) -> dict[str, object]:
         ref_date = reference_date or timezone.localdate()
 
+        # #1721: a task diaria roda todo dia do calendario, mas a distancia em dias
+        # uteis ate um vencimento util e IDENTICA para sexta/sabado/domingo. Como a
+        # chave de dedupe da NotificacaoInterna inclui referencia_data (= hoje),
+        # processar num dia nao-util cria copias das notificacoes ja enviadas na
+        # sexta (cada fase dispararia ate 3x no fim de semana). Pular dias nao-uteis
+        # (fim de semana + feriados) mantem 1 disparo por fase. O skip continua
+        # auditado para nao cegar o monitoramento de "a task rodou?".
+        if not BusinessCalendarService.is_business_day(ref_date):
+            skipped_metrics: dict[str, object] = {
+                "reference_date": ref_date.isoformat(),
+                "skipped_non_business_day": True,
+                "actions_evaluated": 0,
+                "actions_triggered": 0,
+                "notifications_created": 0,
+                "notifications_deduplicated": 0,
+                "fallback_actions": 0,
+                "phases": {},
+            }
+            AuditLog.objects.create(
+                usuario=None,
+                action=AuditLog.Action.ACOES_NOTIFICACOES_DAILY,
+                model_name="AcaoInstancia",
+                details=skipped_metrics,
+            )
+            return skipped_metrics
+
         actions_qs = (
             AcaoInstancia.objects.select_related(
                 "template",

--- a/v2/backend/apps/core/tests/test_notificacoes_acoes_service.py
+++ b/v2/backend/apps/core/tests/test_notificacoes_acoes_service.py
@@ -200,3 +200,34 @@ def test_task_wrapper_returns_metrics_and_writes_audit_log(base_context, user_fa
     assert audit is not None
     assert audit.details["reference_date"] == "2026-03-10"
     assert audit.details["notifications_created"] == 2
+
+
+@pytest.mark.django_db
+def test_run_skips_non_business_day_weekend(base_context, user_factory):
+    """#1721: a distancia em dias uteis ate um vencimento util e IDENTICA para
+    sexta, sabado e domingo. Como a task diaria roda todo dia do calendario e a
+    chave de dedupe inclui referencia_data, cada fase (D-7/D-3/D-1) dispararia
+    ate 3x no fim de semana. Rodar num dia nao-util deve PULAR (0 notificacoes)."""
+    ciclo = base_context["ciclo"]
+    # data_vencimento = add_business_days(anchor, 1) = 2026-03-18 (quarta-feira).
+    action = _create_action(ciclo=ciclo, ordem=510, anchor=date(2026, 3, 17), executor_group="Comercial")
+    user_factory(prefix="coord", groups=["Comercial", "Coordenador"])
+    user_factory(prefix="manager", groups=["Comercial", "Gerente"])
+
+    # Sanidade: sexta 2026-03-13 e dia util e esta a 3 dias uteis do vencimento -> D-3 dispara (2 notifs).
+    metrics_friday = AcoesNotificacaoDailyService.run(reference_date=date(2026, 3, 13))
+    assert metrics_friday["phases"] == {"D-3": 1}
+    assert metrics_friday["notifications_created"] == 2
+
+    # Sabado 2026-03-14 tambem esta a 3 dias uteis do vencimento (o bug criaria +2 duplicatas).
+    metrics_saturday = AcoesNotificacaoDailyService.run(reference_date=date(2026, 3, 14))
+    assert metrics_saturday["notifications_created"] == 0
+    assert metrics_saturday.get("skipped_non_business_day") is True
+
+    # Apenas as 2 notificacoes de sexta permanecem.
+    assert NotificacaoInterna.objects.filter(acao_instancia=action).count() == 2
+
+    # O skip continua auditado (nao cega o monitoramento de "a task rodou?").
+    audit = AuditLog.objects.filter(action="ACOES_NOTIFICACOES_DAILY").order_by("-created_at").first()
+    assert audit is not None
+    assert audit.details.get("skipped_non_business_day") is True


### PR DESCRIPTION
Closes #1721.

## Problema
A task diária de escalonamento roda **todo dia do calendário** (`crontab(hour=8)` sem `day_of_week`, `config/celery.py`). Como `BusinessCalendarService.business_days_between` retorna o **mesmo valor** para sexta/sábado/domingo em relação a um vencimento útil, e a chave de dedupe da `NotificacaoInterna` inclui `referencia_data` (= hoje), cada fase (D-7/D-3/D-1) era reenviada **até 3×** no fim de semana.

## Correção
`AcoesNotificacaoDailyService.run` retorna cedo quando `ref_date` não é dia útil (`is_business_day`), com métrica `skipped_non_business_day`. O `AuditLog` do skip é preservado — não cega o monitoramento de "a task rodou?".

## Test plan (TDD, RED → GREEN)
- `test_run_skips_non_business_day_weekend`: sexta `2026-03-13` dispara D-3 (sanidade: 2 notificações); sábado `2026-03-14` (mesma distância de 3 dias úteis) agora cria **0** — antes criava +2 duplicatas.
- RED confirmado antes da correção (`assert 2 == 0`).
- Regressão: suíte core completa **3121 passed, 37 skipped, 0 failed**.

## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Rodado localmente no branch `fix/notificacoes-dia-nao-util-1721` (subtargets `staging-build → staging-up → staging-test → staging-down`, workaround do bug de Windows do `staging-full`):

```
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS
ALL 8 CHECKS PASSED
```
