### PR TITLE
fix(gcal): pula UPDATE de evento inalterado, evita reenvio de e-mail (#1722)

### DIFF
--- a/v2/backend/apps/core/services/gcal/sync.py
+++ b/v2/backend/apps/core/services/gcal/sync.py
@@ -330,6 +330,15 @@ def upsert_one(
                 # DB não tinha o ID, mas evento existe → ADOPT
                 action = "ADOPT"
 
+            # #1722 (RF05 idempotência): se o evento já está publicado (DB tem o ID)
+            # e o payload não mudou desde a última publicação, PULA o UPDATE. Sem isto,
+            # todo re-publish de um evento inalterado chama client.update() e, com
+            # GCAL_SEND_UPDATES=all, reenvia e-mail a TODOS os convidados sem mudança
+            # real. O resync zera gcal_payload_hash de propósito (resync_solicitacao /
+            # batch resync), então o SKIP nunca bloqueia um reenvio intencional.
+            if action == "UPDATE" and s.gcal_payload_hash and s.gcal_payload_hash == _payload_hash(payload):
+                return SyncOutcome("SKIP", s.id, s.external_event_id, payload["summary"])
+
             if not dry_run:
                 try:
                     # RF05: Retry com backoff exponencial (PR19)

--- a/v2/backend/apps/core/tests/test_gcal_republish_idempotent_1722.py
+++ b/v2/backend/apps/core/tests/test_gcal_republish_idempotent_1722.py
@@ -1,0 +1,95 @@
+"""
+Regressao #1722: re-publish de um evento aprovado INALTERADO deve PULAR o UPDATE.
+
+Sem isto, todo re-publish chama client.update() e, com GCAL_SEND_UPDATES=all
+(valor de producao), reenvia e-mail a todos os convidados sem nenhuma mudanca real.
+A idempotencia vem de comparar o gcal_payload_hash armazenado com o do payload novo.
+
+100% fake/mocked (GCAL_CLIENT=fake), sem rede real.
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportOptionalMemberAccess=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportMissingTypeArgument=false, reportCallIssue=false
+
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import patch
+
+from django.utils import timezone
+
+import pytest
+
+from apps.core.models import Solicitacao
+from apps.core.services.gcal_fake_client import FakeCalendarClient
+from apps.core.tests.factories import (
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
+
+
+@pytest.fixture
+def solicitacao_aprovada(db):
+    """Solicitacao aprovada, ainda nao publicada no GCal."""
+    user = UsuarioFactory(username="republish_1722", email="republish_1722@test.com", cpf="98765432100")
+    municipio = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+    projeto = ProjetoFactory(nome="Projeto 1722", codigo="R1722", fluxo="SUPER", ativo=True)
+    tipo_evento = TipoEventoFactory(nome="Formacao 1722")
+
+    now = timezone.now()
+    return SolicitacaoFactory(
+        usuario=user,
+        municipio=municipio,
+        projeto=projeto,
+        tipo_evento=tipo_evento,
+        tipo="evento",
+        inicio=now + timedelta(days=1),
+        fim=now + timedelta(days=1, hours=3),
+        status="aprovado",
+        gcal_status=Solicitacao.GCalStatus.NONE,
+    )
+
+
+@pytest.mark.django_db
+@patch("django.conf.settings.GCAL_CLIENT", "fake")
+def test_republish_unchanged_event_skips_update(solicitacao_aprovada):
+    """Publicar e re-publicar sem mudanca: a 2a passada deve retornar SKIP e NAO chamar update()."""
+    from apps.core.services.gcal_sync_service import apply_one_solicitacao
+
+    # Cliente fake COMPARTILHADO para o evento persistir entre as duas passadas.
+    client = FakeCalendarClient()
+
+    first = apply_one_solicitacao(solicitacao_aprovada, dry_run=False, apply_blocked=True, client=client)
+    assert first.action == "CREATE"
+    solicitacao_aprovada.refresh_from_db()
+    assert solicitacao_aprovada.gcal_payload_hash  # hash foi armazenado no publish
+
+    with patch.object(client, "update", wraps=client.update) as spy_update:
+        second = apply_one_solicitacao(solicitacao_aprovada, dry_run=False, apply_blocked=True, client=client)
+
+    assert second.action == "SKIP"
+    spy_update.assert_not_called()  # nenhum UPDATE => nenhum e-mail reenviado aos convidados
+
+
+@pytest.mark.django_db
+@patch("django.conf.settings.GCAL_CLIENT", "fake")
+def test_resync_clears_hash_and_forces_update(solicitacao_aprovada):
+    """O resync zera gcal_payload_hash de proposito: a re-publicacao entao DEVE fazer UPDATE."""
+    from apps.core.services.gcal_sync_service import apply_one_solicitacao
+
+    client = FakeCalendarClient()
+
+    apply_one_solicitacao(solicitacao_aprovada, dry_run=False, apply_blocked=True, client=client)
+    solicitacao_aprovada.refresh_from_db()
+
+    # Simula o resync (endpoint/servico zeram o hash para forcar o reenvio).
+    solicitacao_aprovada.gcal_payload_hash = None
+    solicitacao_aprovada.save(update_fields=["gcal_payload_hash"])
+
+    with patch.object(client, "update", wraps=client.update) as spy_update:
+        outcome = apply_one_solicitacao(solicitacao_aprovada, dry_run=False, apply_blocked=True, client=client)
+
+    assert outcome.action == "UPDATE"
+    spy_update.assert_called_once()


### PR DESCRIPTION
Closes #1722.

## Problema
`gcal_payload_hash` era calculado mas **nunca comparado** antes do UPDATE. Todo re-publish de um evento aprovado **inalterado** chamava `client.update()` e, com `GCAL_SEND_UPDATES=all` (valor de produção), **reenviava e-mail a todos os convidados** sem mudança real.

## Correção
No branch UPDATE de `upsert_one` (`services/gcal/sync.py`): retorna `SKIP` quando o evento já tem `external_event_id` e o `payload_hash` novo bate com `s.gcal_payload_hash`. O resync zera o hash de propósito (`resync_solicitacao` / batch resync), então segue forçando UPDATE quando o reenvio é intencional.

## Test plan (TDD, RED → GREEN)
- `test_republish_unchanged_event_skips_update`: re-publish inalterado → `SKIP` e `update()` **não chamado** (nenhum e-mail).
- `test_resync_clears_hash_and_forces_update`: hash zerado → `UPDATE` (guard de resync, garante que a idempotência não bloqueia reenvio intencional).
- RED confirmado antes da correção (`UPDATE != SKIP`).
- Regressão: suíte core completa **3121 passed, 37 skipped, 0 failed**; testes gcal/sync/dryrun/resync verdes.

## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Rodado localmente no branch `fix/gcal-payload-hash-1722` (subtargets `staging-build → staging-up → staging-test → staging-down`, workaround do bug de Windows do `staging-full`):

```
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS
ALL 8 CHECKS PASSED
```
