### PR TITLE
chore(deps): remove 5 dependências backend não usadas (#1723)

### DIFF
--- a/v2/backend/requirements-minimal.txt
+++ b/v2/backend/requirements-minimal.txt
@@ -26,6 +26,5 @@ pytest-django==4.12.0
 
 # Utils
 python-dateutil==2.9.0.post0
-pytz==2024.2
 redis==5.2.1
 whitenoise==6.8.2

--- a/v2/backend/requirements-prod.txt
+++ b/v2/backend/requirements-prod.txt
@@ -30,10 +30,6 @@ django-cors-headers==4.9.0
 django-filter==24.3
 whitenoise==6.7.0
 
-# Forms & Validation
-django-crispy-forms==2.6
-crispy-bootstrap5==2024.2
-
 # Storage & Files
 django-storages==1.14.6
 python-magic==0.4.27
@@ -58,13 +54,10 @@ gunicorn==23.0.0
 openpyxl==3.1.5
 pandas==2.3.3
 Pillow==12.3.0
-xlsxwriter==3.2.0
 
 # Utilities
 python-dateutil==2.9.0.post0
 python-decouple==3.8
-pytz==2024.2
-rapidfuzz==3.6.1
 requests==2.33.0
 django-environ==0.13.0
 

--- a/v2/backend/requirements.txt
+++ b/v2/backend/requirements.txt
@@ -10,7 +10,6 @@ bandit==1.9.4
 black==26.5.1
 boto3==1.43.31
 celery==5.5.3
-crispy-bootstrap5==2024.2
 # ================================================================
 # Core Framework
 # ================================================================
@@ -27,7 +26,6 @@ django-cors-headers==4.9.0
 # ================================================================
 # Forms & Validation
 # ================================================================
-django-crispy-forms==2.6
 django-debug-toolbar==5.2.0
 django-environ==0.13.0
 django-extensions==4.1
@@ -100,8 +98,6 @@ pytest-xdist==3.8.0
 # ================================================================
 python-dateutil==2.9.0.post0
 python-decouple==3.8
-pytz==2024.2
-rapidfuzz==3.6.1
 
 # ================================================================
 # Cache & Task Queue
@@ -124,4 +120,3 @@ python-json-logger==2.0.7
 sentry-sdk==2.13.0
 watchdog==4.0.2
 whitenoise==6.7.0
-xlsxwriter==3.2.0


### PR DESCRIPTION
Parte de #1723 (higiene). Slice 1/2: **dependências backend não usadas**.

## O quê
Remove 5 dependências declaradas e com **zero uso** no código (grep-confirmado em `v2/backend`, excluindo os próprios requirements):

| Pacote | Motivo |
|---|---|
| `pytz` | Django 5.2 usa `zoneinfo`; resquício pré-migração |
| `django-crispy-forms` | backend é API-only (DRF+React), sem forms de template; nem está em `INSTALLED_APPS` |
| `crispy-bootstrap5` | idem (companion do crispy-forms) |
| `xlsxwriter` | a lib Excel usada no projeto é `openpyxl` |
| `rapidfuzz` | 0 usos; o `export_contract_projeto_resolver.py` não o importa |

Arquivos tocados: `requirements.txt`, `requirements-prod.txt`, `requirements-minimal.txt` (13 deleções).

## Mantido de propósito
- **`watchdog`** — não é importado no código, mas o autoreload do `runserver` do Django o usa **implicitamente**. Remover só degradaria o reload de dev; fora do escopo.

## Verificação
- `grep -riE "pytz|crispy|xlsxwriter|rapidfuzz"` em `v2/backend` (fora dos requirements) = **0 matches**.
- **Staging gate rodado localmente** neste branch (imagem prod rebuildada sem as 5 deps → boot + smoke OK).

## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

```
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS
ALL 8 CHECKS PASSED
```

## Fora deste PR (slice seguinte do #1723)
- Dead code frontend (`Solicitacoes.tsx`, `useRealtimeSync.ts`, funções mortas em `ops.ts`, options duplicadas em `solicitacoes.ts`, funções TODO em `datModule.ts`, `RemoteSelect.tsx`). **Nota:** `useCrudOperations.ts` **não** é dead code — `useTableFilters` importa o tipo `PaginationState` dele; será tratado à parte, não neste sweep.
- `js-yaml`: `npm install` para aplicar o `overrides` do `package.json` no lockfile (CVE High DoS, transitivo dev).
