### PR TITLE
fix(notificacoes): pula escalonamento em dia nao-util (#1721)

### DIFF
--- a/v2/backend/apps/core/services/notificacoes_acoes_service.py
+++ b/v2/backend/apps/core/services/notificacoes_acoes_service.py
@@ -271,6 +271,31 @@ class AcoesNotificacaoDailyService:
     ) -> dict[str, object]:
         ref_date = reference_date or timezone.localdate()
 
+        # #1721: escalonamento e um conceito de dia util. Rodar num dia nao-util
+        # (fim de semana/feriado) recria as notificacoes do ultimo dia util:
+        # business_days_between() devolve o mesmo inteiro para sex/sab/dom e a
+        # referencia_data (=ref_date) muda a cada dia, escapando do dedupe. Pula
+        # o dia nao-util para nao duplicar.
+        if not BusinessCalendarService.is_business_day(ref_date):
+            skip_metrics: dict[str, object] = {
+                "reference_date": ref_date.isoformat(),
+                "skipped": True,
+                "reason": "not_a_business_day",
+                "actions_evaluated": 0,
+                "actions_triggered": 0,
+                "notifications_created": 0,
+                "notifications_deduplicated": 0,
+                "fallback_actions": 0,
+                "phases": {},
+            }
+            AuditLog.objects.create(
+                usuario=None,
+                action=AuditLog.Action.ACOES_NOTIFICACOES_DAILY,
+                model_name="AcaoInstancia",
+                details=skip_metrics,
+            )
+            return skip_metrics
+
         actions_qs = (
             AcaoInstancia.objects.select_related(
                 "template",

--- a/v2/backend/apps/core/tests/test_notificacoes_acoes_service.py
+++ b/v2/backend/apps/core/tests/test_notificacoes_acoes_service.py
@@ -200,3 +200,34 @@ def test_task_wrapper_returns_metrics_and_writes_audit_log(base_context, user_fa
     assert audit is not None
     assert audit.details["reference_date"] == "2026-03-10"
     assert audit.details["notifications_created"] == 2
+
+
+@pytest.mark.django_db
+def test_weekend_run_creates_no_notifications(base_context, user_factory):
+    """#1721: escalonamento nao deve rodar (nem duplicar) em dia nao-util.
+
+    business_days_between() devolve o mesmo inteiro para sexta, sabado e domingo
+    contra um vencimento util futuro; como referencia_data (=hoje) entra na chave de
+    dedupe, sab/dom recriavam a notificacao de sexta (ate 3x). A task deve pular o
+    dia nao-util.
+    """
+    ciclo = base_context["ciclo"]
+    # vencimento = quarta 2026-03-18 (anchor terca 2026-03-17 + 1 dia util)
+    action = _create_action(ciclo=ciclo, ordem=507, anchor=date(2026, 3, 17), executor_group="Comercial")
+    user_factory(prefix="coord", groups=["Comercial", "Coordenador"])
+    user_factory(prefix="manager", groups=["Comercial", "Gerente"])
+
+    # Sexta 2026-03-13 (dia util): D-3 dispara -> prova que a notificacao existe.
+    friday = AcoesNotificacaoDailyService.run(reference_date=date(2026, 3, 13))
+    assert friday["notifications_created"] == 2
+    assert friday["phases"] == {"D-3": 1}
+
+    # Sabado/Domingo (dia nao-util): business_days_between ainda da 3 -> D-3 dispararia
+    # (o bug), mas nada novo deve ser criado.
+    saturday = AcoesNotificacaoDailyService.run(reference_date=date(2026, 3, 14))
+    sunday = AcoesNotificacaoDailyService.run(reference_date=date(2026, 3, 15))
+    assert saturday["notifications_created"] == 0
+    assert sunday["notifications_created"] == 0
+
+    # Total permanece 2 (so os de sexta), nao 6.
+    assert NotificacaoInterna.objects.filter(acao_instancia=action).count() == 2


### PR DESCRIPTION
## #1721 — escalonamento de prazo duplica notificações no fim de semana

Piloto do **loop orientado a issues** (desenho em `E:\loop.enginnering\15`), rodado à mão em **Level 2**: RED→GREEN→verify, teto **Draft PR** (humano promove e faz o merge).

### O que mudou
Early-return em `AcoesNotificacaoDailyService.run` quando `ref_date` não é dia útil. `is_business_day` já cobre **fim de semana E feriado**. **Sem migração** — a 2ª sugestão da issue (remover `referencia_data` do `UniqueConstraint`) é migração de schema e foi deixada de fora de propósito (área barrada no desenho do loop).

### Causa raiz
`business_days_between()` devolve o mesmo inteiro para sex/sáb/dom contra um vencimento útil futuro; a `referencia_data` (=`ref_date`) entra na chave de dedupe e muda a cada dia → `get_or_create` recria a notificação de sexta no sábado e no domingo (até 3×).

### Evidência (checks que rodaram e passaram)
- **pytest RED→GREEN**: `test_weekend_run_creates_no_notifications` — falhava em `assert 2 == 0` (sábado criava 2 duplicatas); agora passa.
- **regressão**: `test_notificacoes_acoes_service.py` **7/7**; cluster relacionado (`test_celery_notificacoes_schedule` + `test_acoes_notificacao_models` + `test_api_acoes_notificacao`) **19/19**.
- **pyright**: 0 errors nos arquivos alterados (warnings restantes são pré-existentes).
- **black + isort**: sem mudanças.
- **staging gate** (subtargets `v2/infra`, imagens prod da branch `a4f7c1c9`, stack isolada `aprender_staging`): **ALL 8 CHECKS PASSED** (8/8 PASS) — readyz · version · CSRF · auth · worker · beat · frontend HTTP · frontend health. Evidencia anexada.

### Não-objetivos
- Não mexe no `UniqueConstraint` (sem migração).
- Não altera as regras D-7/D-3/D-1 nem o dedupe intra-dia.

### Verificação pendente (humano, antes do Ready)
- [x] staging gate (8/8) — rodado pelo **loop** (checker), evidência acima
- [ ] revisar o diff e dar o veredito (Ready + merge) — passo humano (outer loop)

Closes #1721
