### PR TITLE
fix(deslocamentos): filtros Origem/Destino nao desmontam a pagina (#1622)

### DIFF
--- a/v2/frontend/src/pages/Deslocamentos/DeslocamentosPage.tsx
+++ b/v2/frontend/src/pages/Deslocamentos/DeslocamentosPage.tsx
@@ -84,7 +84,12 @@ interface ApiErrorType {
 
 export default function DeslocamentosPage(): JSX.Element {
   const [canAccess, setCanAccess] = useState<boolean>(false);
-  const [loading, setLoading] = useState<boolean>(true);
+  // #1622: dois loadings separados. `pageLoading` gateia a página inteira (só o
+  // carregamento inicial de usuário/permissão); `tableLoading` gateia SÓ a tabela.
+  // Antes um `loading` único fazia o fetch de filtro desmontar a página (input
+  // perdia foco/valor).
+  const [pageLoading, setPageLoading] = useState<boolean>(true);
+  const [tableLoading, setTableLoading] = useState<boolean>(false);
   const [deslocamentos, setDeslocamentos] = useState<DeslocamentoRecord[]>([]);
   const [usuarios, setUsuarios] = useState<UsuarioOptionType[]>([]);
   const [pagination, setPagination] = useState<TablePaginationConfig>({ current: 1, pageSize: 50, total: 0 });
@@ -109,7 +114,7 @@ export default function DeslocamentosPage(): JSX.Element {
         logger.error('Erro ao carregar usuário:', error);
         setCanAccess(false);
       } finally {
-        setLoading(false);
+        setPageLoading(false);
       }
     }
 
@@ -118,7 +123,7 @@ export default function DeslocamentosPage(): JSX.Element {
 
   // Load deslocamentos
   const loadDeslocamentos = useCallback(async (page = 1): Promise<void> => {
-    setLoading(true);
+    setTableLoading(true);
     try {
       const data = await listDeslocamentos({ ...filters, page });
       setDeslocamentos(data.results || []);
@@ -130,7 +135,7 @@ export default function DeslocamentosPage(): JSX.Element {
     } catch (error) {
       message.error((error as Error).message);
     } finally {
-      setLoading(false);
+      setTableLoading(false);
     }
   }, [filters]);
 
@@ -144,12 +149,23 @@ export default function DeslocamentosPage(): JSX.Element {
     }
   }, []);
 
+  // Opções de formador carregam UMA vez (não dependem dos filtros).
   useEffect(() => {
     if (canAccess) {
-      loadDeslocamentos();
       loadFormadores();
     }
-  }, [canAccess, filters, loadDeslocamentos, loadFormadores]);
+  }, [canAccess, loadFormadores]);
+
+  // Lista recarrega ao mudar filtros, com debounce (evita 1 request por tecla).
+  useEffect(() => {
+    if (!canAccess) {
+      return;
+    }
+    const timer = setTimeout(() => {
+      loadDeslocamentos(1);
+    }, 350);
+    return () => clearTimeout(timer);
+  }, [canAccess, filters, loadDeslocamentos]);
 
   // Handle table change (pagination)
   const handleTableChange = (paginationConfig: TablePaginationConfig): void => {
@@ -321,7 +337,7 @@ export default function DeslocamentosPage(): JSX.Element {
   ];
 
   // Permission check
-  if (loading) {
+  if (pageLoading) {
     return <div className="p-6">Carregando...</div>;
   }
 
@@ -388,6 +404,7 @@ export default function DeslocamentosPage(): JSX.Element {
             <Input
               placeholder="Origem"
               prefix={<SearchOutlined />}
+              value={filters.origem ?? ''}
               onChange={(e: ChangeEvent<HTMLInputElement>) => handleFilterChange('origem', e.target.value)}
             />
           </Col>
@@ -395,6 +412,7 @@ export default function DeslocamentosPage(): JSX.Element {
             <Input
               placeholder="Destino"
               prefix={<SearchOutlined />}
+              value={filters.destino ?? ''}
               onChange={(e: ChangeEvent<HTMLInputElement>) => handleFilterChange('destino', e.target.value)}
             />
           </Col>
@@ -407,7 +425,7 @@ export default function DeslocamentosPage(): JSX.Element {
           columns={columns}
           dataSource={deslocamentos}
           rowKey="id"
-          loading={loading}
+          loading={tableLoading}
           pagination={pagination}
           onChange={handleTableChange}
           scroll={{ x: 1000 }}

--- a/v2/frontend/src/pages/Deslocamentos/__tests__/DeslocamentosPage.filtros.test.tsx
+++ b/v2/frontend/src/pages/Deslocamentos/__tests__/DeslocamentosPage.filtros.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * #1622 [M09-06] Deslocamentos: filtros Origem/Destino inutilizáveis.
+ *
+ * Bug: `loading` é estado único → o early-return `if (loading) return <Carregando/>`
+ * desmonta a página inteira a cada fetch de filtro (input perde foco/valor), os inputs
+ * Origem/Destino são não-controlados (voltam vazios ao remontar) e `loadFormadores`
+ * refaz a chamada de opções a cada tecla.
+ */
+
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { MemoryRouter } from 'react-router';
+
+const { getMeMock, listDeslocamentosMock, listFormadoresMock } = vi.hoisted(() => ({
+  getMeMock: vi.fn(),
+  listDeslocamentosMock: vi.fn(),
+  listFormadoresMock: vi.fn(),
+}));
+
+vi.mock('../../../api/availability', () => ({ getMe: getMeMock }));
+vi.mock('../../../api/deslocamentos', () => ({
+  listDeslocamentos: listDeslocamentosMock,
+  listFormadoresDoSetor: listFormadoresMock,
+  createDeslocamento: vi.fn(),
+  updateDeslocamento: vi.fn(),
+  deleteDeslocamento: vi.fn(),
+}));
+vi.mock('../../../hooks/usePermissions', () => ({
+  computePermissions: () => ({
+    canControle: false,
+    canCoordenador: true,
+    canDAT: false,
+    inSuperintendencia: false,
+  }),
+}));
+vi.mock('../../../components/DatImportsCentralizedBanner', () => ({ default: () => null }));
+
+import DeslocamentosPage from '../DeslocamentosPage';
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <DeslocamentosPage />
+    </MemoryRouter>
+  );
+}
+
+describe('DeslocamentosPage — filtros (#1622)', () => {
+  beforeEach(() => {
+    getMeMock.mockReset();
+    listDeslocamentosMock.mockReset();
+    listFormadoresMock.mockReset();
+    getMeMock.mockResolvedValue({ id: 1, username: 'coord', groups: ['Coordenador'] });
+    listDeslocamentosMock.mockResolvedValue({ count: 0, next: null, previous: null, results: [] });
+    listFormadoresMock.mockResolvedValue([]);
+  });
+
+  test('digitar no filtro Origem: input preserva valor, página não desmonta, opções não refetadas', async () => {
+    renderPage();
+
+    const origem = (await screen.findByPlaceholderText('Origem', undefined, { timeout: 5000 })) as HTMLInputElement;
+    await waitFor(() => expect(listFormadoresMock).toHaveBeenCalledTimes(1));
+
+    // Digita no filtro (um único change com o valor completo evita corridas de remontagem).
+    fireEvent.change(origem, { target: { value: 'Fortaleza' } });
+
+    // O fetch de filtro (debounced) acontece com o valor digitado.
+    await waitFor(() =>
+      expect(listDeslocamentosMock).toHaveBeenCalledWith(expect.objectContaining({ origem: 'Fortaleza' }))
+    );
+
+    // A página NÃO desmontou para "Carregando..." — o card de Filtros permanece.
+    expect(screen.getByText('Filtros')).toBeInTheDocument();
+
+    // O input mantém o valor digitado (controlado).
+    expect((screen.getByPlaceholderText('Origem') as HTMLInputElement).value).toBe('Fortaleza');
+
+    // As opções de formador NÃO são refetadas a cada mudança de filtro.
+    expect(listFormadoresMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## #1622 [M09-06] Deslocamentos: filtros Origem/Destino desmontam a página a cada tecla

Piloto #2 do **loop orientado a issues** (desenho em `E:\loop.enginnering\15`), rodado à mão em **Level 2** — o primeiro a exercitar a **perna Playwright (V4)**. RED→GREEN→verify, teto **Draft PR** (humano promove e faz o merge).

### O que mudou (1 arquivo: `DeslocamentosPage.tsx`)
- `loading` único gateava a página inteira (early-return "Carregando...") **e** a tabela → cada fetch de filtro **remontava a página** e o input perdia foco/valor. Split em **`pageLoading`** (só o load inicial de permissão) e **`tableLoading`** (só a tabela).
- Inputs Origem/Destino eram **não-controlados** (voltavam vazios ao remontar) → agora `value={filters.origem ?? ''}` / `value={filters.destino ?? ''}`.
- Fetch de lista com **debounce de 350ms** (era 1 request por tecla).
- `loadFormadores` movido para **efeito próprio** (carrega 1×, não a cada tecla).

### Não-barrada / single-module
1 arquivo de frontend; **sem** contrato de API alterado (mesmos query params), sem migração, sem RBAC (o `canAccess` local é defesa-em-camadas, intacto).

### Evidência (checks que rodaram e passaram)
- **vitest RED→GREEN**: `DeslocamentosPage.filtros.test.tsx` — falhava em `expected '' to be 'Fortaleza'` (input perdia o valor); agora passa (valor preservado, página não desmonta, formadores 1×).
- **V4 Playwright** (browser real, dev dockerizado, logado como Coordenador, digitando 9 chars caractere-a-caractere no filtro Origem):
  - `origemIsFocused: true` — **o foco nunca morreu**.
  - `origemValue: "Fortaleza"` — valor íntegro.
  - `mostraCarregando: false` — página não remontou.
  - rede: **1** `GET /api/options/formadores-do-setor/` (no load) + **1** `GET /api/deslocamentos/?origem=Fortaleza` debounced (não 9).
- **eslint**: limpo. **tsc --noEmit**: 0 erros.
- **staging gate** (subtargets `v2/infra`, imagens prod da branch, stack isolada `aprender_staging`): readyz · version · CSRF · auth · worker · beat · frontend HTTP · frontend health — todos PASS.

## Staging Gate

- [x] `make staging-full` executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR (trecho de log contendo "ALL 8 CHECKS PASSED")

### Evidencia Staging Gate

```text
ALL 8 CHECKS PASSED
[1/8] readyz PASS · [2/8] version PASS · [3/8] CSRF PASS · [4/8] auth PASS (HTTP 400)
[5/8] worker PASS · [6/8] beat PASS · [7/8] frontend HTTP PASS · [8/8] frontend health PASS
```

### Verificação (humano)
- [x] revisado e promovido a Ready — veredito do outer loop

Closes #1622
