### PR TITLE
chore(login): oculta aviso LGPD ate juridico preencher placeholders

### DIFF
--- a/v2/frontend/src/pages/Auth/LoginPage.tsx
+++ b/v2/frontend/src/pages/Auth/LoginPage.tsx
@@ -14,7 +14,9 @@ import { login } from '../../api/auth';
 import logoLogin from '../../assets/logo-login.webp';
 import logger from '../../utils/logger';
 import { BRAND_COLORS } from '../../contexts/ThemeContext';
-import AvisoTransparenciaLGPD from '../../components/lgpd/AvisoTransparenciaLGPD';
+// Aviso LGPD ocultado temporariamente ate o juridico preencher a base legal e o Encarregado (DPO)
+// em AvisoTransparenciaLGPD (placeholders [A PREENCHER]). Reativar: descomentar este import e o uso abaixo.
+// import AvisoTransparenciaLGPD from '../../components/lgpd/AvisoTransparenciaLGPD';
 
 /**
  * Login form values interface
@@ -147,8 +149,11 @@ export default function LoginPage({ onLoginSuccess }: LoginPageProps): JSX.Eleme
         </Form>
       </article>
 
-      {/* LGPD art. 9º: aviso de transparência no momento da coleta (não é consentimento). */}
-      <AvisoTransparenciaLGPD />
+      {/* LGPD art. 9º: aviso de transparência no momento da coleta (não é consentimento).
+          Ocultado temporariamente ate o juridico preencher a base legal e o Encarregado (DPO) —
+          os placeholders [A PREENCHER] apareciam ao usuario. Reativar: descomentar o import (topo)
+          e a linha abaixo. O componente e a Politica de Privacidade permanecem intactos. */}
+      {/* <AvisoTransparenciaLGPD /> */}
       </main>
     </>
   );


### PR DESCRIPTION
## Resumo

Oculta temporariamente o aviso de transparencia LGPD ("Tratamento dos seus dados") na tela de login, porque ele exibia os placeholders **[A PREENCHER pelo juridico]** e **[A PREENCHER]** (Encarregado/DPO) diretamente ao usuario -- o juridico ainda nao preencheu a base legal nem o DPO.

## O que mudou

- 1 arquivo (`LoginPage.tsx`): o import e o uso do componente `AvisoTransparenciaLGPD` foram **comentados**, com nota explicando como reativar.
- O componente `AvisoTransparenciaLGPD` e a Politica de Privacidade permanecem **intactos** no codigo -- reativar e so descomentar duas linhas quando o juridico preencher os campos.

## Evidencia

- `tsc --noEmit`: 0 erros.
- `eslint`: limpo.
- Confirmacao visual no ambiente dev: a tela de login passa a mostrar apenas o formulario (logo, CPF, Senha, Entrar); o bloco "Tratamento dos seus dados" nao aparece mais.

## Staging Gate

- [ ] `make staging-full` executado com sucesso (8/8 PASS)
- [ ] Evidencia anexada no PR (trecho de log contendo "ALL 8 CHECKS PASSED")
