### PR TITLE
feat(backup): dead-man diario alerta backup mais novo que 24h

### DIFF
--- a/v2/backend/apps/core/tasks_backup.py
+++ b/v2/backend/apps/core/tasks_backup.py
@@ -166,6 +166,41 @@ def perform_database_backup(
         raise
 
 
+def _latest_backup_age_hours(backup_dir: Path) -> tuple[Path | None, float]:
+    """Retorna (backup mais recente, idade em horas) ou (None, 0.0) se nao houver.
+
+    Cobre os DOIS sufixos: `.sql.gz` (sem cifra) e `.sql.gz.age` (SEC-017 — o que
+    producao realmente grava). `glob("backup_full_*.sql.gz")` NAO casa
+    `backup_full_*.sql.gz.age` (fnmatch exige que o padrao termine o nome): sem os
+    dois globs, um diretorio cheio de dumps cifrados validos seria lido como vazio e
+    o alarme gritaria "sem backup" toda vez (#1455). Diretorio inexistente → `glob`
+    devolve vazio → (None, 0.0). SSOT do frescor: usado pelo health check semanal e
+    pelo dead-man diario.
+    """
+    backups = [
+        *backup_dir.glob("backup_full_*.sql.gz"),
+        *backup_dir.glob("backup_full_*.sql.gz.age"),
+    ]
+    if not backups:
+        return None, 0.0
+    latest = max(backups, key=lambda p: p.stat().st_mtime)
+    age_hours = (datetime.now().timestamp() - latest.stat().st_mtime) / 3600
+    return latest, age_hours
+
+
+def _alert_backup_deadman(message: str) -> None:
+    """Dispara o alarme do dead-man: ERROR no log (chega a alguem mesmo sem Sentry,
+    ja que SENTRY_DSN e vazio em prod) + evento de erro no Sentry quando configurado."""
+    logger.error(message)
+    if getattr(settings, "SENTRY_DSN", ""):
+        try:
+            import sentry_sdk
+
+            sentry_sdk.capture_message(message, level="error")
+        except ImportError:
+            pass
+
+
 @shared_task(name="backup.verify_backup_health")
 def verify_backup_health() -> dict[str, str | int | list[str]]:
     """
@@ -194,19 +229,11 @@ def verify_backup_health() -> dict[str, str | int | list[str]]:
     else:
         checks_passed += 1
 
-    # Check 2: Recent backup exists (within last 25 hours)
-    #
-    # Dois sufixos: `.sql.gz` (sem cifra) e `.sql.gz.age` (SEC-017 — o que producao
-    # realmente grava). `glob("*.sql.gz")` NAO casa `.sql.gz.age`: o alarme olharia um
-    # diretorio cheio de backups validos e diria "No backups found" (#1455).
-    recent_backups = [
-        *backup_dir.glob("backup_full_*.sql.gz"),
-        *backup_dir.glob("backup_full_*.sql.gz.age"),
-    ]
-    if recent_backups:
-        latest_backup = max(recent_backups, key=lambda p: p.stat().st_mtime)
-        age_hours = (datetime.now().timestamp() - latest_backup.stat().st_mtime) / 3600
-
+    # Check 2: Recent backup exists (within last 25 hours). O glob dos dois sufixos
+    # (`.sql.gz` + `.sql.gz.age`, SEC-017/#1455) vive em `_latest_backup_age_hours` —
+    # mesma fonte de frescor que o dead-man diario (`check_backup_freshness`) usa.
+    latest_backup, age_hours = _latest_backup_age_hours(backup_dir)
+    if latest_backup is not None:
         if age_hours > 25:
             warnings.append(f"Latest backup is {age_hours:.1f}h old (expected < 25h)")
         else:
@@ -262,4 +289,62 @@ def verify_backup_health() -> dict[str, str | int | list[str]]:
         "checks_passed": checks_passed,
         "checks_total": checks_total,
         "warnings": warnings,
+    }
+
+
+@shared_task(name="backup.check_backup_freshness")
+def check_backup_freshness() -> dict[str, str | float | None]:
+    """Dead-man switch DIARIO: alarme quando o backup mais recente fica velho demais.
+
+    O backup roda diariamente as 2am (`backup.perform_database_backup`). Esta task
+    roda de manha e, se o backup mais novo passar de `BACKUP_DEADMAN_MAX_AGE_HOURS`
+    (default 24h) — ou se nao houver backup nenhum — dispara alarme via
+    `_alert_backup_deadman` (ERROR no log + Sentry quando ha DSN).
+
+    Foi a AUSENCIA deste alarme que deixou o backup diario morrer em silencio por
+    ~10 dias (2026-08-03 -> 08-17), so descoberto quando o gate de backup fresco do
+    deploy travou. O `verify_backup_health` e mais largo (dir/S3/frescor) mas so
+    roda aos domingos; este e o dead-man de cadencia diaria, focado em frescor.
+
+    Limitacao residual (honesta): se o proprio beat/worker estiver morto, esta task
+    tambem nao roda — o backstop externo continua sendo o gate `check_backup.sh` do
+    `aprender-applier`, que recusa deploy sem backup fresco.
+
+    Returns:
+        dict com `status` ('fresh' | 'stale' | 'missing'), nome do backup, idade em
+        horas e o limite aplicado.
+    """
+    backup_dir = Path(getattr(settings, "BACKUP_DIR", "/backups"))
+    max_age_hours = float(getattr(settings, "BACKUP_DEADMAN_MAX_AGE_HOURS", 24))
+
+    latest_backup, age_hours = _latest_backup_age_hours(backup_dir)
+
+    if latest_backup is None:
+        _alert_backup_deadman(
+            f"DEAD-MAN de backup: nenhum backup encontrado em {backup_dir} — o backup diario pode ter parado de rodar"
+        )
+        return {
+            "status": "missing",
+            "latest_backup": None,
+            "age_hours": None,
+            "max_age_hours": max_age_hours,
+        }
+
+    if age_hours > max_age_hours:
+        _alert_backup_deadman(
+            f"DEAD-MAN de backup: o backup mais recente ({latest_backup.name}) tem {age_hours:.1f}h (limite {max_age_hours:.0f}h) — o backup diario pode ter parado"
+        )
+        return {
+            "status": "stale",
+            "latest_backup": latest_backup.name,
+            "age_hours": round(age_hours, 1),
+            "max_age_hours": max_age_hours,
+        }
+
+    logger.info(f"Dead-man de backup OK: {latest_backup.name} ({age_hours:.1f}h, limite {max_age_hours:.0f}h)")
+    return {
+        "status": "fresh",
+        "latest_backup": latest_backup.name,
+        "age_hours": round(age_hours, 1),
+        "max_age_hours": max_age_hours,
     }

--- a/v2/backend/apps/core/tests/test_celery_beat_registration.py
+++ b/v2/backend/apps/core/tests/test_celery_beat_registration.py
@@ -77,3 +77,6 @@ def test_beat_agenda_o_backup_diario() -> None:
     dados = _sondar()
     assert "backup.perform_database_backup" in dados["agendadas"]
     assert "backup.verify_backup_health" in dados["agendadas"]
+    # Dead-man diario: foi a ausencia deste agendamento que deixou o backup morrer
+    # 10 dias em silencio (2026-08). Se alguem remover a entrada, o alarme some.
+    assert "backup.check_backup_freshness" in dados["agendadas"]

--- a/v2/backend/apps/core/tests/test_deadman_backup.py
+++ b/v2/backend/apps/core/tests/test_deadman_backup.py
@@ -1,0 +1,98 @@
+"""Dead-man switch do backup: alerta quando o backup mais recente fica velho demais.
+
+Motivacao (2026-08): o backup diario morreu em silencio por ~10 dias (08-03 -> 08-17)
+e so foi descoberto quando o gate de backup fresco do deploy travou. O health check
+`verify_backup_health` existe, mas so roda aos domingos — janela larga demais. Esta
+task roda DIARIAMENTE e grita (ERROR + Sentry) assim que o frescor passa do limite.
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportIndexIssue=false, reportOperatorIssue=false, reportFunctionMemberAccess=false
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+from django.test import override_settings
+
+from apps.core.tasks_backup import check_backup_freshness
+
+
+def _write_backup(tmp_path: Path, name: str, *, age_hours: float) -> Path:
+    """Cria um artefato de backup com mtime `age_hours` no passado."""
+    f = tmp_path / name
+    f.write_bytes(b"age-encryption.org/v1\nfake payload")
+    ts = os.path.getmtime(f) - age_hours * 3600
+    os.utime(f, (ts, ts))
+    return f
+
+
+class TestCheckBackupFreshness:
+    """Contrato do dead-man: fresh=silencio, stale/missing=ERROR."""
+
+    def test_fresh_backup_returns_fresh_and_does_not_alert(self, tmp_path: Path) -> None:
+        # backup de 4h atras, limite 24h → saudavel, sem alarme
+        _write_backup(tmp_path, "backup_full_20260817_020000.sql.gz.age", age_hours=4)
+        with (
+            override_settings(BACKUP_DIR=str(tmp_path), SENTRY_DSN="", BACKUP_DEADMAN_MAX_AGE_HOURS=24),
+            patch("apps.core.tasks_backup.logger") as mock_logger,
+        ):
+            result = check_backup_freshness()
+
+        assert result["status"] == "fresh"
+        assert result["latest_backup"] == "backup_full_20260817_020000.sql.gz.age"
+        assert not mock_logger.error.called, "backup fresco NAO deve disparar alarme"
+
+    def test_stale_backup_alerts_in_error_and_returns_stale(self, tmp_path: Path) -> None:
+        # o backup mais novo tem 30h → passou do limite de 24h → dead-man dispara
+        _write_backup(tmp_path, "backup_full_20260810_020000.sql.gz.age", age_hours=30)
+        with (
+            override_settings(BACKUP_DIR=str(tmp_path), SENTRY_DSN="", BACKUP_DEADMAN_MAX_AGE_HOURS=24),
+            patch("apps.core.tasks_backup.logger") as mock_logger,
+        ):
+            result = check_backup_freshness()
+
+        assert result["status"] == "stale"
+        assert mock_logger.error.called, "backup velho DEVE sair em logger.error (alarme em prod)"
+        error_text = " ".join(str(c) for c in mock_logger.error.call_args_list)
+        assert "DEAD-MAN" in error_text
+
+    def test_no_backup_alerts_and_returns_missing(self, tmp_path: Path) -> None:
+        # diretorio vazio → nenhum backup → dead-man dispara com status 'missing'
+        with (
+            override_settings(BACKUP_DIR=str(tmp_path), SENTRY_DSN="", BACKUP_DEADMAN_MAX_AGE_HOURS=24),
+            patch("apps.core.tasks_backup.logger") as mock_logger,
+        ):
+            result = check_backup_freshness()
+
+        assert result["status"] == "missing"
+        assert result["latest_backup"] is None
+        assert mock_logger.error.called
+
+    def test_encontra_backup_cifrado_age(self, tmp_path: Path) -> None:
+        """Producao grava `.sql.gz.age` — o dead-man DEVE enxerga-lo (nao so `.sql.gz`)."""
+        _write_backup(tmp_path, "backup_full_20260817_020000.sql.gz.age", age_hours=1)
+        with (
+            override_settings(BACKUP_DIR=str(tmp_path), SENTRY_DSN="", BACKUP_DEADMAN_MAX_AGE_HOURS=24),
+            patch("apps.core.tasks_backup.logger") as mock_logger,
+        ):
+            result = check_backup_freshness()
+
+        assert result["status"] == "fresh"
+        assert not mock_logger.error.called
+
+    def test_respects_custom_threshold(self, tmp_path: Path) -> None:
+        # 2h de idade com limite de 1h → stale
+        _write_backup(tmp_path, "backup_full_20260817_000000.sql.gz.age", age_hours=2)
+        with (
+            override_settings(BACKUP_DIR=str(tmp_path), SENTRY_DSN="", BACKUP_DEADMAN_MAX_AGE_HOURS=1),
+            patch("apps.core.tasks_backup.logger") as mock_logger,
+        ):
+            result = check_backup_freshness()
+
+        assert result["status"] == "stale"
+        assert mock_logger.error.called
+
+    def test_task_is_registered_with_expected_name(self) -> None:
+        assert check_backup_freshness.name == "backup.check_backup_freshness"

--- a/v2/backend/config/celery.py
+++ b/v2/backend/config/celery.py
@@ -47,6 +47,16 @@ existing_schedule.update(
             "schedule": crontab(hour=3, minute=0, day_of_week=0),
             "options": {"expires": 1800},
         },
+        # Dead-man DIARIO de backup: alarme se o backup mais novo passar de 24h.
+        # O backup roda as 2am (timeout 1h) — checar as 6am da folga p/ ele concluir
+        # e separa o dia saudavel (~4h) do primeiro dia perdido (~28h). O health check
+        # acima e largo mas so roda aos domingos; este fecha a janela que deixou o
+        # backup morrer 10 dias em silencio (2026-08). Ver apps/core/tasks_backup.py.
+        "daily-backup-deadman-check": {
+            "task": "backup.check_backup_freshness",
+            "schedule": crontab(hour=6, minute=0),
+            "options": {"expires": 3600},
+        },
         # #871: Daily notifications/escalation processing at 08:00 (America/Fortaleza)
         "acoes-notificacoes-diarias": {
             "task": "apps.core.tasks.processar_notificacoes_acoes_diarias",

--- a/v2/backend/config/settings.py
+++ b/v2/backend/config/settings.py
@@ -843,6 +843,12 @@ IMPORT_JOB_ARTIFACT_RETENTION_DAYS = int(os.getenv("IMPORT_JOB_ARTIFACT_RETENTIO
 AUDITLOG_RETENTION_DAYS = int(os.getenv("AUDITLOG_RETENTION_DAYS", "1825"))
 # S3 bucket name (without s3://). Use empty string to disable uploads.
 BACKUP_S3_BUCKET = os.getenv("BACKUP_S3_BUCKET", "")
+# Dead-man do backup (task `backup.check_backup_freshness`, roda diariamente): se o
+# backup mais recente passar deste limite — ou se nao houver backup — dispara alarme
+# (logger.error + Sentry). Default 24h: o backup e diario as 2am e a checagem das 6am
+# separa o dia saudavel (~4h) do primeiro dia perdido (~28h). Foi a ausencia deste
+# alarme que deixou o backup morrer 10 dias em silencio (2026-08).
+BACKUP_DEADMAN_MAX_AGE_HOURS = int(os.getenv("BACKUP_DEADMAN_MAX_AGE_HOURS", "24"))
 
 # Removidos (#1541): USE_EXTERNAL_HASH_V2 (nunca lido — auditoria_planilhas_v2 usa
 # compute_hash_v2 incondicional) e os gates ETL_MAX_DUPLICATES_PCT /


### PR DESCRIPTION
## Resumo

Dead-man switch **diário** para o backup automático. O backup diário (2am) morreu em
silêncio por ~10 dias (2026-08-03 → 08-17) e só foi descoberto quando o gate de backup
fresco do deploy travou. O único guardião existente (`verify_backup_health`) roda **apenas
aos domingos** — janela larga demais para um artefato de recuperação de desastre.

Nova task `backup.check_backup_freshness` (beat diário 6am): se o backup mais recente
passar de `BACKUP_DEADMAN_MAX_AGE_HOURS` (default 24h) **ou inexistir**, dispara alarme via
`logger.error` (chega a alguém mesmo com `SENTRY_DSN` vazio em prod) + Sentry quando há DSN.

### O que mudou
- `apps/core/tasks_backup.py`: task `check_backup_freshness` + helper `_latest_backup_age_hours`
  (SSOT do frescor — o fix do sufixo `.age`/SEC-017 passa a viver num lugar só, reusado por
  `verify_backup_health`) + `_alert_backup_deadman`.
- `config/celery.py`: entrada de beat `daily-backup-deadman-check` (crontab 6am).
- `config/settings.py`: `BACKUP_DEADMAN_MAX_AGE_HOURS` (env-tunable, default 24).
- `tests/test_celery_beat_registration.py`: sentinela estendida — exige a task agendada
  **e** registrada (autodiscover), fechando o mesmo buraco #1455 que deixou o backup morrer.

### Por que 6am / 24h
Backup 2am (timeout 1h): dia saudável ~4h de idade (**passa**), 1º dia perdido ~28h
(**dispara**). Separação limpa com o limite de 24h.

### Limitação residual (honesta)
Se o próprio beat/worker morrer, esta task também não roda. O backstop **externo** continua
sendo o gate `check_backup.sh` do `aprender-applier`, que recusa deploy sem backup fresco.

## Checklist Tecnico (Code Review Expert - Slim)

- [x] Arquitetura e SOLID: task de responsabilidade única + helper compartilhado (SSOT do frescor)
- [x] Seguranca: sem segredo, sem novo vetor; alarme não expõe PII (só nome do artefato)
- [x] Performance: um glob de diretório por dia — custo desprezível
- [x] Tratamento de erros: `missing` / `stale` / `fresh` cobertos; dir inexistente → `missing`
- [x] Condicoes de fronteira: sem backup, backup cifrado `.age`, threshold custom

## Workflow (Superpowers - Parcial)

- [x] Escopo definido em ate 5 passos objetivos antes da implementacao
- [x] Testes criados/ajustados (TDD RED→GREEN): fresh/stale/missing/`.age`/threshold/registro + sentinela de beat
- [x] Evidencias anexadas (outputs de teste): 24/24 verde na suíte celery/backup/schedule; Black + isort + ruff-lint limpos

## Validacoes

- [x] Checks `[required]` verdes (somente gates bloqueantes)
- [x] Checks `[info]` revisados quando falharem (sem bloquear merge)
- [x] Sem alteracoes fora do escopo combinado
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `0f45136f`, slot `0` / projeto `aprender_staging`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
