### PR TITLE
fix(auditoria): redige CPF em AuditLog.details.username de login (M03-10)

### DIFF
--- a/v2/backend/apps/core/pii.py
+++ b/v2/backend/apps/core/pii.py
@@ -1,0 +1,29 @@
+"""Redacao central de PII (LGPD art. 46) para caminhos de PERSISTENCIA.
+
+O `PIIRedactionFilter` (logging_filters.py) protege o pipeline de LOGS. Este modulo
+cobre o que o filtro de log nao alcanca: valores que vao para o banco (ex.: o JSONField
+`AuditLog.details`). Um helper por tipo de dado sensivel, reusavel na escrita e na leitura.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+# CPF nas DUAS formas: 11 digitos crus OU formatado 000.000.000-00. As ancoras `\b`
+# garantem que so o TOKEN inteiro casa — um username como `user_<hex>` (digitos cercados
+# de word-chars) NAO tem fronteira de palavra no meio e por isso nunca e alterado.
+_CPF_RE = re.compile(r"\b(?:\d{3}\.\d{3}\.\d{3}-\d{2}|\d{11})\b")
+
+# Convencao alinhada ao PIIRedactionFilter dos logs (logging_filters.py).
+_CPF_PLACEHOLDER = "<cpf>"
+
+
+def redact_cpf(value: Any) -> Any:
+    """Troca qualquer CPF (cru ou formatado) por `<cpf>`; no-op se nao houver CPF.
+
+    Defensivo para JSONField heterogeneo: valores nao-string voltam intactos.
+    """
+    if not isinstance(value, str):
+        return value
+    return _CPF_RE.sub(_CPF_PLACEHOLDER, value)

--- a/v2/backend/apps/core/serializers/auditoria.py
+++ b/v2/backend/apps/core/serializers/auditoria.py
@@ -16,6 +16,7 @@ from typing import Any
 from rest_framework import serializers  # type: ignore[attr-defined]
 
 from apps.core.models import AuditLog
+from apps.core.pii import redact_cpf
 
 # SEC-AUDIT-01: PII fields to redact for non-superuser access
 _PII_KEYS_TO_REMOVE = {"user_agent"}
@@ -57,6 +58,11 @@ def _redact_details(details: Any) -> Any:
                 redacted[key] = _mask_email(value)
             else:
                 redacted[key] = "***"
+        elif key == "username" and isinstance(value, str):
+            # M03-10 (#1657): 'username' de login pode ser um CPF -> redigir POR VALOR
+            # (nao por chave: 'admin'/username real devem passar). Cobre linhas legadas
+            # gravadas antes da redacao na escrita (views_auth.py).
+            redacted[key] = redact_cpf(value)
         elif isinstance(value, dict):
             redacted[key] = _redact_details(value)
         else:

--- a/v2/backend/apps/core/tests/test_sec_enum_audit.py
+++ b/v2/backend/apps/core/tests/test_sec_enum_audit.py
@@ -196,6 +196,14 @@ class TestAuditLogPIIRedaction(TestCase):
         assert redacted["target_username"] == "***"
         assert redacted["target_user_id"] == 42  # id nao e PII, preservado
 
+    def test_redact_username_cpf_by_value(self):
+        # M03-10 (#1657): 'username' (login) que E um CPF e redigido POR VALOR na leitura,
+        # nas duas formas (cru e formatado); username nao-CPF e preservado — nao e mask
+        # por chave (senao 'admin' viraria '***' e quebraria test_redact_preserves_non_pii).
+        assert _redact_details({"username": "11144477735"})["username"] == "<cpf>"
+        assert _redact_details({"username": "111.444.777-35"})["username"] == "<cpf>"
+        assert _redact_details({"username": "admin"})["username"] == "admin"
+
     def test_redact_preserves_non_pii(self):
         details = {
             "username": "admin",

--- a/v2/backend/apps/core/tests/test_views_auth.py
+++ b/v2/backend/apps/core/tests/test_views_auth.py
@@ -214,6 +214,18 @@ def test_login_invalid_credentials_rejected(api_client, usuario_ativo):
     assert "lockout_minutes" not in response.data
 
 
+@pytest.mark.parametrize("cpf_username", ["11144477735", "111.444.777-35"])
+def test_login_failed_redige_cpf_no_details_username(api_client, cpf_username):
+    """M03-10 (#1657): CPF usado como username em login falho NAO pode ser gravado em
+    claro no AuditLog.details (PII-at-rest, LGPD art. 46). Redige na ESCRITA, nas duas
+    formas (cru e formatado)."""
+    resp = api_client.post("/api/auth/login/", {"username": cpf_username, "password": "wrongpass"}, format="json")
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST
+    log = AuditLog.objects.filter(action="LOGIN_FAILED").latest("created_at")
+    assert log.details["username"] == "<cpf>"
+    assert cpf_username not in str(log.details)
+
+
 @override_settings(ACCOUNT_LOCKOUT_THRESHOLD=1, ACCOUNT_LOCKOUT_DURATION=900)
 def test_login_locked_account_returns_generic_error_response(api_client, usuario_ativo):
     """

--- a/v2/backend/apps/core/views_auth.py
+++ b/v2/backend/apps/core/views_auth.py
@@ -31,6 +31,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.throttling import AnonRateThrottle
 
+from apps.core.pii import redact_cpf
 from apps.core.views.utils import _get_client_ip
 
 from .models import AuditLog
@@ -226,7 +227,7 @@ def login(request: Request) -> Response:
             action=AuditLog.Action.LOGIN_BLOCKED,
             model_name="Usuario",
             details={
-                "username": username,
+                "username": redact_cpf(username),
                 "ip_address": client_ip,
                 "user_agent": request.META.get("HTTP_USER_AGENT", "")[:200],
                 "reason": "account_locked",
@@ -249,7 +250,7 @@ def login(request: Request) -> Response:
             action=AuditLog.Action.LOGIN_FAILED,
             model_name="Usuario",
             details={
-                "username": username,
+                "username": redact_cpf(username),
                 "ip_address": client_ip,
                 "user_agent": request.META.get("HTTP_USER_AGENT", "")[:200],
                 "reason": "invalid_credentials",
@@ -269,7 +270,7 @@ def login(request: Request) -> Response:
             action=AuditLog.Action.LOGIN_FAILED,
             model_name="Usuario",
             details={
-                "username": username,
+                "username": redact_cpf(username),
                 "ip_address": client_ip,
                 "user_agent": request.META.get("HTTP_USER_AGENT", "")[:200],
                 "reason": "inactive_user",


### PR DESCRIPTION
## Resumo

**M03-10 (#1657, épico LGPD)** — fecha o residual do parcial `6b35fa40`.

O `username` de uma tentativa de login **pode ser um CPF** (no sistema `username=cpf`). Hoje
ele é gravado **em claro** no JSONField `AuditLog.details` (PII-at-rest, LGPD art. 46) e
devolvido a auditores **não-superuser**. O parcial anterior só redigia no pipeline de **logs**
(`PIIRedactionFilter`), nunca no caminho de **persistência**.

### O que mudou
- **`apps/core/pii.py`** (novo): helper central `redact_cpf(value)` — regex das **duas formas**
  (cru `11144477735` e formatado `111.444.777-35`). As âncoras `\b` garantem que só o **token-CPF
  inteiro** casa: um username tipo `user_<hex>` (dígitos cercados de word-chars) **nunca** é alterado.
- **Escrita** (`views_auth.py`): redige `details['username']` nos **3 sites de login falho**
  (`LOGIN_BLOCKED`, `LOGIN_FAILED` invalid, `LOGIN_FAILED` inactive) → o CPF **nunca chega ao banco**.
- **Leitura** (`serializers/auditoria.py::_redact_details`): redige `username` **por valor** (não
  mask por chave — `admin` e usernames reais continuam passando), cobrindo **linhas legadas** já gravadas.

### Por que não usei o `_PII_KEYS_TO_MASK`
Mascarar por chave (`username → ***`) quebraria `test_redact_preserves_non_pii` (username `admin`
deve passar). A redação por valor só age quando o valor **parece um CPF**.

## Validações (TDD RED→GREEN, no Docker)

- **RED provado**: os 3 testes novos falharam com o CPF cru antes do fix.
- **GREEN**: 53 verdes — `test_views_auth.py` (15) + `test_sec_enum_audit.py` (17) +
  `test_pr6_audit_logs_policy.py` (21). **0 regressão.**
- Black + isort limpos.

## Escopo

- Backend, **sem migration**, **sem mudança de contrato FE↔BE** (aditivo server-side; nenhum
  campo novo na resposta de `/api/audit-logs/`).
- Superuser continua vendo detalhes completos (linhas novas já nascem redigidas na escrita).
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `78fb8683`, slot `0` / projeto `aprender_staging`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
