### PR TITLE
fix(auditoria): audita create/update/activate/deactivate de usuario no REST (M07-03)

### DIFF
--- a/v2/backend/apps/core/admin.py
+++ b/v2/backend/apps/core/admin.py
@@ -129,32 +129,15 @@ class UsuarioAdmin(admin.ModelAdmin):
         Mudança de grupos vai pelo `save_related` (m2m). O change_view do admin já
         roda em `transaction.atomic()`, então o on_commit reflete o commit real.
         """
-        from apps.core.services.audit import registrar_auditoria
+        from apps.core.services.audit import auditar_privilege_flags
 
         before: dict[str, Any] = {}
         if change and obj.pk:
             before = Usuario.objects.filter(pk=obj.pk).values("is_superuser", "is_staff", "is_active").first() or {}
         super().save_model(request, obj, form, change)
-
-        changes: dict[str, Any] = {}
-        for flag in ("is_superuser", "is_staff", "is_active"):
-            after_val = bool(getattr(obj, flag))
-            before_val = before.get(flag)
-            # Em criação (change=False) só audita flag LIGADA (concessão inicial).
-            if (change and before_val != after_val) or (not change and after_val):
-                changes[flag] = {"before": before_val, "after": after_val}
-        if changes:
-            registrar_auditoria(
-                actor=request.user,
-                action=AuditLog.Action.USER_PRIVILEGE_CHANGED,
-                model_name="Usuario",
-                details={
-                    "target_user_id": obj.pk,
-                    "target_username": obj.username,
-                    "changes": changes,
-                    "via": "django_admin",
-                },
-            )
+        # SSOT com o path REST (#1618): mesma logica before/after + contrato de details,
+        # para os dois caminhos (Admin e API) nao voltarem a divergir.
+        auditar_privilege_flags(actor=request.user, target_user=obj, before=(before or None), via="django_admin")
 
     def save_related(self, request: HttpRequest, form: Any, formsets: Any, change: bool) -> None:
         """

--- a/v2/backend/apps/core/serializers/usuario.py
+++ b/v2/backend/apps/core/serializers/usuario.py
@@ -18,11 +18,13 @@ from django.core.exceptions import ValidationError
 from rest_framework import serializers  # type: ignore[attr-defined]
 
 from apps.core.constants import FUNCAO_GROUPS, RESERVED_GROUPS, SETOR_GROUPS
-from apps.core.models import GroupClassificacao, PermissaoFuncional
+from apps.core.models import AuditLog, GroupClassificacao, PermissaoFuncional
 from apps.core.services.audit import (
     auditar_assign_groups,
     auditar_group_capabilities_set,
+    auditar_privilege_flags,
     auditar_reset_senha,
+    registrar_auditoria,
 )
 from apps.core.services.rbac_service import get_assignable_group_names
 
@@ -278,6 +280,16 @@ class UsuarioAdminSerializer(serializers.ModelSerializer):
         user = super().create(validated_data)
         actor = self._actor()
 
+        # M07-03 (#1618): a criacao e a concessao inicial de flags auditam igual ao
+        # Django Admin (antes o path REST so auditava senha e grupos).
+        registrar_auditoria(
+            actor=actor,
+            action=AuditLog.Action.CREATE,
+            model_name="Usuario",
+            details={"target_user_id": user.pk, "target_username": user.username},
+        )
+        auditar_privilege_flags(actor=actor, target_user=user, before=None, via="rest_api")
+
         if password:
             user.set_password(password)
             user.save()
@@ -306,8 +318,23 @@ class UsuarioAdminSerializer(serializers.ModelSerializer):
         password = validated_data.pop("password", None)
         actor = self._actor()
         before_group_ids = set(instance.groups.values_list("pk", flat=True))
+        # M07-03 (#1618): snapshot dos flags ANTES do super().update (DRF muta a instance
+        # in-place — ler depois daria before==after e nada auditaria).
+        before_flags = {f: bool(getattr(instance, f)) for f in ("is_superuser", "is_staff", "is_active")}
+        cadastral_keys = sorted(k for k in validated_data if k not in ("is_superuser", "is_staff", "is_active"))
 
         user = super().update(instance, validated_data)
+
+        # M07-03: flip de privilegio via REST (activate/deactivate/promote) audita igual ao Admin.
+        auditar_privilege_flags(actor=actor, target_user=user, before=before_flags, via="rest_api")
+        # M07-03: alteracao cadastral — so os NOMES dos campos escritos (nunca valores/PII).
+        if cadastral_keys:
+            registrar_auditoria(
+                actor=actor,
+                action=AuditLog.Action.UPDATE,
+                model_name="Usuario",
+                details={"target_user_id": user.pk, "target_username": user.username, "campos": cadastral_keys},
+            )
 
         if password:
             user.set_password(password)

--- a/v2/backend/apps/core/services/audit.py
+++ b/v2/backend/apps/core/services/audit.py
@@ -283,3 +283,43 @@ def auditar_user_delete(
         },
         imediato=imediato,
     )
+
+
+def auditar_privilege_flags(
+    *,
+    actor: Any,
+    target_user: Any,
+    before: dict[str, Any] | None,
+    via: str,
+    imediato: bool = False,
+) -> bool:
+    """Auditoria dos flips de flags de PRIVILEGIO (is_superuser/is_staff/is_active).
+
+    `before` = snapshot {flag: valor} lido ANTES da mutacao, ou None na criacao. Em
+    update audita cada flag que mudou; em create (before=None) audita a flag LIGADA
+    (concessao inicial). Emite UM `USER_PRIVILEGE_CHANGED` com o contrato do Django
+    Admin (target_user_id, target_username, changes, via) — SSOT para os dois caminhos
+    (Admin e REST), para nao voltarem a divergir (#1618). Retorna True se registrou.
+    """
+    is_create = before is None
+    changes: dict[str, Any] = {}
+    for flag in ("is_superuser", "is_staff", "is_active"):
+        after_val = bool(getattr(target_user, flag))
+        before_val = None if is_create else before.get(flag)
+        if (not is_create and before_val != after_val) or (is_create and after_val):
+            changes[flag] = {"before": before_val, "after": after_val}
+    if not changes:
+        return False
+    registrar_auditoria(
+        actor=actor,
+        action=AuditLog.Action.USER_PRIVILEGE_CHANGED,
+        model_name="Usuario",
+        details={
+            "target_user_id": target_user.pk,
+            "target_username": getattr(target_user, "username", None),
+            "changes": changes,
+            "via": via,
+        },
+        imediato=imediato,
+    )
+    return True

--- a/v2/backend/apps/core/tests/test_audit_privilege_sites.py
+++ b/v2/backend/apps/core/tests/test_audit_privilege_sites.py
@@ -220,6 +220,74 @@ class TestDeletions:
 
 
 # ============================================================================
+# M07-03 (#1618): usuarios-admin REST audita create/update/activate/deactivate
+# (o path REST antes so auditava senha e grupos; o flip de flags e a criacao
+#  ficavam sem trilha — assimetria com o Django Admin, que ja auditava)
+# ============================================================================
+
+
+class TestUsuarioCadastralViaREST:
+    def test_deactivate_audita_privilege(self, api_client, superuser, common_user, django_capture_on_commit_callbacks):
+        api_client.force_authenticate(user=superuser)
+        AuditLog.objects.filter(action="USER_PRIVILEGE_CHANGED").delete()
+        with django_capture_on_commit_callbacks(execute=True):
+            resp = api_client.patch(f"/api/usuarios-admin/{common_user.id}/", {"is_active": False}, format="json")
+        assert resp.status_code == 200, resp.content
+        log = AuditLog.objects.filter(action="USER_PRIVILEGE_CHANGED").latest("created_at")
+        assert log.details["changes"]["is_active"] == {"before": True, "after": False}
+        assert log.details["via"] == "rest_api"
+        assert log.details["target_user_id"] == common_user.id
+
+    def test_promote_superuser_audita_privilege(
+        self, api_client, superuser, common_user, django_capture_on_commit_callbacks
+    ):
+        api_client.force_authenticate(user=superuser)
+        AuditLog.objects.filter(action="USER_PRIVILEGE_CHANGED").delete()
+        with django_capture_on_commit_callbacks(execute=True):
+            resp = api_client.patch(f"/api/usuarios-admin/{common_user.id}/", {"is_superuser": True}, format="json")
+        assert resp.status_code == 200, resp.content
+        log = AuditLog.objects.filter(action="USER_PRIVILEGE_CHANGED").latest("created_at")
+        assert log.details["changes"]["is_superuser"] == {"before": False, "after": True}
+        assert log.details["via"] == "rest_api"
+
+    def test_create_usuario_audita(self, api_client, superuser, django_capture_on_commit_callbacks):
+        api_client.force_authenticate(user=superuser)
+        AuditLog.objects.filter(action="CREATE", model_name="Usuario").delete()
+        with django_capture_on_commit_callbacks(execute=True):
+            resp = api_client.post(
+                "/api/usuarios-admin/",
+                {
+                    "username": "novo_m0703",
+                    "cpf": "11144477735",
+                    "password": "SenhaForte123",  # gitleaks:allow (literal de teste, nao e segredo)
+                    "email": "novo_m0703@t.com",
+                    "first_name": "Novo",
+                    "last_name": "User",
+                },
+                format="json",
+            )
+        assert resp.status_code == 201, resp.content
+        log = AuditLog.objects.filter(action="CREATE", model_name="Usuario").latest("created_at")
+        assert log.details["target_username"] == "novo_m0703"
+        assert "target_user_id" in log.details
+
+    def test_update_cadastral_audita_sem_pii(
+        self, api_client, superuser, common_user, django_capture_on_commit_callbacks
+    ):
+        api_client.force_authenticate(user=superuser)
+        AuditLog.objects.filter(action="UPDATE", model_name="Usuario").delete()
+        with django_capture_on_commit_callbacks(execute=True):
+            resp = api_client.patch(
+                f"/api/usuarios-admin/{common_user.id}/", {"email": "novo_email@t.com"}, format="json"
+            )
+        assert resp.status_code == 200, resp.content
+        log = AuditLog.objects.filter(action="UPDATE", model_name="Usuario").latest("created_at")
+        assert "email" in log.details["campos"]
+        # contrato PII: o VALOR do campo nunca entra nos details, so o NOME do campo
+        assert "novo_email@t.com" not in str(log.details)
+
+
+# ============================================================================
 # Import de usuários (apply audita; dry-run não)
 # ============================================================================
 


### PR DESCRIPTION
## Resumo

**M07-03 (#1618)** — fecha o residual do parcial `aba033f1`.

O `UsuarioAdminViewSet` (`POST/PUT/PATCH /api/usuarios-admin/`) só deixava trilha de auditoria
para **senha** e **grupos**. Ficavam **sem `AuditLog`**:
- a **criação** do usuário,
- a **alteração cadastral** (email/nome/telefone/cargo…),
- o **flip de `is_superuser`/`is_active`** via REST — ou seja, **activate/deactivate/promote**.

Isso era uma **assimetria de segurança**: a mesma mutação pelo **Django Admin** já gerava
`USER_PRIVILEGE_CHANGED` (`save_model`), mas pela **API** não deixava rastro.

### O que mudou
- **`services/audit.py::auditar_privilege_flags`** (novo): SSOT do `before/after` de
  `is_superuser`/`is_staff`/`is_active` + contrato de `details`. O **`save_model` do Admin passa a
  reusar esse helper** → os dois caminhos (Admin e REST) **não voltam a divergir** (a causa raiz).
- **`UsuarioAdminSerializer.create`**: emite `CREATE` + `auditar_privilege_flags(before=None)`.
- **`UsuarioAdminSerializer.update`**: snapshot dos flags **antes** do `super().update()` (o DRF muta
  a instance in-place), depois `auditar_privilege_flags(before)` + `UPDATE` com os **nomes** dos campos
  cadastrais escritos — **nunca valores/PII**.

## Validações (TDD RED→GREEN, no Docker)

- **RED provado**: os 4 testes novos falharam com `AuditLog.DoesNotExist` antes do fix.
- **GREEN**: `test_audit_privilege_sites.py` **17/17** + rede de regressão **195 passed / 0 fail**
  (`test_admin_api`, `test_admin_user_security`, `test_anonimizacao_usuario`, `test_assign_groups`,
  `test_modular_serializers`, `test_rbac_matrix_endpoint_coverage`, `test_rbac_superuser_target_protection`,
  `test_rbac_tier0_group_gate`).
- Black + isort limpos.

## Escopo

- Backend, **sem migration** (`CREATE`/`UPDATE`/`USER_PRIVILEGE_CHANGED` já no enum), **sem mudança de
  contrato FE↔BE** (aditivo server-side).
- `target_username` nos `details` segue o contrato existente (mascarado na leitura para não-superuser via `_PII_KEYS_TO_MASK`).
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `a8ec7881`, slot `0` / projeto `aprender_staging`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
