### PR TITLE
fix(deslocamentos): latest-wins nos filtros, descarta resposta out-of-order (M09-06)

### DIFF
--- a/v2/frontend/src/api/deslocamentos.ts
+++ b/v2/frontend/src/api/deslocamentos.ts
@@ -74,10 +74,11 @@ export interface DeslocamentoPayload {
  * Lista deslocamentos visíveis ao usuário (paginado, 50 por página).
  */
 export async function listDeslocamentos(
-  filters: DeslocamentoFilters = {}
+  filters: DeslocamentoFilters = {},
+  options: { signal?: AbortSignal } = {}
 ): Promise<PaginatedResponse<DeslocamentoRecord>> {
   const url = buildUrl('/deslocamentos/', filters as QueryParams);
-  return await fetchAPI<PaginatedResponse<DeslocamentoRecord>>(url);
+  return await fetchAPI<PaginatedResponse<DeslocamentoRecord>>(url, { ...options });
 }
 
 /**

--- a/v2/frontend/src/pages/Deslocamentos/DeslocamentosPage.tsx
+++ b/v2/frontend/src/pages/Deslocamentos/DeslocamentosPage.tsx
@@ -17,7 +17,7 @@
  * - DELETE /api/deslocamentos/{id}/ (delete)
  */
 
-import { useState, useEffect, useCallback, ChangeEvent, JSX } from 'react';
+import { useState, useEffect, useCallback, useRef, ChangeEvent, JSX } from 'react';
 import {
   Table,
   Button,
@@ -121,11 +121,19 @@ export default function DeslocamentosPage(): JSX.Element {
     loadUser();
   }, []);
 
+  // M09-06 (#1622): guarda de sequência (latest-wins). O debounce reduz mas não
+  // elimina a corrida — se um request antigo (filtro obsoleto) resolver DEPOIS do
+  // atual, ele sobrescreveria a tabela com o resultado errado. Espelha o idioma
+  // canônico de useAvailabilityPreview.ts (seqRef + AbortController).
+  const seqRef = useRef(0);
+
   // Load deslocamentos
-  const loadDeslocamentos = useCallback(async (page = 1): Promise<void> => {
+  const loadDeslocamentos = useCallback(async (page = 1, signal?: AbortSignal): Promise<void> => {
+    const seq = ++seqRef.current;
     setTableLoading(true);
     try {
-      const data = await listDeslocamentos({ ...filters, page });
+      const data = await listDeslocamentos({ ...filters, page }, { signal });
+      if (seq !== seqRef.current) return; // resposta obsoleta: um filtro/página mais novo venceu
       setDeslocamentos(data.results || []);
       setPagination({
         current: page,
@@ -133,9 +141,11 @@ export default function DeslocamentosPage(): JSX.Element {
         total: data.count || 0,
       });
     } catch (error) {
+      if (signal?.aborted) return; // cancelamento no cleanup não é falha
+      if (seq !== seqRef.current) return; // erro de request obsoleto: não polui a UI atual
       message.error((error as Error).message);
     } finally {
-      setTableLoading(false);
+      if (seq === seqRef.current) setTableLoading(false);
     }
   }, [filters]);
 
@@ -157,14 +167,20 @@ export default function DeslocamentosPage(): JSX.Element {
   }, [canAccess, loadFormadores]);
 
   // Lista recarrega ao mudar filtros, com debounce (evita 1 request por tecla).
+  // O AbortController cancela o request em voo quando o filtro muda de novo (o
+  // seqRef já descarta a resposta obsoleta; o abort evita o trabalho de rede).
   useEffect(() => {
     if (!canAccess) {
       return;
     }
+    const controller = new AbortController();
     const timer = setTimeout(() => {
-      loadDeslocamentos(1);
+      loadDeslocamentos(1, controller.signal);
     }, 350);
-    return () => clearTimeout(timer);
+    return () => {
+      clearTimeout(timer);
+      controller.abort();
+    };
   }, [canAccess, filters, loadDeslocamentos]);
 
   // Handle table change (pagination)

--- a/v2/frontend/src/pages/Deslocamentos/__tests__/DeslocamentosPage.filtros.test.tsx
+++ b/v2/frontend/src/pages/Deslocamentos/__tests__/DeslocamentosPage.filtros.test.tsx
@@ -66,7 +66,10 @@ describe('DeslocamentosPage — filtros (#1622)', () => {
 
     // O fetch de filtro (debounced) acontece com o valor digitado.
     await waitFor(() =>
-      expect(listDeslocamentosMock).toHaveBeenCalledWith(expect.objectContaining({ origem: 'Fortaleza' }))
+      expect(listDeslocamentosMock).toHaveBeenCalledWith(
+        expect.objectContaining({ origem: 'Fortaleza' }),
+        expect.anything()
+      )
     );
 
     // A página NÃO desmontou para "Carregando..." — o card de Filtros permanece.
@@ -77,5 +80,55 @@ describe('DeslocamentosPage — filtros (#1622)', () => {
 
     // As opções de formador NÃO são refetadas a cada mudança de filtro.
     expect(listFormadoresMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('resposta fora de ordem: o filtro mais recente vence (latest-wins)', async () => {
+    const resultado = (id: number, nome: string, origem: string) => ({
+      count: 1,
+      next: null,
+      previous: null,
+      results: [
+        {
+          id,
+          usuario: 1,
+          usuario_nome: nome,
+          origem,
+          destino: 'Destino',
+          start_date: '2026-01-01',
+          end_date: '2026-01-02',
+        },
+      ],
+    });
+
+    renderPage();
+    const origem = (await screen.findByPlaceholderText('Origem', undefined, { timeout: 5000 })) as HTMLInputElement;
+    await waitFor(() => expect(listDeslocamentosMock).toHaveBeenCalled()); // load inicial
+
+    // 1º filtro 'A' → request LENTO (resolvido sob controle, mais tarde).
+    let resolveStale!: (v: unknown) => void;
+    listDeslocamentosMock.mockImplementationOnce(() => new Promise((resolve) => (resolveStale = resolve)));
+    fireEvent.change(origem, { target: { value: 'A' } });
+    await waitFor(() =>
+      expect(listDeslocamentosMock).toHaveBeenCalledWith(expect.objectContaining({ origem: 'A' }), expect.anything())
+    );
+
+    // 2º filtro 'AB' → request RÁPIDO (resolvido sob controle, antes).
+    let resolveFresh!: (v: unknown) => void;
+    listDeslocamentosMock.mockImplementationOnce(() => new Promise((resolve) => (resolveFresh = resolve)));
+    fireEvent.change(origem, { target: { value: 'AB' } });
+    await waitFor(() =>
+      expect(listDeslocamentosMock).toHaveBeenCalledWith(expect.objectContaining({ origem: 'AB' }), expect.anything())
+    );
+
+    // Resolve o MAIS NOVO ('AB') primeiro; a tabela mostra o resultado dele.
+    resolveFresh(resultado(99, 'FormadorFresh', 'AB'));
+    await screen.findByText('FormadorFresh');
+
+    // ...e o OBSOLETO ('A') chega DEPOIS (fora de ordem) — NÃO pode sobrescrever.
+    resolveStale(resultado(11, 'FormadorStale', 'A'));
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(screen.getByText('FormadorFresh')).toBeInTheDocument();
+    expect(screen.queryByText('FormadorStale')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Resumo

**M09-06 (#1622)** — fecha o residual do parcial `6d73ba29`.

O parcial consertou o **remount** da página (split loading, inputs controlados, debounce).
Mas a **corrida out-of-order** dos filtros continuava: `loadDeslocamentos` fazia
`setDeslocamentos(data.results)` **incondicional**. Se um request de filtro **antigo**
resolvesse **depois** do atual (rede mais lenta), ele **sobrescrevia** a tabela com o
resultado do filtro errado. O debounce (350ms) **reduz mas não elimina** — basta o 1º
request ficar lento e o 2º voltar antes.

### O que mudou (cirúrgico — não toca o que o parcial entregou)
- **`api/deslocamentos.ts`**: `listDeslocamentos(filters, { signal })` repassa o `signal` ao `fetchAPI`.
- **`DeslocamentosPage.tsx`**: guarda de sequência **`seqRef`** (latest-wins) + **`AbortController`** no
  efeito de filtro — espelhando o idioma canônico já usado em `useAvailabilityPreview.ts`.
  `setDeslocamentos` só aplica se `seq === seqRef.current`; `abort()` no cleanup; erro de request
  obsoleto/abortado não polui a UI atual.

## Validações (TDD RED→GREEN, no Docker)

- **RED provado**: removendo só o guard `seqRef`, o teste out-of-order falha (o resultado obsoleto
  'A' sobrescreve 'AB').
- **GREEN**: `DeslocamentosPage.filtros.test.tsx` **2/2** — o teste novo simula o filtro lento 'A'
  resolvendo **depois** do rápido 'AB' e prova que a tabela mostra **'AB'** (descarta 'A').
- `tsc --noEmit` + `eslint` limpos.

## Escopo

- Frontend apenas, sem mudança de contrato de API. O `fetchAPI` já encaminha `signal`.
- Nota de acompanhamento (fora deste PR): o hook compartilhado `useTableFilters.ts` tem a
  **mesma lacuna** — pode virar um follow-up sob o épico #1668.
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `67f4dd7e`, slot `0` / projeto `aprender_staging`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
