### PR TITLE
fix(solicitacao): valida elegibilidade de compra tambem no PATCH (#1738)

### DIFF
--- a/v2/backend/apps/core/serializers/solicitacao.py
+++ b/v2/backend/apps/core/serializers/solicitacao.py
@@ -184,14 +184,19 @@ class SolicitacaoSerializer(serializers.ModelSerializer):
                     }
                 )
 
-        # Regra 4: Elegibilidade de compra por município+projeto (somente criação)
+        # Regra 4: Elegibilidade de compra por município+projeto.
+        # Aplica na criação e sempre que o par município/projeto for (re)atribuído
+        # num update. (#1738: a checagem era create-only, então um PATCH trocando o
+        # par para um sem compra contornava a regra.) Edições que não mexem no par
+        # não disparam a checagem, preservando a edição de solicitações antigas.
         # Superuser mantém bypass explícito.
-        if instance is None:
-            request = cast(Any, self.context.get("request"))
-            user = getattr(request, "user", None)
-            if not (user and getattr(user, "is_superuser", False)):
-                municipio = attrs.get("municipio")
-                projeto = attrs.get("projeto")
+        request = cast(Any, self.context.get("request"))
+        user = getattr(request, "user", None)
+        if not (user and getattr(user, "is_superuser", False)):
+            reatribui_par = instance is None or "municipio" in attrs or "projeto" in attrs
+            if reatribui_par:
+                municipio = attrs.get("municipio", getattr(instance, "municipio", None))
+                projeto = attrs.get("projeto", getattr(instance, "projeto", None))
                 if municipio is not None and projeto is not None:
                     has_compra = Compra.objects.filter(municipio=municipio, projeto=projeto).exists()
                     if not has_compra:
@@ -199,7 +204,7 @@ class SolicitacaoSerializer(serializers.ModelSerializer):
                             {
                                 "municipio": (
                                     f"O município '{municipio.nome} - {municipio.uf}' não possui compra registrada "
-                                    f"para o projeto '{projeto.nome}'. Registre a compra antes de criar a solicitação."
+                                    f"para o projeto '{projeto.nome}'. Registre a compra antes de vincular esse par."
                                 )
                             }
                         )

--- a/v2/backend/apps/core/tests/test_solicitacao_edit.py
+++ b/v2/backend/apps/core/tests/test_solicitacao_edit.py
@@ -996,3 +996,86 @@ class TestSolicitacaoDelete:
 
         # DRF retorna 403 para não autenticados (configuração padrão)
         assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+# ============================================================================
+# TESTES DE ELEGIBILIDADE DE COMPRA NA EDIÇÃO (#1738)
+# ============================================================================
+
+
+class TestSolicitacaoEditCompraEligibility:
+    """
+    #1738: a validação de elegibilidade de compra (Regra 4 do serializer) era
+    create-only — um PATCH que (re)atribuía município/projeto para um par sem
+    Compra contornava a regra. Estes testes garantem que a checagem roda também
+    no update quando o par é alterado, e SOMENTE quando é alterado (não quebra
+    a edição de solicitações antigas cujo par não tem Compra registrada).
+    """
+
+    def _make_compra(self, municipio, projeto):
+        from apps.core.models import Compra
+
+        return Compra.objects.create(
+            codigo=f"COMP-{uuid4().hex[:8]}",
+            projeto=projeto,
+            municipio=municipio,
+            quantidade=1,
+            data=timezone.now().date(),
+            uso="teste elegibilidade",
+            external_hash=uuid4().hex,
+        )
+
+    def test_patch_changing_projeto_to_pair_without_compra_is_rejected(
+        self, api_client, usuario_owner, solicitacao_editavel
+    ):
+        """PATCH que troca o projeto para um par município+projeto SEM Compra é rejeitado (400)."""
+        api_client.force_authenticate(user=usuario_owner)
+        projeto_sem_compra = ProjetoFactory(nome=f"Projeto sem compra {uuid4().hex[:8]}", fluxo="SUPER")
+
+        response = api_client.patch(
+            f"/api/solicitacoes/{solicitacao_editavel.id}/",
+            {"projeto": projeto_sem_compra.id},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        # A API embrulha erros de validação em {code, detail, errors}.
+        errors = response.data.get("errors", response.data)
+        assert "municipio" in errors
+        solicitacao_editavel.refresh_from_db()
+        assert solicitacao_editavel.projeto_id != projeto_sem_compra.id
+
+    def test_patch_changing_projeto_to_pair_with_compra_is_allowed(
+        self, api_client, usuario_owner, solicitacao_editavel, municipio
+    ):
+        """PATCH que troca o projeto para um par COM Compra registrada é permitido (200)."""
+        api_client.force_authenticate(user=usuario_owner)
+        projeto_com_compra = ProjetoFactory(nome=f"Projeto com compra {uuid4().hex[:8]}", fluxo="SUPER")
+        self._make_compra(municipio, projeto_com_compra)
+
+        response = api_client.patch(
+            f"/api/solicitacoes/{solicitacao_editavel.id}/",
+            {"projeto": projeto_com_compra.id},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        solicitacao_editavel.refresh_from_db()
+        assert solicitacao_editavel.projeto_id == projeto_com_compra.id
+
+    def test_patch_unrelated_field_does_not_require_compra(self, api_client, usuario_owner, solicitacao_editavel):
+        """
+        Editar um campo que não é o par (ex.: observacoes) NÃO dispara a checagem de
+        compra — preserva a edição de solicitações antigas cujo par não tem Compra.
+        """
+        api_client.force_authenticate(user=usuario_owner)
+
+        response = api_client.patch(
+            f"/api/solicitacoes/{solicitacao_editavel.id}/",
+            {"observacoes": "editado sem mexer no par"},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        solicitacao_editavel.refresh_from_db()
+        assert solicitacao_editavel.observacoes == "editado sem mexer no par"

--- a/v2/docs/audits/ACHADOS_REAIS.md
+++ b/v2/docs/audits/ACHADOS_REAIS.md
@@ -112,6 +112,7 @@ revalidação dos 46 restantes.
 | `M10-04` | **P1** | aberto | solicitacoes: extra_participants aceita alvo arbitrário sem policy, sem limite e estoura 500 | Grande. `create` exige `HasPerm("create_solicitation")` (views_solicit… | #1626 | — |
 | `M10-05` | **P1** | aberto | solicitacoes: edição não reconcilia participantes — convidados e COORD_ACOMPANHA ficam órfãos e… | Existe e é o fluxo comum: 42 Coordenadores ativos + 9 Gerentes + 1 sup… | #1627 | — |
 | `M10-07` | **P1** | aberto | imports/eventos: reimport sobrescreve decisão de aprovação, owner e datas e reporta "unchanged" | DAT (3 membros ativos não-superuser) + superuser (1). `import_spreadsh… | #1628 | — |
+| `M10-08` | **P2** | em andamento | solicitações: PATCH (re)atribui município/projeto para par sem Compra — elegibilidade era create-only (auditoria dinâmica 2026-08-17) | Coordenador (42 ativos) e demais criadores editando a própria solicitação | #1738 | — |
 | `M12-19` | **P1** | aberto | Pré-agenda: polling estoura o throttle do operador e a lista mostra total inalcançável | Sim. Rota `/pre-agenda` e `/controle/pre-agenda` sao gateadas por `Req… | #1629 | — |
 | `M14-02` | **P1** | aberto | Grade mensal: evento com 2+ participantes multiplica CH, codigo e detalhes por participante | Amplo e real. `MonthlyAvailabilityView.permission_classes = [IsAuthent… | #1630 | — |
 | `M14-05` | **P1** | aberto | Disponibilidade/Grade Mensal: unificar a população da grade — visão "Todas" usa coorte históric… | Permanentemente: Controle (1 ativo), DAT (3 ativos), superuser (1) — t… | #1631 | — |


### PR DESCRIPTION
## Resumo

Corrige o bypass da validacao de elegibilidade de compra no PATCH de solicitacao (#1738, achado da auditoria dinamica 2026-08-17; reconciliado como `M10-08` em `ACHADOS_REAIS.md`).

A Regra 4 do serializer (exigir `Compra` para o par municipio+projeto) estava atras de `if instance is None:` — so rodava no create. Um PATCH trocando `municipio`/`projeto` (ambos gravaveis) para um par sem `Compra` contornava a regra. Agora a checagem roda no create **e** quando o par e (re)atribuido num update; edicoes que nao mexem no par nao disparam a checagem, preservando a edicao de solicitacoes antigas.

Fecha #1738. Relacionado ao epico #1654 e a `M10-02`/#1624 (mesma superficie PATCH, validacao distinta).

## Checklist Tecnico (Code Review Expert - Slim)

- [x] Arquitetura e SOLID: mudanca localizada no `validate()`, mesma regra reaproveitada
- [x] Seguranca: sem segredo/injecao; fecha lacuna de integridade de negocio
- [x] Performance: 1 query `.exists()` e so quando o par muda
- [x] Tratamento de erros: `ValidationError` com mensagem por campo (`municipio`)
- [x] Condicoes de fronteira: PATCH parcial (so municipio ou so projeto) usa o valor efetivo da instancia; None coberto

## Workflow (Superpowers - Parcial)

- [x] Escopo definido: mover a Regra 4 para fora do gate create-only
- [x] Testes criados/ajustados: `TestSolicitacaoEditCompraEligibility` (TDD RED->GREEN, 3 casos)
- [x] Evidencias anexadas (output de teste abaixo)

RED (antes do fix): PATCH para par sem compra retornava 200 (`assert 200 == 400`).
GREEN (depois):
```
apps/core/tests/test_solicitacao_edit.py::TestSolicitacaoEditCompraEligibility::test_patch_changing_projeto_to_pair_without_compra_is_rejected PASSED
apps/core/tests/test_solicitacao_edit.py::TestSolicitacaoEditCompraEligibility::test_patch_changing_projeto_to_pair_with_compra_is_allowed PASSED
apps/core/tests/test_solicitacao_edit.py::TestSolicitacaoEditCompraEligibility::test_patch_unrelated_field_does_not_require_compra PASSED
```
Regressao: 76 passed / 1 skipped em fluxo+lookup+publish-chain+1452+edit (0 regressoes no caminho de create).

## Staging Gate

<!-- Obrigatorio para PRs com impacto em runtime (v2/backend). -->
- [ ] `make staging-full` executado com sucesso (8/8 PASS)
- [ ] Evidencia anexada no PR (trecho de log contendo "ALL 8 CHECKS PASSED")

### Evidencia Staging Gate (obrigatorio para merge)

```text
(pendente — rodando make staging-full)
```

## Validacoes

- [x] Checks `[required]` verdes (somente gates bloqueantes)
- [x] Checks `[info]` revisados quando falharem
- [x] Sem alteracoes fora do escopo combinado (serializer + teste + doc ACHADOS)
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `b6a59cff`, slot `0` / projeto `aprender_staging`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
