### PR TITLE
fix(dat-registros): datas AVALIAR multivaloradas, para de truncar ao primeiro (M16-07)

### DIFF
--- a/v2/frontend/src/pages/DATModule/DATRegistrosPage.tsx
+++ b/v2/frontend/src/pages/DATModule/DATRegistrosPage.tsx
@@ -99,48 +99,41 @@ interface DATRegistroFormValues {
   envio_codigos_status?: string | null;
   envio_codigos_data?: Dayjs | null;
   obs_formar?: string | null;
-  // AVALIAR (a UI usa nome singular; o serializer usa o plural — ver buildDATRegistroPayload)
+  // AVALIAR: multivalorado (JSONField array). O nome do form já é o plural do serializer.
   usa_avaliar?: boolean;
   alunos_recebidos_status?: string | null;
-  alunos_recebidos_data?: Dayjs | null;
+  alunos_recebidos_datas?: Dayjs[] | null;
   alunos_validados_status?: string | null;
-  alunos_validados_data?: Dayjs | null;
+  alunos_validados_datas?: Dayjs[] | null;
   alunos_importados_status?: string | null;
-  alunos_importados_data?: Dayjs | null;
+  alunos_importados_datas?: Dayjs[] | null;
   obs_avaliar?: string | null;
 }
 
-// Mapeia o nome singular do DatePicker AVALIAR (form) para o campo plural do serializer (JSONField).
-const AVALIAR_DATE_FIELDS = [
-  ['alunos_recebidos_data', 'alunos_recebidos_datas'],
-  ['alunos_validados_data', 'alunos_validados_datas'],
-  ['alunos_importados_data', 'alunos_importados_datas'],
-] as const;
-
 const toISODate = (d?: Dayjs | null): string | null => (d ? d.format('YYYY-MM-DD') : null);
-const toISODateList = (d?: Dayjs | null): string[] => (d ? [d.format('YYYY-MM-DD')] : []);
+// M16-07: as datas AVALIAR são multivaloradas (JSONField array no serializer). Mapeia TODAS
+// as datas do DatePicker `multiple`, sem truncar ao primeiro item (o resíduo do parcial 3954e208).
+const toISODateArray = (ds?: Dayjs[] | null): string[] => (ds ?? []).map((d) => d.format('YYYY-MM-DD'));
 
 /**
  * Converte os valores do formulário no payload que os serializers DRF aceitam (M16-07):
  * - datas FORMAR (DateField) viram `YYYY-MM-DD`; sem isso o Dayjs cru vira datetime ISO
  *   (`2026-07-20T03:00:00.000Z`) e o DateField rejeita com 400, perdendo o formulário inteiro;
- * - datas AVALIAR migram do nome singular do form para o plural do serializer (JSONField
- *   multivalorado), como array de um elemento; sem isso o backend responde 200/201 e
- *   descarta as datas em silêncio.
+ * - datas AVALIAR são multivaloradas (JSONField array): o nome do form já é o plural do
+ *   serializer, então envia o array INTEIRO. Antes truncava ao primeiro item e perdia o
+ *   histórico das demais datas em silêncio.
  */
 export function buildDATRegistroPayload(values: DATRegistroFormValues): Record<string, unknown> {
-  const payload: Record<string, unknown> = {
+  return {
     ...values,
     reuniao_dat: toISODate(values.reuniao_dat),
     chaves_inscricao_data: toISODate(values.chaves_inscricao_data),
     instrucoes_data: toISODate(values.instrucoes_data),
     envio_codigos_data: toISODate(values.envio_codigos_data),
+    alunos_recebidos_datas: toISODateArray(values.alunos_recebidos_datas),
+    alunos_validados_datas: toISODateArray(values.alunos_validados_datas),
+    alunos_importados_datas: toISODateArray(values.alunos_importados_datas),
   };
-  for (const [singular, plural] of AVALIAR_DATE_FIELDS) {
-    payload[plural] = toISODateList(values[singular]);
-    delete payload[singular];
-  }
-  return payload;
 }
 
 interface ProjetoGeralOption {
@@ -271,11 +264,12 @@ export default function DATRegistrosPage(): JSX.Element {
 
   const handleEdit = (record: DATRegistroRecord) => {
     setEditingRegistro(record);
-    // Reconstrução explícita (record é frouxo, `[key: string]: unknown`): hidrata os 7
-    // DatePickers e mapeia as datas AVALIAR do plural persistido de volta ao singular do form.
+    // Reconstrução explícita (record é frouxo, `[key: string]: unknown`): hidrata os
+    // DatePickers. As datas AVALIAR persistem como array (JSONField) e voltam INTEIRAS
+    // ao DatePicker `multiple` — antes só o primeiro item era hidratado (M16-07).
     const r = record as Record<string, unknown>;
     const asDate = (v: unknown): Dayjs | null => (v ? dayjs(v as string) : null);
-    const firstOf = (v: unknown): Dayjs | null => asDate((v as string[] | undefined)?.[0]);
+    const toDateArray = (v: unknown): Dayjs[] => ((v as string[] | undefined) ?? []).map((s) => dayjs(s));
     form.setFieldsValue({
       municipio: record.municipio,
       projeto_geral: record.projeto_geral,
@@ -295,11 +289,11 @@ export default function DATRegistrosPage(): JSX.Element {
       obs_formar: record.obs_formar,
       usa_avaliar: record.usa_avaliar,
       alunos_recebidos_status: record.alunos_recebidos_status,
-      alunos_recebidos_data: firstOf(r.alunos_recebidos_datas),
+      alunos_recebidos_datas: toDateArray(r.alunos_recebidos_datas),
       alunos_validados_status: record.alunos_validados_status,
-      alunos_validados_data: firstOf(r.alunos_validados_datas),
+      alunos_validados_datas: toDateArray(r.alunos_validados_datas),
       alunos_importados_status: record.alunos_importados_status,
-      alunos_importados_data: firstOf(r.alunos_importados_datas),
+      alunos_importados_datas: toDateArray(r.alunos_importados_datas),
       obs_avaliar: record.obs_avaliar,
     });
     setModalVisible(true);
@@ -820,8 +814,8 @@ export default function DATRegistrosPage(): JSX.Element {
                         </Form.Item>
                         <Text strong>Alunos Recebidos</Text>
                       </Space>
-                      <Form.Item name="alunos_recebidos_data" noStyle>
-                        <DatePicker format="DD/MM/YYYY" placeholder="Data" style={{ width: '100%', maxWidth: 130 }} />
+                      <Form.Item name="alunos_recebidos_datas" noStyle>
+                        <DatePicker multiple format="DD/MM/YYYY" placeholder="Datas" style={{ width: '100%', minWidth: 130 }} />
                       </Form.Item>
                     </div>
                   </Card>
@@ -840,8 +834,8 @@ export default function DATRegistrosPage(): JSX.Element {
                         </Form.Item>
                         <Text strong>Alunos Validados</Text>
                       </Space>
-                      <Form.Item name="alunos_validados_data" noStyle>
-                        <DatePicker format="DD/MM/YYYY" placeholder="Data" style={{ width: '100%', maxWidth: 130 }} />
+                      <Form.Item name="alunos_validados_datas" noStyle>
+                        <DatePicker multiple format="DD/MM/YYYY" placeholder="Datas" style={{ width: '100%', minWidth: 130 }} />
                       </Form.Item>
                     </div>
                   </Card>
@@ -860,8 +854,8 @@ export default function DATRegistrosPage(): JSX.Element {
                         </Form.Item>
                         <Text strong>Alunos Importados</Text>
                       </Space>
-                      <Form.Item name="alunos_importados_data" noStyle>
-                        <DatePicker format="DD/MM/YYYY" placeholder="Data" style={{ width: '100%', maxWidth: 130 }} />
+                      <Form.Item name="alunos_importados_datas" noStyle>
+                        <DatePicker multiple format="DD/MM/YYYY" placeholder="Datas" style={{ width: '100%', minWidth: 130 }} />
                       </Form.Item>
                     </div>
                   </Card>

--- a/v2/frontend/src/pages/DATModule/__tests__/buildDATRegistroPayload.test.ts
+++ b/v2/frontend/src/pages/DATModule/__tests__/buildDATRegistroPayload.test.ts
@@ -5,10 +5,11 @@ import { buildDATRegistroPayload } from '../DATRegistrosPage';
 
 /**
  * M16-07: o formulário de /dat/registros perdia datas em silêncio.
- * Estas asserções codificam o contrato que o payload precisa cumprir — exatamente o
- * que a lógica inline anterior violava (só `reuniao_dat` era adaptada; as demais iam
- * como Dayjs cru -> datetime ISO -> 400; as datas AVALIAR iam no nome singular ->
- * ignoradas pelo serializer -> 201/200 sem persistir).
+ * Estas asserções codificam o contrato que o payload precisa cumprir:
+ * - datas FORMAR viram `YYYY-MM-DD` (Dayjs cru -> datetime ISO -> 400 no DateField);
+ * - datas AVALIAR são multivaloradas (JSONField array): o payload envia TODAS as datas
+ *   escolhidas no DatePicker `multiple`. O resíduo do parcial 3954e208 truncava ao
+ *   primeiro item (single-picker + firstOf/toISODateList), perdendo o histórico.
  */
 describe('buildDATRegistroPayload (M16-07)', () => {
   const base = { municipio: 1, projeto_geral: 2, projeto: 3 } as const;
@@ -32,20 +33,20 @@ describe('buildDATRegistroPayload (M16-07)', () => {
     }
   });
 
-  it('mapeia datas AVALIAR do singular do form para o plural do serializer (array), removendo o singular', () => {
+  it('AVALIAR multivalorado: envia TODAS as datas escolhidas (array), sem truncar ao primeiro', () => {
     const payload = buildDATRegistroPayload({
       ...base,
-      alunos_recebidos_data: dayjs('2026-07-20'),
-      alunos_validados_data: dayjs('2026-07-21'),
-      alunos_importados_data: dayjs('2026-07-22'),
+      alunos_recebidos_datas: [dayjs('2026-07-20'), dayjs('2026-08-01')],
+      alunos_validados_datas: [dayjs('2026-07-21')],
+      alunos_importados_datas: [dayjs('2026-07-22'), dayjs('2026-09-10'), dayjs('2026-10-05')],
     });
 
-    expect(payload.alunos_recebidos_datas).toEqual(['2026-07-20']);
+    // TODAS as datas preservadas — o resíduo antigo reduzia o array ao primeiro item.
+    expect(payload.alunos_recebidos_datas).toEqual(['2026-07-20', '2026-08-01']);
     expect(payload.alunos_validados_datas).toEqual(['2026-07-21']);
-    expect(payload.alunos_importados_datas).toEqual(['2026-07-22']);
+    expect(payload.alunos_importados_datas).toEqual(['2026-07-22', '2026-09-10', '2026-10-05']);
 
-    // O nome singular NÃO pode vazar no payload (é o campo que o serializer ignora hoje
-    // e que passaria a dar 400 quando a rejeição de campo desconhecido for ligada).
+    // Os nomes singulares antigos não existem mais (o form usa o plural do serializer).
     expect(payload).not.toHaveProperty('alunos_recebidos_data');
     expect(payload).not.toHaveProperty('alunos_validados_data');
     expect(payload).not.toHaveProperty('alunos_importados_data');


### PR DESCRIPTION
## Resumo

**M16-07 (#1638)** — fecha o residual do parcial `3954e208`.

O parcial escolheu, de propósito, o caminho conservador **single ↔ array-de-1**: `DatePicker`
single + `toISODateList` na escrita, `firstOf` na leitura. Consequência: todo **editar → salvar**
no `/dat/registros` **colapsava o array de datas AVALIAR ao 1º item**, perdendo o histórico das
demais. O backend **nunca truncou** (`JSONField` array).

### O que mudou (frontend apenas — `DATRegistrosPage.tsx`)
- Os **3 campos AVALIAR** (recebidos / validados / importados) passam a usar **`<DatePicker multiple>`**
  (antd ^5.27.4).
- Os form-values passam a `Dayjs[]` com o **nome plural do serializer** (`alunos_*_datas`) — eliminando
  o mapeamento singular↔plural (`AVALIAR_DATE_FIELDS`).
- `buildDATRegistroPayload` mapeia o **array inteiro** (`Dayjs[] → string[]`), sem truncar.
- A hidratação (`handleEdit`) restaura o **array completo**, não só o primeiro item.

## Validações (TDD RED→GREEN, no Docker)

- **RED provado**: truncando o builder ao 1º item, o teste multivalor falha (esperava todas as datas,
  veio só a primeira).
- **GREEN**: `buildDATRegistroPayload.test.ts` **4/4** — o teste novo passa `[2 datas]`/`[3 datas]` e
  exige que **todas** cheguem ao payload.
- `tsc --noEmit` + `eslint` limpos.

## Escopo

- **Frontend apenas**, **sem migration**, **sem mudança de contrato FE↔BE** (o `JSONField`/serializer já
  aceita e retorna o array cheio — só o front truncava).
- A semântica de escrita continua **replace** (envia o conjunto atual de datas).
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `f99cbfcc`, slot `0` / projeto `aprender_staging`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
