### PR TITLE
fix(forms): corrige field-drift form<->serializer (titulo e observacoes) (#1739)

### DIFF
--- a/v2/docs/audits/ACHADOS_REAIS.md
+++ b/v2/docs/audits/ACHADOS_REAIS.md
@@ -127,6 +127,7 @@ revalidação dos 46 restantes.
 | `M17-01` | **P1** | aberto | DAT/imports: card "Importar CADASTROS DAT" grava AcaoDAT legacy, que nenhuma tela le | DAT (3 membros ativos nao-superuser) + 1 superuser. O gate do card e d… | #1640 | — |
 | `M17-02` | **P1** | resolvido | DAT (Ações/Cadastros): editar pelo modal apaga silenciosamente as datas do registro | DAT, Controle e Assistente Administrativo | #1641 | `a0553fd7` (2026-08-11) |
 | `M19-01` | **P1** | resolvido | DAT/PlanoFormacoes: CH total e anual ficam um PATCH atrasadas ao atualizar formação inline | DAT e superuser | #1642 | `f9e40902` (2026-08-11) |
+| `M19-02` | **P2** | em andamento | field-drift form↔serializer: DATFormacao.titulo obrigatório sem Form.Item (400 no create) + Solicitacao.observacoes coage null para allow_null=False (auditoria dinâmica 2026-08-17; instância do épico #1655) | DAT (3 ativos) e Coordenador (42 ativos) criadores | #1739 | — |
 | `M22-14` | **P1** | aberto | Import de bloqueios: resolucao por nome com fallback substring cria bloqueio auto-aprovado na a… | Grupo DAT (3 membros ativos nao-superuser) + 1 superuser ativo, via `H… | #1643 | — |
 | `M23-02` | **P1** | aberto | auditoria: redigir CPF (`username`) nos AuditLog de LOGIN_FAILED, na escrita e na leitura | DAT (3 ativos), Controle (1), Superintendencia (1), Gerente (9) — 14 n… | #1644 | — |
 | `M26-02` | **P1** | aberto | DR: restore_db.sh declara "Restore completed successfully!" com exit 0 apos um restore que perd… | Operador de DR com SSH na VM02 (na pratica o unico superuser/dono). Na… | #1645 | — |

--- a/v2/frontend/src/pages/DATModule/FormacoesPage.tsx
+++ b/v2/frontend/src/pages/DATModule/FormacoesPage.tsx
@@ -101,6 +101,7 @@ interface FormacoesFilters {
 }
 
 interface FormacaoFormValues {
+  titulo: string;
   projeto: number;
   municipio: number;
   coordenador: number | null;
@@ -668,6 +669,13 @@ export default function FormacoesPage(): JSX.Element {
         <Form form={form} layout="vertical" autoComplete="off" onFinish={handleSave}>
           {/* Identificação */}
           <Card size="small" title="Identificação" className="mb-4">
+            <Form.Item
+              name="titulo"
+              label="Título da Formação"
+              rules={[{ required: true, message: 'Informe o título da formação' }]}
+            >
+              <Input placeholder="Ex.: Formação inicial de Língua Portuguesa" maxLength={200} />
+            </Form.Item>
             <Row gutter={16}>
               <Col xs={24} sm={8}>
                 <Form.Item

--- a/v2/frontend/src/pages/DATModule/__tests__/formacoesTitulo.test.tsx
+++ b/v2/frontend/src/pages/DATModule/__tests__/formacoesTitulo.test.tsx
@@ -1,0 +1,47 @@
+/**
+ * #1739: o formulário de Nova Formação não coletava o campo `titulo`, que é obrigatório
+ * no serializer (DATFormacao.titulo é CharField NOT NULL) → todo create tomava 400
+ * "titulo: este campo é obrigatório". O fix adiciona o Form.Item name="titulo".
+ *
+ * RED no código antigo: o modal de criação não tinha o campo Título da Formação.
+ */
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router';
+
+vi.mock('../../../api/datModule', () => ({
+  listFormacoes: vi.fn().mockResolvedValue({ results: [], count: 0, next: null, previous: null }),
+  createFormacao: vi.fn().mockResolvedValue({}),
+  updateFormacao: vi.fn().mockResolvedValue({}),
+  deleteFormacao: vi.fn().mockResolvedValue({}),
+  getFormacoesStats: vi.fn().mockResolvedValue({ total: 0, este_mes: 0, realizadas: 0 }),
+  getFormacoesCalendario: vi.fn().mockResolvedValue({ results: [] }),
+  getMunicipiosOptions: vi.fn().mockResolvedValue({ results: [] }),
+  getProjetosOptions: vi.fn().mockResolvedValue({ results: [] }),
+  getCoordenadoresOptions: vi.fn().mockResolvedValue({ results: [] }),
+}));
+
+import FormacoesPage from '../FormacoesPage';
+
+describe('#1739: Nova Formação coleta o Título obrigatório', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  // Timeouts folgados: renderizar a página inteira (Table + filtros + options) em jsdom
+  // é lento; o comportamento testado (o campo existe no modal) é rápido.
+  test(
+    'abrir "Nova Formação" mostra o campo Título da Formação',
+    async () => {
+      render(
+        <MemoryRouter>
+          <FormacoesPage />
+        </MemoryRouter>,
+      );
+      const novaBtn = await screen.findByRole('button', { name: /Nova Formação/i }, { timeout: 15000 });
+      await userEvent.click(novaBtn);
+      const titulo = await screen.findByLabelText(/Título da Formação/i, {}, { timeout: 10000 });
+      expect(titulo).toBeTruthy();
+    },
+    20000,
+  );
+});

--- a/v2/frontend/src/pages/Solicitacoes/EditSolicitacaoPage.tsx
+++ b/v2/frontend/src/pages/Solicitacoes/EditSolicitacaoPage.tsx
@@ -33,6 +33,7 @@ import utc from 'dayjs/plugin/utc';
 import timezone from 'dayjs/plugin/timezone';
 
 import { getSolicitacao, updateSolicitacao } from '../../api/solicitacoes';
+import { optionalText } from './optionalText';
 import {
   lookupMunicipios,
   lookupProjetos,
@@ -274,7 +275,7 @@ export default function EditSolicitacaoPage(): JSX.Element {
         tipo: formData.tipo || null,
         encontro: formData.encontro || null,
         segmento: formData.segmento || null,
-        observacoes: formData.observacoes || null,
+        observacoes: optionalText(formData.observacoes),
         local: formData.local || '',
         is_online: !!formData.is_online,
         extra_participants: {

--- a/v2/frontend/src/pages/Solicitacoes/NewSolicitacaoWizard.tsx
+++ b/v2/frontend/src/pages/Solicitacoes/NewSolicitacaoWizard.tsx
@@ -36,6 +36,7 @@ import utc from 'dayjs/plugin/utc';
 import timezone from 'dayjs/plugin/timezone';
 
 import { createSolicitacao } from '../../api/solicitacoes';
+import { optionalText } from './optionalText';
 import {
   lookupMunicipiosWithFilters,
   lookupProjetos,
@@ -325,7 +326,7 @@ export default function NewSolicitacaoWizard(): JSX.Element {
         tipo: formData.tipo || null,
         encontro: formData.encontro || null,
         segmento: formData.segmento || null,
-        observacoes: formData.observacoes || null,
+        observacoes: optionalText(formData.observacoes),
         local: formData.local || '',
         // PR19: incluir modalidade no payload
         is_online: !!formData.is_online,

--- a/v2/frontend/src/pages/Solicitacoes/__tests__/optionalText.test.ts
+++ b/v2/frontend/src/pages/Solicitacoes/__tests__/optionalText.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+
+import { optionalText } from '../optionalText';
+
+/**
+ * #1739 (field-drift form<->serializer): campos de texto opcionais cujo model e'
+ * `TextField(blank=True)` viram `allow_null=False` no serializer DRF. O front coagia
+ * texto opcional vazio para `null` (`formData.observacoes || null`), tomando 400
+ * "Este campo nao pode ser nulo". optionalText coage para '' (nunca null).
+ */
+describe('optionalText (#1739 field-drift)', () => {
+  it('coage vazio/ausente para string vazia, nunca null', () => {
+    expect(optionalText('')).toBe('');
+    expect(optionalText(undefined)).toBe('');
+    expect(optionalText(null)).toBe('');
+  });
+
+  it('preserva texto preenchido', () => {
+    expect(optionalText('observação')).toBe('observação');
+  });
+
+  it('nunca retorna null e sempre retorna string (contrato allow_null=False)', () => {
+    for (const v of ['', null, undefined, 'x'] as const) {
+      expect(optionalText(v)).not.toBeNull();
+      expect(typeof optionalText(v)).toBe('string');
+    }
+  });
+});

--- a/v2/frontend/src/pages/Solicitacoes/optionalText.ts
+++ b/v2/frontend/src/pages/Solicitacoes/optionalText.ts
@@ -1,0 +1,9 @@
+/**
+ * #1739 (field-drift form<->serializer): campos de texto opcionais cujo model e'
+ * `TextField(blank=True)` (sem `null=True`) viram `allow_null=False` no serializer DRF.
+ * Enviar `null` para um desses campos toma 400 "Este campo nao pode ser nulo".
+ *
+ * Coage texto opcional vazio/ausente para string vazia (aceita por `allow_blank=True`),
+ * nunca `null`. Usar sempre que o payload mandar um campo de texto opcional ao backend.
+ */
+export const optionalText = (value: string | null | undefined): string => value || '';


### PR DESCRIPTION
## Resumo

Corrige o field-drift form↔serializer (#1739, achado da auditoria dinâmica 2026-08-17; `M19-02`, instância do épico #1655).

- **`DATFormacao.titulo`** é `CharField` obrigatório no serializer, mas o form de Nova Formação **não coletava o campo** → todo create tomava 400 "titulo obrigatório". Adiciona o `Form.Item name="titulo"` (required) + o campo no tipo `FormacaoFormValues`.
- **`Solicitacao.observacoes`** é `TextField(blank=True)` (`allow_null=False`), mas o wizard e a edição coagiam texto vazio para `null` (`|| null`) → 400 "não pode ser nulo". Novo helper `optionalText` coage para `''` (nunca null), usado nos dois payloads.

Fecha #1739.

## Checklist Tecnico (Code Review Expert - Slim)

- [x] Arquitetura e SOLID: helper `optionalText` como SSOT do contrato de texto opcional (épico #1655)
- [x] Seguranca: sem segredo/injecao
- [x] Performance: mudança de form/coerção, sem impacto
- [x] Tratamento de erros: elimina 400 de contrato no create/edit
- [x] Condicoes de fronteira: `optionalText('' | null | undefined) === ''`; titulo required no form

## Workflow (Superpowers - Parcial)

- [x] Escopo definido: adicionar campo titulo + coerção observacoes → ''
- [x] Testes criados: `optionalText.test.ts` (contrato) + `formacoesTitulo.test.tsx` (render do campo)
- [x] Evidencias anexadas (output de teste abaixo)

GREEN (vitest, container frontend):
```
✓ src/pages/Solicitacoes/__tests__/optionalText.test.ts (3 tests)
✓ src/pages/DATModule/__tests__/formacoesTitulo.test.tsx (1 test) — abrir "Nova Formação" mostra o campo Título
Test Files 2 passed | Tests 4 passed
```
RED (código antigo): o modal de criação não tinha o campo Título (`findByLabelText` estouraria o timeout); observacoes ia como `null` no payload. `tsc --noEmit` limpo; eslint 0 erros.

## Staging Gate

<!-- Obrigatorio para PRs com impacto em runtime (v2/frontend). -->
- [x] `make staging-full` executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR (trecho de log contendo "ALL 8 CHECKS PASSED")

### Evidencia Staging Gate (obrigatorio para merge)

```text
(pendente — rodando gate)
```

## Validacoes

- [x] Checks `[required]` verdes (somente gates bloqueantes)
- [x] Sem alteracoes fora do escopo combinado (forms + helper + testes + doc ACHADOS)
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `9e7ac607`, slot `0` / projeto `aprender_staging`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
