### PR TITLE
chore(higiene): remove dead code de função (ops.ts, solicitacoes.ts) — Closes #1723

### DIFF
--- a/v2/frontend/src/api/ops.ts
+++ b/v2/frontend/src/api/ops.ts
@@ -48,32 +48,6 @@ export interface Compra {
 }
 
 /**
- * Acao record
- */
-export interface Acao {
-  id: number;
-  municipio: string;
-  projeto: string;
-  uf: string;
-  data: string;
-  descricao: string;
-  status: string;
-}
-
-/**
- * Cadastro record
- */
-export interface Cadastro {
-  id: number;
-  municipio: string;
-  projeto: string;
-  uf: string;
-  data: string;
-  tipo: string;
-  status: string;
-}
-
-/**
  * Compras filter parameters
  */
 export interface ComprasFilters {
@@ -84,13 +58,6 @@ export interface ComprasFilters {
   to?: string;
   q?: string;
   [key: string]: string | undefined;
-}
-
-/**
- * Generic filter parameters
- */
-export interface GenericFilters {
-  [key: string]: string | number | undefined;
 }
 
 /**
@@ -386,22 +353,4 @@ export async function listCompras(filters: ComprasFilters = {}): Promise<Compra[
   const url = buildUrl('/controle/compras/', filters);
   const data = await fetchAPI<{ results?: Compra[] } | Compra[]>(url);
   return (data as { results: Compra[] }).results || (data as Compra[]);
-}
-
-/**
- * Lista AÇÕES de Controle com filtros opcionais.
- */
-export async function listAcoes(filters: GenericFilters = {}): Promise<Acao[]> {
-  const url = buildUrl('/controle/acoes/', filters);
-  const data = await fetchAPI<{ results?: Acao[] } | Acao[]>(url);
-  return (data as { results: Acao[] }).results || (data as Acao[]);
-}
-
-/**
- * Lista CADASTROS DAT com filtros opcionais.
- */
-export async function listCadastros(filters: GenericFilters = {}): Promise<Cadastro[]> {
-  const url = buildUrl('/dat/acoes/', filters);
-  const data = await fetchAPI<{ results?: Cadastro[] } | Cadastro[]>(url);
-  return (data as { results: Cadastro[] }).results || (data as Cadastro[]);
 }

--- a/v2/frontend/src/api/solicitacoes.ts
+++ b/v2/frontend/src/api/solicitacoes.ts
@@ -13,10 +13,6 @@ import type {
   Solicitacao,
   SolicitacaoPayload,
   SolicitacaoFilters,
-  MunicipioOption,
-  ProjetoOption,
-  TipoEventoOption,
-  UsuarioOption,
   BatchOperationResult,
   PublishResult,
 } from '../types';
@@ -232,41 +228,6 @@ export async function cancelSolicitacao(id: ID): Promise<PublishResult> {
   syncChannel.publish('preagenda', { action: 'cancelled' });
   syncChannel.publish('solicitacoes', { action: 'updated' });
   return result;
-}
-
-// ========================================
-// Endpoints de opções (dropdowns/selects)
-// ========================================
-
-/**
- * Lista municípios para seleção.
- */
-export async function listMunicipiosOptions(): Promise<MunicipioOption[]> {
-  return await fetchAPI('/options/municipios/');
-}
-
-/**
- * Lista projetos para seleção.
- */
-export async function listProjetosOptions(): Promise<ProjetoOption[]> {
-  return await fetchAPI('/options/projetos/');
-}
-
-/**
- * Lista tipos de evento para seleção.
- */
-export async function listTiposEventoOptions(): Promise<TipoEventoOption[]> {
-  return await fetchAPI('/options/tipos-evento/');
-}
-
-/**
- * Lista usuários para seleção.
- *
- * @param params - Parâmetros opcionais (ex: search)
- */
-export async function listUsuariosOptions(params: QueryParams = {}): Promise<UsuarioOption[]> {
-  const url = buildUrl('/options/usuarios/', params);
-  return await fetchAPI(url);
 }
 
 // ========================================


### PR DESCRIPTION
## Resumo

Fecha o residual do **#1723** (dead code cross-arquivo, invisível ao linter — `tsc`/`eslint` limpos, confirmado por grep de uso real).

### Removido (0 uso real, homônimos vivos / duplicados)
- **`api/ops.ts`**: `listAcoes`/`listCadastros` + tipos `Acao`/`Cadastro` (homônimos vivos em `datModule.ts`) + `GenericFilters` (órfão após remover as 2 fns).
- **`api/solicitacoes.ts`**: as 4 fns de options (`listMunicipios`/`Projetos`/`TiposEvento`/`UsuariosOptions`) que duplicavam `lookup.ts` + os imports de tipo que só elas usavam.

### Mantido de propósito (avaliado — não é dead code acidental)
- **`datModule.ts`** (`getPlanoFormacoesCalendario`/`ResumoProjeto`, `updateAcompanhamento`/`ProvaInline`): base da **feature planejada** no TODO de `PlanoFormacoesPage` (Calendário/Resumo por Projeto).
- **`useCrudOperations.ts`**: o hook é só-teste, mas o arquivo exporta `PaginationState` usado por `useTableFilters` (7 telas) — mantido pelo #1728.
- **`views_controle_dat.py`**: endpoints mantidos p/ o programa de imports órfãos (o próprio issue pede avaliar antes de remover).

### js-yaml
Já estava resolvido em **4.3.1** no lockfile (override aplicado num `npm install` posterior) — CVE dev-only já corrigido.

## Validação
`tsc --noEmit` + `eslint` limpos; **164 testes** das áreas afetadas (8 arquivos que importam ops/solicitacoes) verdes. Só deleções (90 linhas), zero adições.
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `8364f7a7`, slot `0` / projeto `aprender_staging`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
