### PR TITLE
fix(auditoria): redige CPF em target_username na escrita + sentinela — Closes #1657

### DIFF
--- a/v2/backend/apps/core/services/audit.py
+++ b/v2/backend/apps/core/services/audit.py
@@ -31,6 +31,7 @@ from django.contrib.auth.models import Group
 from django.db import transaction
 
 from apps.core.models import AuditLog, PermissaoFuncional
+from apps.core.pii import redact_cpf
 
 # Sentinela para distinguir "nao passei usuario_id" de "passei usuario_id=None".
 _UNSET: Any = object()
@@ -218,7 +219,7 @@ def auditar_assign_groups(
         details={
             "actor_user_id": _actor_id(actor),
             "target_user_id": target_user.pk,
-            "target_username": getattr(target_user, "username", None),
+            "target_username": redact_cpf(getattr(target_user, "username", None)),
             "added_groups": _group_names(added),
             "removed_groups": _group_names(removed),
             "groups_after": _group_names(after),
@@ -248,7 +249,7 @@ def auditar_reset_senha(
         details={
             "actor_user_id": _actor_id(actor),
             "target_user_id": target_user.pk,
-            "target_username": getattr(target_user, "username", None),
+            "target_username": redact_cpf(getattr(target_user, "username", None)),
             "contexto": contexto,
         },
         imediato=imediato,
@@ -278,7 +279,7 @@ def auditar_user_delete(
         details={
             "actor_user_id": actor_id,
             "target_user_id": target_user.pk,
-            "target_username": getattr(target_user, "username", None),
+            "target_username": redact_cpf(getattr(target_user, "username", None)),
             "target_is_superuser": bool(getattr(target_user, "is_superuser", False)),
         },
         imediato=imediato,
@@ -316,7 +317,7 @@ def auditar_privilege_flags(
         model_name="Usuario",
         details={
             "target_user_id": target_user.pk,
-            "target_username": getattr(target_user, "username", None),
+            "target_username": redact_cpf(getattr(target_user, "username", None)),
             "changes": changes,
             "via": via,
         },

--- a/v2/backend/apps/core/tests/test_audit_privilege_sites.py
+++ b/v2/backend/apps/core/tests/test_audit_privilege_sites.py
@@ -372,3 +372,45 @@ class TestUsuarioAdminAudit:
         assert log.usuario_id == superuser.id
         assert log.details["target_user_id"] == common_user.id
         assert log.details["added_groups"] == ["DAT"]
+
+
+# ============================================================================
+# M23-02 / #1657: `target_username` (que pode ser CPF) e redigido na ESCRITA —
+# o AuditLog "nasce sem PII integral", nao depende da redacao de leitura.
+# ============================================================================
+
+
+class TestTargetUsernameRedigidoNaEscrita:
+    def test_target_username_cpf_redigido_na_escrita(self, superuser, django_capture_on_commit_callbacks):
+        from apps.core.services.audit import auditar_reset_senha
+
+        alvo = UsuarioFactory(username="11144477735", cpf="11144477735")
+        AuditLog.objects.filter(action="RESET_PASSWORD").delete()
+        with django_capture_on_commit_callbacks(execute=True):
+            auditar_reset_senha(actor=superuser, target_user=alvo)
+        log = AuditLog.objects.filter(action="RESET_PASSWORD").latest("created_at")
+        assert log.details["target_username"] == "<cpf>"
+        assert "11144477735" not in str(log.details)
+
+    def test_sentinela_identidade_nao_persiste_cpf_cru(self, superuser, django_capture_on_commit_callbacks):
+        import re
+
+        from apps.core.services.audit import auditar_assign_groups, auditar_privilege_flags, auditar_reset_senha
+
+        cpf = "11144477735"
+        alvo = UsuarioFactory(username=cpf, cpf=cpf)
+        grupo = GroupFactory(name="DAT")
+        AuditLog.objects.all().delete()
+        with django_capture_on_commit_callbacks(execute=True):
+            auditar_reset_senha(actor=superuser, target_user=alvo)
+            auditar_privilege_flags(
+                actor=superuser,
+                target_user=alvo,
+                before={"is_superuser": False, "is_staff": False, "is_active": False},
+                via="rest_api",
+            )
+            auditar_assign_groups(actor=superuser, target_user=alvo, before_group_ids=[], after_group_ids=[grupo.pk])
+        logs = list(AuditLog.objects.all())
+        assert logs, "esperava AuditLogs das mutacoes de identidade"
+        for log in logs:
+            assert not re.search(r"\b\d{11}\b", str(log.details)), f"CPF cru persistido em {log.action}: {log.details}"


### PR DESCRIPTION
## Resumo

Fecha a última faceta aberta do **épico LGPD #1657** (M23-02): `target_username` — que pode ser um CPF (`username=cpf`) — era gravado **cru** no `AuditLog.details` e só redigido na **leitura** (denylist → `***` para não-superuser; o superuser via o CPF cru). Agora o AuditLog **nasce sem o CPF integral**.

### O que mudou
- **`services/audit.py`**: os 4 helpers de mutação de identidade (`auditar_assign_groups`, `auditar_reset_senha`, `auditar_user_delete`, `auditar_privilege_flags`) redigem `target_username` com **`redact_cpf` na escrita** — reusa o helper central introduzido em #1735 (M03-10).
- **Teste-sentinela**: nenhum AuditLog de mutação de identidade persiste 11 dígitos consecutivos (CPF cru); + teste do `RESET_PASSWORD` com `username=CPF`.

### O épico #1657 fica completo (4 facetas)
| Faceta | Resolvido por |
|---|---|
| M07-03 — AuditLog em todas as mutações do UsuarioAdminViewSet | #1736 |
| M05-05 — buffer global removido, auditoria transacional c/ ator explícito | #1672 |
| M23-02 — CPF redigido em `LOGIN_FAILED` e `target_username` (escrita+leitura) | este + #1735 |
| M03-10 — `Usuario.__str__` sem CPF + `username` redigido | #1735 + `6b35fa40` |

## Validação (TDD RED→GREEN)
- **RED provado**: revertendo o wrap, os 2 testes novos falham (target_username cru; sentinela pega o CPF).
- **GREEN + regressão**: **92 testes verdes** — audit privilege (19) + audit service (20) + policy (21) + login (15) + read redaction (17). Black + isort limpos.

## Escopo
Backend, **sem migration**, **sem mudança de contrato**. Aditivo/defensivo. (A redação por **allowlist** arquitetural — em vez de redigir campos-PII conhecidos — fica como hardening futuro; o objetivo prático "AuditLog sem CPF cru" está atingido e guardado por sentinela.)
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `6beab79b`, slot `0` / projeto `aprender_staging`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
