### PR TITLE
fix(pre-agenda): controla ciclo de requisicoes da Pre-agenda (M12-19)

### DIFF
--- a/v2/frontend/src/hooks/__tests__/usePolling.test.ts
+++ b/v2/frontend/src/hooks/__tests__/usePolling.test.ts
@@ -1,0 +1,47 @@
+/**
+ * usePolling — opção `immediate` (#1668 / M12-19).
+ *
+ * O caminho de polling da Pré-agenda fazia carga inicial DUPLA: o efeito de
+ * filtro da página dispara loadData no mount E o usePolling também busca na hora.
+ * A opção `immediate: false` deixa o mount-load ser dono do efeito de filtro,
+ * mantendo o intervalo e o fetch-ao-voltar-para-a-aba (visibilitychange).
+ */
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { usePolling } from '../usePolling';
+
+describe('usePolling', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test('por padrão busca imediatamente no mount', () => {
+    const fn = vi.fn();
+    renderHook(() => usePolling(fn, { enabled: true, intervalMs: 5000 }));
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  test('immediate:false pula o fetch no mount mas mantém o polling por intervalo', () => {
+    const fn = vi.fn();
+    renderHook(() => usePolling(fn, { enabled: true, intervalMs: 5000, immediate: false }));
+
+    // NÃO busca no mount (evita a carga inicial dupla).
+    expect(fn).not.toHaveBeenCalled();
+
+    // O intervalo continua ativo.
+    vi.advanceTimersByTime(5000);
+    expect(fn).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(5000);
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  test('enabled:false não busca nem agenda intervalo', () => {
+    const fn = vi.fn();
+    renderHook(() => usePolling(fn, { enabled: false, intervalMs: 5000 }));
+    vi.advanceTimersByTime(20000);
+    expect(fn).not.toHaveBeenCalled();
+  });
+});

--- a/v2/frontend/src/hooks/usePolling.ts
+++ b/v2/frontend/src/hooks/usePolling.ts
@@ -7,6 +7,12 @@ export interface UsePollingOptions {
   intervalMs: number;
   /** Custom DOM events that trigger an immediate fetch (e.g. 'notificacoes:refresh'). */
   events?: string[];
+  /**
+   * When false, skips the fetch-on-mount. The interval and the fetch-on-visible
+   * (returning to a hidden tab) still run. Use it when the page already owns the
+   * initial load elsewhere, to avoid a duplicate request on mount. Default true.
+   */
+  immediate?: boolean;
 }
 
 /**
@@ -27,7 +33,7 @@ export function usePolling(
   fetchFn: () => void | Promise<void>,
   options: UsePollingOptions,
 ): void {
-  const { enabled, intervalMs, events } = options;
+  const { enabled, intervalMs, events, immediate = true } = options;
 
   // Always call the latest fetchFn without restarting the effect
   const fetchRef = useRef(fetchFn);
@@ -79,8 +85,9 @@ export function usePolling(
     // Page Visibility API
     document.addEventListener('visibilitychange', handleVisibility);
 
-    // Initial fetch + start polling if tab is visible
-    doFetch();
+    // Initial fetch + start polling if tab is visible. `immediate: false` skips
+    // only the mount fetch (the interval and fetch-on-visible still run).
+    if (immediate) doFetch();
     if (!document.hidden) startPolling();
 
     // Custom events (e.g. 'notificacoes:refresh')
@@ -96,5 +103,5 @@ export function usePolling(
         window.removeEventListener(event, doFetch);
       }
     };
-  }, [enabled, intervalMs, eventsKey]);
+  }, [enabled, intervalMs, eventsKey, immediate]);
 }

--- a/v2/frontend/src/pages/PreAgenda/PreAgendaPage.tsx
+++ b/v2/frontend/src/pages/PreAgenda/PreAgendaPage.tsx
@@ -78,6 +78,12 @@ import { formatFortaleza } from '../../utils/datetime';
 import logger from '../../utils/logger';
 import type { ID, Solicitacao, GCalStatus, CurrentUser, PaginatedResponse } from '../../types';
 
+// #1668 (M12-19): orçamento de requisições da Pré-agenda.
+/** Carrega a pré-agenda inteira como lista única (paginação client-side). */
+const PREAGENDA_PAGE_SIZE = 100;
+/** Após um 429, pula N ticks de polling (N × intervalo ≈ janela de backoff). */
+const POLL_BACKOFF_TICKS = 3;
+
 const { Title, Text } = Typography;
 const { RangePicker } = DatePicker;
 
@@ -177,48 +183,90 @@ export default function PreAgendaPage(): JSX.Element {
     loadUser();
   }, []);
 
+  // #1668 (M12-19): controle do ciclo de requisições.
+  // - seqRef: guarda de sequência (latest-wins) — descarta resposta obsoleta.
+  // - pollBackoffRef: ticks de polling a pular após um 429.
+  // - filtersRef: mantém loadData estável (não recria a cada tecla).
+  const seqRef = useRef(0);
+  const pollBackoffRef = useRef(0);
+  const filtersRef = useRef({ searchTerm, sectorFilter, dateRange });
+  filtersRef.current = { searchTerm, sectorFilter, dateRange };
+
   const loadData = useCallback(async (): Promise<void> => {
+    const seq = ++seqRef.current;
     try {
       setLoading(true);
 
+      const { searchTerm, sectorFilter, dateRange } = filtersRef.current;
       const filters: Record<string, string> = { status: 'approved' };
       if (searchTerm) filters.q = searchTerm;
       if (sectorFilter) filters.sector = sectorFilter;
       if (dateRange[0]) filters.date_from = dateRange[0].format('YYYY-MM-DD');
       if (dateRange[1]) filters.date_to = dateRange[1].format('YYYY-MM-DD');
 
-      // Carregar ambos os fluxos e resumo
+      // page_size alto: a pré-agenda é uma lista única (paginação client-side),
+      // então carrega o conjunto de aprovados de uma vez, não só a 1ª página.
+      const listParams = { ...filters, page_size: PREAGENDA_PAGE_SIZE };
       const [superData, naoSuperData, summaryData] = await Promise.all([
-        listSolicitacoes({ ...filters, flow: 'SUPER' }) as Promise<PaginatedResponse<Solicitacao> | Solicitacao[]>,
-        listSolicitacoes({ ...filters, flow: 'NAO_SUPER' }) as Promise<PaginatedResponse<Solicitacao> | Solicitacao[]>,
+        listSolicitacoes({ ...listParams, flow: 'SUPER' }) as Promise<PaginatedResponse<Solicitacao> | Solicitacao[]>,
+        listSolicitacoes({ ...listParams, flow: 'NAO_SUPER' }) as Promise<PaginatedResponse<Solicitacao> | Solicitacao[]>,
         getStatusSummary(filters),
       ]);
 
+      if (seq !== seqRef.current) return; // carga obsoleta: uma mais nova venceu
+
       const superRows = 'results' in superData ? superData.results : superData;
       const naoRows = 'results' in naoSuperData ? naoSuperData.results : naoSuperData;
-      const superCount = 'count' in superData ? superData.count : (superData as Solicitacao[]).length;
-      const naoCount = 'count' in naoSuperData ? naoSuperData.count : (naoSuperData as Solicitacao[]).length;
+      const loadedRows = [...superRows, ...naoRows];
 
-      setRows([...superRows, ...naoRows]);
-      setTotal(superCount + naoCount);
+      pollBackoffRef.current = 0; // sucesso zera o backoff
+      setRows(loadedRows);
+      // Contador honesto: exibe o total efetivamente carregado, nunca o count do
+      // servidor sobre uma lista de 1 página (total inalcançável).
+      setTotal(loadedRows.length);
       setSummary(summaryData);
     } catch (error) {
+      if (seq !== seqRef.current) return; // erro de carga obsoleta: não polui a UI
+      const status = (error as { status?: number }).status;
+      if (status === 429) {
+        // O operador estourou o próprio throttle; recua alguns ticks de polling.
+        pollBackoffRef.current = POLL_BACKOFF_TICKS;
+      }
       message.error('Erro ao carregar pré-agenda: ' + (error as Error).message);
     } finally {
-      setLoading(false);
+      if (seq === seqRef.current) setLoading(false);
     }
-  }, [searchTerm, sectorFilter, dateRange]);
+  }, []);
 
+  // Carga inicial imediata no mount + recargas por filtro com debounce: o valor
+  // digitado nunca dispara um request por tecla, e não há carga dupla (o polling
+  // roda com immediate:false).
+  const firstRunRef = useRef(true);
   useEffect(() => {
-    loadData();
-  }, [loadData]);
+    if (firstRunRef.current) {
+      firstRunRef.current = false;
+      void loadData();
+      return;
+    }
+    const timer = setTimeout(() => {
+      void loadData();
+    }, TIMING.DEBOUNCE_SEARCH_MS);
+    return () => clearTimeout(timer);
+  }, [searchTerm, sectorFilter, dateRange, loadData]);
 
-  // RT-02: Polling 5s for cross-device sync (#1032)
-  const loadDataRef = useRef(loadData);
-  loadDataRef.current = loadData;
-  usePolling(() => loadDataRef.current(), {
+  // RT-02: Polling 5s para sync cross-device (#1032). immediate:false → a carga
+  // inicial é do efeito de filtro (sem carga dupla). O tick honra o backoff de 429.
+  const handlePollTick = useCallback((): void => {
+    if (pollBackoffRef.current > 0) {
+      pollBackoffRef.current -= 1;
+      return;
+    }
+    void loadData();
+  }, [loadData]);
+  usePolling(handlePollTick, {
     enabled: true,
     intervalMs: TIMING.SYNC_POLL_INTERVAL_MS,
+    immediate: false,
     events: ['preagenda:refresh', 'solicitacoes:refresh'],
   });
 

--- a/v2/frontend/src/pages/PreAgenda/__tests__/PreAgendaPage.lifecycle.test.tsx
+++ b/v2/frontend/src/pages/PreAgenda/__tests__/PreAgendaPage.lifecycle.test.tsx
@@ -1,0 +1,223 @@
+/**
+ * #1668 [M12-19] Pré-agenda: ciclo de requisições.
+ *
+ * Bugs cobertos (todos confirmados no código atual):
+ *  1. Carga inicial DUPLA — o efeito de filtro dispara loadData no mount E o
+ *     usePolling busca na hora → usePolling deve receber `immediate: false`.
+ *  2. Tempestade por tecla — searchTerm/sectorFilter nas deps de loadData +
+ *     efeito re-disparando a cada tecla, SEM debounce.
+ *  3. Sem latest-wins — setRows grava incondicionalmente; resposta obsoleta
+ *     sobrescreve a atual.
+ *  4. Contador incoerente — total exibido = count do servidor sobre uma lista
+ *     de 1 página (inalcançável). Deve refletir o carregado.
+ *  5. Sem backoff em 429 — o polling continua martelando o throttle do operador.
+ *
+ * O usePolling é mockado como CAPTOR: guarda o callback e as opções passadas,
+ * para (a) asserir o wiring de `immediate` e (b) disparar "ticks" de polling
+ * de forma determinística, sem depender de timers reais do intervalo.
+ */
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { TIMING } from '../../../constants/timing';
+
+const { poll, getMeMock, listSolicitacoesMock, getStatusSummaryMock, fetchAPIMock } = vi.hoisted(() => ({
+  poll: { fn: null as null | (() => void), opts: null as null | Record<string, unknown> },
+  getMeMock: vi.fn(),
+  listSolicitacoesMock: vi.fn(),
+  getStatusSummaryMock: vi.fn(),
+  fetchAPIMock: vi.fn(),
+}));
+
+vi.mock('../../../api/config', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return { ...actual, fetchAPI: fetchAPIMock };
+});
+vi.mock('../../../api/availability', () => ({ getMe: getMeMock }));
+vi.mock('../../../api/solicitacoes', () => ({
+  listSolicitacoes: listSolicitacoesMock,
+  previewSolicitacao: vi.fn(),
+  publishSolicitacao: vi.fn(),
+  resyncSolicitacao: vi.fn(),
+  cancelSolicitacao: vi.fn(),
+}));
+vi.mock('../../../api/gcal', () => ({
+  getStatusSummary: getStatusSummaryMock,
+  reapplyBatch: vi.fn(),
+  resyncBatch: vi.fn(),
+}));
+vi.mock('../../../hooks/useGoogleIntegration', () => ({
+  default: () => ({
+    status: { connected: true, isExpired: false, googleEmail: 'x@y.br', tokenExpiry: null, expiresInDays: null },
+    disconnect: vi.fn(),
+    loading: false,
+    error: null,
+    fetchStatus: vi.fn(),
+  }),
+}));
+vi.mock('../../../hooks/useGoogleGuard', () => ({
+  default: () => ({ requireGoogleConnection: () => true, handleGoogleError: () => false, isConnected: true }),
+}));
+// Captor: guarda callback + opções, não executa nada sozinho.
+vi.mock('../../../hooks/usePolling', () => ({
+  usePolling: (fn: () => void, opts: Record<string, unknown>) => {
+    poll.fn = fn;
+    poll.opts = opts;
+  },
+}));
+vi.mock('../../../services/syncChannel', () => ({
+  syncChannel: { subscribe: () => () => {}, publish: vi.fn() },
+}));
+vi.mock('../../../components/google/GoogleIntegrationCard', () => ({
+  default: () => <div data-testid="google-card" />,
+}));
+
+import PreAgendaPage from '../PreAgendaPage';
+
+const row = (id: number, municipio: string) => ({
+  id,
+  municipio_nome: municipio,
+  projeto_nome: 'Projeto',
+  tipo: 'Formação',
+  gcal_status: 'NONE',
+  inicio: '2026-08-10T09:00:00',
+  external_event_id: null,
+  meet_link: null,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  poll.fn = null;
+  poll.opts = null;
+  getMeMock.mockResolvedValue({ setores: ['Controle'], funcoes: [], is_superuser: false });
+  listSolicitacoesMock.mockResolvedValue({ results: [], count: 0 });
+  getStatusSummaryMock.mockResolvedValue({ counts: {}, total: 0 });
+  fetchAPIMock.mockResolvedValue({});
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('PreAgendaPage — ciclo de requisições (#1668 / M12-19)', () => {
+  test('1. configura usePolling com immediate:false (sem carga inicial dupla)', async () => {
+    render(<PreAgendaPage />);
+    await waitFor(() => expect(poll.opts).not.toBeNull());
+    expect(poll.opts?.immediate).toBe(false);
+  });
+
+  test('2. digitar no filtro faz UMA recarga debounced, não uma por tecla', async () => {
+    vi.useFakeTimers();
+    render(<PreAgendaPage />);
+    await vi.advanceTimersByTimeAsync(0); // flush mount (getMe + load inicial)
+
+    const before = listSolicitacoesMock.mock.calls.length;
+
+    const busca = screen.getByPlaceholderText('Buscar por município, projeto...');
+    fireEvent.change(busca, { target: { value: 'a' } });
+    fireEvent.change(busca, { target: { value: 'ab' } });
+    fireEvent.change(busca, { target: { value: 'abc' } });
+
+    await vi.advanceTimersByTimeAsync(TIMING.DEBOUNCE_SEARCH_MS + 10);
+
+    // Uma única recarga = 2 chamadas (fluxo SUPER + NAO_SUPER).
+    expect(listSolicitacoesMock.mock.calls.length - before).toBe(2);
+  });
+
+  test('3. latest-wins: resposta obsoleta não sobrescreve a mais recente', async () => {
+    type Deferred = { resolve: (v: unknown) => void; flow: string };
+    const deferreds: Deferred[] = [];
+    listSolicitacoesMock.mockImplementation(
+      (f: { flow: string }) => new Promise((resolve) => deferreds.push({ resolve, flow: f.flow })),
+    );
+
+    render(<PreAgendaPage />);
+    // Carga do mount: 2 chamadas (SUPER + NAO_SUPER).
+    await waitFor(() => expect(deferreds.length).toBe(2));
+    await act(async () => {
+      deferreds.forEach((d) => d.resolve({ results: [], count: 0 }));
+    });
+    deferreds.length = 0;
+
+    // Dois ticks de polling em sequência → duas cargas concorrentes.
+    act(() => {
+      poll.fn?.(); // carga #1 (obsoleta)
+    });
+    act(() => {
+      poll.fn?.(); // carga #2 (mais recente)
+    });
+    await waitFor(() => expect(deferreds.length).toBe(4));
+
+    // Resolve a MAIS RECENTE (#2, índices 2 e 3) primeiro.
+    await act(async () => {
+      deferreds[2].resolve({ results: [row(99, 'FRESH')], count: 1 });
+      deferreds[3].resolve({ results: [], count: 0 });
+    });
+    await screen.findByText('FRESH');
+
+    // A OBSOLETA (#1) chega DEPOIS (fora de ordem) — não pode sobrescrever.
+    await act(async () => {
+      deferreds[0].resolve({ results: [row(11, 'STALE')], count: 1 });
+      deferreds[1].resolve({ results: [], count: 0 });
+    });
+    await new Promise((r) => setTimeout(r, 30));
+
+    expect(screen.getByText('FRESH')).toBeInTheDocument();
+    expect(screen.queryByText('STALE')).not.toBeInTheDocument();
+  });
+
+  test('4. contador reflete o carregado, não o count do servidor', async () => {
+    listSolicitacoesMock.mockImplementation((f: { flow: string }) =>
+      Promise.resolve(
+        f.flow === 'SUPER'
+          ? { results: [row(1, 'A'), row(2, 'B')], count: 100 }
+          : { results: [row(3, 'C')], count: 50 },
+      ),
+    );
+
+    render(<PreAgendaPage />);
+
+    // 3 linhas carregadas (2 SUPER + 1 NAO_SUPER); o total NÃO pode ser 150.
+    await screen.findByText('A');
+    await waitFor(() => expect(screen.getByText(/Total: 3\b/)).toBeInTheDocument());
+    expect(screen.queryByText(/Total: 150\b/)).not.toBeInTheDocument();
+  });
+
+  test('5. backoff em 429: após um 429 o polling pula ticks antes de voltar', async () => {
+    render(<PreAgendaPage />);
+    await waitFor(() => expect(poll.fn).not.toBeNull());
+    // Deixa a carga do mount assentar.
+    await waitFor(() => expect(listSolicitacoesMock.mock.calls.length).toBeGreaterThanOrEqual(2));
+
+    // Próxima carga (tick) devolve 429.
+    const err = Object.assign(new Error('Throttled'), { status: 429 });
+    listSolicitacoesMock.mockRejectedValue(err);
+    const afterMount = listSolicitacoesMock.mock.calls.length;
+
+    await act(async () => {
+      poll.fn?.(); // tick que recebe 429 → aciona backoff
+    });
+    await waitFor(() => expect(listSolicitacoesMock.mock.calls.length).toBe(afterMount + 2));
+    const after429 = listSolicitacoesMock.mock.calls.length;
+
+    // Volta a responder OK, mas os próximos ticks devem ser PULADOS (backoff).
+    listSolicitacoesMock.mockResolvedValue({ results: [], count: 0 });
+    act(() => {
+      poll.fn?.();
+    });
+    act(() => {
+      poll.fn?.();
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(listSolicitacoesMock.mock.calls.length).toBe(after429); // nenhum request novo
+
+    // Depois de esgotar o backoff, volta a buscar.
+    act(() => {
+      poll.fn?.();
+    });
+    act(() => {
+      poll.fn?.();
+    });
+    await waitFor(() => expect(listSolicitacoesMock.mock.calls.length).toBeGreaterThan(after429));
+  });
+});


### PR DESCRIPTION
## Contexto

Fecha o último item aberto do épico **#1668** (páginas de alta interação sem controle de ciclo de requisições). O sub-item **M09-06 (Deslocamentos)** já estava resolvido no #1622; este PR entrega o **M12-19 (Pré-agenda)**.

## Problema (confirmado no código)

A Pré-agenda tratava cada interação como recarga total e não tinha orçamento de requisições:

| # | Bug | Antes |
|---|-----|-------|
| 1 | Tempestade por tecla | `searchTerm`/`sectorFilter` nas deps de `loadData` + efeito re-disparando a cada tecla, **sem debounce** (cada carga = 3 requests) |
| 2 | Carga inicial dupla | efeito de filtro + fetch-on-mount do `usePolling` |
| 3 | Sem latest-wins | `setRows` gravava incondicionalmente → resposta obsoleta sobrescrevia a atual |
| 4 | Contador incoerente | `count` do servidor sobre lista de 1 página (total inalcançável) |
| 5 | Sem backoff em 429 | polling 5s continuava martelando o throttle do operador |

## Correção

- **`loadData` estável** (lê filtros de `ref`) + **guarda de sequência `seqRef`** (latest-wins, espelha `useAvailabilityPreview`).
- **Efeito único**: carga inicial imediata no mount + recargas por filtro **com debounce** (`DEBOUNCE_SEARCH_MS`).
- **`usePolling` ganha `immediate?: boolean`** (default `true`, retrocompatível); Pré-agenda usa `immediate: false` → sem carga dupla. Mantém a pausa por `visibilitychange` (já existia).
- **Contador honesto**: `total` = linhas efetivamente carregadas (`page_size` maior + paginação client-side).
- **Backoff de 429**: após um 429, o tick de polling pula `POLL_BACKOFF_TICKS` ciclos antes de voltar.

## Test plan (TDD RED→GREEN)

- `src/hooks/__tests__/usePolling.test.ts` — opção `immediate` (mount vs intervalo).
- `src/pages/PreAgenda/__tests__/PreAgendaPage.lifecycle.test.tsx` — 5 comportamentos (wiring immediate:false, debounce, latest-wins, contador honesto, backoff 429).
- Regressão `PreAgendaPage.gcal.test.tsx` 3/3 ✅ · `tsc --noEmit` 0 ✅ · `eslint` 0 ✅.

Closes #1668
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `d2f226cc`, slot `0` / projeto `aprender_staging`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
