### PR TITLE
fix(dat): guarda latest-wins no useTableFilters (7 telas DAT)

### DIFF
--- a/v2/frontend/src/hooks/__tests__/useTableFilters.test.ts
+++ b/v2/frontend/src/hooks/__tests__/useTableFilters.test.ts
@@ -297,4 +297,46 @@ describe('useTableFilters', () => {
     const lastCall = mockListFn.mock.calls[mockListFn.mock.calls.length - 1][0];
     expect(lastCall.page).toBe(2);
   });
+
+  // #1668 (F1 amplo): corrida last-writer-wins. Ao mudar o filtro em sequência,
+  // uma resposta antiga (obsoleta) que chega DEPOIS da atual sobrescrevia a
+  // tabela — protege as 7 telas DAT que consomem o hook.
+  test('latest-wins: resposta obsoleta não sobrescreve a mais recente', async () => {
+    const deferreds: Array<(v: unknown) => void> = [];
+    mockListFn.mockImplementation(() => new Promise((resolve) => deferreds.push(resolve)));
+
+    const { result } = renderHook(() =>
+      useTableFilters<MockFilters, MockRecord, MockStats>({
+        defaultFilters,
+        listFn: mockListFn,
+      }),
+    );
+
+    // Fetch inicial (mount).
+    await waitFor(() => expect(deferreds.length).toBe(1));
+
+    // Filtro 'a' → fetch #2 (será o OBSOLETO, resolvido por último).
+    act(() => {
+      result.current.setFilters({ search: 'a', uf: undefined, municipio: undefined });
+    });
+    await waitFor(() => expect(deferreds.length).toBe(2));
+
+    // Filtro 'ab' → fetch #3 (o MAIS RECENTE, resolvido primeiro).
+    act(() => {
+      result.current.setFilters({ search: 'ab', uf: undefined, municipio: undefined });
+    });
+    await waitFor(() => expect(deferreds.length).toBe(3));
+
+    // Resolve o MAIS RECENTE (#3) primeiro.
+    await act(async () => {
+      deferreds[2]({ results: [{ id: 99, nome: 'FRESH' }], count: 1 });
+    });
+    expect(result.current.data).toEqual([{ id: 99, nome: 'FRESH' }]);
+
+    // O OBSOLETO (#2) chega DEPOIS (fora de ordem) — NÃO pode sobrescrever.
+    await act(async () => {
+      deferreds[1]({ results: [{ id: 11, nome: 'STALE' }], count: 1 });
+    });
+    expect(result.current.data).toEqual([{ id: 99, nome: 'FRESH' }]);
+  });
 });

--- a/v2/frontend/src/hooks/useTableFilters.ts
+++ b/v2/frontend/src/hooks/useTableFilters.ts
@@ -108,8 +108,14 @@ export function useTableFilters<F extends object, T, S = unknown>({
   const defaultFiltersRef = useRef(defaultFilters);
   defaultFiltersRef.current = defaultFilters;
 
+  // #1668 (F1 amplo): guarda de sequência (latest-wins). Ao trocar o filtro em
+  // sequência, um fetch antigo que resolve DEPOIS do atual não pode sobrescrever
+  // a tabela. Espelha o idioma de useAvailabilityPreview.
+  const seqRef = useRef(0);
+
   const fetchData = useCallback(
     async (page = 1, pageSizeOverride?: number): Promise<void> => {
+      const seq = ++seqRef.current;
       setLoading(true);
       try {
         const requestPageSize = pageSizeOverride ?? pagination.pageSize;
@@ -133,6 +139,8 @@ export function useTableFilters<F extends object, T, S = unknown>({
           statsFn ? statsFn(params) : Promise.resolve(undefined),
         ]);
 
+        if (seq !== seqRef.current) return; // resposta obsoleta: uma busca mais nova venceu
+
         const results =
           (listResp as PaginatedResponse<T>).results ??
           (Array.isArray(listResp) ? (listResp as T[]) : []);
@@ -145,10 +153,11 @@ export function useTableFilters<F extends object, T, S = unknown>({
           setStats((statsResp as S) ?? null);
         }
       } catch (error) {
+        if (seq !== seqRef.current) return; // erro de busca obsoleta: não polui a UI atual
         const err = error as Error;
         message.error(`Erro ao carregar ${entityName}: ${err.message}`);
       } finally {
-        setLoading(false);
+        if (seq === seqRef.current) setLoading(false);
       }
     },
     [buildParams, filters, listFn, statsFn, defaultOrdering, entityName, pagination.pageSize],


### PR DESCRIPTION
## Contexto

Parte "F1 amplo" da rodada do épico #1668: além das 2 páginas nomeadas no épico (Deslocamentos/Pré-agenda), o **hook compartilhado** `useTableFilters` — consumido pelas **7 telas do DATModule** — sofre da mesma classe de corrida.

## Problema

`fetchData` faz `Promise.all([listFn, statsFn])` e, ao resolver, chama `setData(results)` **incondicionalmente** — sem guarda de sequência e sem `AbortController`. Ao trocar o filtro em sequência (digitação), uma resposta **antiga** que chega **depois** da atual sobrescreve a tabela com o resultado errado (last-writer-wins).

## Correção

Guarda de sequência `seqRef` espelhando `useAvailabilityPreview`: cada `fetchData` incrementa `seqRef`; a resposta só escreve estado (`setData`/`setPagination`/`setStats`) se `seq === seqRef.current`, senão é descartada. Mesma proteção no `catch` (erro obsoleto não polui a UI) e no `finally` (só o request vigente reseta `loading`).

Mesmo idioma já aplicado pontualmente em Deslocamentos (#1622) e Pré-agenda (#1668, M12-19); aqui conserta a **classe inteira** de uma vez.

## Test plan (TDD RED→GREEN)

- `useTableFilters.test.ts` — novo teste de corrida out-of-order (RED: `[STALE]` vencia; GREEN: `[FRESH]` permanece).
- 15/15 verdes (14 existentes + 1 novo) · `tsc --noEmit` 0 · `eslint` sem novos avisos.

Closes #1751
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `90b952c6`, slot `1` / projeto `aprender_staging_s1`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local-s1, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
