### PR TITLE
fix(oauth): disconnect Google atomico — so apaga credencial local se revoke confirmar (#1742 PR-C)

### DIFF
--- a/v2/backend/apps/core/services/oauth/token_manager.py
+++ b/v2/backend/apps/core/services/oauth/token_manager.py
@@ -256,12 +256,18 @@ def revoke_token(credential: GoogleOAuthCredential) -> bool:
 
         response: requests.Response = requests.post(revoke_url, data=payload, timeout=settings.GCAL_OAUTH_TOKEN_TIMEOUT)
 
-        # 200 OK: revogado com sucesso
-        # 400 Bad Request: token já inválido (ok, continuar)
+        # 200 OK: revogado com sucesso. 400: token já inválido no Google (também
+        # efetivamente revogado). Qualquer OUTRO status = revogação NÃO confirmada →
+        # S4 (#1742): NÃO apagar a credencial local, senão o refresh_token fica vivo
+        # no Google e órfão localmente (sem como retentar). Preserva p/ retry + sinaliza
+        # falha. (Exceções de rede já caem no except abaixo, que também preserva.)
         if response.status_code not in [200, 400]:
-            logger.warning(f"⚠️ Revoke retornou status {response.status_code}")
+            logger.error(
+                f"❌ Revoke Google retornou status {response.status_code}; " "credencial local preservada para retry"
+            )
+            return False
 
-        # Remover credencial local
+        # Revogado com sucesso → remover credencial local
         user: Usuario = credential.user
         google_email: str = credential.google_email
         credential.delete()

--- a/v2/backend/apps/core/tests/test_oauth_disconnect_atomic_1742.py
+++ b/v2/backend/apps/core/tests/test_oauth_disconnect_atomic_1742.py
@@ -1,0 +1,78 @@
+"""
+#1742 PR-C (S4): `revoke_token` (oauth/token_manager) apagava a credencial local
+com `credential.delete()` MESMO quando o revoke remoto no Google retornava status
+!= 200/400 — deixando o refresh_token vivo no Google e orfao localmente (sem como
+retentar). O fix: so apaga se o Google confirmar (200 = revogado, 400 = ja invalido);
+qualquer outro status preserva a credencial e retorna False.
+
+RED no codigo antigo: status 500 ainda caia no delete + retornava True.
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportAttributeAccessIssue=false
+
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import MagicMock, patch
+
+from django.utils import timezone
+
+import pytest
+
+from apps.core.models import GoogleOAuthCredential
+from apps.core.services.oauth.token_manager import revoke_token
+from apps.core.tests.factories import UsuarioFactory
+
+
+@pytest.fixture
+def cred(db):
+    user = UsuarioFactory(username="oauth_revoke_1742", cpf="11144477735")
+    return GoogleOAuthCredential.objects.create(
+        user=user,
+        google_email="revoke@aprendereditora.com.br",
+        access_token_encrypted=b"enc-access",
+        refresh_token_encrypted=b"enc-refresh",
+        token_expiry=timezone.now() + timedelta(hours=1),
+        scope="https://www.googleapis.com/auth/calendar",
+        default_calendar_id="primary",
+    )
+
+
+@pytest.mark.django_db
+class TestRevokeTokenAtomicidade:
+    """S4 (#1742): delete local so quando o Google confirma a revogacao."""
+
+    @patch("apps.core.services.oauth.token_manager.decrypt_token", return_value="ref")
+    @patch("apps.core.services.oauth.token_manager.requests.post")
+    def test_status_500_preserva_credencial(self, mock_post, _mock_decrypt, cred):
+        """RED: antes o delete rodava e retornava True mesmo em 500."""
+        mock_post.return_value = MagicMock(status_code=500)
+        cid = cred.id
+
+        result = revoke_token(cred)
+
+        assert result is False
+        assert GoogleOAuthCredential.objects.filter(id=cid).exists()
+
+    @patch("apps.core.services.oauth.token_manager.decrypt_token", return_value="ref")
+    @patch("apps.core.services.oauth.token_manager.requests.post")
+    def test_status_200_apaga_credencial(self, mock_post, _mock_decrypt, cred):
+        mock_post.return_value = MagicMock(status_code=200)
+        cid = cred.id
+
+        result = revoke_token(cred)
+
+        assert result is True
+        assert not GoogleOAuthCredential.objects.filter(id=cid).exists()
+
+    @patch("apps.core.services.oauth.token_manager.decrypt_token", return_value="ref")
+    @patch("apps.core.services.oauth.token_manager.requests.post")
+    def test_status_400_apaga_credencial(self, mock_post, _mock_decrypt, cred):
+        """400 = token ja invalido no Google (efetivamente revogado) -> apaga local."""
+        mock_post.return_value = MagicMock(status_code=400)
+        cid = cred.id
+
+        result = revoke_token(cred)
+
+        assert result is True
+        assert not GoogleOAuthCredential.objects.filter(id=cid).exists()


### PR DESCRIPTION
## #1742 (baixos consolidados) — PR-C de 3

`revoke_token` (`services/oauth/token_manager.py`) chamava `credential.delete()` **mesmo quando o revoke remoto no Google retornava status ≠ 200/400** (ex.: 500, 403). Resultado: o `refresh_token` seguia **vivo no Google**, mas a credencial sumia localmente — órfã, sem como retentar a revogação.

## Correção
- Status **≠ 200/400** → **não apaga**; loga erro e retorna `False` (preserva p/ retry).
- **200** (revogado) e **400** (já inválido no Google = efetivamente revogado) → apaga local + `True`.
- Exceções de rede já caíam no `except` (que também preserva) — sem mudança lá.

## Teste (`test_oauth_disconnect_atomic_1742.py`, 3)
Mock de `requests.post`: **500 → credencial preservada + `False`**; **200/400 → apagada + `True`**.

> Nota: o arquivo foi nomeado sem "token" de propósito — o `.gitignore` tem `*token*` (para secrets) que engoliria um `test_*token*.py`.

Parte de #1742
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `511443b5`, slot `0` / projeto `aprender_staging`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
