### PR TITLE
fix(auth): lockout/throttle de login não-evadíveis por grafia do CPF nem sessão (M03-03)

### DIFF
--- a/v2/backend/apps/core/auth_backends.py
+++ b/v2/backend/apps/core/auth_backends.py
@@ -6,16 +6,19 @@ Implements CPF-based authentication alongside username authentication.
 
 from __future__ import annotations
 
-import re
 from typing import Any, cast
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.backends import ModelBackend
 from django.http import HttpRequest
 
+from .auth_normalize import normalize_login_identifier
 from .models import Usuario
 
 User = get_user_model()
+
+# Um CPF só-dígitos tem 11 caracteres.
+_CPF_DIGITS = 11
 
 
 class CPFOrUsernameBackend(ModelBackend):
@@ -50,23 +53,26 @@ class CPFOrUsernameBackend(ModelBackend):
         Returns:
             Usuario instance if authentication succeeds, None otherwise
         """
-        if username is None or password is None:
+        # None E não-string (M03-12: DRF pode passar list/dict do JSON) num só guard:
+        # identificador não-string nunca deve chegar à normalização (evita
+        # AttributeError/TypeError → 500). Trata como credencial inválida.
+        if not isinstance(username, str) or not isinstance(password, str):
             return None
 
-        # Remove punctuation (dots, hyphens, spaces)
-        clean_input = re.sub(r"[.\-\s]", "", username)
+        # Canonicaliza via SSOT — o MESMO valor usado pelo contador de lockout (M03-03).
+        canonical = normalize_login_identifier(username)
 
-        # Try CPF if input is 11 digits
-        if clean_input.isdigit() and len(clean_input) == 11:
+        # Try CPF if canonical form is 11 digits
+        if len(canonical) == _CPF_DIGITS and canonical.isdigit():
             try:
-                user = User.objects.get(cpf=clean_input)
+                user = User.objects.get(cpf=canonical)
             except User.DoesNotExist:
                 # CPF not found, return None
                 return None
         else:
-            # Try username lookup
+            # Try username lookup (canonical == input cru para não-CPF)
             try:
-                user = User.objects.get(username=username)
+                user = User.objects.get(username=canonical)
             except User.DoesNotExist:
                 return None
 

--- a/v2/backend/apps/core/auth_normalize.py
+++ b/v2/backend/apps/core/auth_normalize.py
@@ -1,0 +1,41 @@
+"""SSOT da canonicalização do identificador de login (CPF ou username) — AS v2.
+
+Motivação (M03-03 / #1614): antes, `CPFOrUsernameBackend.authenticate` removia a
+pontuação do CPF para resolver a conta, mas o contador de lockout chaveava por
+`username.lower()` cru. Resultado: cada grafia do mesmo CPF (com/sem pontos, hífens
+ou espaços) caía num balde de lockout independente, enquanto todas autenticavam a
+mesma conta — o lockout ficava sem teto efetivo.
+
+Esta função é a fonte única: o backend de autenticação **e** a derivação da chave de
+lockout consomem exatamente o mesmo valor canônico, de modo que todas as grafias de
+um mesmo CPF colapsam num único balde.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Mesma classe de caracteres que o backend historicamente removia do CPF
+# (pontos, hífens e espaços, em qualquer quantidade/posição).
+_LOGIN_PUNCT_RE = re.compile(r"[.\-\s]")
+
+# Comprimento de um CPF só-dígitos.
+_CPF_DIGITS = 11
+
+
+def normalize_login_identifier(raw: str) -> str:
+    """Canonicaliza o identificador EXATAMENTE como o backend resolve a conta.
+
+    - Remove pontuação de CPF (``.``, ``-`` e espaços). Se o resultado for 11 dígitos,
+      essa é a forma canônica do CPF — todas as grafias equivalentes colapsam nela.
+    - Caso contrário, devolve o input **cru** (sem lowercase): é o valor com que o
+      backend faz ``User.objects.get(username=...)`` (lookup case-sensitive), então
+      preservá-lo garante que a chave de lockout case com a identidade que autentica.
+
+    Não é mais agressiva que a normalização histórica do backend (só ``[.\\-\\s]``),
+    para não quebrar login por ``username`` que contenha esses caracteres.
+    """
+    clean = _LOGIN_PUNCT_RE.sub("", raw)
+    if len(clean) == _CPF_DIGITS and clean.isdigit():
+        return clean
+    return raw

--- a/v2/backend/apps/core/tests/test_auth_backends.py
+++ b/v2/backend/apps/core/tests/test_auth_backends.py
@@ -322,3 +322,41 @@ def test_authenticate_alphanumeric_tries_username(backend, request_factory, usua
 
     assert user is not None
     assert user == user_alpha
+
+
+# ===================================================================
+# M03-03 (#1614) — NORMALIZAÇÃO SSOT DO IDENTIFICADOR
+# ===================================================================
+
+
+def test_normalize_login_identifier_colapsa_grafias_de_cpf():
+    """SSOT: todas as grafias do mesmo CPF canonicalizam para os 11 dígitos.
+
+    RED: `apps.core.auth_normalize` ainda não existe.
+    """
+    from apps.core.auth_normalize import normalize_login_identifier
+
+    assert normalize_login_identifier("111.444.777-35") == "11144477735"
+    assert normalize_login_identifier("111 444 777 35") == "11144477735"
+    assert normalize_login_identifier("1 1 1 4 4 4 7 7 7 3 5") == "11144477735"
+    assert normalize_login_identifier("11144477735") == "11144477735"
+
+
+def test_normalize_login_identifier_preserva_username():
+    """SSOT: identificador que não é CPF de 11 dígitos é devolvido cru (case-sensitive),
+    exatamente como o backend faz `User.objects.get(username=...)`."""
+    from apps.core.auth_normalize import normalize_login_identifier
+
+    assert normalize_login_identifier("joao") == "joao"
+    assert normalize_login_identifier("user123") == "user123"
+    assert normalize_login_identifier("Joao") == "Joao"  # não força lowercase
+    assert normalize_login_identifier("1234567890") == "1234567890"  # 10 dígitos → username path
+    assert normalize_login_identifier("joao@example.com") == "joao@example.com"
+
+
+def test_backend_usa_normalizacao_ssot():
+    """Sentinela de wiring: o backend consome a MESMA função SSOT (uma única definição)."""
+    import apps.core.auth_backends as ab
+    from apps.core.auth_normalize import normalize_login_identifier
+
+    assert ab.normalize_login_identifier is normalize_login_identifier

--- a/v2/backend/apps/core/tests/test_login_throttle_simple.py
+++ b/v2/backend/apps/core/tests/test_login_throttle_simple.py
@@ -61,17 +61,20 @@ def test_login_throttle_instantiates_successfully():
     assert throttle.duration > 0
 
 
-def test_login_throttle_extends_anon_rate_throttle():
+def test_login_throttle_extends_simple_rate_throttle():
     """
-    SEC-P1: LoginThrottle deve herdar de AnonRateThrottle.
+    SEC-P1 / M03-03 (#1614): LoginThrottle herda de SimpleRateThrottle e chaveia
+    por IP **inclusive** para caller autenticado.
 
-    Garante throttling por IP (não por usuário autenticado).
+    Antes herdava de AnonRateThrottle, cujo get_cache_key retorna None quando
+    request.user.is_authenticated — deixando um usuário logado fazer brute force
+    em /api/auth/login/ sem throttle. Agora o balde é sempre o IP.
     """
-    from rest_framework.throttling import AnonRateThrottle
+    from rest_framework.throttling import SimpleRateThrottle
 
     assert issubclass(
-        LoginThrottle, AnonRateThrottle
-    ), "LoginThrottle deve herdar de AnonRateThrottle (throttling por IP)"
+        LoginThrottle, SimpleRateThrottle
+    ), "LoginThrottle deve herdar de SimpleRateThrottle (throttle por IP, anon E autenticado)"
 
 
 def test_login_view_has_throttle_applied():

--- a/v2/backend/apps/core/tests/test_security_hardening.py
+++ b/v2/backend/apps/core/tests/test_security_hardening.py
@@ -24,6 +24,7 @@ from apps.core.views_auth import (
     _get_lockout_key,
     _increment_failed_attempts,
     _is_account_locked,
+    _lockout_bucket,
 )
 
 
@@ -211,10 +212,17 @@ class TestCompoundLockout(TestCase):
         assert "global" in key
         assert "admin" in key
 
-    def test_lockout_key_case_insensitive(self):
-        key1 = _get_lockout_key("Admin", "1.2.3.4")
-        key2 = _get_lockout_key("admin", "1.2.3.4")
-        assert key1 == key2
+    def test_lockout_bucket_colapsa_grafias_do_mesmo_cpf(self):
+        """M03-03 (#1614): o balde de lockout é o MESMO para todas as grafias do CPF.
+
+        Antes o key lowercaseava o username cru (evadível por pontuação/espaço).
+        Agora o balde vem de HMAC(identificador-canônico): pontos, hífens e espaços
+        colapsam. (Username segue case-sensitive, casando com a identidade que autentica.)
+        """
+        assert _lockout_bucket("111.444.777-35") == _lockout_bucket("11144477735")
+        assert _lockout_bucket("111 444 777 35") == _lockout_bucket("11144477735")
+        # baldes de contas diferentes não colidem
+        assert _lockout_bucket("11144477735") != _lockout_bucket("22255588846")
 
     @override_settings(ACCOUNT_LOCKOUT_THRESHOLD=3, ACCOUNT_LOCKOUT_DURATION=60)
     def test_lockout_by_ip_username(self):

--- a/v2/backend/apps/core/tests/test_views_auth.py
+++ b/v2/backend/apps/core/tests/test_views_auth.py
@@ -442,12 +442,15 @@ def test_lockout_compartilha_bucket_entre_grafias_do_mesmo_cpf(api_client, usuar
     mascarada autentica (200). GREEN: o bucket é derivado do identificador canônico →
     a conta está bloqueada e a resposta é a genérica 400.
     """
-    for _ in range(10):
-        resp = _post_login(api_client, _CPF_CRU, "wrongpass")
-        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+    # Bypass do throttle: este teste é sobre LOCKOUT (precisa de >10 POSTs). O rate de
+    # login em CI é 10/min e mascararia o lockout com 429 — concerns separados.
+    with patch("apps.core.views_auth.LoginThrottle.allow_request", return_value=True):
+        for _ in range(10):
+            resp = _post_login(api_client, _CPF_CRU, "wrongpass")
+            assert resp.status_code == status.HTTP_400_BAD_REQUEST
 
-    # Senha CORRETA, mas na grafia mascarada → deve estar bloqueado (mesmo bucket do CPF cru).
-    locked = _post_login(api_client, _CPF_MASCARA, "testpass123")
+        # Senha CORRETA, mas na grafia mascarada → deve estar bloqueado (mesmo bucket do CPF cru).
+        locked = _post_login(api_client, _CPF_MASCARA, "testpass123")
     assert locked.status_code == status.HTTP_400_BAD_REQUEST
     assert locked.data == {"error": "Credenciais inválidas."}
 
@@ -461,13 +464,15 @@ def test_lockout_nao_e_evadido_por_espacos(api_client, usuario_cpf_conhecido):
     correta autentica (200). GREEN: colapsam no bucket canônico → global=6 → bloqueado (400).
     """
     grafias = [_CPF_ESPACOS, "11144 477 735", "1 1 1 4 4 4 7 7 7 3 5"]  # todas = 11144477735 (11 díg.)
-    for grafia in grafias:
-        for _ in range(2):
-            resp = _post_login(api_client, grafia, "wrongpass")
-            assert resp.status_code == status.HTTP_400_BAD_REQUEST
+    # Bypass do throttle (rate 10/min em CI mascararia o lockout global com 429).
+    with patch("apps.core.views_auth.LoginThrottle.allow_request", return_value=True):
+        for grafia in grafias:
+            for _ in range(2):
+                resp = _post_login(api_client, grafia, "wrongpass")
+                assert resp.status_code == status.HTTP_400_BAD_REQUEST
 
-    # 7ª tentativa — senha CORRETA no CPF cru → global lockout deve bloquear.
-    locked = _post_login(api_client, _CPF_CRU, "testpass123")
+        # 7ª tentativa — senha CORRETA no CPF cru → global lockout deve bloquear.
+        locked = _post_login(api_client, _CPF_CRU, "testpass123")
     assert locked.status_code == status.HTTP_400_BAD_REQUEST
 
 

--- a/v2/backend/apps/core/tests/test_views_auth.py
+++ b/v2/backend/apps/core/tests/test_views_auth.py
@@ -15,13 +15,15 @@ Valida:
 
 from __future__ import annotations
 
+import threading
 from unittest.mock import patch
 from uuid import uuid4
 
 from django.core.cache import cache
 from django.test import override_settings
 from rest_framework import status
-from rest_framework.test import APIClient
+from rest_framework.request import Request
+from rest_framework.test import APIClient, APIRequestFactory
 
 import pytest
 
@@ -29,6 +31,12 @@ from apps.core.models import AuditLog
 from apps.core.tests.factories import UsuarioFactory
 
 pytestmark = pytest.mark.django_db
+
+# CPF válido (mod-11) fixo para os testes de bucket de lockout — as três grafias
+# abaixo canonicalizam para o MESMO identificador.
+_CPF_CRU = "11144477735"
+_CPF_MASCARA = "111.444.777-35"
+_CPF_ESPACOS = "111 444 777 35"
 
 
 @pytest.fixture(autouse=True)
@@ -402,3 +410,155 @@ def test_logout_clears_session(api_client, usuario_ativo):
     # Tentar logout novamente sem auth (deve falhar)
     response = api_client.post("/api/auth/logout/")
     assert response.status_code in [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN]
+
+
+# ===================================================================
+# M03-03 (#1614) — LOCKOUT/THROTTLE NÃO EVADÍVEIS
+# ===================================================================
+
+
+@pytest.fixture
+def usuario_cpf_conhecido():
+    """Usuário com CPF fixo (mod-11 válido) para exercitar bucket de lockout por grafia."""
+    uid = uuid4().hex
+    return UsuarioFactory(
+        username=f"cpfuser_{uid}",
+        email=f"cpfuser_{uid}@example.com",
+        password="testpass123",
+        cpf=_CPF_CRU,
+        is_active=True,
+    )
+
+
+def _post_login(client: APIClient, username: str, password: str):
+    return client.post("/api/auth/login/", {"username": username, "password": password}, format="json")
+
+
+@override_settings(ACCOUNT_LOCKOUT_THRESHOLD=10)
+def test_lockout_compartilha_bucket_entre_grafias_do_mesmo_cpf(api_client, usuario_cpf_conhecido):
+    """10 falhas no CPF cru devem bloquear TAMBÉM a grafia com máscara (mesmo bucket).
+
+    RED (bug M03-03): cada grafia é um bucket independente → a senha correta na grafia
+    mascarada autentica (200). GREEN: o bucket é derivado do identificador canônico →
+    a conta está bloqueada e a resposta é a genérica 400.
+    """
+    for _ in range(10):
+        resp = _post_login(api_client, _CPF_CRU, "wrongpass")
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+
+    # Senha CORRETA, mas na grafia mascarada → deve estar bloqueado (mesmo bucket do CPF cru).
+    locked = _post_login(api_client, _CPF_MASCARA, "testpass123")
+    assert locked.status_code == status.HTTP_400_BAD_REQUEST
+    assert locked.data == {"error": "Credenciais inválidas."}
+
+
+@override_settings(ACCOUNT_LOCKOUT_THRESHOLD=100)  # isola o caminho GLOBAL (IP-path nunca dispara)
+@patch("apps.core.views_auth._GLOBAL_LOCKOUT_THRESHOLD", 6)
+def test_lockout_nao_e_evadido_por_espacos(api_client, usuario_cpf_conhecido):
+    """Falhas espalhadas por grafias com espaços diferentes acumulam no MESMO bucket global.
+
+    RED: 3 grafias × 2 falhas = 6 falhas, mas em 3 buckets distintos (máx 2 < 6) → a senha
+    correta autentica (200). GREEN: colapsam no bucket canônico → global=6 → bloqueado (400).
+    """
+    grafias = [_CPF_ESPACOS, "11144 477 735", "1 1 1 4 4 4 7 7 7 3 5"]  # todas = 11144477735 (11 díg.)
+    for grafia in grafias:
+        for _ in range(2):
+            resp = _post_login(api_client, grafia, "wrongpass")
+            assert resp.status_code == status.HTTP_400_BAD_REQUEST
+
+    # 7ª tentativa — senha CORRETA no CPF cru → global lockout deve bloquear.
+    locked = _post_login(api_client, _CPF_CRU, "testpass123")
+    assert locked.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_login_throttle_keia_caller_autenticado_wiring():
+    """WIRING/regressão: LoginThrottle.get_cache_key NUNCA retorna None (nem p/ autenticado).
+
+    RED (AnonRateThrottle): retorna None quando request.user.is_authenticated → sem throttle.
+    """
+    from apps.core.views_auth import LoginThrottle
+
+    class _Authed:
+        is_authenticated = True
+
+    raw = APIRequestFactory().post("/api/auth/login/", REMOTE_ADDR=f"10.0.0.{uuid4().int % 250}")
+    req = Request(raw)
+    req.user = _Authed()  # type: ignore[assignment]
+
+    key = LoginThrottle().get_cache_key(req, view=object())
+    assert key is not None
+
+
+def test_login_throttla_caller_autenticado():
+    """COMPORTAMENTAL (nível-classe, determinístico): caller autenticado É throttleado.
+
+    Cache locmem dedicado + ident único + rate baixo distintivo (2/min) → imune ao
+    cache.clear() paralelo. RED: autenticado nunca chaveia → [True, True, True].
+    GREEN: chaveia por IP → [True, True, False].
+    """
+    from apps.core.views_auth import LoginThrottle
+
+    class _Authed:
+        is_authenticated = True
+
+    unique_ip = f"172.16.0.{uuid4().int % 250}"
+    cache_loc = f"throttle-authed-{uuid4().hex}"
+
+    with override_settings(
+        CACHES={
+            "default": {
+                "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+                "LOCATION": cache_loc,
+            }
+        }
+    ):
+        throttle = LoginThrottle()
+        throttle.rate = "2/minute"
+        throttle.num_requests, throttle.duration = throttle.parse_rate("2/minute")
+        view = object()
+
+        results = []
+        for _ in range(3):
+            raw = APIRequestFactory().post("/api/auth/login/", REMOTE_ADDR=unique_ip)
+            req = Request(raw)
+            req.user = _Authed()  # type: ignore[assignment]
+            results.append(throttle.allow_request(req, view))
+
+    assert results == [True, True, False]
+
+
+def test_incremento_concorrente_nao_perde_tentativa():
+    """30 incrementos concorrentes de _safe_increment não podem perder tentativa.
+
+    RED (_safe_increment = cache.get + cache.set, não atômico): contador < 30.
+    GREEN (cache.add + cache.incr atômico do Redis): contador == 30.
+    """
+    from apps.core.views_auth import _safe_increment
+
+    key = f"test_incr_concurrency_{uuid4().hex}"
+    cache.delete(key)
+    n_threads = 30
+    barrier = threading.Barrier(n_threads)
+
+    def worker():
+        barrier.wait()  # dispara todas ~ao mesmo tempo p/ maximizar contenção
+        _safe_increment(key, timeout=60)
+
+    threads = [threading.Thread(target=worker) for _ in range(n_threads)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert int(cache.get(key)) == n_threads
+    cache.delete(key)
+
+
+def test_login_rejeita_username_nao_string(api_client, usuario_cpf_conhecido):
+    """Payload com username não-string deve retornar 400, nunca 500 (M03-12, mesma raiz).
+
+    RED: authenticate(username=["a"]) → re.sub sobre lista → TypeError → 500.
+    GREEN: validação de tipo na entrada → 400.
+    """
+    resp = api_client.post("/api/auth/login/", {"username": ["a"], "password": "testpass123"}, format="json")
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST

--- a/v2/backend/apps/core/views_auth.py
+++ b/v2/backend/apps/core/views_auth.py
@@ -16,6 +16,10 @@ Security Audit 2025-01:
 
 from __future__ import annotations
 
+import hashlib
+import hmac
+import logging
+
 from django.conf import settings
 from django.contrib.auth import authenticate
 from django.contrib.auth import login as django_login
@@ -29,12 +33,15 @@ from rest_framework.decorators import api_view, permission_classes, throttle_cla
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
-from rest_framework.throttling import AnonRateThrottle
+from rest_framework.throttling import SimpleRateThrottle
 
+from apps.core.auth_normalize import normalize_login_identifier
 from apps.core.pii import redact_cpf
 from apps.core.views.utils import _get_client_ip
 
 from .models import AuditLog
+
+logger = logging.getLogger(__name__)
 
 # ================================================================
 # Account Lockout (Security Audit 2025-01, SEC-AUTH-01)
@@ -47,21 +54,37 @@ _GLOBAL_LOCKOUT_THRESHOLD = 50
 _GLOBAL_LOCKOUT_DURATION = 1800  # 30 minutes
 
 
-def _get_lockout_key(username: str, ip: str = "") -> str:
-    """Gera chave Redis para tracking de tentativas de login por IP+username."""
+def _lockout_bucket(username: str) -> str:
+    """Deriva um balde estável e sem-PII para o identificador de login.
+
+    HMAC-SHA256(SECRET_KEY, identificador-canônico) — usa a SSOT
+    :func:`normalize_login_identifier` para que **todas as grafias do mesmo CPF**
+    colapsem no mesmo balde (M03-03), e o HMAC evita gravar CPF em claro nas
+    chaves do Redis (PII-at-rest, LGPD). SECRET_KEY torna o digest não-enumerável.
+    """
+    canonical = normalize_login_identifier(username)
+    return hmac.new(
+        settings.SECRET_KEY.encode("utf-8"),
+        canonical.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+
+
+def _get_lockout_key(bucket: str, ip: str = "") -> str:
+    """Gera chave Redis para tracking de tentativas por IP+bucket (ou global por bucket)."""
     if ip:
-        return f"login_attempts:{username.lower()}:{ip}"
-    return f"login_attempts_global:{username.lower()}"
+        return f"login_attempts:{bucket}:{ip}"
+    return f"login_attempts_global:{bucket}"
 
 
-def _get_failed_attempts(username: str, ip: str = "") -> int:
-    """Retorna número de tentativas falhas de login."""
-    key = _get_lockout_key(username, ip)
+def _get_failed_attempts(bucket: str, ip: str = "") -> int:
+    """Retorna número de tentativas falhas de login para o balde."""
+    key = _get_lockout_key(bucket, ip)
     attempts = cache.get(key)
     return int(attempts) if attempts else 0
 
 
-def _increment_failed_attempts(username: str, ip: str) -> int:
+def _increment_failed_attempts(bucket: str, ip: str) -> int:
     """
     Incrementa contadores de tentativas falhas (IP-specific e global).
     Retorna o novo total de tentativas IP-specific.
@@ -69,55 +92,60 @@ def _increment_failed_attempts(username: str, ip: str) -> int:
     lockout_duration = getattr(settings, "ACCOUNT_LOCKOUT_DURATION", 900)
 
     # Increment IP-specific counter
-    ip_key = _get_lockout_key(username, ip)
+    ip_key = _get_lockout_key(bucket, ip)
     ip_attempts = _safe_increment(ip_key, lockout_duration)
 
     # Increment global counter
-    global_key = _get_lockout_key(username)
+    global_key = _get_lockout_key(bucket)
     _safe_increment(global_key, _GLOBAL_LOCKOUT_DURATION)
 
     return ip_attempts
 
 
 def _safe_increment(key: str, timeout: int) -> int:
-    """Safely increment a Redis counter with TTL."""
+    """Incrementa um contador no Redis de forma ATÔMICA, com TTL de janela fixa.
+
+    ``cache.add`` faz o bootstrap via SETNX (só cria se ausente, atômico) e ``cache.incr``
+    mapeia para o INCR do Redis (atômico) — tentativas concorrentes não se perdem
+    (M03-03). O TTL é ancorado na PRIMEIRA falha (janela fixa; ``incr`` não reseta o TTL),
+    semântica correta de "N falhas em T minutos".
+
+    Falha de cache é **observável** (log) e **fail-closed**: devolve o teto global para
+    não conceder tentativas grátis quando o contador não pôde ser persistido.
+    """
     try:
-        current = cache.get(key)
-        if current is None:
-            cache.set(key, 1, timeout=timeout)
-            return 1
-        new_value = int(current) + 1
-        cache.set(key, new_value, timeout=timeout)
-        return new_value
+        cache.add(key, 0, timeout=timeout)
+        return int(cache.incr(key))
     except Exception:
-        return 1
+        logger.warning("lockout: falha ao incrementar contador de tentativas (fail-closed)", exc_info=True)
+        return _GLOBAL_LOCKOUT_THRESHOLD
 
 
-def _clear_failed_attempts(username: str, ip: str) -> None:
+def _clear_failed_attempts(bucket: str, ip: str) -> None:
     """Limpa contadores de tentativas após login bem-sucedido."""
-    cache.delete(_get_lockout_key(username, ip))
-    cache.delete(_get_lockout_key(username))
+    cache.delete(_get_lockout_key(bucket, ip))
+    cache.delete(_get_lockout_key(bucket))
 
 
-def _is_account_locked(username: str, ip: str) -> bool:
+def _is_account_locked(bucket: str, ip: str) -> bool:
     """Verifica se a conta está bloqueada (IP-specific OU global)."""
     threshold = getattr(settings, "ACCOUNT_LOCKOUT_THRESHOLD", 10)
 
     # Check IP-specific lockout
-    if _get_failed_attempts(username, ip) >= threshold:
+    if _get_failed_attempts(bucket, ip) >= threshold:
         return True
 
     # Check global lockout (distributed attack protection)
-    if _get_failed_attempts(username) >= _GLOBAL_LOCKOUT_THRESHOLD:
+    if _get_failed_attempts(bucket) >= _GLOBAL_LOCKOUT_THRESHOLD:
         return True
 
     return False
 
 
-def _get_lockout_remaining_time(username: str, ip: str) -> int | None:
+def _get_lockout_remaining_time(bucket: str, ip: str) -> int | None:
     """Retorna tempo restante de bloqueio em segundos, ou None se não bloqueado."""
     # Check IP-specific first, then global
-    for key in [_get_lockout_key(username, ip), _get_lockout_key(username)]:
+    for key in [_get_lockout_key(bucket, ip), _get_lockout_key(bucket)]:
         ttl = cache.ttl(key) if hasattr(cache, "ttl") else None
         if ttl and ttl > 0:
             return ttl
@@ -157,8 +185,8 @@ def csrf_token(request: Request) -> Response:
     return Response({"csrfToken": get_token(request)}, status=status.HTTP_200_OK)
 
 
-# Issue #133: Rate limiting para prevenir brute force (SEC-P1)
-class LoginThrottle(AnonRateThrottle):
+# Issue #133 / M03-03 (#1614): Rate limiting para prevenir brute force (SEC-P1)
+class LoginThrottle(SimpleRateThrottle):
     """
     Rate limiting para endpoint de login — configurado por ambiente.
 
@@ -169,10 +197,21 @@ class LoginThrottle(AnonRateThrottle):
     A taxa é lida de `REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]["login"]`
     em `config/settings.py` — `10/minute` por padrão, sobrescrito para
     `1000/minute` quando `ENVIRONMENT=development`.
+
+    M03-03 (#1614): herda de `SimpleRateThrottle` (não `AnonRateThrottle`) e
+    **sempre** chaveia por IP — inclusive para caller já autenticado. O
+    `AnonRateThrottle.get_cache_key` retorna ``None`` quando
+    ``request.user.is_authenticated``, deixando um usuário logado fazer brute
+    force em ``/api/auth/login/`` contra outra conta sem throttle. Aqui o balde é
+    sempre o IP (via ``get_ident``, que respeita ``NUM_PROXIES``).
     """
 
     # Escopo dedicado — DRF resolve a taxa via DEFAULT_THROTTLE_RATES[scope].
     scope = "login"
+
+    def get_cache_key(self, request: Request, view: object) -> str:
+        # Nunca retorna None: throttle vale para anônimo E autenticado.
+        return self.cache_format % {"scope": self.scope, "ident": self.get_ident(request)}
 
 
 @api_view(["POST"])
@@ -200,16 +239,24 @@ def login(request: Request) -> Response:
     username = request.data.get("username")
     password = request.data.get("password")
 
+    # M03-12 (#1614): identificador/senha não-string (ex.: {"username": ["a"]}) deve
+    # virar 400, nunca 500 — a normalização a jusante espera str.
+    if not isinstance(username, str) or not isinstance(password, str):
+        return Response({"error": "Username e password são obrigatórios."}, status=status.HTTP_400_BAD_REQUEST)
+
     if not username or not password:
         return Response({"error": "Username e password são obrigatórios."}, status=status.HTTP_400_BAD_REQUEST)
 
-    # SEC-AUTH-01: compound lockout key (IP + username)
+    # SEC-AUTH-01 / M03-03: balde de lockout derivado do identificador CANÔNICO
+    # (mesmo valor que autentica), sem PII em claro (HMAC). Todas as grafias do
+    # mesmo CPF caem no mesmo balde.
     client_ip = _get_client_ip(request)
+    bucket = _lockout_bucket(username)
 
     # Security hardening #745:
     # - Keep a generic client response for all auth failures
     # - Preserve detailed reason only in AuditLog
-    is_locked = _is_account_locked(username, client_ip)
+    is_locked = _is_account_locked(bucket, client_ip)
 
     user = authenticate(request, username=username, password=password)
     if user is None:
@@ -218,8 +265,8 @@ def login(request: Request) -> Response:
 
     if is_locked:
         threshold = getattr(settings, "ACCOUNT_LOCKOUT_THRESHOLD", 10)
-        attempts = _get_failed_attempts(username, client_ip)
-        lockout_remaining_seconds = _get_lockout_remaining_time(username, client_ip)
+        attempts = _get_failed_attempts(bucket, client_ip)
+        lockout_remaining_seconds = _get_lockout_remaining_time(bucket, client_ip)
 
         # Log tentativa de login em conta bloqueada (detalhes só internamente)
         AuditLog.objects.create(
@@ -241,7 +288,7 @@ def login(request: Request) -> Response:
 
     if user is None:
         # Incrementa contador de tentativas falhas (estado interno)
-        attempts = _increment_failed_attempts(username, client_ip)
+        attempts = _increment_failed_attempts(bucket, client_ip)
         threshold = getattr(settings, "ACCOUNT_LOCKOUT_THRESHOLD", 10)
 
         # Log tentativa falha
@@ -263,7 +310,7 @@ def login(request: Request) -> Response:
 
     if not user.is_active:
         # Defensive fallback for alternate backends that might return inactive users.
-        attempts = _increment_failed_attempts(username, client_ip)
+        attempts = _increment_failed_attempts(bucket, client_ip)
         threshold = getattr(settings, "ACCOUNT_LOCKOUT_THRESHOLD", 10)
         AuditLog.objects.create(
             usuario=None,
@@ -281,7 +328,7 @@ def login(request: Request) -> Response:
         return _invalid_credentials_response()
 
     # Login bem-sucedido: limpa contadores de tentativas (IP-specific e global)
-    _clear_failed_attempts(username, client_ip)
+    _clear_failed_attempts(bucket, client_ip)
 
     # Realiza login
     django_login(request, user)


### PR DESCRIPTION
Closes #1614

## Problema (M03-03)

O identificador de login era normalizado só num lado: o backend removia pontuação do CPF para autenticar, mas o contador de lockout chaveava por `username.lower()` cru. Cada grafia do mesmo CPF (com/sem pontos, hífens, **espaços**) virava um balde independente → o lockout (IP e global) ficava **sem teto efetivo**. Três agravantes na mesma superfície: throttle não cobre caller autenticado, contador não-atômico, e identificador não-string → 500.

## Correção

| # | Defeito | Fix |
|---|---------|-----|
| 1 | Grafias de CPF = baldes independentes | **SSOT** `apps/core/auth_normalize.py::normalize_login_identifier`, consumida pelo backend **e** pela chave de lockout — todas as grafias colapsam num balde |
| 2 | CPF em claro nas chaves Redis (PII) | balde = **HMAC-SHA256(SECRET_KEY, canônico)** |
| 3 | `_safe_increment` = get+set (perde corrida) | **`cache.add` + `cache.incr`** (SETNX/INCR atômicos), janela TTL fixa, falha observável + fail-closed |
| 4 | Throttle não cobre autenticado | `LoginThrottle(SimpleRateThrottle)` com `get_cache_key` que **nunca** retorna None (chaveia por IP, anon E autenticado) |
| 5 | `username` não-string → 500 | guarda `isinstance(str)` na view e no backend (M03-12) |

**Deferido:** XFF/`NUM_PROXIES` (ler pela direita) — exige ler a config do edge de produção; coordenar com M01-01 (#1660).

## TDD (RED→GREEN)

9 testes novos, cada um provado RED antes do fix:
- `test_lockout_compartilha_bucket_entre_grafias_do_mesmo_cpf` — 200→**400** (grafia mascarada bloqueada)
- `test_lockout_nao_e_evadido_por_espacos` — global colapsa grafias com espaço
- `test_login_throttle_keia_caller_autenticado_wiring` + `test_login_throttla_caller_autenticado` — throttle determinístico (wiring + comportamental nível-classe, sem 25-POST flaky)
- `test_incremento_concorrente_nao_perde_tentativa` — 8/30 → **30/30** (5× sem flake)
- `test_login_rejeita_username_nao_string` — 500 → **400**
- `test_normalize_login_identifier_*` + `test_backend_usa_normalizacao_ssot` — SSOT

Testes existentes que codificavam o contrato antigo foram atualizados: `LoginThrottle` herda de `SimpleRateThrottle`; lockout key case-sensitive por design (colapso é por CPF, não por case de username).

## Verificação

`pytest test_views_auth test_auth_backends test_security_hardening test_login_throttle_* test_throttle_scopes_sentinela --no-migrations` → **72 passed, 5 skipped**. `black --check` limpo, `flake8` limpo.

## Risco de rollout

- **Formato das chaves de cache muda** — contadores em voo são descartados no deploy (contas bloqueadas destravam, contadores reiniciam). Aceitável; não migrar chaves.
- Throttle passa a valer p/ autenticado — em dev/staging rate é `1000/min`, E2E não quebra.
- Sem migração, sem modelo tocado.
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `2236fded`, slot `1` / projeto `aprender_staging_s1`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local-s1, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
