### PR TITLE
fix(oauth): vincula ownership do state ao cache + CanUseGcal no callback (M12-15)

### DIFF
--- a/v2/backend/apps/core/services/oauth/oauth_flow.py
+++ b/v2/backend/apps/core/services/oauth/oauth_flow.py
@@ -117,27 +117,24 @@ def validate_oauth_state(state: str, user_id: int) -> dict:
 
     Security:
         - Valida CSRF token contra cache (one-time use)
-        - Verifica user_id match
+        - Verifica ownership pelo CACHE (não pelo sufixo adulterável do state) — M12-15
         - Valida return_to (previne open redirect)
-        - Remove state do cache após validação
+        - Consome o state atomicamente (anti-replay concorrente) — M12-15
+
+    M12-15 (#1652): o dono do fluxo NÃO é mais lido do sufixo `|user_id` do state (que vem
+    por query string e é 100% controlado por quem monta a URL). A fonte de verdade é o
+    `user_id` gravado no cache por :func:`build_authorization_url`. O sufixo, se presente,
+    é dado morto — mantido só por compatibilidade de formato até o state ficar opaco.
     """
     from django.core.cache import cache
 
     try:
-        # Parse state
+        # Parse state — só o csrf_token importa; return_to e user_id vêm do CACHE.
         parts: list[str] = state.split("|")
         if len(parts) != 3:
             return {"valid": False, "return_to": "/pre-agenda", "error": "State format invalid"}
 
-        csrf_token, return_to, state_user_id_str = parts
-        state_user_id: int = int(state_user_id_str)
-
-        # Verificar user_id match
-        if state_user_id != user_id:
-            logger.error(
-                f"❌ OAuth state validation: user_id mismatch " f"(state={state_user_id}, authenticated={user_id})"
-            )
-            return {"valid": False, "return_to": "/pre-agenda", "error": "User ID mismatch"}
+        csrf_token: str = parts[0]
 
         # Buscar state no cache
         cache_key: str = f"oauth_state:{csrf_token}"
@@ -151,14 +148,26 @@ def validate_oauth_state(state: str, user_id: int) -> dict:
                 "error": "State token invalid or expired",
             }
 
+        # M12-15: autenticar o DONO pelo cache (não pelo sufixo do state, adulterável).
+        if cached_state.get("user_id") != user_id:
+            logger.error(
+                "❌ OAuth state validation: ownership mismatch "
+                f"(cache={cached_state.get('user_id')}, authenticated={user_id})"
+            )
+            return {"valid": False, "return_to": "/pre-agenda", "error": "State ownership mismatch"}
+
         # Validar return_to
         cached_return_to: str = cached_state.get("return_to", "/pre-agenda")
         if not _is_safe_url(cached_return_to):
             logger.warning(f"⚠️ OAuth state validation: unsafe return_to in cache ({cached_return_to})")
             cached_return_to = "/pre-agenda"
 
-        # Remover state do cache (one-time use)
-        cache.delete(cache_key)
+        # M12-15: consumo ATÔMICO (one-time). ``cache.delete`` devolve se removeu — só o
+        # primeiro a consumir vence, fechando a janela de replay concorrente.
+        if not cache.delete(cache_key):
+            logger.warning(f"⚠️ OAuth state validation: já consumido (replay?) ({csrf_token[:8]}...)")
+            return {"valid": False, "return_to": "/pre-agenda", "error": "State token invalid or expired"}
+
         logger.info(f"✅ OAuth state validado: {csrf_token[:8]}... (user={user_id})")
 
         return {"valid": True, "return_to": cached_return_to, "error": None}

--- a/v2/backend/apps/core/tests/test_google_oauth.py
+++ b/v2/backend/apps/core/tests/test_google_oauth.py
@@ -123,6 +123,19 @@ def usuario_formador(db):
 
 
 @pytest.fixture
+def usuario_super(db):
+    """Usuário do grupo Superintendência (tem CanUseGcal) — vítima do fluxo forjado que
+    AINDA passa pela policy do callback, isolando o check de ownership (M12-15, item 1)."""
+    return UsuarioFactory(
+        username="super_oauth_test",
+        email="super_oauth@aprendereditora.com.br",
+        password="testpass123",
+        cpf="33333333333",
+        groups=["Superintendência"],
+    )
+
+
+@pytest.fixture
 def google_oauth_credential(usuario_controle):
     """
     Cria credencial OAuth para testes.
@@ -683,7 +696,89 @@ class TestOAuthSecurity:
     - State/CSRF validation
     - Open redirect
     - Replay attacks
+    - Ownership do state lido do cache, não do sufixo adulterável (M12-15 / #1652)
     """
+
+    def test_validate_state_rejeita_dono_diferente_do_cache(self, usuario_controle, usuario_super):
+        """M12-15 (#1652): a validação do state deve autenticar o dono pelo CACHE, não pelo
+        sufixo (adulterável) do state. State criado por A (controle); atacante troca o sufixo
+        para o id da vítima B (super) e a envia. Deve ser REJEITADO.
+
+        RED: hoje o check compara o sufixo do state com o usuário autenticado (ambos = B) e
+        aceita — o dono real gravado no cache (A) nunca é lido.
+        """
+        from django.core.cache import cache
+
+        from apps.core.services.google_oauth import validate_oauth_state
+
+        csrf = "csrf_forjado_owner_123"
+        # A (controle) iniciou o fluxo → o cache pertence a A.
+        cache.set(
+            f"oauth_state:{csrf}",
+            {"user_id": usuario_controle.id, "return_to": "/pre-agenda", "created_at": timezone.now().isoformat()},
+            timeout=600,
+        )
+        # Atacante troca o sufixo para o id da vítima B e valida como B.
+        forjado = f"{csrf}|/pre-agenda|{usuario_super.id}"
+        result = validate_oauth_state(forjado, usuario_super.id)
+        assert result["valid"] is False  # hoje retorna True (bug M12-15)
+
+    @patch.dict(
+        "os.environ",
+        {
+            "GCAL_OAUTH_CLIENT_ID": "test_client_id_123",
+            "GCAL_OAUTH_CLIENT_SECRET": "test_client_secret_456",
+            "GCAL_OAUTH_REDIRECT_URI": "http://localhost:8002/api/oauth/google/callback/",
+            "GCAL_ALLOWED_DOMAIN": "aprendereditora.com.br",
+        },
+    )
+    @patch("apps.core.services.google_oauth.requests.post")
+    @patch("apps.core.services.google_oauth.requests.get")
+    def test_callback_forjado_nao_grava_credencial_para_vitima(
+        self, mock_get, mock_post, usuario_controle, usuario_super, mock_google_api
+    ):
+        """M12-15: callback com state forjado (cache pertence a A, sufixo = vítima B) NÃO pode
+        gravar GoogleOAuthCredential para B. B tem CanUseGcal (Superintendência), então a policy
+        não mascara o check de ownership.
+
+        RED: hoje o fluxo aceita o state forjado e grava a credencial de A na conta de B.
+        """
+        from django.core.cache import cache
+
+        mock_post.return_value = MagicMock(status_code=200, json=mock_google_api["exchange"])
+        mock_get.return_value = MagicMock(status_code=200, json=lambda: {"email": "controle@aprendereditora.com.br"})
+
+        csrf = "csrf_forjado_callback_456"
+        cache.set(
+            f"oauth_state:{csrf}",
+            {"user_id": usuario_controle.id, "return_to": "/pre-agenda", "created_at": timezone.now().isoformat()},
+            timeout=600,
+        )
+
+        client = APIClient()
+        client.force_authenticate(user=usuario_super)  # vítima B
+        client.get(
+            "/api/oauth/google/callback/",
+            {"code": "fake_code_de_A", "state": f"{csrf}|/pre-agenda|{usuario_super.id}"},
+        )
+
+        # Nenhuma credencial nem auditoria de conexão pode nascer para a vítima.
+        assert not GoogleOAuthCredential.objects.filter(user=usuario_super).exists()
+        assert not AuditLog.objects.filter(usuario=usuario_super, action="GOOGLE_CONNECT").exists()
+
+    def test_callback_exige_can_use_gcal(self, usuario_formador):
+        """M12-15 (item 4): o callback deve reaplicar CanUseGcal. Um usuário autenticado SEM a
+        policy (Formador) não pode receber credencial GCal → 403.
+
+        RED: hoje o callback só exige IsAuthenticated (sem @permission_classes([CanUseGcal])).
+        """
+        client = APIClient()
+        client.force_authenticate(user=usuario_formador)
+        response = client.get(
+            "/api/oauth/google/callback/",
+            {"code": "x", "state": "y|/pre-agenda|1"},
+        )
+        assert response.status_code == http_status.HTTP_403_FORBIDDEN
 
     def test_oauth_state_validated_in_callback(self, usuario_controle):
         """

--- a/v2/backend/apps/core/views_oauth.py
+++ b/v2/backend/apps/core/views_oauth.py
@@ -289,6 +289,7 @@ def google_oauth_start(request: Request) -> Response:
 
 
 @api_view(["GET"])
+@permission_classes([CanUseGcal])  # M12-15 (#1652): quem não pode usar GCal não recebe credencial GCal
 def google_oauth_callback(request: Request) -> Response:
     """
     Callback OAuth 2.0 após autorização do usuário no Google.


### PR DESCRIPTION
Closes #1652

## Problema (M12-15)

`validate_oauth_state` decidia **de quem é o fluxo OAuth lendo o próprio state** (`csrf|return_to|user_id`), que vem por query string e é 100% controlado por quem monta a URL. O `user_id` gravado no cache por `build_authorization_url` existia mas **nunca era lido**. O check `if state_user_id != user_id` compara o *sufixo* do state com o usuário autenticado — trivialmente satisfeito por quem adultera o sufixo.

**Cadeia de abuso:** A (com `CanUseGcal`) inicia o fluxo, recebe `code` da própria conta Google; monta `/callback?code=<code_de_A>&state=<csrf_de_A>|/pre-agenda|<id_de_B>`; a vítima B abre o link → o callback grava `GoogleOAuthCredential` com os tokens e `google_email` de **A** na conta de **B**. B passa a publicar formações no calendário de A. Agrava: o callback **não reaplica `CanUseGcal`** (era só `IsAuthenticated`), então a vítima podia ser qualquer um dos 148 autenticados.

## Correção

| # | Item | Fix |
|---|------|-----|
| 1 | ownership pelo sufixo adulterável | `validate_oauth_state` autentica o dono pelo **cache** (`cached_state["user_id"] != user_id` → rejeita). O sufixo vira dado morto. |
| 2 | janela de replay concorrente | consumo **atômico** do state: `cache.delete` com retorno — só o primeiro consumidor vence. |
| 4 | callback sem policy | `@permission_classes([CanUseGcal])` no `google_oauth_callback` → quem não pode usar GCal não recebe credencial GCal (403). |

**Deferido (item 3 — state opaco):** quebra fluxos OAuth **em voo** no deploy (TTL 10 min) e exige reescrever os testes que montam state manualmente. O item 1 já fecha a vulnerabilidade (o sufixo deixa de ser fonte de verdade). Follow-up separado.

## TDD (RED→GREEN)

3 testes novos, provados RED antes do fix:
- `test_validate_state_rejeita_dono_diferente_do_cache` — state de A com sufixo trocado p/ B: `valid=False` (era `True`)
- `test_callback_forjado_nao_grava_credencial_para_vitima` — vítima **com** CanUseGcal; forjado NÃO grava credencial (RED provou que gravava a credencial de A na conta da vítima)
- `test_callback_exige_can_use_gcal` — Formador (sem policy) → **403** (era 302)

**Verificação:** `pytest apps/core/tests/test_google_oauth.py --no-migrations` → **41 passed** (3 novos + 38 existentes, zero regressão). `validate_oauth_state` só é chamado pelo callback; nenhum outro teste toca o path. `black`/`flake8` limpos.

## Risco de rollout

Baixo. Itens 1+2 são compatíveis com o formato atual do state (sem quebrar fluxo em voo). Item 4 pode retornar 403 no callback p/ credencial legada de usuário **fora** de Controle/Superintendência/superuser — se existir, é justamente o indício a investigar (o dev DB não tem). Sem migration; rollback = reverter o commit.
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `31040ccd`, slot `1` / projeto `aprender_staging_s1`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local-s1, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
