### PR TITLE
fix(gcal): tasks Celery de publish/cancel com atomic() + select_for_update() (#1726)

### DIFF
--- a/v2/backend/apps/core/tasks.py
+++ b/v2/backend/apps/core/tasks.py
@@ -212,34 +212,40 @@ def task_publish_solicitacao_to_gcal(
             }
 
     try:
-        # Buscar solicitação
-        s = Solicitacao.objects.get(id=solicitation_id)
+        from django.db import transaction
 
-        # Aplicar publicação (com cliente OAuth se disponível)
-        outcome = apply_one_solicitacao(s, dry_run=dry_run, apply_blocked=apply_blocked, client=client)
+        # #1726: lock de linha + atomic — evita lost-update entre publish/cancel concorrentes
+        # do mesmo evento (o corpo re-lê a Solicitacao e persiste os campos de sync). O
+        # `except` de erro fica FORA deste bloco, para marcar ERROR mesmo após rollback.
+        with transaction.atomic():
+            # Buscar solicitação (com lock de linha)
+            s = Solicitacao.objects.select_for_update().get(id=solicitation_id)
 
-        # Criar AuditLog (apenas se não for dry_run)
-        if not dry_run:
-            audit_details = {
-                "solicitacao_id": s.id,
-                "action": outcome.action,
-                "external_event_id": outcome.external_event_id,
-                "summary": outcome.summary,
-                "dry_run": dry_run,
-                "apply_blocked": apply_blocked,
-            }
+            # Aplicar publicação (com cliente OAuth se disponível)
+            outcome = apply_one_solicitacao(s, dry_run=dry_run, apply_blocked=apply_blocked, client=client)
 
-            # OAuth Phase 3: Incluir google_email no AuditLog se disponível
-            if google_email:
-                audit_details["google_email"] = google_email
-                audit_details["operator_user_id"] = operator_user_id
+            # Criar AuditLog (apenas se não for dry_run)
+            if not dry_run:
+                audit_details = {
+                    "solicitacao_id": s.id,
+                    "action": outcome.action,
+                    "external_event_id": outcome.external_event_id,
+                    "summary": outcome.summary,
+                    "dry_run": dry_run,
+                    "apply_blocked": apply_blocked,
+                }
 
-            AuditLog.objects.create(
-                usuario=operator,  # OAuth: registrar operador; service_account: None
-                action=AuditLog.Action.PUBLISH_GCAL,
-                model_name="Solicitacao",
-                details=audit_details,
-            )
+                # OAuth Phase 3: Incluir google_email no AuditLog se disponível
+                if google_email:
+                    audit_details["google_email"] = google_email
+                    audit_details["operator_user_id"] = operator_user_id
+
+                AuditLog.objects.create(
+                    usuario=operator,  # OAuth: registrar operador; service_account: None
+                    action=AuditLog.Action.PUBLISH_GCAL,
+                    model_name="Solicitacao",
+                    details=audit_details,
+                )
 
         return {
             "action": outcome.action,
@@ -358,24 +364,29 @@ def task_cancel_solicitacao_from_gcal(
             }
 
     try:
-        # Buscar solicitação
-        s = Solicitacao.objects.get(id=solicitation_id)
+        from django.db import transaction
 
-        # Cancelar evento no Calendar e limpar campos
-        outcome = cancel_solicitacao(s, client=client)
+        # #1726: lock de linha + atomic — evita lost-update entre cancel/publish concorrentes
+        # do mesmo evento (cancel_solicitacao deleta no Google e limpa os campos de sync).
+        with transaction.atomic():
+            # Buscar solicitação (com lock de linha)
+            s = Solicitacao.objects.select_for_update().get(id=solicitation_id)
 
-        # Criar AuditLog
-        AuditLog.objects.create(
-            usuario=None,  # Task assíncrona, sem usuário direto
-            action=AuditLog.Action.CANCEL_GCAL,
-            model_name="Solicitacao",
-            details={
-                "solicitacao_id": s.id,
-                "action": outcome.action,
-                "external_event_id": outcome.external_event_id,
-                "summary": outcome.summary,
-            },
-        )
+            # Cancelar evento no Calendar e limpar campos
+            outcome = cancel_solicitacao(s, client=client)
+
+            # Criar AuditLog
+            AuditLog.objects.create(
+                usuario=None,  # Task assíncrona, sem usuário direto
+                action=AuditLog.Action.CANCEL_GCAL,
+                model_name="Solicitacao",
+                details={
+                    "solicitacao_id": s.id,
+                    "action": outcome.action,
+                    "external_event_id": outcome.external_event_id,
+                    "summary": outcome.summary,
+                },
+            )
 
         return {
             "action": outcome.action,

--- a/v2/backend/apps/core/tests/test_celery_task_suite.py
+++ b/v2/backend/apps/core/tests/test_celery_task_suite.py
@@ -99,6 +99,37 @@ class TestPublishTask:
         assert result["action"] == "ERROR"
         assert "999999" in result["summary"]
 
+    def test_publish_task_usa_select_for_update(self, task_solicitacao):
+        """#1726: a task deve reler a Solicitacao com select_for_update() (dentro de atomic())
+        antes de mutar/persistir — evita lost-update entre publish/cancel concorrentes do
+        mesmo evento.
+
+        RED: hoje a task faz `Solicitacao.objects.get(id=...)` puro (sem lock).
+        """
+        from apps.core.services.gcal.sync import SyncOutcome
+        from apps.core.tasks import task_publish_solicitacao_to_gcal
+
+        task_solicitacao.gcal_status = Solicitacao.GCalStatus.NONE
+        task_solicitacao.external_event_id = None
+        task_solicitacao.save()
+
+        with (
+            patch("apps.core.services.gcal_sync_service.apply_one_solicitacao") as mock_apply,
+            patch.object(
+                Solicitacao.objects, "select_for_update", wraps=Solicitacao.objects.select_for_update
+            ) as spy_lock,
+        ):
+            mock_apply.return_value = SyncOutcome(
+                action="CREATE",
+                solicitation_id=task_solicitacao.id,
+                external_event_id=f"asv2-{task_solicitacao.id}",
+                summary=f"Solicitação #{task_solicitacao.id}",
+            )
+            result = task_publish_solicitacao_to_gcal(task_solicitacao.id, dry_run=True)
+
+        assert result["error"] is None
+        spy_lock.assert_called()  # a task travou a linha antes de operar
+
 
 class TestCancelTask:
     """Tests for task_cancel_solicitacao_from_gcal."""
@@ -121,6 +152,32 @@ class TestCancelTask:
 
             assert result["action"] == "DELETE"
             assert result["error"] is None
+
+    def test_cancel_task_usa_select_for_update(self, task_solicitacao):
+        """#1726: idem publish — a task de cancel deve travar a linha (select_for_update
+        dentro de atomic()) antes de deletar o evento e limpar os campos de sync.
+
+        RED: hoje faz `Solicitacao.objects.get(id=...)` puro (sem lock).
+        """
+        from apps.core.services.gcal.sync import SyncOutcome
+        from apps.core.tasks import task_cancel_solicitacao_from_gcal
+
+        with (
+            patch("apps.core.services.gcal_sync_service.cancel_solicitacao") as mock_cancel,
+            patch.object(
+                Solicitacao.objects, "select_for_update", wraps=Solicitacao.objects.select_for_update
+            ) as spy_lock,
+        ):
+            mock_cancel.return_value = SyncOutcome(
+                action="DELETE",
+                solicitation_id=task_solicitacao.id,
+                external_event_id=None,
+                summary=f"Solicitação #{task_solicitacao.id} (cancelada)",
+            )
+            result = task_cancel_solicitacao_from_gcal(task_solicitacao.id)
+
+        assert result["error"] is None
+        spy_lock.assert_called()
 
     def test_cancel_task_creates_audit_log(self, task_solicitacao):
         """Task creates AuditLog entry on success."""


### PR DESCRIPTION
Closes #1726

## Problema
As tasks Celery `task_publish_solicitacao_to_gcal` e `task_cancel_solicitacao_from_gcal` reliam a `Solicitacao` com `.get()` puro e persistiam os campos de sync **sem** `transaction.atomic()` nem `select_for_update()`. O próprio `upsert_one` (`services/gcal/sync.py:181-188`) **documenta** que produção deveria envolver a operação em `atomic()` + lock de linha — mas as tasks ignoravam.

**Impacto:** lost-update entre publish e cancel concorrentes do mesmo evento (ou dois triggers do mesmo publish) sobrescrevendo os campos de sync (`external_event_id`, `gcal_status`, `last_sync_*`). Severidade baixo-médio, latente.

## Correção
- O corpo de sucesso de cada task roda em `with transaction.atomic():` relendo a `Solicitacao` via `select_for_update().get(id=...)` — **serializa operações concorrentes no MESMO evento** (lock por-linha; não bloqueia outros eventos). Como as tasks são por-solicitação única, o lock é mantido durante uma única chamada HTTP ao Google (~1-2s), que é exatamente a serialização desejada — não o anti-padrão de travar um batch inteiro.
- O `except` de erro do publish fica **fora** do `atomic()`, para marcar `gcal_status=ERROR` mesmo após o rollback do bloco.

## TDD (RED→GREEN)
2 testes novos, provados RED antes do fix (spy em `select_for_update`):
- `test_publish_task_usa_select_for_update` — RED: `Expected 'select_for_update' to have been called`
- `test_cancel_task_usa_select_for_update` — idem

**Verificação:** `test_celery_task_suite.py` → **9 passed**; suítes gcal amplas (batch / cancel-resync / oauth-mode / publish-chain / delete-swallow / approval-PA) → **45 passed**. `black`/`flake8` limpos. Sem migration; rollback = reverter o commit.

## Nota
O comentário `CONCURRENCY SAFETY` em `sync.py` também sugere o padrão no **command batch** (iterar `select_for_update()` no queryset). Este PR cobre só as **tasks Celery** (caso específico do #1726); o batch é superfície separada.
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `32b95a07`, slot `1` / projeto `aprender_staging_s1`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local-s1, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
