### PR TITLE
fix(dat-compra): invariantes no serializer + clamp no dashboard (M15-02, parcial)

### DIFF
--- a/v2/backend/apps/core/serializers/dat_module/dat_compra.py
+++ b/v2/backend/apps/core/serializers/dat_module/dat_compra.py
@@ -77,7 +77,7 @@ class DATCompraSerializer(serializers.ModelSerializer["DATCompra"]):
         Em PATCH, monta os valores EFETIVOS a partir da instância antes de comparar
         (o payload pode conter só um subconjunto dos campos).
         """
-        inst = self.instance
+        inst: DATCompra | None = self.instance
 
         def eff(field: str) -> Any:
             if field in attrs:

--- a/v2/backend/apps/core/serializers/dat_module/dat_compra.py
+++ b/v2/backend/apps/core/serializers/dat_module/dat_compra.py
@@ -9,6 +9,8 @@ Extracted from serializers/dat_module.py.
 
 from __future__ import annotations
 
+from typing import Any
+
 from rest_framework import serializers  # type: ignore[attr-defined]
 
 from apps.core.models import DATCompra
@@ -69,7 +71,7 @@ class DATCompraSerializer(serializers.ModelSerializer["DATCompra"]):
         ]
         read_only_fields = ["id", "created_by", "status_uso", "created_at", "updated_at"]
 
-    def validate(self, attrs: dict) -> dict:
+    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
         """M15-02 (#1632): invariantes de estoque/valor/coerência (SSOT de entrada).
 
         Em PATCH, monta os valores EFETIVOS a partir da instância antes de comparar
@@ -77,7 +79,7 @@ class DATCompraSerializer(serializers.ModelSerializer["DATCompra"]):
         """
         inst = self.instance
 
-        def eff(field: str):
+        def eff(field: str) -> Any:
             if field in attrs:
                 return attrs[field]
             return getattr(inst, field) if inst is not None else None

--- a/v2/backend/apps/core/serializers/dat_module/dat_compra.py
+++ b/v2/backend/apps/core/serializers/dat_module/dat_compra.py
@@ -69,6 +69,46 @@ class DATCompraSerializer(serializers.ModelSerializer["DATCompra"]):
         ]
         read_only_fields = ["id", "created_by", "status_uso", "created_at", "updated_at"]
 
+    def validate(self, attrs: dict) -> dict:
+        """M15-02 (#1632): invariantes de estoque/valor/coerência (SSOT de entrada).
+
+        Em PATCH, monta os valores EFETIVOS a partir da instância antes de comparar
+        (o payload pode conter só um subconjunto dos campos).
+        """
+        inst = self.instance
+
+        def eff(field: str):
+            if field in attrs:
+                return attrs[field]
+            return getattr(inst, field) if inst is not None else None
+
+        quantidade = eff("quantidade")
+        quantidade_utilizada = eff("quantidade_utilizada")
+        valor_unitario = eff("valor_unitario")
+        produto = eff("produto")
+        descricao_produto = eff("descricao_produto")
+        projeto = eff("projeto")
+
+        errors: dict[str, str] = {}
+
+        if quantidade is not None and quantidade_utilizada is not None and quantidade_utilizada > quantidade:
+            errors["quantidade_utilizada"] = (
+                f"Quantidade utilizada ({quantidade_utilizada}) não pode exceder a adquirida ({quantidade})."
+            )
+        if valor_unitario is not None and valor_unitario < 0:
+            errors["valor_unitario"] = "Valor unitário não pode ser negativo."
+        if produto is None and not (descricao_produto or "").strip():
+            errors["descricao_produto"] = "Informe um produto cadastrado ou uma descrição do produto."
+        if produto is not None and projeto is not None and produto.projeto_id != projeto.id:
+            errors["produto"] = (
+                f"O produto '{produto}' pertence ao projeto '{produto.projeto}', "
+                f"diferente do projeto da compra ('{projeto}')."
+            )
+
+        if errors:
+            raise serializers.ValidationError(errors)
+        return attrs
+
 
 class DATCompraListSerializer(serializers.ModelSerializer["DATCompra"]):
     """List serializer for DATCompra (table view)."""

--- a/v2/backend/apps/core/serializers/dat_module/dat_compra.py
+++ b/v2/backend/apps/core/serializers/dat_module/dat_compra.py
@@ -77,12 +77,12 @@ class DATCompraSerializer(serializers.ModelSerializer["DATCompra"]):
         Em PATCH, monta os valores EFETIVOS a partir da instância antes de comparar
         (o payload pode conter só um subconjunto dos campos).
         """
-        inst: DATCompra | None = self.instance
+        # Padrão que passa pyright strict (espelha serializers/solicitacao.py): getattr(self,
+        # "instance", None) devolve Any (conhecido); getattr(instance, field, None) com default.
+        instance = getattr(self, "instance", None)
 
         def eff(field: str) -> Any:
-            if field in attrs:
-                return attrs[field]
-            return getattr(inst, field) if inst is not None else None
+            return attrs.get(field, getattr(instance, field, None))
 
         quantidade = eff("quantidade")
         quantidade_utilizada = eff("quantidade_utilizada")

--- a/v2/backend/apps/core/tests/test_dat_compra_invariantes.py
+++ b/v2/backend/apps/core/tests/test_dat_compra_invariantes.py
@@ -1,0 +1,131 @@
+"""M15-02 (#1632): invariantes de DATCompra + paridade agregação-x-property do dashboard.
+
+Cobre a FATIA de aplicação (serializer + dashboard) — não as CheckConstraints do banco
+(item 2/5, que exigem levantamento + datafix em prod) nem a decisão sobre quantidade=0
+(item 3, decisão do dono). Ver o issue #1632.
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportOptionalMemberAccess=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportMissingTypeArgument=false, reportCallIssue=false, reportIndexIssue=false, reportOperatorIssue=false, reportOptionalSubscript=false, reportUnknownLambdaType=false
+
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+
+from rest_framework import status
+
+from apps.core.models import DATCompra
+from apps.core.models.organizacao import Produto
+from apps.core.tests.factories import ProjetoFactory
+from apps.core.tests.test_dat_module import DATModuleAPITestCase
+
+COMPRAS_URL = "/api/dat/compras-materiais/"
+DASHBOARD_URL = "/api/dat/compras-materiais/dashboard/"
+
+
+def _errs(response):
+    """Dict de erros de campo — a API embrulha validação em {code, detail, errors: {...}}."""
+    data = response.data
+    if isinstance(data, dict) and "errors" in data and isinstance(data["errors"], dict):
+        return data["errors"]
+    return data
+
+
+class DATCompraInvariantesAPITests(DATModuleAPITestCase):
+    """POSTs inválidos devem retornar 400 (não 201) por campo, e o dashboard deve
+    concordar com a soma das linhas (clamp por linha)."""
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        uid = uuid.uuid4().hex[:6]
+        cls.produto = Produto.objects.create(codigo=f"INV-{uid}", nome="Produto Inv", projeto=cls.projeto)
+        cls.projeto_outro = ProjetoFactory(nome=f"Outro Proj {uid}", codigo=f"OP{uid[:4]}", fluxo="NAO_SUPER")
+        cls.produto_outro_projeto = Produto.objects.create(
+            codigo=f"OUT-{uid}", nome="Produto Outro", projeto=cls.projeto_outro
+        )
+
+    def _payload(self, **overrides):
+        base = {
+            "municipio": self.municipio.id,
+            "projeto": self.projeto.id,
+            "produto": self.produto.id,
+            "quantidade": 10,
+            "quantidade_utilizada": 0,
+            "valor_unitario": "5.00",
+            "ano_uso": 2026,
+        }
+        base.update(overrides)
+        return base
+
+    def test_post_sobreuso_retorna_400(self):
+        """quantidade_utilizada > quantidade → 400 no campo quantidade_utilizada."""
+        self.client.force_authenticate(user=self.dat_user)
+        r = self.client.post(COMPRAS_URL, self._payload(quantidade=10, quantidade_utilizada=999), format="json")
+        assert r.status_code == status.HTTP_400_BAD_REQUEST, f"aceito com {r.status_code}"
+        assert "quantidade_utilizada" in _errs(r)
+
+    def test_post_valor_negativo_retorna_400(self):
+        """valor_unitario < 0 → 400 no campo valor_unitario."""
+        self.client.force_authenticate(user=self.dat_user)
+        r = self.client.post(COMPRAS_URL, self._payload(valor_unitario="-100.00"), format="json")
+        assert r.status_code == status.HTTP_400_BAD_REQUEST, f"aceito com {r.status_code}"
+        assert "valor_unitario" in _errs(r)
+
+    def test_post_item_vazio_retorna_400(self):
+        """produto None E descricao_produto vazio → 400 (não identifica material)."""
+        self.client.force_authenticate(user=self.dat_user)
+        r = self.client.post(COMPRAS_URL, self._payload(produto=None, descricao_produto=""), format="json")
+        assert r.status_code == status.HTTP_400_BAD_REQUEST, f"aceito com {r.status_code}"
+        assert "descricao_produto" in _errs(r)
+
+    def test_post_produto_de_outro_projeto_retorna_400(self):
+        """produto.projeto != projeto da compra → 400 no campo produto."""
+        self.client.force_authenticate(user=self.dat_user)
+        r = self.client.post(COMPRAS_URL, self._payload(produto=self.produto_outro_projeto.id), format="json")
+        assert r.status_code == status.HTTP_400_BAD_REQUEST, f"aceito com {r.status_code}"
+        assert "produto" in _errs(r)
+
+    def test_post_valido_ainda_passa(self):
+        """Não-regressão: payload válido continua 201."""
+        self.client.force_authenticate(user=self.dat_user)
+        r = self.client.post(COMPRAS_URL, self._payload(quantidade=10, quantidade_utilizada=3), format="json")
+        assert r.status_code == status.HTTP_201_CREATED, f"rejeitou válido: {r.data}"
+
+    def test_dashboard_disponivel_igual_soma_das_linhas(self):
+        """O KPI total_disponivel deve bater com a soma das .disponivel (clamp por linha).
+
+        Linhas com sobreuso são criadas via ORM (import/shell bypassa o serializer), como
+        acontece em prod. RED: a agregação SEM clamp diverge da soma clamped.
+        """
+        # Linha normal: disponível = 10 - 3 = 7
+        DATCompra.objects.create(
+            municipio=self.municipio,
+            projeto=self.projeto,
+            produto=self.produto,
+            quantidade=10,
+            quantidade_utilizada=3,
+            valor_unitario=Decimal("5.00"),
+            ano_uso=2026,
+            created_by=self.dat_user,
+        )
+        # Linha com sobreuso: disponível clampado = max(0, 10 - 999) = 0
+        DATCompra.objects.create(
+            municipio=self.municipio,
+            projeto=self.projeto,
+            produto=self.produto,
+            quantidade=10,
+            quantidade_utilizada=999,
+            valor_unitario=Decimal("1.00"),
+            ano_uso=2026,
+            created_by=self.dat_user,
+        )
+
+        self.client.force_authenticate(user=self.dat_user)
+        r = self.client.get(DASHBOARD_URL)
+        assert r.status_code == status.HTTP_200_OK, f"dashboard {r.status_code}"
+
+        soma_linhas = sum(c.disponivel for c in DATCompra.objects.all())
+        assert (
+            r.data["kpis"]["total_disponivel"] == soma_linhas
+        ), f"dashboard={r.data['kpis']['total_disponivel']} != soma_das_linhas={soma_linhas}"

--- a/v2/backend/apps/core/views/dat_module.py
+++ b/v2/backend/apps/core/views/dat_module.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from django.db.models import Count, Exists, F, Max, OuterRef, Q, Sum, Value
-from django.db.models.functions import Coalesce
+from django.db.models.functions import Coalesce, Greatest
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.filters import OrderingFilter, SearchFilter
@@ -495,8 +495,14 @@ class DATCompraViewSet(viewsets.ModelViewSet):
 
         total_itens = qs.aggregate(total=Sum("quantidade"))["total"] or 0
         total_entregue = qs.aggregate(total=Sum("quantidade_utilizada"))["total"] or 0
+        # M15-02 (#1632): clamp por linha via Greatest para a agregação concordar com a
+        # property DATCompra.disponivel (= max(0, quantidade - utilizada)). Sem o clamp,
+        # uma linha com sobreuso (utilizada > quantidade) puxava o KPI para negativo.
         total_disponivel = (
-            qs.aggregate(total=Sum(F("quantidade") - Coalesce(F("quantidade_utilizada"), 0)))["total"] or 0
+            qs.aggregate(total=Sum(Greatest(F("quantidade") - Coalesce(F("quantidade_utilizada"), 0), Value(0))))[
+                "total"
+            ]
+            or 0
         )
 
         municipios_atendidos = qs.values("municipio_id").distinct().count()


### PR DESCRIPTION
Refs #1632 *(parcial — não fecha; itens 2/3/5 deferidos, ver abaixo)*

## Problema (M15-02)
`DATCompra` aceitava, com **HTTP 201**, POSTs que violam invariantes — nem o `DATCompraSerializer` (ModelSerializer puro, sem `validate()`) nem o banco (`Meta` só com `indexes`) validavam:
- **sobreuso**: `quantidade_utilizada` (999) > `quantidade` (10);
- **valor unitário negativo**: `valor_unitario = -100`;
- **item vazio**: `produto = null` **e** `descricao_produto = ""`;
- **produto de outro projeto**: `produto.projeto_id != projeto_id`.

Agravante: o clamp existia só na leitura por linha (`DATCompra.disponivel = max(0, ...)`), mas o **dashboard** agregava sem clamp (`Sum(F("quantidade") - Coalesce(F("quantidade_utilizada"), 0))`) → soma das linhas = **15**, KPI = **-974**. Números silenciosamente errados numa tela de decisão.

## Correção (fatia de aplicação, baixo risco, sem migration)
| Item | Fix |
|------|-----|
| 1 | `DATCompraSerializer.validate()` (SSOT de entrada) rejeita os 4 casos com **400 por campo**; em PATCH monta os valores efetivos a partir da instância antes de comparar |
| 4 | Dashboard usa `Greatest(F("quantidade") - Coalesce(F("quantidade_utilizada"), 0), Value(0))` → a agregação concorda com a property `disponivel` por construção |

## Deferido (mantém #1632 aberta)
- **Item 2** (CheckConstraints no banco — defesa p/ import/shell/admin) + **item 5** (datafix): a migration de constraint **FALHA se prod já tiver linhas violando** → exige levantamento read-only em prod + datafix com snapshot/rollback ANTES. Precisa de acesso ao DB de prod + autorização.
- **Item 3** (`save()` com `quantidade=0` → esgotado): exige **decisão do dono** (proibir `quantidade >= 1` vs mapear para `disponivel`).

## TDD (RED→GREEN)
6 testes novos, provados RED antes do fix:
- 4× POST inválido → **400** (RED: retornavam 201)
- `test_post_valido_ainda_passa` → 201 (não-regressão)
- `test_dashboard_disponivel_igual_soma_das_linhas` → paridade (RED: dashboard **-982 ≠ 7**)

**Verificação:** `test_dat_compra_invariantes` (6) + `test_dat_module` (56) + suítes compras/rbac amplas (79) → **todas verdes**. `black`/`flake8` limpos. Sem migration; rollback = reverter o commit.
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `c940405d`, slot `1` / projeto `aprender_staging_s1`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local-s1, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
