### PR TITLE
fix(compra): external_hash imutável no PATCH + rejeita quantidade<=0 (M15-03, parcial)

### DIFF
--- a/v2/backend/apps/core/serializers/compra.py
+++ b/v2/backend/apps/core/serializers/compra.py
@@ -9,6 +9,8 @@ Type-checked with Pyright (strict mode).
 
 from __future__ import annotations
 
+from typing import Any
+
 from rest_framework import serializers  # type: ignore[attr-defined]
 
 from apps.core.models import Compra
@@ -42,8 +44,18 @@ class CompraSerializer(serializers.ModelSerializer):
         ]
         read_only_fields = ["id", "created_at", "updated_at"]
 
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        # M15-03 (#1633): external_hash é a chave de idempotência de import — imutável após
+        # a criação. No update (PATCH/PUT) fica read-only, para um CRUD não reescrever a
+        # chave de uma linha importada (quebraria a idempotência de imports futuros). No
+        # create segue gravável (compatível com o path de import).
+        if self.instance is not None:
+            self.fields["external_hash"].read_only = True
+
     def validate_quantidade(self, value: int) -> int:
-        """Quantidade não pode ser negativa."""
-        if value < 0:
-            raise serializers.ValidationError("Quantidade não pode ser negativa.")
+        """M15-03 (#1633): compra de estoque zero/negativo é inválida — quantidade=0
+        habilitava solicitação com estoque zerado (gate `.exists()` sem filtro de estoque)."""
+        if value <= 0:
+            raise serializers.ValidationError("Quantidade deve ser maior que zero.")
         return value

--- a/v2/backend/apps/core/tests/test_compras_domain_boundary.py
+++ b/v2/backend/apps/core/tests/test_compras_domain_boundary.py
@@ -143,3 +143,76 @@ def test_dat_user_cannot_access_controle_compra_domain(
     api_client.force_authenticate(user=dat_user)
     response = api_client.get("/api/controle/compras/", secure=True)
     assert response.status_code == 403
+
+
+# ===================================================================
+# M15-03 (#1633) — external_hash imutável no PATCH + quantidade > 0
+# ===================================================================
+
+
+def _errs(response):
+    """Dict de erros de campo — a API embrulha validação em {code, detail, errors: {...}}."""
+    data = response.data
+    if isinstance(data, dict) and "errors" in data and isinstance(data["errors"], dict):
+        return data["errors"]
+    return data
+
+
+def test_patch_nao_reescreve_external_hash(
+    api_client: APIClient,
+    dat_user: Usuario,
+    compra_core: Compra,
+) -> None:
+    """M15-03 (#1633): external_hash é a chave de idempotência de import — imutável após
+    a criação. Um PATCH não pode reescrevê-la (quebraria a idempotência de imports futuros).
+
+    RED: hoje o PATCH reescreve o hash e retorna 200 com o valor forjado.
+    """
+    api_client.force_authenticate(user=dat_user)
+    original = compra_core.external_hash
+    response = api_client.patch(
+        f"/api/compras/{compra_core.id}/", {"external_hash": "f" * 64}, format="json", secure=True
+    )
+    assert response.status_code == 200
+    compra_core.refresh_from_db()
+    assert compra_core.external_hash == original  # RED: virava "f"*64
+
+
+def test_post_quantidade_zero_retorna_400(
+    api_client: APIClient,
+    dat_user: Usuario,
+    municipio: Municipio,
+    projeto: Projeto,
+) -> None:
+    """M15-03: compra de estoque zero é inválida (habilitava solicitação com estoque zerado).
+
+    RED: hoje quantidade=0 é aceito com 201 (validate_quantidade só barra negativo).
+    """
+    api_client.force_authenticate(user=dat_user)
+    payload = {
+        "codigo": "ZERO-001",
+        "projeto": projeto.id,
+        "municipio": municipio.id,
+        "quantidade": 0,
+        "data": "2026-03-01",
+        "uso": "teste",
+        "external_hash": "a" * 64,
+    }
+    response = api_client.post("/api/compras/", payload, format="json", secure=True)
+    assert response.status_code == 400, f"aceito com {response.status_code}"
+    assert "quantidade" in _errs(response)
+
+
+def test_patch_campo_normal_ok_hash_intacto(
+    api_client: APIClient,
+    dat_user: Usuario,
+    compra_core: Compra,
+) -> None:
+    """Não-regressão: PATCH de campo normal funciona e o external_hash fica intacto."""
+    api_client.force_authenticate(user=dat_user)
+    original = compra_core.external_hash
+    response = api_client.patch(f"/api/compras/{compra_core.id}/", {"quantidade": 9}, format="json", secure=True)
+    assert response.status_code == 200
+    compra_core.refresh_from_db()
+    assert compra_core.quantidade == 9
+    assert compra_core.external_hash == original


### PR DESCRIPTION
Refs #1633 *(parcial — não fecha; itens 1/2/3/5 + 6b deferidos, ver abaixo)*

## Problema (M15-03)
`CompraSerializer` (`CompraViewSet` em `/api/compras/`, escrita = `manage_purchases_and_materials` → DAT+Controle) deixava:
- **Reescrever a chave de idempotência de import via PATCH.** `external_hash` não estava em `read_only_fields`; um `PATCH {"external_hash": "ffff…"}` numa linha importada retornava **200** e sobrescrevia o hash → imports futuros deixam de reconhecê-la e **recriam duplicata**.
- **Compra de estoque zero.** `validate_quantidade` só barrava negativo → `quantidade=0` nascia **201** e habilitava solicitação com estoque zerado (o gate de elegibilidade é `.exists()` sem filtro de estoque).

Reproduzido no issue (DAT e Controle, atores reais): `PATCH external_hash → 200 | no banco: ffff…`; `POST quantidade=0 → 201`.

## Correção (fatia de aplicação — itens 4 e 6a do issue, "PR curto imediato"; sem migration)
- `__init__` torna `external_hash` **read-only quando há `self.instance`** (update): imutável no PATCH/PUT, gravável no create (compatível com o path de import).
- `validate_quantidade` exige **`> 0`**.

## Deferido (mantém #1633 aberta)
- **Itens 1/2/3/5** — identidade natural-key (`codigo+municipio+projeto+data`) + tirar campos mutáveis do payload do hash + backfill + `UniqueConstraint`: exigem **reconciliação de dados em prod** (a migration falha/duplica se houver colisão) — acesso a prod + decisão.
- **Item 6b** — gate de `serializers/solicitacao.py:196` filtrar `quantidade__gt=0`: é **regra de fluxo core (RF)** → prefiro aval do dono antes de mexer na elegibilidade da solicitação.

## TDD (RED→GREEN)
3 testes novos, provados RED:
- `test_patch_nao_reescreve_external_hash` — RED: `'ffff…' == 'cccc…'` (PATCH reescrevia)
- `test_post_quantidade_zero_retorna_400` — RED: `201 == 400`
- `test_patch_campo_normal_ok_hash_intacto` — não-regressão (PATCH normal ok, hash intacto)

**Verificação:** suítes compras/admin/modular/rbac **verdes** (fresh DB); `black`/`flake8` limpos. Sem migration; rollback = reverter o commit.

> Nota: a falha local de `test_compra_external_hash_index_1742` era estado stale do test-DB reusado entre modos — passa com `--create-db`; independe desta mudança (serializer não cria índice).
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `d3d7aaf9`, slot `1` / projeto `aprender_staging_s1`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local-s1, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
