### PR TITLE
ci(frontend): cacheia browsers do Playwright + timeout no install

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -92,7 +92,17 @@ jobs:
 
     - uses: ./.github/actions/setup-node-deps
 
+    - name: Cache Playwright browsers
+      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ hashFiles('v2/frontend/package-lock.json') }}
+
     - name: Install Playwright browsers
+      # timeout curto: se o download do browser travar (flake de rede no CDN,
+      # visto no run 32251606405 — 30min pendurado), falha rápido p/ re-run
+      # em vez de queimar o budget do job. Em cache-hit o download é pulado.
+      timeout-minutes: 10
       run: npx playwright install chromium --with-deps
 
     - name: Start backend services for functional contract checklist
@@ -195,7 +205,17 @@ jobs:
 
     - uses: ./.github/actions/setup-node-deps
 
+    - name: Cache Playwright browsers
+      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ hashFiles('v2/frontend/package-lock.json') }}
+
     - name: Install Playwright browsers
+      # timeout curto: se o download do browser travar (flake de rede no CDN,
+      # visto no run 32251606405 — 30min pendurado), falha rápido p/ re-run
+      # em vez de queimar o budget do job. Em cache-hit o download é pulado.
+      timeout-minutes: 10
       run: npx playwright install chromium --with-deps
 
     - name: Start backend services and seed E2E data


### PR DESCRIPTION
## Problema

No run [32251606405](https://github.com/matheusnorjosa/aprender_sistema/actions/runs/32251606405) (PR #1763), o step **"Install Playwright browsers"** do job `e2e-journeys` **pendurou 30 min e foi cancelado** pelo timeout.

**Diagnóstico — flake de rede, não sistêmico:** no MESMO run, o job paralelo `[required] checklist tests` roda o comando **idêntico** (`npx playwright install chromium --with-deps`) e baixou em **3m21s**. Mesmo comando, mesma hora, runners diferentes → um travou no download do browser (CDN do Playwright). Um-off (runs vizinhos passaram).

**Causa de fundo:** a action `setup-node-deps` cacheia `node_modules` mas **não** os browsers (`~/.cache/ms-playwright`), então todo run re-baixa ~150MB e fica exposto ao flake toda vez.

## Correção

- **`actions/cache` de `~/.cache/ms-playwright`** (key = `runner.os` + hash do `v2/frontend/package-lock.json`; invalida no bump do Playwright) nos **dois** jobs que instalam browsers: `[required] checklist-tests` e `[info] e2e-journeys`. Em cache-hit o download é **pulado** (segundos, sem exposição ao flake).
- **`timeout-minutes: 10`** no step de install: num hang futuro, **falha rápido** para re-run em vez de queimar o budget do job (25/30 min).

SHA da action pinado igual ao já usado em `setup-node-deps` (`actions/cache@caa2961…` v4), conforme a política de pin do repo.

## Validação

- YAML valida (`yaml.safe_load`); os 2 jobs têm o cache step + `timeout-minutes: 10` no install.
- Additive-only (nenhum step existente alterado exceto o `timeout` no install). O próprio CI desta PR (`checklist-tests`) exercita o novo caminho de cache.

## Nota

Mudança CI-only (não toca app). Não deploya.
