### PR TITLE
feat(imports): classify dat_registro + dat_cadastro no export-contract (Onda 2)

### DIFF
--- a/v2/backend/apps/core/services/export_contract_importer.py
+++ b/v2/backend/apps/core/services/export_contract_importer.py
@@ -34,7 +34,9 @@ from apps.core.imports.normalization import normalize_cpf_digits
 from apps.core.models import (
     DATAcao,
     DATArea,
+    DATCadastro,
     DATCoordenador,
+    DATRegistro,
     Gerencia,
     Municipio,
     PlanoFormacoes,
@@ -91,6 +93,8 @@ IMPLEMENTED = {
     "dat_coordenador",
     "dat_acao",
     "plano_formacao",
+    "dat_registro",
+    "dat_cadastro",
 }
 
 # Papel canonico (PAPEL_MAPPING) -> nome do Django Group (FUNCAO_GROUPS). Fonte do papel no
@@ -188,6 +192,10 @@ class ExportContractImporter:
     def _municipio_index(self) -> dict[tuple[str, str], int]:
         """Índice (norm(nome), uf.upper()) → municipio_id, para resolver FK por nome+uf."""
         return {(_norm(n), (u or "").upper()): mid for mid, n, u in Municipio.objects.values_list("id", "nome", "uf")}
+
+    def _projeto_geral_index(self) -> dict[str, int]:
+        """Índice norm(nome) → projeto_geral_id (ProjetoGeral.nome é unique)."""
+        return {_norm(n): pid for pid, n in ProjetoGeral.objects.values_list("id", "nome")}
 
     # ── handlers da fatia implementada ──
     def _classify_master(self, name: str) -> dict[str, Any]:
@@ -331,6 +339,39 @@ class ExportContractImporter:
                     tally["would_reject"] += 1
                     continue
                 st, _ = diff_and_classify({} if (mun_id, proj_id) in existing else None, {}, protected)
+                tally[st] += 1
+
+        elif name == "dat_registro":
+            # NK = (municipio_id, projeto_geral_id, projeto_id). Município por (norm(nome), uf);
+            # projeto_geral por norm(nome); projeto via resolver (#1372). FK não-resolvida → would_reject.
+            # Existence-based (não compara campos operacionais; status/nr_codigos ficam para o apply).
+            mun_idx = self._municipio_index()
+            pg_idx = self._projeto_geral_index()
+            existing = set(DATRegistro.objects.values_list("municipio_id", "projeto_geral_id", "projeto_id"))
+            for r in rows:
+                mun_id = mun_idx.get((_norm(r.get("municipio") or ""), (r.get("uf") or "").upper()))
+                pg_id = pg_idx.get(_norm(r.get("projeto_geral") or ""))
+                proj_id = self.resolve_projeto(r.get("projeto") or "")
+                if mun_id is None or pg_id is None or proj_id is None:
+                    tally["would_reject"] += 1
+                    continue
+                st, _ = diff_and_classify({} if (mun_id, pg_id, proj_id) in existing else None, {}, protected)
+                tally[st] += 1
+
+        elif name == "dat_cadastro":
+            # NK = (municipio_id, projeto_geral_id, plataforma). plataforma faz parte da chave
+            # (FORMAR|AVALIAR); valor fora do domínio → would_reject. Existence-based.
+            mun_idx = self._municipio_index()
+            pg_idx = self._projeto_geral_index()
+            existing = set(DATCadastro.objects.values_list("municipio_id", "projeto_geral_id", "plataforma"))
+            for r in rows:
+                mun_id = mun_idx.get((_norm(r.get("municipio") or ""), (r.get("uf") or "").upper()))
+                pg_id = pg_idx.get(_norm(r.get("projeto_geral") or ""))
+                plataforma = (r.get("plataforma") or "").strip().upper()
+                if mun_id is None or pg_id is None or plataforma not in ("FORMAR", "AVALIAR"):
+                    tally["would_reject"] += 1
+                    continue
+                st, _ = diff_and_classify({} if (mun_id, pg_id, plataforma) in existing else None, {}, protected)
                 tally[st] += 1
 
         tally["export_rows"] = len(rows)

--- a/v2/backend/apps/core/tests/test_export_contract_importer.py
+++ b/v2/backend/apps/core/tests/test_export_contract_importer.py
@@ -24,7 +24,9 @@ import pytest
 from apps.core.models import (
     DATAcao,
     DATArea,
+    DATCadastro,
     DATCoordenador,
+    DATRegistro,
     Gerencia,
     PlanoFormacoes,
     Produto,
@@ -306,8 +308,58 @@ def test_demo_dez_entidades_implementadas(tmp_path):
         "dat_coordenador": "usuario,area\ncoord@ex.com,Area\n",
         "dat_acao": "municipio,uf,projeto\nC,CE,P\n",
         "plano_formacao": "municipio,uf,projeto\nC,CE,P\n",
+        "dat_registro": "municipio,uf,projeto_geral,projeto\nC,CE,PG,P\n",
+        "dat_cadastro": "municipio,uf,projeto_geral,plataforma\nC,CE,PG,FORMAR\n",
     }
     r = ExportContractImporter(path=_write_export(tmp_path, files)).run()["por_entidade"]
     for ent in files:
         assert "status" not in r[ent], f"{ent} deveria estar implementada"
         assert "export_rows" in r[ent]
+
+
+# ───────── classify das fatias DAT (Onda 2: dat_registro + dat_cadastro) ─────────
+def test_classify_dat_registro_skip_create_reject(tmp_path):
+    """NK (municipio, projeto_geral, projeto): skip/create/reject (município e projeto_geral)."""
+    creator = UsuarioFactory(username="u_dr_creator", password="x", cpf="33344455566")
+    mun_a = MunicipioFactory(nome="Cidade Reg Um", uf="CE", ativo=True)
+    MunicipioFactory(nome="Cidade Reg Dois", uf="CE", ativo=True)
+    pg = ProjetoGeral.objects.create(nome="PG Registro Teste", usa_avaliar=False)
+    proj = ProjetoFactory(nome="Proj Registro Teste", fluxo="NAO_SUPER")
+    DATRegistro.objects.create(municipio=mun_a, projeto_geral=pg, projeto=proj, aluno_qtde=10, created_by=creator)
+    csv = (
+        "municipio,uf,projeto_geral,projeto\n"
+        "Cidade Reg Um,CE,PG Registro Teste,Proj Registro Teste\n"  # existe -> skip
+        "Cidade Reg Dois,CE,PG Registro Teste,Proj Registro Teste\n"  # resolve, sem registro -> create
+        "Cidade Fantasma XYZ,CE,PG Registro Teste,Proj Registro Teste\n"  # municipio nao resolve -> reject
+        "Cidade Reg Um,CE,PG Inexistente,Proj Registro Teste\n"  # projeto_geral nao resolve -> reject
+    )
+    r = ExportContractImporter(path=_write_export(tmp_path, {"dat_registro": csv})).run()["por_entidade"][
+        "dat_registro"
+    ]
+    assert r["would_skip_same"] == 1
+    assert r["would_create"] == 1
+    assert r["would_reject"] == 2
+    assert r["would_update"] == 0
+
+
+def test_classify_dat_cadastro_skip_create_reject(tmp_path):
+    """NK (municipio, projeto_geral, plataforma): plataforma faz parte da chave; inválida -> reject."""
+    creator = UsuarioFactory(username="u_dc_creator", password="x", cpf="44455566677")
+    mun_a = MunicipioFactory(nome="Cidade Cad Um", uf="CE", ativo=True)
+    MunicipioFactory(nome="Cidade Cad Dois", uf="CE", ativo=True)
+    pg = ProjetoGeral.objects.create(nome="PG Cadastro Teste", usa_avaliar=True)
+    DATCadastro.objects.create(municipio=mun_a, projeto_geral=pg, plataforma="FORMAR", created_by=creator)
+    csv = (
+        "municipio,uf,projeto_geral,plataforma\n"
+        "Cidade Cad Um,CE,PG Cadastro Teste,FORMAR\n"  # existe -> skip
+        "Cidade Cad Um,CE,PG Cadastro Teste,AVALIAR\n"  # mesmo mun/pg, plataforma nova -> create
+        "Cidade Cad Dois,CE,PG Cadastro Teste,FORMAR\n"  # resolve, sem cadastro -> create
+        "Cidade Cad Um,CE,PG Cadastro Teste,XPTO\n"  # plataforma invalida -> reject
+    )
+    r = ExportContractImporter(path=_write_export(tmp_path, {"dat_cadastro": csv})).run()["por_entidade"][
+        "dat_cadastro"
+    ]
+    assert r["would_skip_same"] == 1
+    assert r["would_create"] == 2
+    assert r["would_reject"] == 1
+    assert r["would_update"] == 0


### PR DESCRIPTION
## Contexto

Onda 2 do programa de **imports órfãos** (`v2/docs/plans/PLANO_IMPORTS_ORFAOS.md`). Investigação com o dono revelou que o destino operacional das planilhas DAT (`DATCadastro` + `DATRegistro`) deve ser populado pelo **pipeline export-contract** (`sheets.banco` → CSV → `import_export_contract`), **não** pelo importador legado `dat_cadastros_import.py` → `AcaoDAT` (que lê a aba `CADASTROS` ambígua que o pipeline moderno descartou de propósito).

O `ExportContractImporter` já tinha `dat_cadastro`/`dat_registro` no `ENTITY_ORDER`, mas em `not_implemented`. Este PR implementa a **camada classify** (dry-run) das duas fatias.

## O que muda

- **`dat_registro`** → `DATRegistro`, NK `(municipio, projeto_geral, projeto)`.
- **`dat_cadastro`** → `DATCadastro`, NK `(municipio, projeto_geral, plataforma)` — `plataforma` (FORMAR|AVALIAR) faz parte da chave; valor fora do domínio → `would_reject`.
- Ambas **existence-based**, seguindo o molde de `dat_acao`/`plano_formacao`. FK não-resolvida (município via índice nome+uf, projeto_geral via novo índice, projeto via resolver #1372) → `would_reject`.
- Novo helper **`_projeto_geral_index`** (`ProjetoGeral.nome` é unique) — não existia resolver de `projeto_geral`, e ambas as NKs dependem dele.

## Escopo (só classify — NÃO grava)

Este PR **não escreve nada** (dry-run). O **apply** (create real) fica para o PR seguinte, que depende de 3 coisas ainda em aberto:
1. `created_by` via `--as-user <cpf>` (decidido com o dono).
2. Normalização de status (a planilha emite emoji `⚠️`/`-`/data → enum do Django).
3. **Dedupe do `dat_cadastro`** no lado `sheets.banco` — o CSV atual emite **múltiplas linhas por NK** (uma por variante de projeto), o que colidiria com a UniqueConstraint no apply. Requisição já enviada ao dono para repassar.

## Testes (TDD RED→GREEN)

- `test_classify_dat_registro_skip_create_reject` — skip/create + reject de município **e** projeto_geral.
- `test_classify_dat_cadastro_skip_create_reject` — plataforma na chave; plataforma inválida → reject.
- O teste "todas implementadas" agora cobre **12** entidades (antes 10).
- Suíte export-contract completa: **67 testes verdes** (`--create-db`). Black/isort/flake8 limpos; pyright 0 erros.

## Checklist

- [x] Nenhum dado real importado (dry-run; fixtures sintéticos)
- [x] Segue o padrão existence-based do `dat_acao`
- [x] Respeita a política dry-run-first do importer
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `1e4b5394`, slot `1` / projeto `aprender_staging_s1`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local-s1, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
