### PR TITLE
fix(rbac): policy ator×alvo bloqueia takeover de conta aprovadora (M07-01/M07-02)

### DIFF
--- a/v2/backend/apps/core/rbac/__init__.py
+++ b/v2/backend/apps/core/rbac/__init__.py
@@ -65,6 +65,7 @@ from apps.core.rbac.policies import (
     CanViewOverviewDashboard,
     CanViewReports,
     CanViewTeamDashboard,
+    can_admin_mutate_target,
     resolve_public_policies,
     user_has_policy,
 )
@@ -85,6 +86,7 @@ __all__ = [
     "PUBLIC_POLICY_KEYS",
     "user_has_policy",
     "resolve_public_policies",
+    "can_admin_mutate_target",
     "CanAccessAuditLogs",
     "CanAccessControleSection",
     "CanAccessSolicitationApprovals",

--- a/v2/backend/apps/core/rbac/policies.py
+++ b/v2/backend/apps/core/rbac/policies.py
@@ -514,10 +514,47 @@ def resolve_public_policies(user: AbstractBaseUser | AnonymousUser | None) -> li
     return sorted(k for k in PUBLIC_POLICY_KEYS if user_has_policy(user, k))
 
 
+def can_admin_mutate_target(
+    actor: AbstractBaseUser | AnonymousUser | None,
+    target: AbstractBaseUser | AnonymousUser | None,
+    action: str | None = None,
+) -> bool:
+    """
+    SSOT ator×alvo (M07-01/M07-02, #1616/#1617): um admin não-superuser pode
+    mutar `target` (reset de senha, e-mail, is_active, delete/anonimizar)?
+
+    Regra (fail-secure):
+    - superuser-ator       → True  (bypass total; mantém P0-0/P0-1)
+    - target == actor      → True  (self-service nunca é escalonamento)
+    - target superuser     → False (Tier-0; a queryset da view já dá 404 antes)
+    - target APROVADOR     → False (tomar a conta viabiliza auto-aprovação de
+                                    solicitações, violando CP-02). "Aprovador" =
+                                    autoridade de aprovação — Gerente da
+                                    Superintendência OU Assistente Administrativo
+                                    do Controle (SSOT `access_solicitation_approvals`)
+    - demais (conta comum) → True
+
+    `action` fica reservado para o épico #1656 (escopo por operação); hoje a
+    invariante é agnóstica à ação — qualquer mutação sobre alvo mais privilegiado
+    é barrada.
+    """
+    if getattr(actor, "is_superuser", False):
+        return True
+    actor_pk = getattr(actor, "pk", None)
+    if actor_pk is not None and actor_pk == getattr(target, "pk", None):
+        return True
+    if getattr(target, "is_superuser", False):
+        return False
+    if user_has_policy(target, "access_solicitation_approvals"):
+        return False
+    return True
+
+
 __all__ = [
     "ACCESS_POLICIES",
     "PUBLIC_POLICY_KEYS",
     "_PolicyPermission",
+    "can_admin_mutate_target",
     "user_can_delegate_availability_block",
     "user_has_policy",
     "resolve_public_policies",

--- a/v2/backend/apps/core/serializers/usuario.py
+++ b/v2/backend/apps/core/serializers/usuario.py
@@ -19,6 +19,7 @@ from rest_framework import serializers  # type: ignore[attr-defined]
 
 from apps.core.constants import FUNCAO_GROUPS, RESERVED_GROUPS, SETOR_GROUPS
 from apps.core.models import AuditLog, GroupClassificacao, PermissaoFuncional
+from apps.core.rbac import can_admin_mutate_target
 from apps.core.services.audit import (
     auditar_assign_groups,
     auditar_group_capabilities_set,
@@ -195,6 +196,16 @@ class UsuarioAdminSerializer(serializers.ModelSerializer):
         ):
             raise serializers.ValidationError(
                 {"detail": "Você não tem permissão para alterar uma conta de superusuário."}
+            )
+
+        # M07-01/M07-02 (#1616/#1617): defense-in-depth ator×alvo — um não-superuser
+        # não muta conta APROVADORA (tomar a conta viabiliza auto-aprovação de
+        # solicitações, violando CP-02). A view (`UsuarioAdminViewSet.get_object`)
+        # já barra com 403 antes daqui; esta checagem protege reuso do serializer
+        # fora daquela view. SSOT: `can_admin_mutate_target`.
+        if instance is not None and request_user is not None and not can_admin_mutate_target(request_user, instance):
+            raise serializers.ValidationError(
+                {"detail": "Você não tem permissão para alterar esta conta."}
             )
 
         current_is_superuser = bool(getattr(instance, "is_superuser", False)) if instance is not None else False

--- a/v2/backend/apps/core/serializers/usuario.py
+++ b/v2/backend/apps/core/serializers/usuario.py
@@ -204,9 +204,7 @@ class UsuarioAdminSerializer(serializers.ModelSerializer):
         # já barra com 403 antes daqui; esta checagem protege reuso do serializer
         # fora daquela view. SSOT: `can_admin_mutate_target`.
         if instance is not None and request_user is not None and not can_admin_mutate_target(request_user, instance):
-            raise serializers.ValidationError(
-                {"detail": "Você não tem permissão para alterar esta conta."}
-            )
+            raise serializers.ValidationError({"detail": "Você não tem permissão para alterar esta conta."})
 
         current_is_superuser = bool(getattr(instance, "is_superuser", False)) if instance is not None else False
         current_is_active = bool(getattr(instance, "is_active", True)) if instance is not None else True

--- a/v2/backend/apps/core/tests/test_rbac_approver_target_protection.py
+++ b/v2/backend/apps/core/tests/test_rbac_approver_target_protection.py
@@ -1,0 +1,186 @@
+"""
+M07-01/M07-02 (#1616/#1617) — Proteção ator×alvo de contas APROVADORAS.
+
+Contexto (v2/docs/audits/ACHADOS_REAIS.md, achados M07-01/M07-02):
+Um admin não-superuser com `manage_admin_registries` (DAT) conseguia tomar uma
+conta APROVADORA (Gerente da Superintendência ou Assistente Administrativo do
+Controle) pelo `UsuarioAdminViewSet` — reset de senha, troca de e-mail,
+desativação e hard delete/anonimização — em uma requisição. Tomar a conta de um
+aprovador viabiliza auto-aprovação de solicitações (login-como-aprovador),
+violando CP-02 (PA-01..07).
+
+P0-0 (2026-07-17) já fechou o vetor para alvo SUPERUSER (404-invisível). Este
+módulo estende a invariante para o alvo APROVADOR não-superuser, que P0-0 não
+cobria (a queryset só exclui `is_superuser=True`).
+
+Invariante de segurança (o que estes testes asseguram):
+- Um não-superuser NÃO muta (senha/e-mail/is_active/delete/anonimizar) uma conta
+  aprovadora → **403** (existe, mas é intocável; distinto do 404-Tier-0).
+- Aprovador continua VISÍVEL/legível ao DAT (não é Tier-0): `retrieve`/`list` OK.
+- Superuser-ator mantém bypass total.
+- Contas comuns (não-aprovador, não-superuser) seguem administráveis pelo DAT.
+- `can_admin_mutate_target` é o SSOT ator×alvo (semeia o épico #1656).
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportOptionalMemberAccess=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportMissingTypeArgument=false, reportIndexIssue=false, reportOptionalSubscript=false, reportCallIssue=false
+
+from __future__ import annotations
+
+from rest_framework import status
+from rest_framework.test import APIClient
+
+import pytest
+
+from apps.core.models import Usuario
+from apps.core.rbac import can_admin_mutate_target
+from apps.core.tests.factories import GroupFactory, UsuarioFactory
+
+APPROVER_PASSWORD = "AprovOldPass!123"
+COMMON_PASSWORD = "CommonOld!123"
+DETAIL = "/api/usuarios-admin/{}/"
+ANONIMIZAR = "/api/usuarios-admin/{}/anonimizar/"
+
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+
+@pytest.fixture
+def usuario_dat(db):
+    """DAT: tem manage_admin_registries (seed). Não é aprovador nem superuser."""
+    user = UsuarioFactory(username="dat_m07", cpf="90000000021")
+    user.groups.add(GroupFactory(name="DAT"))
+    return user
+
+
+@pytest.fixture
+def aprovador(db):
+    """Alvo aprovador: Gerente da Superintendência (composite Setor × Função).
+
+    Autoridade de aprovação (CP-02) sem ser superuser — o alvo exato do M07.
+    """
+    user = UsuarioFactory(
+        username="gerente_super_m07",
+        cpf="10000007706",
+        password=APPROVER_PASSWORD,
+    )
+    user.groups.add(GroupFactory(name="Gerente"), GroupFactory(name="Superintendência"))
+    return user
+
+
+@pytest.fixture
+def common_user(db):
+    """Conta comum (não-aprovador) — administrável pelo DAT."""
+    return UsuarioFactory(username="comum_m07", cpf="10000008427", password=COMMON_PASSWORD)
+
+
+@pytest.mark.django_db
+class TestApproverTargetProtectionAPI:
+    """DAT (não-superuser) não toma conta aprovadora pelo UsuarioAdminViewSet."""
+
+    def test_dat_reset_approver_password_forbidden_and_unchanged(self, api_client, usuario_dat, aprovador):
+        api_client.force_authenticate(user=usuario_dat)
+        resp = api_client.patch(DETAIL.format(aprovador.id), {"password": "Hacked!newpass9"}, format="json")
+        assert resp.status_code == status.HTTP_403_FORBIDDEN
+        aprovador.refresh_from_db()
+        assert aprovador.check_password(APPROVER_PASSWORD)
+        assert not aprovador.check_password("Hacked!newpass9")
+
+    def test_dat_deactivate_approver_forbidden_and_still_active(self, api_client, usuario_dat, aprovador):
+        api_client.force_authenticate(user=usuario_dat)
+        resp = api_client.patch(DETAIL.format(aprovador.id), {"is_active": False}, format="json")
+        assert resp.status_code == status.HTTP_403_FORBIDDEN
+        aprovador.refresh_from_db()
+        assert aprovador.is_active is True
+
+    def test_dat_change_approver_email_forbidden_and_unchanged(self, api_client, usuario_dat, aprovador):
+        original = aprovador.email
+        api_client.force_authenticate(user=usuario_dat)
+        resp = api_client.patch(DETAIL.format(aprovador.id), {"email": "hacked@example.com"}, format="json")
+        assert resp.status_code == status.HTTP_403_FORBIDDEN
+        aprovador.refresh_from_db()
+        assert aprovador.email == original
+        assert aprovador.email != "hacked@example.com"
+
+    def test_dat_delete_approver_forbidden_and_still_exists(self, api_client, usuario_dat, aprovador):
+        api_client.force_authenticate(user=usuario_dat)
+        resp = api_client.delete(DETAIL.format(aprovador.id))
+        assert resp.status_code == status.HTTP_403_FORBIDDEN
+        assert Usuario.objects.filter(pk=aprovador.id).exists()
+
+    def test_dat_anonimizar_approver_forbidden_and_pii_intact(self, api_client, usuario_dat, aprovador):
+        aprovador.first_name = "Nome Real"
+        aprovador.save(update_fields=["first_name"])
+        api_client.force_authenticate(user=usuario_dat)
+        resp = api_client.post(ANONIMIZAR.format(aprovador.id), {}, format="json")
+        assert resp.status_code == status.HTTP_403_FORBIDDEN
+        aprovador.refresh_from_db()
+        assert aprovador.first_name == "Nome Real"
+
+    def test_dat_can_retrieve_approver(self, api_client, usuario_dat, aprovador):
+        """Aprovador NÃO é Tier-0: leitura é permitida (não vira 404 como superuser)."""
+        api_client.force_authenticate(user=usuario_dat)
+        resp = api_client.get(DETAIL.format(aprovador.id))
+        assert resp.status_code == status.HTTP_200_OK
+        assert resp.data["id"] == aprovador.id
+
+    def test_dat_list_includes_approver(self, api_client, usuario_dat, aprovador, common_user):
+        api_client.force_authenticate(user=usuario_dat)
+        resp = api_client.get("/api/usuarios-admin/")
+        assert resp.status_code == status.HTTP_200_OK
+        ids = {item["id"] for item in resp.data["results"]}
+        assert aprovador.id in ids
+        assert common_user.id in ids
+
+
+@pytest.mark.django_db
+class TestApproverBypassAndRegression:
+    def test_superuser_actor_can_reset_approver_password(self, api_client, aprovador):
+        actor = UsuarioFactory(username="root_m07", cpf="90000000029", superuser=True)
+        api_client.force_authenticate(user=actor)
+        resp = api_client.patch(DETAIL.format(aprovador.id), {"password": "RotatedByRoot!789"}, format="json")
+        assert resp.status_code == status.HTTP_200_OK
+        aprovador.refresh_from_db()
+        assert aprovador.check_password("RotatedByRoot!789")
+
+    def test_dat_can_still_reset_common_user_password(self, api_client, usuario_dat, common_user):
+        api_client.force_authenticate(user=usuario_dat)
+        resp = api_client.patch(DETAIL.format(common_user.id), {"password": "NewCommon!456"}, format="json")
+        assert resp.status_code == status.HTTP_200_OK
+        common_user.refresh_from_db()
+        assert common_user.check_password("NewCommon!456")
+
+    def test_dat_can_still_delete_common_user(self, api_client, usuario_dat, common_user):
+        api_client.force_authenticate(user=usuario_dat)
+        resp = api_client.delete(DETAIL.format(common_user.id))
+        assert resp.status_code == status.HTTP_204_NO_CONTENT
+        assert not Usuario.objects.filter(pk=common_user.id).exists()
+
+
+@pytest.mark.django_db
+class TestCanAdminMutateTargetHelper:
+    """Unit do SSOT ator×alvo — semeia o épico #1656."""
+
+    def test_superuser_actor_can_mutate_anyone(self, aprovador):
+        actor = UsuarioFactory(username="root_unit", cpf="90000000030", superuser=True)
+        assert can_admin_mutate_target(actor, aprovador) is True
+
+    def test_non_superuser_cannot_mutate_superuser_target(self, usuario_dat):
+        target = UsuarioFactory(username="su_target", cpf="90000000031", superuser=True)
+        assert can_admin_mutate_target(usuario_dat, target) is False
+
+    def test_non_superuser_cannot_mutate_gerente_super_approver(self, usuario_dat, aprovador):
+        assert can_admin_mutate_target(usuario_dat, aprovador) is False
+
+    def test_non_superuser_cannot_mutate_asst_admin_controle_approver(self, usuario_dat):
+        target = UsuarioFactory(username="asst_controle", cpf="90000000032")
+        target.groups.add(GroupFactory(name="Controle"), GroupFactory(name="Assistente Administrativo"))
+        assert can_admin_mutate_target(usuario_dat, target) is False
+
+    def test_non_superuser_can_mutate_common_target(self, usuario_dat, common_user):
+        assert can_admin_mutate_target(usuario_dat, common_user) is True
+
+    def test_actor_can_mutate_self(self, aprovador):
+        """Mutar a própria conta nunca é escalonamento (self-service)."""
+        assert can_admin_mutate_target(aprovador, aprovador) is True

--- a/v2/backend/apps/core/views/admin.py
+++ b/v2/backend/apps/core/views/admin.py
@@ -13,7 +13,7 @@ from django.db import transaction
 from django.db.models import Count, Q, QuerySet
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
-from rest_framework.exceptions import ValidationError
+from rest_framework.exceptions import PermissionDenied, ValidationError
 from rest_framework.filters import OrderingFilter, SearchFilter
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
@@ -36,7 +36,7 @@ from apps.core.models import (
     Usuario,
 )
 from apps.core.permissions import HasPerm, SuperuserOnly
-from apps.core.rbac.policies import CanAccessAuditLogs
+from apps.core.rbac.policies import CanAccessAuditLogs, can_admin_mutate_target
 from apps.core.serializers import (
     AuditLogSerializer,
     CompraSerializer,
@@ -388,6 +388,22 @@ class UsuarioAdminViewSet(viewsets.ModelViewSet):
         if not getattr(self.request.user, "is_superuser", False):
             qs = qs.exclude(is_superuser=True)
         return qs
+
+    def get_object(self) -> Usuario:
+        """
+        M07-01/M07-02 (#1616/#1617): guard ator×alvo nas ações de MUTAÇÃO. Um
+        não-superuser não toma conta APROVADORA (senha/e-mail/is_active/delete/
+        anonimizar) — tomar a conta viabiliza auto-aprovação (viola CP-02) → 403.
+
+        Leitura (retrieve/list) segue livre: aprovador NÃO é Tier-0 (o alvo
+        superuser já vira 404-invisível em `get_queryset`, P0-0). SSOT da regra:
+        `can_admin_mutate_target`.
+        """
+        obj = super().get_object()
+        mutating = {"update", "partial_update", "destroy", "anonimizar"}
+        if self.action in mutating and not can_admin_mutate_target(self.request.user, obj):
+            raise PermissionDenied("Você não tem permissão para alterar esta conta.")
+        return obj
 
     def perform_destroy(self, instance: Usuario) -> None:
         """


### PR DESCRIPTION
## Contexto

Escalonamento de privilégio VIVO (auditoria M07-01/M07-02, #1616/#1617), confirmado contra `origin/main` HEAD nesta sessão.

Um admin **não-superuser** com `manage_admin_registries` (setor **DAT**) tomava uma conta **APROVADORA** — Gerente da Superintendência **ou** Assistente Administrativo do Controle — pelo `UsuarioAdminViewSet`: reset de senha, troca de e-mail, desativação e hard delete/anonimização, tudo em **uma requisição**. Tomar a conta de um aprovador viabiliza **auto-aprovação de solicitações** (login-como-aprovador), violando **CP-02** (PA-01..07).

`P0-0` (2026-07-17) fechou apenas o alvo **superuser** (404-invisível via `get_queryset`); o alvo aprovador **não-superuser** ficava desprotegido, pois a queryset só exclui `is_superuser=True`.

## Mudança

- **SSOT ator×alvo** `can_admin_mutate_target(actor, target, action)` em `apps.core.rbac` (fail-secure):
  - superuser-ator → `True` (bypass total, mantém P0-0/P0-1)
  - `target == actor` (self-service) → `True`
  - alvo **superuser** → `False`
  - alvo **aprovador** → `False` — reusa o SSOT `access_solicitation_approvals` (não reinventa o composite; sem trip no `rbac_lint`)
- **Guard centralizado** em `UsuarioAdminViewSet.get_object` para as ações de mutação (`update`/`partial_update`/`destroy`/`anonimizar`) → **403**. Leitura (`retrieve`/`list`) segue livre: aprovador **não é Tier-0** (aparece nas listas do DAT, apenas não pode ser tomado).
- **Defense-in-depth** espelhada em `UsuarioAdminSerializer.validate` (protege reuso do serializer fora da view).
- Semeia o primitivo do épico **#1656** (escopo ator×alvo), que cobre outras superfícies (M08-01, M10-01/04, M14-01) — **não** fechado aqui.

## Testes (TDD RED→GREEN)

Novo `test_rbac_approver_target_protection.py` — 16 casos:
- **RED provado**: sem os guards, as 5 mutações retornam 200/204 (escalonamento).
- **GREEN**: mutação de aprovador por DAT → 403; leitura/listagem OK; conta comum administrável; bypass superuser intacto; 6 unit do `can_admin_mutate_target` (inclui variante Asst-Admin-Controle e self).
- **Regressão**: 263 testes de usuário-admin / RBAC / policies verdes (`test_rbac_superuser_target_protection`, `test_admin_api`, `test_anonimizacao_usuario`, `test_assign_groups`, `test_audit_privilege_sites`, `test_me_policies`, `test_rbac_tier0_group_gate`, …).

Closes #1616
Closes #1617
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `8006c5d2`, slot `1` / projeto `aprender_staging_s1`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local-s1, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
