### PR TITLE
fix(availability): titularidade de bloqueio é imutável na edição (M08-01)

### DIFF
--- a/v2/backend/apps/core/tests/test_availability_owner_transfer_1619.py
+++ b/v2/backend/apps/core/tests/test_availability_owner_transfer_1619.py
@@ -1,0 +1,152 @@
+"""
+M08-01 (#1619) — titularidade de AvailabilityBlock é imutável na edição.
+
+Contexto: `AvailabilityBlockViewSet` tratava delegação só no CREATE
+(`perform_create`), mas NÃO tinha `perform_update`. O campo write-only
+`usuario_id` (attname da FK) chegava intacto ao `ModelSerializer.update()`
+default e **reatribuía o dono** do bloco num PATCH/PUT — transferência
+silenciosa para um usuário arbitrário, sem policy de delegação e sem AuditLog.
+`get_queryset` restringe o comum ao próprio bloco, então ele transferia o
+PRÓPRIO bloqueio (aprovado) para outra pessoa.
+
+Invariante: editar um bloqueio altera horário/motivo, NUNCA o dono. A concessão
+de titularidade existe apenas no CREATE (perform_create, delegação PR 13).
+Tentar mudar `usuario_id` na edição → 403.
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportOptionalMemberAccess=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportMissingTypeArgument=false, reportCallIssue=false, reportIndexIssue=false, reportOptionalSubscript=false
+
+from __future__ import annotations
+
+import itertools
+from datetime import timedelta
+
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+import pytest
+
+from apps.core.models import AvailabilityBlock, Usuario
+from apps.core.tests.factories import UsuarioFactory
+
+pytestmark = pytest.mark.django_db
+
+_CPF_COUNTER = itertools.count(73000000000)
+
+
+def _user_in_groups(*group_names: str, label: str = "user", is_active: bool = True) -> Usuario:
+    cpf = str(next(_CPF_COUNTER)).zfill(11)
+    return UsuarioFactory(
+        username=f"{label}_{cpf}",
+        email=f"{label}_{cpf}@example.com",
+        password="testpass",
+        cpf=cpf,
+        is_active=is_active,
+        groups=list(group_names),
+    )
+
+
+def _formador(label: str = "formador", is_active: bool = True) -> Usuario:
+    return _user_in_groups("Formador", label=label, is_active=is_active)
+
+
+def _make_block(owner: Usuario, created_by: Usuario | None = None) -> AvailabilityBlock:
+    inicio = timezone.now() + timedelta(days=1)
+    return AvailabilityBlock.objects.create(
+        usuario=owner,
+        created_by=created_by or owner,
+        tipo="T",
+        inicio=inicio,
+        fim=inicio + timedelta(hours=2),
+        status="aprovado",
+    )
+
+
+def _detail(pk: int) -> str:
+    return f"/api/availability-blocks/{pk}/"
+
+
+class TestOwnerTransferBlocked:
+    def test_common_user_cannot_transfer_own_block_via_patch(self):
+        """RED: hoje o PATCH aplica usuario_id e transfere o dono (200)."""
+        owner = _formador(label="owner_patch")
+        outro = _formador(label="alvo_patch")
+        block = _make_block(owner)
+
+        client = APIClient()
+        client.force_authenticate(owner)
+        resp = client.patch(_detail(block.id), {"usuario_id": outro.id}, format="json")
+
+        assert resp.status_code == 403, f"esperado 403, obteve {resp.status_code}"
+        block.refresh_from_db()
+        assert block.usuario_id == owner.id  # RED: virava outro.id
+
+    def test_common_user_cannot_transfer_own_block_via_put(self):
+        owner = _formador(label="owner_put")
+        outro = _formador(label="alvo_put")
+        block = _make_block(owner)
+
+        client = APIClient()
+        client.force_authenticate(owner)
+        inicio = timezone.now() + timedelta(days=2)
+        payload = {
+            "tipo": "T",
+            "inicio": inicio.isoformat(),
+            "fim": (inicio + timedelta(hours=2)).isoformat(),
+            "motivo": "editado",
+            "usuario_id": outro.id,
+        }
+        resp = client.put(_detail(block.id), payload, format="json")
+
+        assert resp.status_code == 403
+        block.refresh_from_db()
+        assert block.usuario_id == owner.id
+
+    def test_transfer_blocked_even_for_superuser(self):
+        """A imutabilidade da titularidade é invariante de dados — vale p/ todos.
+        Superuser que precise reatribuir exclui e recria."""
+        owner = _formador(label="owner_su")
+        outro = _formador(label="alvo_su")
+        block = _make_block(owner)
+
+        su = UsuarioFactory(superuser=True)
+        client = APIClient()
+        client.force_authenticate(su)
+        resp = client.patch(_detail(block.id), {"usuario_id": outro.id}, format="json")
+
+        assert resp.status_code == 403
+        block.refresh_from_db()
+        assert block.usuario_id == owner.id
+
+
+class TestLegitimateEditStillWorks:
+    def test_owner_edits_times_without_usuario_id(self):
+        """Não-regressão: editar horário do próprio bloqueio funciona; dono intacto."""
+        owner = _formador(label="owner_edit")
+        block = _make_block(owner)
+
+        client = APIClient()
+        client.force_authenticate(owner)
+        novo_inicio = timezone.now() + timedelta(days=3)
+        resp = client.patch(
+            _detail(block.id),
+            {"inicio": novo_inicio.isoformat(), "fim": (novo_inicio + timedelta(hours=1)).isoformat()},
+            format="json",
+        )
+        assert resp.status_code == 200, resp.data
+        block.refresh_from_db()
+        assert block.usuario_id == owner.id
+        assert abs((block.inicio - novo_inicio).total_seconds()) < 2
+
+    def test_patch_usuario_id_equal_self_is_noop(self):
+        """usuario_id == dono atual não é transferência — passa e mantém o dono."""
+        owner = _formador(label="owner_self")
+        block = _make_block(owner)
+
+        client = APIClient()
+        client.force_authenticate(owner)
+        resp = client.patch(_detail(block.id), {"usuario_id": owner.id, "motivo": "ok"}, format="json")
+
+        assert resp.status_code == 200, resp.data
+        block.refresh_from_db()
+        assert block.usuario_id == owner.id

--- a/v2/backend/apps/core/views_availability.py
+++ b/v2/backend/apps/core/views_availability.py
@@ -199,6 +199,28 @@ class AvailabilityBlockViewSet(viewsets.ModelViewSet):
             },
         )
 
+    def perform_update(self, serializer):
+        """
+        M08-01 (#1619): a titularidade de um bloqueio é IMUTÁVEL na edição.
+
+        O campo write-only `usuario_id` (attname da FK) chegava intacto ao
+        `ModelSerializer.update()` default (não havia `perform_update`), então um
+        PATCH/PUT reatribuía o dono do bloco — transferência silenciosa para um
+        usuário arbitrário, sem policy de delegação nem AuditLog. A concessão de
+        titularidade existe apenas no CREATE (`perform_create`, delegação PR 13);
+        editar um bloqueio altera horário/motivo, nunca o dono.
+
+        Aqui `usuario_id` é retirado do payload (não reatribui) e uma tentativa
+        de mudar o dono para outro usuário é rejeitada com 403.
+        """
+        from rest_framework.exceptions import PermissionDenied
+
+        instance = serializer.instance
+        target_id = serializer.validated_data.pop("usuario_id", None)
+        if target_id is not None and target_id != instance.usuario_id:
+            raise PermissionDenied("Não é possível transferir a titularidade de um bloqueio pela edição.")
+        serializer.save()
+
 
 class AvailabilityCheckView(APIView):
     """


### PR DESCRIPTION
## Contexto

M08-01 (#1619), confirmado VIVO contra `main` na triagem authz.

`AvailabilityBlockViewSet` tratava delegação apenas no CREATE (`perform_create`) mas **não tinha `perform_update`**. O campo write-only `usuario_id` (attname da FK) chegava intacto ao `ModelSerializer.update()` default e **reatribuía o dono** do bloco num PATCH/PUT — transferência silenciosa para um usuário arbitrário, sem policy de delegação nem AuditLog. Como `get_queryset` restringe o comum ao próprio bloco, ele transferia o **próprio bloqueio (aprovado)** para outra pessoa.

## Mudança

- Novo `perform_update`: retira `usuario_id` do payload (não reatribui) e **rejeita com 403** qualquer tentativa de mudar o dono. Editar um bloqueio altera horário/motivo, **nunca a titularidade** — a concessão existe só no CREATE (delegação PR 13).
- Invariante de dados: vale para **todos** (inclui superuser). Reatribuir = excluir e recriar.

## Testes (TDD RED→GREEN)

Novo `test_availability_owner_transfer_1619.py` — 5 casos:
- **RED provado**: sem o guard, PATCH/PUT com `usuario_id` de outro transfere o dono (200).
- **GREEN**: PATCH/PUT/superuser → 403, dono intacto; editar horário e `usuario_id==self` → 200.
- **Regressão**: `test_pr13_delegated_availability_blocks` (delegação no create) + `test_availability_block_idor` + `test_api_availability_blocks` verdes (27 passed).

Closes #1619
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `bb7103f7`, slot `1` / projeto `aprender_staging_s1`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local-s1, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
