### PR TITLE
ci(frontend): retry no install do Playwright (mata o flake recorrente do CDN)

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -99,11 +99,23 @@ jobs:
         key: ${{ runner.os }}-playwright-${{ hashFiles('v2/frontend/package-lock.json') }}
 
     - name: Install Playwright browsers
-      # timeout curto: se o download do browser travar (flake de rede no CDN,
-      # visto no run 32251606405 — 30min pendurado), falha rápido p/ re-run
-      # em vez de queimar o budget do job. Em cache-hit o download é pulado.
-      timeout-minutes: 10
-      run: npx playwright install chromium --with-deps
+      # Retry no download do browser: o CDN do Playwright pendura de forma
+      # transitória (visto em #1763/#1768/#1770). Cada tentativa tem timeout de
+      # 6min; até 3 tentativas. Um sucesso salva o cache (post-step) e destrava
+      # os próximos runs. Em cache-hit o download é pulado (segundos).
+      run: |
+        for attempt in 1 2 3; do
+          echo "::group::playwright install (tentativa $attempt/3)"
+          if timeout 360 npx playwright install chromium --with-deps; then
+            echo "::endgroup::"
+            exit 0
+          fi
+          echo "::endgroup::"
+          echo "tentativa $attempt falhou/timeout; aguardando 15s antes de tentar de novo…"
+          sleep 15
+        done
+        echo "playwright install falhou após 3 tentativas" >&2
+        exit 1
 
     - name: Start backend services for functional contract checklist
       working-directory: .
@@ -212,11 +224,23 @@ jobs:
         key: ${{ runner.os }}-playwright-${{ hashFiles('v2/frontend/package-lock.json') }}
 
     - name: Install Playwright browsers
-      # timeout curto: se o download do browser travar (flake de rede no CDN,
-      # visto no run 32251606405 — 30min pendurado), falha rápido p/ re-run
-      # em vez de queimar o budget do job. Em cache-hit o download é pulado.
-      timeout-minutes: 10
-      run: npx playwright install chromium --with-deps
+      # Retry no download do browser: o CDN do Playwright pendura de forma
+      # transitória (visto em #1763/#1768/#1770). Cada tentativa tem timeout de
+      # 6min; até 3 tentativas. Um sucesso salva o cache (post-step) e destrava
+      # os próximos runs. Em cache-hit o download é pulado (segundos).
+      run: |
+        for attempt in 1 2 3; do
+          echo "::group::playwright install (tentativa $attempt/3)"
+          if timeout 360 npx playwright install chromium --with-deps; then
+            echo "::endgroup::"
+            exit 0
+          fi
+          echo "::endgroup::"
+          echo "tentativa $attempt falhou/timeout; aguardando 15s antes de tentar de novo…"
+          sleep 15
+        done
+        echo "playwright install falhou após 3 tentativas" >&2
+        exit 1
 
     - name: Start backend services and seed E2E data
       working-directory: .


### PR DESCRIPTION
## Problema

O step **"Install Playwright browsers"** flakeia por **hang transitório no download** do browser (CDN do Playwright). Bateu em **#1763, #1768 e #1770** — bloqueando merge por um problema que não é do código.

O #1765 (cache + `timeout-minutes`) só fazia **falhar rápido**, mas não resolvia a raiz: o `actions/cache` **só salva o cache quando o job passa**. Como o install flakeia e o job falha, o cache **nunca populava** → todo run re-baixa e fica exposto ao flake. (Confirmado: step "Post Cache Playwright browsers" = **skipped** nos runs que falharam; lista de caches do repo vazia.)

## Correção

**Retry no install**: até 3 tentativas, `timeout 360` (6min) por tentativa (loop máx ~18min, dentro do budget do job de 25/30min). Um install que passa no retry faz o **job passar** → o post-step **salva o cache** → os próximos runs pegam **cache-hit** (pulam o download, segundos).

Ou seja: resolve o flake **E** destrava o cache do #1765 de uma vez.

Aplicado nos dois jobs que instalam browsers: `checklist-tests` **[required]** e `e2e-journeys` **[info]**. Remove o `timeout-minutes: 10` do step (o timeout por tentativa cobre o hang).

## Validação

- YAML valida; os 2 jobs têm o loop de retry (`for attempt in 1 2 3` + `timeout 360`).
- O próprio CI desta PR exercita o novo install com retry.
- CI-only; não toca app; não deploya.
