### PR TITLE
fix(solicitacao): valida tipo de `ids` em batch approve/reject (M11-04)

### DIFF
--- a/v2/backend/apps/core/tests/test_batch_approval_ids_validation_1650.py
+++ b/v2/backend/apps/core/tests/test_batch_approval_ids_validation_1650.py
@@ -1,0 +1,116 @@
+"""
+M11-04 (#1650) — validação do payload `ids` em batch-approve / batch-reject.
+
+Sem validação de entrada, a view repassava `ids` cru ao serviço, que só checava
+falsiness e tamanho:
+- string `"8910"` → `filter(id__in="8910")` decompõe em dígitos → aprova alvos
+  não nomeados (8, 9, 1, 0), sem que apareçam no payload;
+- int escalar `5` → `len(5)` estoura TypeError → HTTP 500;
+- dict / lista com não-inteiros passavam adiante.
+
+Contrato: `ids` DEVE ser uma lista não-vazia de inteiros positivos (≤100);
+qualquer outra coisa → 400 (nunca 200 com alvo implícito, nunca 500).
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportOptionalMemberAccess=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportMissingTypeArgument=false, reportCallIssue=false, reportIndexIssue=false, reportOptionalSubscript=false
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+import pytest
+
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
+
+pytestmark = pytest.mark.django_db
+
+APPROVE_URL = "/api/solicitacoes/batch-approve/"
+REJECT_URL = "/api/solicitacoes/batch-reject/"
+
+
+@pytest.fixture
+def aprovador():
+    """Gerente da Superintendência → policy access_solicitation_approvals (PA-02)."""
+    user = UsuarioFactory(username="aprovador_m1104", cpf="74000000001")
+    user.groups.add(GroupFactory(name="Superintendência"), GroupFactory(name="Gerente"))
+    return user
+
+
+@pytest.fixture
+def coordenador():
+    user = UsuarioFactory(username="coord_m1104", cpf="74000000002")
+    user.groups.add(GroupFactory(name="Coordenador"))
+    return user
+
+
+@pytest.fixture
+def solicitacao_pendente(coordenador):
+    return SolicitacaoFactory(
+        usuario=coordenador,
+        municipio=MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True),
+        projeto=ProjetoFactory(nome="Projeto M1104", codigo="M1104", fluxo="SUPER", ativo=True),
+        tipo_evento=TipoEventoFactory(nome="Formacao M1104"),
+        inicio=timezone.now() + timedelta(days=1),
+        fim=timezone.now() + timedelta(days=1, hours=2),
+        status="pendente",
+    )
+
+
+@pytest.fixture
+def client_aprovador(aprovador):
+    c = APIClient()
+    c.force_authenticate(aprovador)
+    return c
+
+
+class TestBatchIdsRejectsMalformed:
+    def test_string_ids_returns_400_nao_decompoe_em_digitos(self, client_aprovador, solicitacao_pendente):
+        """RED: hoje `"8910"` vira id__in dos dígitos e retorna 200 (aprova alvo implícito)."""
+        resp = client_aprovador.post(APPROVE_URL, {"ids": "8910"}, format="json")
+        assert resp.status_code == 400, f"esperado 400, obteve {resp.status_code}"
+        solicitacao_pendente.refresh_from_db()
+        assert solicitacao_pendente.status == "pendente"
+
+    def test_int_escalar_returns_400_nao_500(self, client_aprovador):
+        """RED: hoje `len(5)` estoura TypeError → 500."""
+        resp = client_aprovador.post(APPROVE_URL, {"ids": 5}, format="json")
+        assert resp.status_code == 400, f"esperado 400, obteve {resp.status_code}"
+
+    def test_dict_ids_returns_400(self, client_aprovador):
+        resp = client_aprovador.post(APPROVE_URL, {"ids": {"a": 1}}, format="json")
+        assert resp.status_code == 400
+
+    def test_lista_com_nao_inteiro_returns_400(self, client_aprovador):
+        resp = client_aprovador.post(APPROVE_URL, {"ids": ["abc"]}, format="json")
+        assert resp.status_code == 400
+
+    def test_reject_string_ids_returns_400(self, client_aprovador, solicitacao_pendente):
+        resp = client_aprovador.post(REJECT_URL, {"ids": "8910"}, format="json")
+        assert resp.status_code == 400
+        solicitacao_pendente.refresh_from_db()
+        assert solicitacao_pendente.status == "pendente"
+
+
+class TestBatchIdsAcceptsValid:
+    def test_lista_valida_aprova(self, client_aprovador, solicitacao_pendente):
+        """Não-regressão: lista de inteiros válida aprova normalmente."""
+        resp = client_aprovador.post(APPROVE_URL, {"ids": [solicitacao_pendente.id]}, format="json")
+        assert resp.status_code == 200, resp.data
+        assert resp.data["approved"] == 1
+        solicitacao_pendente.refresh_from_db()
+        assert solicitacao_pendente.status == "aprovado"
+
+    def test_lista_vazia_returns_400(self, client_aprovador):
+        """Contrato preservado: lista vazia continua 400 (obrigatório)."""
+        resp = client_aprovador.post(APPROVE_URL, {"ids": []}, format="json")
+        assert resp.status_code == 400

--- a/v2/backend/apps/core/views_solicitacao.py
+++ b/v2/backend/apps/core/views_solicitacao.py
@@ -12,7 +12,7 @@ import logging
 from typing import Any
 
 from django.db.models import QuerySet
-from rest_framework import status, viewsets
+from rest_framework import serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.filters import OrderingFilter, SearchFilter
 from rest_framework.permissions import IsAuthenticated
@@ -60,6 +60,25 @@ def _get_client_ip(request: Request) -> str:
     if x_real_ip:
         return x_real_ip.strip()
     return request.META.get("REMOTE_ADDR", "unknown")
+
+
+class _BatchIdsSerializer(serializers.Serializer):
+    """
+    M11-04 (#1650): valida o TIPO do corpo das ações batch-approve/batch-reject.
+
+    Sem esta validação, `ids` chegava cru ao serviço, que só checava falsiness e
+    tamanho: uma string `"8910"` era iterada por `id__in` decompondo em dígitos
+    (aprova alvos não nomeados 8/9/1/0) e um int escalar estourava `len()` (500).
+
+    Escopo deliberado: valida apenas que `ids` é uma LISTA de inteiros positivos.
+    Vazio e limite (>100) continuam a cargo do serviço (`batch_*_solicitacoes`),
+    preservando as mensagens de contrato ("obrigatório" / limite de 100).
+    """
+
+    ids = serializers.ListField(
+        child=serializers.IntegerField(min_value=1),
+        allow_empty=True,
+    )
 
 
 @extend_schema_view(
@@ -854,7 +873,11 @@ class SolicitacaoViewSet(viewsets.ModelViewSet):
         PA-05: Cada solicitação gera um AuditLog individual com batch=true.
         Limite: máximo 100 solicitações por requisição.
         """
-        ids = request.data.get("ids", [])
+        # M11-04 (#1650): valida o payload antes do serviço — `ids` cru deixava
+        # string/int/dict passar (id__in decompunha string em dígitos; int → 500).
+        input_serializer = _BatchIdsSerializer(data=request.data)
+        input_serializer.is_valid(raise_exception=True)
+        ids = input_serializer.validated_data["ids"]
 
         # §1 Epic #459: Delegate to service layer
         result = batch_approve_solicitacoes(
@@ -891,7 +914,10 @@ class SolicitacaoViewSet(viewsets.ModelViewSet):
         PA-05: Cada solicitação gera um AuditLog individual com batch=true.
         Limite: máximo 100 solicitações por requisição.
         """
-        ids = request.data.get("ids", [])
+        # M11-04 (#1650): mesma validação de entrada do batch-approve.
+        input_serializer = _BatchIdsSerializer(data=request.data)
+        input_serializer.is_valid(raise_exception=True)
+        ids = input_serializer.validated_data["ids"]
 
         # §1 Epic #459: Delegate to service layer
         result = batch_reject_solicitacoes(


### PR DESCRIPTION
## Contexto

M11-04 (#1650), confirmado VIVO na triagem authz.

As actions `batch-approve` / `batch-reject` repassavam `request.data["ids"]` **cru** ao serviço, que só checava falsiness e tamanho (`if not ids`, `len(ids) > 100`). Consequências:
- **string** `"8910"` → `filter(id__in="8910")` decompõe em dígitos → aprova/reprova alvos **NÃO nomeados** (8, 9, 1, 0), sem aparecer no payload;
- **int escalar** → `len(5)` estoura `TypeError` → **HTTP 500**;
- **dict** / lista com não-inteiros passavam adiante.

## Mudança

- Novo `_BatchIdsSerializer` valida o **tipo**: `ids` deve ser uma **lista de inteiros positivos**. Aplicado nas duas actions antes de delegar ao serviço.
- **Escopo deliberado**: vazio e limite (>100) seguem a cargo do serviço, **preservando as mensagens de contrato** (`"obrigatório"` / limite de 100) — não altera o formato de erro que os testes de coverage existentes assertam.
- O serializer é definido **antes** do `@extend_schema_view` do viewset — senão o decorator o envolveria (`AttributeError: no attribute 'schema'`).

## Testes (TDD RED→GREEN)

Novo `test_batch_approval_ids_validation_1650.py` — 7 casos:
- **RED provado**: sem validação, string `"8910"` → 200 (processa dígitos), int → 500.
- **GREEN**: string/int/dict/lista-com-não-int → 400; lista válida aprova (200); vazio → 400 (via serviço).
- **Regressão**: `test_views_solicitacao_coverage` (empty/limit com mensagem intacta), `test_pr3_approvals_policy`, `test_solicitacao_action_perms`, `test_solicitacao_approval_concurrency` verdes (66+).

Closes #1650
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `0fc8476f`, slot `1` / projeto `aprender_staging_s1`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local-s1, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
