### PR TITLE
fix(nginx): restaura headers de segurança nas locations com add_header (M27-24)

### DIFF
--- a/v2/frontend/Dockerfile.prod
+++ b/v2/frontend/Dockerfile.prod
@@ -47,6 +47,11 @@ RUN rm /etc/nginx/conf.d/default.conf
 # Copiar configuracao customizada do nginx
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 
+# M27-24 (#1647): snippet de security headers reincluído em cada location.
+# Fica FORA de conf.d/ (que o nginx auto-carrega como server) — é incluído
+# explicitamente pelo default.conf.
+COPY security-headers.conf /etc/nginx/security-headers.conf
+
 # Copiar arquivos buildados do stage anterior
 COPY --from=builder /app/dist /usr/share/nginx/html
 

--- a/v2/frontend/nginx.conf
+++ b/v2/frontend/nginx.conf
@@ -23,22 +23,17 @@ server {
     gzip_proxied any;
     gzip_types text/plain text/css text/xml text/javascript application/x-javascript application/xml application/javascript application/json image/svg+xml application/wasm font/woff2;
 
-    # Security headers
-    add_header X-Frame-Options "SAMEORIGIN" always;
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header X-XSS-Protection "0" always;
-    add_header Cross-Origin-Opener-Policy "same-origin" always;
-    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
-    # SEC-CSP-02: unsafe-eval removed — production bundles are static, no eval needed
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'" always;
+    # Security headers — M27-24 (#1647): num snippet reincluído em cada location
+    # com add_header próprio (a herança do nginx descarta os do server quando a
+    # location declara qualquer add_header).
+    include /etc/nginx/security-headers.conf;
 
     # Health check endpoint
     location /health {
         access_log off;
         return 200 "healthy\n";
         add_header Content-Type text/plain;
+        include /etc/nginx/security-headers.conf;  # M27-24: re-herda os headers
     }
 
     # SEC-RECON-02: /metrics removed from public proxy.
@@ -57,6 +52,7 @@ server {
     location /assets/ {
         expires 1y;
         add_header Cache-Control "public, immutable";
+        include /etc/nginx/security-headers.conf;  # M27-24: re-herda os headers
         try_files $uri =404;
     }
 
@@ -64,6 +60,7 @@ server {
     location ~* \.(png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot|webp|avif)$ {
         expires 30d;
         add_header Cache-Control "public";
+        include /etc/nginx/security-headers.conf;  # M27-24: re-herda os headers
         try_files $uri =404;
     }
 
@@ -117,6 +114,7 @@ server {
     # no-cache ensures browser always checks for new version after deploy
     location / {
         add_header Cache-Control "no-cache";
+        include /etc/nginx/security-headers.conf;  # M27-24: re-herda os headers na rota SPA
         try_files $uri $uri/ /index.html;
     }
 

--- a/v2/frontend/security-headers.conf
+++ b/v2/frontend/security-headers.conf
@@ -1,0 +1,18 @@
+# =============================================================================
+# Security headers (M27-24, #1647)
+# =============================================================================
+# Regra de herança do nginx: um `add_header` declarado numa `location` DESCARTA
+# todos os `add_header` herdados do escopo pai (server). Como várias locations
+# definem o próprio `add_header Cache-Control` (/, /assets/, imagens) ou
+# Content-Type (/health), elas apagavam silenciosamente estes headers de
+# segurança em toda a rota SPA. Por isso este snippet é incluído no bloco
+# `server` E reincluído em cada location que tenha `add_header` próprio.
+add_header X-Frame-Options "SAMEORIGIN" always;
+add_header X-Content-Type-Options "nosniff" always;
+add_header X-XSS-Protection "0" always;
+add_header Cross-Origin-Opener-Policy "same-origin" always;
+add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=()" always;
+# SEC-CSP-02: unsafe-eval removed — production bundles are static, no eval needed
+add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'" always;


### PR DESCRIPTION
## Contexto

M27-24 (#1647), confirmado VIVO na triagem authz.

Regra de herança do nginx: um `add_header` declarado numa `location` **descarta TODOS** os `add_header` herdados do bloco `server`. Como `/`, `/assets/`, imagens (`~* \.(png|...)$`) e `/health` declaram o próprio `add_header` (Cache-Control / Content-Type), os **8 headers de segurança** do server eram silenciosamente descartados nessas rotas — incluindo a **rota SPA `/`** (toda navegação servida sem X-Frame-Options, CSP, HSTS, etc.).

## Mudança

- Headers de segurança extraídos para o snippet **`security-headers.conf`**, incluído no bloco `server` **e reincluído em cada location** com `add_header` próprio (`/`, `/assets/`, imagens, `/health`).
- Snippet fica **fora de `conf.d/`** (que o nginx auto-carrega como `server`) → copiado para `/etc/nginx/security-headers.conf` e incluído explicitamente. `Dockerfile.prod` ganhou o `COPY`.

## Verificação (RED→GREEN via nginx real)

Build `nginx:alpine` + curl:
- **RED** (`nginx.conf` original de `main`): `GET /` → só `Cache-Control: no-cache`, **sem** os 8 headers.
- **GREEN** (fix): `GET /`, `/assets/app.js`, `/health` → **os 8 headers presentes**, `Cache-Control` preservado.
- `nginx -t` ok.

Fecha o gap que o `strict-security-headers` (spec `security-headers.spec.ts`, que audita `/`) cobre em staging/prod.

Closes #1647
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `021f1f42`, slot `1` / projeto `aprender_staging_s1`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local-s1, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
