### PR TITLE
ci(frontend): install Playwright sem --with-deps (elimina o hang do apt-get)

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -99,22 +99,21 @@ jobs:
         key: ${{ runner.os }}-playwright-${{ hashFiles('v2/frontend/package-lock.json') }}
 
     - name: Install Playwright browsers
-      # Retry no download do browser: o CDN do Playwright pendura de forma
-      # transitória (visto em #1763/#1768/#1770). Cada tentativa tem timeout de
-      # 6min; até 3 tentativas. Um sucesso salva o cache (post-step) e destrava
-      # os próximos runs. Em cache-hit o download é pulado (segundos).
+      # Só o BROWSER — SEM --with-deps. Diagnóstico (log do run 32291923049): o
+      # flake NÃO era o download do browser; era o `apt-get` do --with-deps
+      # pendurando num mirror lento do Ubuntu (azure.archive.ubuntu.com, ~59kB/s:
+      # 3min só de update, depois hang instalando uma fonte → timeout de 10min).
+      # A imagem ubuntu-latest do GitHub já traz as libs de sistema dos browsers
+      # (actions/runner-images), então --with-deps era redundante E a fonte do
+      # flake. O browser é cacheado (cache-hit = segundos); retry leve cobre um
+      # hang raro do CDN do Playwright.
       run: |
         for attempt in 1 2 3; do
-          echo "::group::playwright install (tentativa $attempt/3)"
-          if timeout 360 npx playwright install chromium --with-deps; then
-            echo "::endgroup::"
-            exit 0
-          fi
-          echo "::endgroup::"
-          echo "tentativa $attempt falhou/timeout; aguardando 15s antes de tentar de novo…"
-          sleep 15
+          timeout 180 npx playwright install chromium && exit 0
+          echo "tentativa $attempt do install do browser falhou; retry em 10s…"
+          sleep 10
         done
-        echo "playwright install falhou após 3 tentativas" >&2
+        echo "playwright install (browser) falhou após 3 tentativas" >&2
         exit 1
 
     - name: Start backend services for functional contract checklist
@@ -224,22 +223,21 @@ jobs:
         key: ${{ runner.os }}-playwright-${{ hashFiles('v2/frontend/package-lock.json') }}
 
     - name: Install Playwright browsers
-      # Retry no download do browser: o CDN do Playwright pendura de forma
-      # transitória (visto em #1763/#1768/#1770). Cada tentativa tem timeout de
-      # 6min; até 3 tentativas. Um sucesso salva o cache (post-step) e destrava
-      # os próximos runs. Em cache-hit o download é pulado (segundos).
+      # Só o BROWSER — SEM --with-deps. Diagnóstico (log do run 32291923049): o
+      # flake NÃO era o download do browser; era o `apt-get` do --with-deps
+      # pendurando num mirror lento do Ubuntu (azure.archive.ubuntu.com, ~59kB/s:
+      # 3min só de update, depois hang instalando uma fonte → timeout de 10min).
+      # A imagem ubuntu-latest do GitHub já traz as libs de sistema dos browsers
+      # (actions/runner-images), então --with-deps era redundante E a fonte do
+      # flake. O browser é cacheado (cache-hit = segundos); retry leve cobre um
+      # hang raro do CDN do Playwright.
       run: |
         for attempt in 1 2 3; do
-          echo "::group::playwright install (tentativa $attempt/3)"
-          if timeout 360 npx playwright install chromium --with-deps; then
-            echo "::endgroup::"
-            exit 0
-          fi
-          echo "::endgroup::"
-          echo "tentativa $attempt falhou/timeout; aguardando 15s antes de tentar de novo…"
-          sleep 15
+          timeout 180 npx playwright install chromium && exit 0
+          echo "tentativa $attempt do install do browser falhou; retry em 10s…"
+          sleep 10
         done
-        echo "playwright install falhou após 3 tentativas" >&2
+        echo "playwright install (browser) falhou após 3 tentativas" >&2
         exit 1
 
     - name: Start backend services and seed E2E data


### PR DESCRIPTION
## Diagnóstico (o real, pelo log)

O flake recorrente do step **"Install Playwright browsers"** (#1763/#1768/#1770) **não era o download do browser** — era o **`apt-get` que o `--with-deps` roda**, pendurando num mirror lento do Ubuntu. Log do run `32291923049`:

```
Fetched 11.4 MB in 3min 12s (59.2 kB/s)     ← apt-get update lentíssimo (azure.archive.ubuntu.com)
Get: ... fonts-ipafont-gothic [3513 kB]     ← trava instalando fonte
##[error] Install Playwright browsers timed out after 10 minutes
Terminate orphan process: npm exec playwright install chromium --with-deps
```

Por isso as tentativas anteriores não resolviam a raiz:
- **#1765** cacheava `~/.cache/ms-playwright` = o **browser**. Mas `--with-deps` roda `apt-get` de qualquer jeito.
- **#1772** dava retry no install inteiro (band-aid; o apt continua lento).

## Fix

Remover **`--with-deps`**. A imagem `ubuntu-latest` do GitHub já traz as libs de sistema dos browsers ([actions/runner-images](https://github.com/actions/runner-images)) → `--with-deps` era **redundante e a fonte do flake**. Sobra só o download do browser — **cacheado** (cache-hit = segundos) + **retry leve** (`timeout 180` × 3) para o hang raro do CDN do Playwright.

Aplicado aos dois jobs: `checklist-tests` **[required]** e `e2e-journeys` **[info]**.

## Prova

O próprio CI deste PR exercita o install **sem `--with-deps`**. Se o `checklist tests` passar aqui, está provado que as libs estão presentes no runner e o flake do apt foi eliminado.

CI-only; não toca app; não deploya.
