### PR TITLE
fix(solicitacao): bloqueia edição/exclusão durante gcal_status=PENDING (M10-03)

### DIFF
--- a/v2/backend/apps/core/serializers/solicitacao.py
+++ b/v2/backend/apps/core/serializers/solicitacao.py
@@ -161,7 +161,7 @@ class SolicitacaoSerializer(serializers.ModelSerializer):
         """
         instance = getattr(self, "instance", None)
 
-        # Regra 2: Bloquear edição após publicação no GCal
+        # Regra 2: Bloquear edição durante a sincronização com o GCal.
         if instance is not None:
             if getattr(instance, "gcal_status", None) == "PUBLISHED":
                 raise serializers.ValidationError(
@@ -169,6 +169,19 @@ class SolicitacaoSerializer(serializers.ModelSerializer):
                         "non_field_errors": [
                             "Não é possível editar uma solicitação já publicada no Google Calendar. "
                             "Cancele o evento primeiro se precisar fazer alterações."
+                        ]
+                    }
+                )
+
+            # M10-03 (#1625): PENDING = task Celery de publish/resync/cancel já
+            # enfileirada. Editar nessa janela faz a task publicar o conteúdo
+            # corrente em vez do snapshot aprovado (TOCTOU / drift).
+            if getattr(instance, "gcal_status", None) == "PENDING":
+                raise serializers.ValidationError(
+                    {
+                        "non_field_errors": [
+                            "Não é possível editar enquanto a sincronização com o Google Calendar está "
+                            "em andamento. Aguarde a conclusão da publicação."
                         ]
                     }
                 )

--- a/v2/backend/apps/core/tests/test_solicitacao_gcal_pending_guard_1625.py
+++ b/v2/backend/apps/core/tests/test_solicitacao_gcal_pending_guard_1625.py
@@ -1,0 +1,130 @@
+"""
+M10-03 (#1625) — bloquear edição/exclusão enquanto gcal_status == PENDING.
+
+Os guards de edição (serializer) e exclusão (perform_destroy) só tratavam
+`PUBLISHED` como imutável. A janela `PENDING` (a task Celery de publish/resync/
+cancel já foi enfileirada, mas ainda não rodou) ficava editável/deletável — a
+task então publicava/operava sobre o conteúdo corrente em vez do snapshot
+aprovado (TOCTOU / drift; ou operava sobre um registro já removido).
+
+Contrato: com gcal_status in (PUBLISHED, PENDING), PATCH/PUT e DELETE → 400.
+Fora dessa janela (NONE/ERROR) as edições legítimas seguem.
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportOptionalMemberAccess=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportMissingTypeArgument=false, reportCallIssue=false, reportIndexIssue=false, reportOptionalSubscript=false
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+import pytest
+
+from apps.core.models import Solicitacao
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def coordenador():
+    user = UsuarioFactory(username="coord_1625", cpf="76000000001")
+    user.groups.add(GroupFactory(name="Coordenador"))
+    return user
+
+
+@pytest.fixture
+def municipio():
+    return MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+
+
+@pytest.fixture
+def tipo_evento():
+    return TipoEventoFactory(nome="Formacao M1625")
+
+
+@pytest.fixture
+def projeto_nao_super():
+    return ProjetoFactory(nome="NaoSuper 1625", codigo="NS1625", fluxo="NAO_SUPER", ativo=True)
+
+
+def _solicitacao(coordenador, municipio, tipo_evento, projeto, gcal_status):
+    inicio = timezone.now() + timedelta(days=5)
+    sol = SolicitacaoFactory(
+        usuario=coordenador,
+        municipio=municipio,
+        projeto=projeto,
+        tipo_evento=tipo_evento,
+        inicio=inicio,
+        fim=inicio + timedelta(hours=2),
+        status="aprovado",
+    )
+    sol.gcal_status = gcal_status
+    sol.save(update_fields=["gcal_status"])
+    return sol
+
+
+@pytest.fixture
+def client_coord(coordenador):
+    c = APIClient()
+    c.force_authenticate(coordenador)
+    return c
+
+
+def _url(sol_id: int) -> str:
+    return f"/api/solicitacoes/{sol_id}/"
+
+
+class TestPendingWindowBlocksMutation:
+    def test_patch_bloqueado_com_gcal_pending(
+        self, client_coord, coordenador, municipio, tipo_evento, projeto_nao_super
+    ):
+        """RED: hoje o guard só cobre PUBLISHED; PENDING passa e edita."""
+        sol = _solicitacao(coordenador, municipio, tipo_evento, projeto_nao_super, Solicitacao.GCalStatus.PENDING)
+
+        resp = client_coord.patch(_url(sol.id), {"observacoes": "editado durante sync"}, format="json")
+
+        assert resp.status_code == 400, f"esperado 400, obteve {resp.status_code}"
+        sol.refresh_from_db()
+        assert sol.observacoes != "editado durante sync"
+
+    def test_delete_bloqueado_com_gcal_pending(
+        self, client_coord, coordenador, municipio, tipo_evento, projeto_nao_super
+    ):
+        """RED: perform_destroy só cobre PUBLISHED; PENDING é deletável."""
+        sol = _solicitacao(coordenador, municipio, tipo_evento, projeto_nao_super, Solicitacao.GCalStatus.PENDING)
+
+        resp = client_coord.delete(_url(sol.id))
+
+        assert resp.status_code == 400, f"esperado 400, obteve {resp.status_code}"
+        assert Solicitacao.objects.filter(pk=sol.id).exists()
+
+
+class TestOutsideWindowStillWorks:
+    def test_patch_permitido_com_gcal_none(self, client_coord, coordenador, municipio, tipo_evento, projeto_nao_super):
+        sol = _solicitacao(coordenador, municipio, tipo_evento, projeto_nao_super, Solicitacao.GCalStatus.NONE)
+
+        resp = client_coord.patch(_url(sol.id), {"observacoes": "edicao legitima"}, format="json")
+
+        assert resp.status_code == 200, resp.data
+        sol.refresh_from_db()
+        assert sol.observacoes == "edicao legitima"
+
+    def test_patch_bloqueado_com_gcal_published(
+        self, client_coord, coordenador, municipio, tipo_evento, projeto_nao_super
+    ):
+        """Não-regressão: PUBLISHED continua bloqueado."""
+        sol = _solicitacao(coordenador, municipio, tipo_evento, projeto_nao_super, Solicitacao.GCalStatus.PUBLISHED)
+
+        resp = client_coord.patch(_url(sol.id), {"observacoes": "x"}, format="json")
+
+        assert resp.status_code == 400

--- a/v2/backend/apps/core/views_solicitacao.py
+++ b/v2/backend/apps/core/views_solicitacao.py
@@ -604,6 +604,16 @@ class SolicitacaoViewSet(viewsets.ModelViewSet):
                 }
             )
 
+        # M10-03 (#1625): PENDING = task Celery de sincronização já enfileirada;
+        # excluir nessa janela deixa a task operar sobre um registro removido.
+        if instance.gcal_status == "PENDING":
+            raise ValidationError(
+                {
+                    "detail": "Não é possível excluir enquanto a sincronização com o Google Calendar está "
+                    "em andamento. Aguarde a conclusão."
+                }
+            )
+
         # Validação adicional para fluxo SUPER
         projeto_fluxo = instance.projeto.fluxo if instance.projeto else None
         if projeto_fluxo == "SUPER" and instance.status != "pendente":


### PR DESCRIPTION
## Contexto

M10-03 (#1625), confirmado VIVO na triagem authz.

Os guards de edição (`serializer.validate`, Regra 2) e exclusão (`perform_destroy`) só tratavam **PUBLISHED** como imutável. A janela **PENDING** — a task Celery de publish/resync/cancel **já enfileirada** (marcada em `solicitacao_publish.py`), mas ainda não executada — ficava editável/deletável. A task então publicava o **conteúdo corrente** no Google Calendar em vez do snapshot aprovado (TOCTOU / drift), ou operava sobre um registro já removido.

## Mudança

- `serializer.validate`: bloqueia PATCH/PUT quando `gcal_status == "PENDING"`.
- `perform_destroy`: bloqueia DELETE quando `gcal_status == "PENDING"`.
- Mensagens próprias ("sincronização em andamento; aguarde a conclusão"); o guard e a mensagem de **PUBLISHED** ficam intactos.

## Testes (TDD RED→GREEN)

Novo `test_solicitacao_gcal_pending_guard_1625.py` — 4 casos:
- **RED provado**: PATCH editava e DELETE retornava 204 durante PENDING.
- **GREEN**: PATCH/DELETE com PENDING → 400; PATCH com `NONE` → 200; PUBLISHED continua 400.
- **Regressão**: `test_views_solicitacao_coverage`, `test_solicitacao_action_perms` verdes (46).

> Escopo: fecha a janela para mutação iniciada pelo usuário. O hardening TOCTOU sob lock (`select_for_update` na cadeia enqueue↔edit) fica como follow-up.

Closes #1625
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `f25c9285`, slot `1` / projeto `aprender_staging_s1`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local-s1, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
