### PR TITLE
fix(solicitacao): escopo ator×gerência em list/edit/delete (M10-01)

### DIFF
--- a/v2/backend/apps/core/rbac/permissions.py
+++ b/v2/backend/apps/core/rbac/permissions.py
@@ -231,7 +231,13 @@ class IsOwnerOrPrivileged(HasFunctionalPermission):  # type: ignore[misc]
         if getattr(user, "is_superuser", False):
             return True
         if self.functional_codename in get_user_functional_permissions(user):
-            return True
+            # M10-01 (#1623): o privilégio de edição de solicitação só vale DENTRO
+            # do escopo do ator (global OU própria gerência OU dono) — não mais
+            # nacional. SSOT: `user_can_access_solicitacao`.
+            from apps.core.services.solicitacao_scope import user_can_access_solicitacao
+
+            if user_can_access_solicitacao(user, obj):
+                return True
 
         obj_usuario = getattr(obj, "usuario", None)
         return obj_usuario == user

--- a/v2/backend/apps/core/services/solicitacao_scope.py
+++ b/v2/backend/apps/core/services/solicitacao_scope.py
@@ -21,6 +21,8 @@ Consumido tanto pelo `get_queryset` do `SolicitacaoViewSet` quanto pelo
 fora do escopo → 404, não distinguível de inexistente).
 """
 
+# pyright: reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportMissingTypeArgument=false
+
 from __future__ import annotations
 
 from typing import Any
@@ -41,7 +43,12 @@ def user_is_solicitacao_global(user: Any) -> bool:
         return False
     if getattr(user, "is_superuser", False):
         return True
-    if user_has_any_perm(user, "operate_preagenda", "manage_admin_registries"):
+    # `approve_solicitation` é EXCLUSIVA do setor Superintendência (o órgão de
+    # oversight/aprovação) — visão global legítima. NÃO incluir
+    # `approve_solicitation_batch` aqui: essa é concedida ao grupo FUNÇÃO "Gerente"
+    # inteiro e é justamente o que vazava alcance nacional p/ Gerente pedagógico
+    # (por isso o escopo abaixo). `operate_preagenda`=Controle, `manage_admin_registries`=DAT.
+    if user_has_any_perm(user, "operate_preagenda", "manage_admin_registries", "approve_solicitation"):
         return True
     # Aprovador composto (Gerente-da-Superintendência OU Asst-Admin-Controle).
     return user_has_policy(user, "access_solicitation_approvals")

--- a/v2/backend/apps/core/services/solicitacao_scope.py
+++ b/v2/backend/apps/core/services/solicitacao_scope.py
@@ -1,0 +1,75 @@
+"""
+M10-01 (#1623) — SSOT de escopo ator×gerência para Solicitacao.
+
+Antes, quem tinha as caps `approve_solicitation` / `approve_solicitation_batch`
+(concedidas ao grupo FUNÇÃO "Gerente" inteiro, não só ao aprovador composto)
+via/editava/excluía solicitações de QUALQUER gerência — alcance nacional sem
+escopo. Um Gerente pedagógico (não-Superintendência) não consegue aprovar (isso
+exige o composite), mas conseguia ler/editar/excluir tudo.
+
+Regra:
+- GLOBAL (vê tudo): superuser, Controle (`operate_preagenda`), DAT
+  (`manage_admin_registries`) e o aprovador composto
+  (`access_solicitation_approvals` = Gerente-da-Superintendência OU Assistente
+  Administrativo do Controle).
+- GESTOR não-global (tem `approve_solicitation*` mas não é global): reduzido de
+  nacional para a(s) própria(s) gerência(s) (via EquipeGerencia) + as próprias.
+- DEMAIS (Coordenador etc.): apenas as próprias (comportamento inalterado).
+
+Consumido tanto pelo `get_queryset` do `SolicitacaoViewSet` quanto pelo
+`IsOwnerOrPrivileged.has_object_permission` (mesma semântica em list e em objeto;
+fora do escopo → 404, não distinguível de inexistente).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from django.db.models import Q, QuerySet
+
+from apps.core.models import EquipeGerencia
+from apps.core.rbac.policies import user_has_policy
+from apps.core.rbac_helpers import user_has_any_perm
+
+# Caps que hoje concediam alcance nacional de solicitação (vazam para todo Gerente).
+_MANAGER_CAPS = ("approve_solicitation", "approve_solicitation_batch")
+
+
+def user_is_solicitacao_global(user: Any) -> bool:
+    """Autoridade que legitimamente enxerga TODAS as solicitações."""
+    if not user or not getattr(user, "is_authenticated", False):
+        return False
+    if getattr(user, "is_superuser", False):
+        return True
+    if user_has_any_perm(user, "operate_preagenda", "manage_admin_registries"):
+        return True
+    # Aprovador composto (Gerente-da-Superintendência OU Asst-Admin-Controle).
+    return user_has_policy(user, "access_solicitation_approvals")
+
+
+def _user_gerencia_ids(user: Any) -> set[int]:
+    return set(EquipeGerencia.objects.filter(usuario=user).values_list("gerencia_id", flat=True))
+
+
+def scope_solicitacoes(qs: QuerySet, user: Any) -> QuerySet:
+    """Restringe `qs` ao escopo do `user` (ver regra no módulo)."""
+    if user_is_solicitacao_global(user):
+        return qs
+    if user_has_any_perm(user, *_MANAGER_CAPS):
+        gerencia_ids = _user_gerencia_ids(user)
+        return qs.filter(Q(usuario=user) | Q(projeto__gerencia_id__in=gerencia_ids))
+    return qs.filter(usuario=user)
+
+
+def user_can_access_solicitacao(user: Any, obj: Any) -> bool:
+    """True sse `user` pode acessar a Solicitacao `obj` (mesma regra do queryset)."""
+    if not user or not getattr(user, "is_authenticated", False):
+        return False
+    if user_is_solicitacao_global(user):
+        return True
+    if getattr(obj, "usuario_id", None) == getattr(user, "id", None):
+        return True
+    if user_has_any_perm(user, *_MANAGER_CAPS):
+        gerencia_id = getattr(getattr(obj, "projeto", None), "gerencia_id", None)
+        return gerencia_id is not None and gerencia_id in _user_gerencia_ids(user)
+    return False

--- a/v2/backend/apps/core/tests/test_solicitacao_gerencia_scope_1623.py
+++ b/v2/backend/apps/core/tests/test_solicitacao_gerencia_scope_1623.py
@@ -1,0 +1,169 @@
+"""
+M10-01 (#1623) — escopo ator×gerência para Solicitacao.
+
+`approve_solicitation_batch` é concedida ao grupo FUNÇÃO "Gerente" inteiro
+(seed), não só ao aprovador composto. Antes, o `get_queryset` dava alcance
+NACIONAL a quem tivesse essa cap, e o `IsOwnerOrPrivileged` liberava edição de
+qualquer objeto — então um Gerente pedagógico (não-Superintendência), que nem
+pode aprovar, lia/editava/excluía solicitações de QUALQUER gerência.
+
+Contrato:
+- GLOBAL (superuser / Controle / DAT / aprovador-composto) → vê e edita tudo.
+- GESTOR não-global (Gerente) → só a(s) própria(s) gerência(s) + as próprias.
+- Fora do escopo → 404 (indistinguível de inexistente).
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportOptionalMemberAccess=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportMissingTypeArgument=false, reportCallIssue=false, reportIndexIssue=false, reportOptionalSubscript=false
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+import pytest
+
+from apps.core.models import EquipeGerencia, Gerencia, Solicitacao
+from apps.core.tests.factories import (
+    GroupFactory,
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def municipio():
+    return MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+
+
+@pytest.fixture
+def tipo_evento():
+    return TipoEventoFactory(nome="Formacao M1623")
+
+
+@pytest.fixture
+def gerencia_a():
+    return Gerencia.objects.create(nome="GERENCIA A 1623", nome_setor="Vidas", ativo=True)
+
+
+@pytest.fixture
+def gerencia_b():
+    return Gerencia.objects.create(nome="GERENCIA B 1623", nome_setor="Fluir", ativo=True)
+
+
+@pytest.fixture
+def coordenador_a():
+    """Dono das solicitações da gerência A (não é o Gerente)."""
+    return UsuarioFactory(username="coord_a_1623", cpf="78000000001")
+
+
+@pytest.fixture
+def gerente_a(gerencia_a):
+    """Gerente pedagógico da gerência A (grupo Gerente → approve_solicitation_batch)."""
+    user = UsuarioFactory(username="gerente_a_1623", cpf="78000000002")
+    user.groups.add(GroupFactory(name="Gerente"))
+    EquipeGerencia.objects.create(usuario=user, gerencia=gerencia_a, papel="GERENTE")
+    return user
+
+
+def _solic(owner, municipio, tipo_evento, projeto):
+    inicio = timezone.now() + timedelta(days=4)
+    return SolicitacaoFactory(
+        usuario=owner,
+        municipio=municipio,
+        projeto=projeto,
+        tipo_evento=tipo_evento,
+        inicio=inicio,
+        fim=inicio + timedelta(hours=2),
+        status="aprovado",
+    )
+
+
+@pytest.fixture
+def sol_a(coordenador_a, municipio, tipo_evento, gerencia_a):
+    projeto = ProjetoFactory(nome="Proj A 1623", gerencia=gerencia_a)
+    return _solic(coordenador_a, municipio, tipo_evento, projeto)
+
+
+@pytest.fixture
+def sol_b(municipio, tipo_evento, gerencia_b):
+    owner = UsuarioFactory(username="coord_b_1623", cpf="78000000003")
+    projeto = ProjetoFactory(nome="Proj B 1623", gerencia=gerencia_b)
+    return _solic(owner, municipio, tipo_evento, projeto)
+
+
+def _url(pk):
+    return f"/api/solicitacoes/{pk}/"
+
+
+class TestGerenteScopedToOwnGerencia:
+    def test_gerente_lista_apenas_propria_gerencia(self, gerente_a, sol_a, sol_b):
+        """RED: hoje o Gerente vê as duas (alcance nacional)."""
+        client = APIClient()
+        client.force_authenticate(gerente_a)
+        resp = client.get("/api/solicitacoes/")
+        assert resp.status_code == 200
+        ids = {item["id"] for item in resp.data.get("results", resp.data)}
+        assert sol_a.id in ids
+        assert sol_b.id not in ids  # RED: sol_b aparecia
+
+    def test_gerente_retrieve_outra_gerencia_404(self, gerente_a, sol_b):
+        client = APIClient()
+        client.force_authenticate(gerente_a)
+        resp = client.get(_url(sol_b.id))
+        assert resp.status_code == 404  # RED: 200
+
+    def test_gerente_patch_outra_gerencia_404(self, gerente_a, sol_b):
+        client = APIClient()
+        client.force_authenticate(gerente_a)
+        resp = client.patch(_url(sol_b.id), {"observacoes": "invadido"}, format="json")
+        assert resp.status_code == 404  # RED: 200 e editava
+        sol_b.refresh_from_db()
+        assert sol_b.observacoes != "invadido"
+
+    def test_gerente_delete_outra_gerencia_404(self, gerente_a, sol_b):
+        client = APIClient()
+        client.force_authenticate(gerente_a)
+        resp = client.delete(_url(sol_b.id))
+        assert resp.status_code == 404  # RED: 204 e excluía
+        assert Solicitacao.objects.filter(pk=sol_b.id).exists()
+
+
+class TestInScopeAndGlobalStillWork:
+    def test_gerente_acessa_propria_gerencia(self, gerente_a, sol_a):
+        client = APIClient()
+        client.force_authenticate(gerente_a)
+        resp = client.get(_url(sol_a.id))
+        assert resp.status_code == 200
+        assert resp.data["id"] == sol_a.id
+
+    def test_superuser_ve_todas(self, sol_a, sol_b):
+        su = UsuarioFactory(username="su_1623", cpf="78000000009", superuser=True)
+        client = APIClient()
+        client.force_authenticate(su)
+        resp = client.get("/api/solicitacoes/")
+        ids = {item["id"] for item in resp.data.get("results", resp.data)}
+        assert sol_a.id in ids and sol_b.id in ids
+
+    def test_gerente_da_superintendencia_ve_todas(self, sol_a, sol_b):
+        """Aprovador composto (Gerente + Superintendência) é GLOBAL."""
+        user = UsuarioFactory(username="gsuper_1623", cpf="78000000010")
+        user.groups.add(GroupFactory(name="Gerente"), GroupFactory(name="Superintendência"))
+        client = APIClient()
+        client.force_authenticate(user)
+        resp = client.get("/api/solicitacoes/")
+        ids = {item["id"] for item in resp.data.get("results", resp.data)}
+        assert sol_a.id in ids and sol_b.id in ids
+
+    def test_dono_ve_a_propria_mesmo_fora_da_gerencia(self, sol_b):
+        """O dono sempre vê a própria solicitação."""
+        client = APIClient()
+        client.force_authenticate(sol_b.usuario)
+        resp = client.get(_url(sol_b.id))
+        assert resp.status_code == 200

--- a/v2/backend/apps/core/views_solicitacao.py
+++ b/v2/backend/apps/core/views_solicitacao.py
@@ -23,8 +23,6 @@ from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiExample, OpenApiParameter, extend_schema, extend_schema_view
 
-from apps.core.rbac_helpers import user_has_any_perm
-
 from .api_schemas import (
     COMMON_ERROR_RESPONSES,
     SOLICITACAO_BATCH_APPROVE_REQUEST,
@@ -47,6 +45,7 @@ from .services.solicitacao_create import resolve_initial_status
 from .services.solicitacao_publish import cancel_from_gcal
 from .services.solicitacao_publish import preview_gcal as preview_gcal_service
 from .services.solicitacao_publish import publish_to_gcal, resync_to_gcal
+from .services.solicitacao_scope import scope_solicitacoes
 
 logger = logging.getLogger(__name__)
 
@@ -240,29 +239,18 @@ class SolicitacaoViewSet(viewsets.ModelViewSet):
                 .select_related("usuario", "municipio", "tipo_evento", "projeto", "coordenador")
                 .prefetch_related("participations__usuario")
             )
-        # Epic 3.2 RBAC Refactor (2026-04-23): hardcoded
-        # `groups.filter(name__in=["Superintendência", "Controle", "DAT"])`
-        # trocado por capability check.
-        # Issue #1222 (Epic 1 RBAC Access Policy Realignment, 2026-04-24):
-        # após realinhamento do seed, `operate_preagenda` ficou só em Controle.
-        # Super (que aprova solicitações) precisa ver todas; adicionada
-        # `approve_solicitation` ao OR para preservar visibilidade de Super.
-        elif user_has_any_perm(
-            self.request.user,
-            "operate_preagenda",
-            "approve_solicitation",
-            "approve_solicitation_batch",
-            "manage_admin_registries",
-        ):
-            qs = Solicitacao.objects.select_related(
+        # M10-01 (#1623): escopo ator×gerência (SSOT `scope_solicitacoes`).
+        # GLOBAL (superuser / Controle `operate_preagenda` / DAT
+        # `manage_admin_registries` / aprovador-composto) vê tudo; GESTOR não-global
+        # (Gerente com `approve_solicitation*`) é reduzido à(s) própria(s) gerência(s)
+        # + as próprias; DEMAIS veem só as próprias. Antes, as caps de aprovação
+        # (concedidas ao grupo FUNÇÃO Gerente inteiro) davam alcance NACIONAL a
+        # qualquer Gerente, inclusive os que não podem aprovar.
+        else:
+            base = Solicitacao.objects.select_related(
                 "usuario", "municipio", "tipo_evento", "projeto", "coordenador"
             ).prefetch_related("participations__usuario")
-        else:
-            qs = (
-                Solicitacao.objects.filter(usuario=self.request.user)
-                .select_related("usuario", "municipio", "tipo_evento", "projeto", "coordenador")
-                .prefetch_related("participations__usuario")
-            )
+            qs = scope_solicitacoes(base, self.request.user)
 
         # PR15: Filtros adicionais via query params
         sector = self.request.query_params.get("sector")


### PR DESCRIPTION
## Contexto

M10-01 (#1623), confirmado VIVO na triagem authz. Decisão do dono: **cada gerência só a sua**.

`approve_solicitation_batch` é concedida ao grupo **FUNÇÃO "Gerente" inteiro** (seed `functional_permissions_seed`: `group_names=("Gerente", "Superintendência")`), não só ao aprovador composto. O `get_queryset` dava **alcance nacional** a quem tivesse a cap, e o `IsOwnerOrPrivileged` liberava edição de **qualquer** objeto — então um Gerente pedagógico (não-Superintendência), que **nem pode aprovar** (isso exige o composite), lia/editava/excluía solicitações de **QUALQUER gerência**.

## Mudança

Novo SSOT `services/solicitacao_scope.py`:
- `user_is_solicitacao_global(user)` — **GLOBAL** (vê tudo): superuser · Controle (`operate_preagenda`) · DAT (`manage_admin_registries`) · aprovador-composto (`access_solicitation_approvals` = Gerente-da-Superintendência OU Asst-Admin-Controle).
- `scope_solicitacoes(qs, user)` — global → tudo; **gestor não-global** (tem `approve_solicitation*`) → própria(s) gerência(s) via `EquipeGerencia` + as próprias; **demais** → só as próprias.
- `user_can_access_solicitacao(user, obj)` — mesma semântica por objeto.

`get_queryset` consome `scope_solicitacoes`; `IsOwnerOrPrivileged.has_object_permission` passa a exigir escopo (o edit cap só vale global / própria-gerência / dono). Fora do escopo → **404** (indistinguível de inexistente; cobre list + retrieve + update + destroy via `get_object`).

**Não expande** visibilidade: quem hoje vê só as próprias (Coordenador sem `approve` cap) segue own-only.

## Testes (TDD RED→GREEN)

Novo `test_solicitacao_gerencia_scope_1623.py` — 8 casos:
- **RED provado**: Gerente listava/retrieve/patch/delete de outra gerência (200/204).
- **GREEN**: Gerente escopado (outra gerência → 404); própria gerência, superuser, Gerente-da-Superintendência e dono seguem.
- **Regressão**: **241 testes** de solicitação/RBAC/aprovação verdes (coverage, action_perms, pr15, edit, pr3_approvals, rbac_matrix, query_optimization, approval_policy_PA, auditlog, compras_publish_chain, multi_sector, …).

Closes #1623
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `567eeb28`, slot `1` / projeto `aprender_staging_s1`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local-s1, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
