### PR TITLE
fix(auth): enforça CSRF no login (barra login-CSRF / session fixation) (M03-02)

### DIFF
--- a/v2/backend/apps/core/tests/test_login_csrf_enforcement_1648.py
+++ b/v2/backend/apps/core/tests/test_login_csrf_enforcement_1648.py
@@ -1,0 +1,74 @@
+"""
+M03-02 (#1648) — login enforça CSRF (barra login-CSRF / session fixation).
+
+A view de login é `@api_view` (csrf_exempt implícito) e, sendo anônima, o
+`enforce_csrf` do SessionAuthentication do DRF nunca dispara — um POST
+cross-origin conseguia estabelecer sessão. O fix enforça o CSRF manualmente.
+
+Nota de teste: o `APIClient` padrão (enforce_csrf_checks=False) PULA o check via
+`_dont_enforce_csrf_checks`, então os testes de login existentes continuam
+válidos. Para exercitar o CSRF real usamos `APIClient(enforce_csrf_checks=True)`.
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportOptionalMemberAccess=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportMissingTypeArgument=false, reportCallIssue=false, reportIndexIssue=false, reportOptionalSubscript=false
+
+from __future__ import annotations
+
+from rest_framework.test import APIClient
+
+import pytest
+
+from apps.core.tests.factories import UsuarioFactory
+
+pytestmark = pytest.mark.django_db
+
+LOGIN_URL = "/api/auth/login/"
+PASSWORD = "SenhaForte!123"
+# Origin same-origin: satisfaz a checagem de Origin do CSRF em HTTPS, isolando a
+# validação do TOKEN (sem isso, o 403 viria da checagem de Referer, não do token).
+ORIGIN = "https://testserver"
+
+
+def _user(username: str, cpf: str):
+    return UsuarioFactory(username=username, password=PASSWORD, cpf=cpf, is_active=True)
+
+
+class TestLoginCsrfEnforced:
+    def test_login_sem_csrf_token_retorna_403(self):
+        """RED: hoje o login (csrf_exempt) sucede sem CSRF mesmo em cliente estrito."""
+        _user("csrf_a", "79000000001")
+        client = APIClient(enforce_csrf_checks=True)
+        resp = client.post(
+            LOGIN_URL,
+            {"username": "csrf_a", "password": PASSWORD},
+            format="json",
+            secure=True,
+            HTTP_ORIGIN=ORIGIN,
+        )
+        assert resp.status_code == 403, f"esperado 403, obteve {resp.status_code}"
+
+    def test_login_com_csrf_token_valido_funciona(self):
+        """Com token CSRF válido (fluxo do frontend), o login procede."""
+        _user("csrf_b", "79000000002")
+        client = APIClient(enforce_csrf_checks=True)
+        # Frontend: busca o token em /api/csrf/ (seta o cookie) e o envia no header.
+        csrf_resp = client.get("/api/csrf/", secure=True, HTTP_ORIGIN=ORIGIN)
+        token = csrf_resp.data["csrfToken"]
+        resp = client.post(
+            LOGIN_URL,
+            {"username": "csrf_b", "password": PASSWORD},
+            format="json",
+            secure=True,
+            HTTP_ORIGIN=ORIGIN,
+            HTTP_X_CSRFTOKEN=token,
+        )
+        assert resp.status_code == 200, resp.data
+
+
+class TestExistingClientsUnaffected:
+    def test_apiclient_padrao_loga_sem_token(self):
+        """Não-regressão: APIClient padrão pula o CSRF (_dont_enforce_csrf_checks)."""
+        _user("csrf_c", "79000000003")
+        client = APIClient()  # enforce_csrf_checks=False (padrão)
+        resp = client.post(LOGIN_URL, {"username": "csrf_c", "password": PASSWORD}, format="json", secure=True)
+        assert resp.status_code == 200, resp.data

--- a/v2/backend/apps/core/views_auth.py
+++ b/v2/backend/apps/core/views_auth.py
@@ -236,6 +236,20 @@ def login(request: Request) -> Response:
         400: Falha de autenticação (resposta genérica)
         429: Too Many Requests (rate limit excedido)
     """
+    # M03-02 (#1648): o login é anônimo, então o enforce_csrf do SessionAuthentication
+    # do DRF nunca dispara (só roda em request autenticado) e o @api_view é csrf_exempt
+    # — um POST cross-origin criava sessão (login-CSRF / session fixation). Enforçamos
+    # o CSRF manualmente. Em testes com APIClient padrão o check é PULADO
+    # (_dont_enforce_csrf_checks), preservando os testes existentes; em produção o token
+    # vem do frontend (fetchAPI já envia X-CSRFToken após buscar /api/csrf/).
+    from rest_framework.authentication import SessionAuthentication
+    from rest_framework.exceptions import PermissionDenied as _CsrfDenied
+
+    try:
+        SessionAuthentication().enforce_csrf(request)
+    except _CsrfDenied:
+        return Response({"error": "Requisição inválida."}, status=status.HTTP_403_FORBIDDEN)
+
     username = request.data.get("username")
     password = request.data.get("password")
 


### PR DESCRIPTION
## Contexto

M03-02 (#1648), confirmado VIVO na triagem authz.

A view de login é `@api_view` (csrf_exempt implícito) e, sendo anônima, o `enforce_csrf` do `SessionAuthentication` do DRF **nunca dispara** (só roda em request autenticado) — um POST cross-origin conseguia estabelecer sessão (**login-CSRF / session fixation**).

## Mudança

- `login()` enforça o CSRF **manualmente** via `SessionAuthentication().enforce_csrf(request)` no início do corpo; falha → **403** genérico.
- **Sem fallout de testes**: o `APIClient` padrão (`enforce_csrf_checks=False`) faz o check ser PULADO via `_dont_enforce_csrf_checks`, então os testes de login existentes seguem válidos. Em produção o frontend já envia `X-CSRFToken` (`fetchAPI` anexa em POST após buscar `/api/csrf/` — verificado em `src/api/config.ts`).
- O gate aceita qualquer 4xx no smoke de auth (`smoke_test_staging.sh`), então o 403 não o quebra.

## Testes (TDD RED→GREEN)

Novo `test_login_csrf_enforcement_1648.py` — 3 casos (com `APIClient(enforce_csrf_checks=True)` + `Origin` same-origin para isolar o token):
- **RED provado**: com Origin válido e **sem token**, o login sucedia (200).
- **GREEN**: sem token → 403; com Origin + token válidos → 200; `APIClient` padrão continua logando (regressão do fluxo de teste).
- **Regressão**: 269 testes de login/auth/lockout/throttle verdes.

Closes #1648
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `b7194371`, slot `1` / projeto `aprender_staging_s1`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local-s1, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 403)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
