### PR TITLE
fix(admin): /usuarios-admin honra page_size + GruposPage carrega todos (M01-07)

### DIFF
--- a/v2/backend/apps/core/tests/test_usuarios_admin_pagination_1612.py
+++ b/v2/backend/apps/core/tests/test_usuarios_admin_pagination_1612.py
@@ -1,0 +1,56 @@
+"""
+M01-07 (#1612) — /usuarios-admin/ honra ?page_size (não capa em 100).
+
+O `UsuarioAdminViewSet` herdava o paginador global (`PageNumberPagination`,
+PAGE_SIZE=100, SEM page_size_query_param) — `?page_size=1000` era ignorado e a
+lista capava em 100. A tela de grupos deriva a membership da lista de usuários e
+salva por full-replace (`sync-members`); com a lista truncada, membros além dos
+100 primeiros (por username) eram revogados em silêncio ao salvar o grupo.
+
+Fix: `pagination_class = LargePagination` (page_size_query_param, max 1000) —
+o frontend já pede ?page_size=1000, agora recebe todos.
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportOptionalMemberAccess=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportMissingTypeArgument=false, reportCallIssue=false, reportIndexIssue=false, reportOptionalSubscript=false
+
+from __future__ import annotations
+
+from rest_framework.test import APIClient
+
+import pytest
+
+from apps.core.tests.factories import UsuarioFactory
+
+pytestmark = pytest.mark.django_db
+
+BULK = 130  # > 100 (cap do paginador global) para provar que o teto foi removido
+
+
+@pytest.fixture
+def superuser():
+    return UsuarioFactory(username="zz_su_1612", superuser=True)
+
+
+@pytest.fixture
+def bulk_users():
+    return [UsuarioFactory(username=f"bulk_{i:04d}") for i in range(BULK)]
+
+
+class TestUsuariosAdminPagination:
+    def test_page_size_1000_retorna_todos(self, superuser, bulk_users):
+        """RED: paginador global ignora ?page_size e capa em 100."""
+        client = APIClient()
+        client.force_authenticate(superuser)
+        resp = client.get("/api/usuarios-admin/?page_size=1000", secure=True)
+        assert resp.status_code == 200
+        returned = [u for u in resp.data["results"] if u["username"].startswith("bulk_")]
+        assert len(returned) == BULK, f"esperado {BULK} bulk, veio {len(returned)}"
+
+    def test_ultimo_membro_por_username_presente(self, superuser, bulk_users):
+        """O membro que ordena por último (bulk_0129) precisa aparecer — é ele que
+        era truncado e revogado no save do grupo."""
+        client = APIClient()
+        client.force_authenticate(superuser)
+        resp = client.get("/api/usuarios-admin/?page_size=1000", secure=True)
+        usernames = {u["username"] for u in resp.data["results"]}
+        assert f"bulk_{BULK - 1:04d}" in usernames

--- a/v2/backend/apps/core/views/admin.py
+++ b/v2/backend/apps/core/views/admin.py
@@ -35,6 +35,7 @@ from apps.core.models import (
     Projeto,
     Usuario,
 )
+from apps.core.pagination import LargePagination
 from apps.core.permissions import HasPerm, SuperuserOnly
 from apps.core.rbac.policies import CanAccessAuditLogs, can_admin_mutate_target
 from apps.core.serializers import (
@@ -365,6 +366,12 @@ class UsuarioAdminViewSet(viewsets.ModelViewSet):
 
     queryset = Usuario.objects.prefetch_related("groups").all()
     serializer_class = UsuarioAdminSerializer
+    # M01-07 (#1612): o paginador global (PageNumberPagination) ignora ?page_size
+    # e capa em 100. A tela de grupos deriva a membership da lista de usuários e
+    # salva por full-replace (sync-members) — com a lista truncada, membros além
+    # dos 100 primeiros (por username) eram revogados em silêncio. LargePagination
+    # honra ?page_size (até 1000), destravando a carga completa que o frontend pede.
+    pagination_class = LargePagination
     # Issue #1222 (Epic 1): admin usuários é cadastro admin DAT puro
     permission_classes = [HasPerm("manage_admin_registries")]
 

--- a/v2/frontend/src/pages/AdminDAT/GruposPage.tsx
+++ b/v2/frontend/src/pages/AdminDAT/GruposPage.tsx
@@ -232,8 +232,21 @@ export default function GruposPage({ forcedType }: GruposPageProps = {}): JSX.El
 
   const fetchUsuarios = async (): Promise<void> => {
     try {
-      const data = await listUsers({ ordering: 'username', page_size: PAGE_SIZES.ALL });
-      setUsuarios(data.results as UserRecord[]);
+      // M01-07 (#1612): a membership do grupo é DERIVADA desta lista e salva por
+      // full-replace (sync-members). Carregar só a 1ª página revogava membros além
+      // do teto do paginador ao salvar. Seguimos `next` até esgotar para garantir o
+      // conjunto COMPLETO de usuários (robusto mesmo acima do max_page_size).
+      const all: UserRecord[] = [];
+      let page = 1;
+      for (;;) {
+        const data = await listUsers({ ordering: 'username', page_size: PAGE_SIZES.ALL, page });
+        all.push(...(data.results as UserRecord[]));
+        if (!data.next) {
+          break;
+        }
+        page += 1;
+      }
+      setUsuarios(all);
     } catch (error) {
       message.error(`Erro ao carregar usuários: ${(error as Error).message}`);
     }


### PR DESCRIPTION
## Contexto

M01-07 (#1612), confirmado VIVO na triagem authz (mapa FE+BE por subagente).

A tela de grupos (`GruposPage.tsx`) **deriva** a membership de um grupo da lista de `/usuarios-admin/` (não existe endpoint "membros do grupo") e salva por **full-replace** (`sync-members` → `user_set.set()`). O `UsuarioAdminViewSet` herdava o paginador global (`PageNumberPagination`, cap 100, **sem** `page_size_query_param`), então o `?page_size=1000` que o frontend **já enviava** era ignorado e a lista capava em 100 — membros além dos 100 primeiros (por `username`) eram **revogados em silêncio** ao salvar o grupo.

## Mudança

- **Backend (causa nomeada)**: `UsuarioAdminViewSet.pagination_class = LargePagination` (`page_size_query_param`, `max_page_size=1000`). O `?page_size` passa a valer.
- **Frontend (robustez)**: `GruposPage.fetchUsuarios` segue `next` até esgotar, em vez de usar só a 1ª página (`data.results`) — garante o conjunto **completo** mesmo acima do teto de página.

`sync_members` segue **full-replace** (design correto para um snapshot do estado desejado); a revogação nascia da **CARGA truncada**, não do save.

## Testes (TDD RED→GREEN)

Novo `test_usuarios_admin_pagination_1612.py` — 2 casos (130 usuários > cap 100):
- **RED provado**: `?page_size=1000` retornava só 100; o último por username (`bulk_0129`) — o que era truncado/revogado — ausente.
- **GREEN**: retorna os 130; `bulk_0129` presente.
- **Regressão**: 115 testes admin/RBAC (`test_admin_api`, `test_modular_views`, `test_assign_groups`, `test_rbac_superuser_target_protection`) verdes.

O frontend é validado pelo `[required] build/lint do frontend` (tsc + eslint) e pelo build da imagem no gate.

Closes #1612
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `ff67a563`, slot `1` / projeto `aprender_staging_s1`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local-s1, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 400)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
