### PR TITLE
fix(dat): nr_codigos por_professor usa Decimal, não float (overshoot no ceil)

### DIFF
--- a/v2/backend/apps/core/models/dat_registro.py
+++ b/v2/backend/apps/core/models/dat_registro.py
@@ -258,8 +258,11 @@ class DATRegistro(models.Model):
 
         if tipo == "por_professor":
             if self.professor_qtde and self.projeto_geral.multiplicador_professor:
-                mult = float(self.projeto_geral.multiplicador_professor)
-                return math.ceil(self.professor_qtde * mult)
+                # Aritmética Decimal (não float): float(Decimal("1.10")) == 1.1000000000000001,
+                # então professor_qtde * mult cai LOGO ACIMA do inteiro e math.ceil estoura
+                # em +1 (ex.: 100 * 1.10 -> 110.00000000000001 -> ceil 111). O campo
+                # multiplicador_professor já é Decimal; multiplicar direto preserva a exatidão.
+                return math.ceil(self.professor_qtde * self.projeto_geral.multiplicador_professor)
             return None
 
         return None

--- a/v2/backend/apps/core/tests/test_dat_registros.py
+++ b/v2/backend/apps/core/tests/test_dat_registros.py
@@ -9,6 +9,7 @@ Ref: v2/docs/SPEC_DAT_REGISTROS.md
 from __future__ import annotations
 
 import json
+import math
 from decimal import Decimal
 
 from django.core.exceptions import ValidationError
@@ -101,6 +102,39 @@ class DATRegistroModelTests(TestCase):
         )
         # 10 * 1.1 = 11 (ceiling)
         self.assertEqual(reg.nr_codigos, 11)
+
+    def test_nr_codigos_por_professor_sem_overshoot_de_float(self):
+        """
+        Adversarial: o cálculo por_professor deve usar aritmética Decimal, não float.
+
+        `float(Decimal("1.1"))` == 1.1000000000000001, então `prof * float(mult)`
+        cai LOGO ACIMA de um inteiro para vários valores (50, 90, 100, 110, 200,
+        340, 450...) → `math.ceil` estoura em +1. O teste antigo usava prof=10, um
+        valor "limpo" (10*1.1 == 11.0), e por isso nunca expôs o bug.
+
+        Propriedade verificada (não um único par input→output):
+            nr_codigos == ceil(professor_qtde * Decimal(multiplicador))
+        para uma varredura de valores — incluindo os que quebram no float.
+        """
+        mult = self.projeto_geral_professor.multiplicador_professor  # Decimal("1.1")
+        # 'sujos' (overshoot no float) + 'limpos' (controle, não devem regredir)
+        casos = [10, 20, 30, 50, 90, 100, 110, 170, 200, 340, 410, 450, 500]
+        for prof in casos:
+            with self.subTest(professor_qtde=prof):
+                reg = DATRegistro(
+                    municipio=self.municipio,
+                    projeto_geral=self.projeto_geral_professor,
+                    projeto=self.projeto,
+                    professor_qtde=prof,
+                    aluno_qtde=1,
+                    created_by=self.user,
+                )
+                esperado = math.ceil(prof * mult)  # referência correta (Decimal)
+                self.assertEqual(
+                    reg._calcular_nr_codigos(),
+                    esperado,
+                    f"prof={prof}: esperado {esperado} (Decimal); float causa overshoot +1",
+                )
 
     def test_nr_codigos_calculated_por_aluno(self):
         """nr_codigos should be calculated using alunos / divisor."""


### PR DESCRIPTION
## Problema

`_calcular_nr_codigos` (por_professor) faz `float(Decimal(\"1.10\"))` → `1.1000000000000001`. Então `professor_qtde * mult` cai **logo acima** do inteiro e `math.ceil` estoura em **+1**:

- `100 * 1.10` → `110.00000000000001` → `ceil = 111` (deveria ser 110)
- Afeta **~5% dos valores** de `professor_qtde` (múltiplos de 10: 50, 90, 100, 110, 170, 200, 340, 410, 450…). Bug de **correção** no cálculo de códigos — super-conta em 1 para todo projeto por_professor em resultado inteiro.

## Como foi descoberto

Reconciliação `nr_codigos` (calculado) × `nr_codigos_planilha` (novo campo do #1770) num apply real do import export-contract, em ambiente isolado: **14 registros divergentes = exatamente este overshoot** (`ceil_Decimal` == planilha, `ceil_float` == valor gravado, sempre +1).

## Fix

Multiplicar direto pelo campo `multiplicador_professor` (já é `Decimal`), sem cast para `float`. `int * Decimal = Decimal`; `math.ceil(Decimal)` é exato.

## Teste (adversarial)

O teste antigo usava `professor_qtde=10` — um valor *limpo* (`10*1.1 == 11.0`) que **nunca expunha o bug**. O novo teste é parametrizado (subTest) sobre valores sujos **e** limpos e verifica a **propriedade** `nr_codigos == ceil(prof * Decimal(mult))`. Vai RED nos 9 valores sujos com o código antigo, GREEN após o fix.

## Impacto / migração

Campo computado em `save()` — **sem migration**. Registros existentes por_professor com valor sujo se auto-corrigem no próximo `save()`. (Recompute em massa dos existentes, se necessário, pode ser follow-up.)

## Validação

- `pytest test_dat_registros.py test_export_contract_importer_apply_dat.py` → **43 passed**.
- TDD provado: RED (9 subfails) → fix → GREEN.
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `ca53d372`, slot `0` / projeto `aprender_staging`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 403)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
