### PR TITLE
test(core): cobertura adversarial em 3 endpoints só-happy-path

### DIFF
--- a/v2/backend/apps/core/tests/test_fluxo_por_projeto.py
+++ b/v2/backend/apps/core/tests/test_fluxo_por_projeto.py
@@ -395,6 +395,76 @@ class TestFluxoPorProjeto(TestCase):
         projeto_teste.refresh_from_db()
         self.assertEqual(projeto_teste.fluxo, "SUPER")
 
+    # -----------------------------------------------------------------
+    # Casos adversariais: autenticação, permissão e elegibilidade
+    # -----------------------------------------------------------------
+
+    def test_criar_sem_autenticacao_403(self):
+        """Adversarial: criar solicitação sem autenticação → 403.
+
+        SessionAuthentication rebaixa NotAuthenticated para PermissionDenied.
+        """
+        client = APIClient()  # sem force_authenticate
+        response = client.post(
+            "/api/solicitacoes/",
+            {
+                "municipio": self.municipio.id,
+                "projeto": self.projeto_super.id,
+                "tipo": "evento",
+                "tipo_evento": self.tipo_evento.id,
+                "inicio": self.inicio.isoformat(),
+                "fim": self.fim.isoformat(),
+                "formadores": [],
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_criar_sem_capability_403(self):
+        """Adversarial: usuário sem a capability create_solicitation → 403."""
+        sem_perm = UsuarioFactory(username="sem_perm_fluxo")  # nenhum grupo → sem create_solicitation
+        self.client.force_authenticate(user=sem_perm)
+        response = self.client.post(
+            "/api/solicitacoes/",
+            {
+                "municipio": self.municipio.id,
+                "projeto": self.projeto_super.id,
+                "tipo": "evento",
+                "tipo_evento": self.tipo_evento.id,
+                "inicio": self.inicio.isoformat(),
+                "fim": self.fim.isoformat(),
+                "formadores": [],
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_criar_sem_compra_registrada_400(self):
+        """Adversarial: par (municipio, projeto) sem Compra registrada → 400 keyed em 'municipio'."""
+        projeto_sem_compra = ProjetoFactory(
+            nome="Projeto Sem Compra",
+            codigo="",
+            fluxo="NAO_SUPER",
+            ativo=True,
+        )
+        self.client.force_authenticate(user=self.coordenador)
+        response = self.client.post(
+            "/api/solicitacoes/",
+            {
+                "municipio": self.municipio.id,
+                "projeto": projeto_sem_compra.id,
+                "tipo": "evento",
+                "tipo_evento": self.tipo_evento.id,
+                "inicio": self.inicio.isoformat(),
+                "fim": self.fim.isoformat(),
+                "formadores": [],
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        # O handler de exceção aninha os erros de campo em data["errors"].
+        self.assertIn("municipio", response.data["errors"])
+
 
 class TestMigrationFluxoProjeto(TestCase):
     """

--- a/v2/backend/apps/core/tests/test_import_job_integration.py
+++ b/v2/backend/apps/core/tests/test_import_job_integration.py
@@ -135,10 +135,7 @@ class TestAsyncPipelineEndToEnd:
 @pytest.fixture
 def malformed_csv():
     """CSV que parseia mas referencia usuário inexistente → linha pulada."""
-    content = (
-        "usuario,inicio,fim,tipo,motivo\n"
-        "Fulano Inexistente Zzz,2026-03-01 08:00,2026-03-01 12:00,P,Consulta\n"
-    )
+    content = "usuario,inicio,fim,tipo,motivo\n" "Fulano Inexistente Zzz,2026-03-01 08:00,2026-03-01 12:00,P,Consulta\n"
     temp = tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False, encoding="utf-8")
     temp.write(content)
     temp.close()
@@ -178,9 +175,7 @@ class TestImportBloqueiosMalformed:
         settings.CELERY_TASK_ALWAYS_EAGER = True
         settings.CELERY_TASK_EAGER_PROPAGATES = True
 
-    def test_malformed_csv_pula_linhas_job_success(
-        self, api_client, controle_user, malformed_csv
-    ):
+    def test_malformed_csv_pula_linhas_job_success(self, api_client, controle_user, malformed_csv):
         api_client.force_authenticate(user=controle_user)
 
         with open(malformed_csv, "rb") as f:

--- a/v2/backend/apps/core/tests/test_import_job_integration.py
+++ b/v2/backend/apps/core/tests/test_import_job_integration.py
@@ -130,3 +130,75 @@ class TestAsyncPipelineEndToEnd:
 
         # Apply mode: bloqueios persistidos de verdade
         assert AvailabilityBlock.objects.filter(usuario=target_user).count() == 2
+
+
+@pytest.fixture
+def malformed_csv():
+    """CSV que parseia mas referencia usuário inexistente → linha pulada."""
+    content = (
+        "usuario,inicio,fim,tipo,motivo\n"
+        "Fulano Inexistente Zzz,2026-03-01 08:00,2026-03-01 12:00,P,Consulta\n"
+    )
+    temp = tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False, encoding="utf-8")
+    temp.write(content)
+    temp.close()
+    yield temp.name
+    Path(temp.name).unlink(missing_ok=True)
+
+
+@pytest.mark.django_db
+class TestImportBloqueiosPermissions:
+    """Adversarial: autenticação, permissão e validação de entrada no upload."""
+
+    def test_upload_requires_authentication(self, api_client):
+        """Sem autenticação → 403 (SessionAuthentication rebaixa 401→403)."""
+        resp = api_client.post(UPLOAD_URL, {}, format="multipart")
+        assert resp.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_upload_forbidden_for_non_privileged_user(self, api_client, target_user, sample_csv):
+        """Usuário sem a policy import_generic_spreadsheet (não-Controle/DAT) → 403."""
+        api_client.force_authenticate(user=target_user)
+        with open(sample_csv, "rb") as f:
+            resp = api_client.post(UPLOAD_URL, {"file": f}, format="multipart")
+        assert resp.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_upload_without_file_returns_400(self, api_client, controle_user):
+        """POST sem o campo 'file' → 400 (validação antes de despachar a task)."""
+        api_client.force_authenticate(user=controle_user)
+        resp = api_client.post(UPLOAD_URL, {}, format="multipart")
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.django_db(transaction=True)
+class TestImportBloqueiosMalformed:
+    """Adversarial: CSV válido mas com dados ruins → job SUCCESS com linhas puladas (nunca FAILED)."""
+
+    @pytest.fixture(autouse=True)
+    def _celery_eager(self, settings):
+        settings.CELERY_TASK_ALWAYS_EAGER = True
+        settings.CELERY_TASK_EAGER_PROPAGATES = True
+
+    def test_malformed_csv_pula_linhas_job_success(
+        self, api_client, controle_user, malformed_csv
+    ):
+        api_client.force_authenticate(user=controle_user)
+
+        with open(malformed_csv, "rb") as f:
+            post = api_client.post(
+                UPLOAD_URL + "?dry_run=false",
+                {"file": f},
+                format="multipart",
+            )
+
+        # A entrada é aceita (202) — dados ruins não abortam o upload.
+        assert post.status_code == status.HTTP_202_ACCEPTED
+        job_id = post.data["id"]
+
+        detail = api_client.get(f"/api/imports/{job_id}/")
+        assert detail.status_code == status.HTTP_200_OK
+
+        # Linhas inválidas são puladas com segurança: job termina SUCCESS, não FAILED,
+        # e nada é persistido (usuário inexistente → skip, sem levantar).
+        assert detail.data["status"] == ImportJob.Status.SUCCESS
+        assert detail.data["stats"]["created"] == 0
+        assert AvailabilityBlock.objects.count() == 0

--- a/v2/backend/apps/core/tests/test_solicitacao_participations_api.py
+++ b/v2/backend/apps/core/tests/test_solicitacao_participations_api.py
@@ -189,3 +189,60 @@ def test_solicitacao_api_no_formadores_field(factory_solicitacao):
 
     # Verificar que "formadores" NÃO está no payload
     assert "formadores" not in payload_str.lower(), "Campo 'formadores' não deve existir no payload"
+
+
+# ---------------------------------------------------------------------------
+# Casos adversariais: autenticação e escopo (data-scope #1779)
+# ---------------------------------------------------------------------------
+
+
+def test_solicitacao_list_requires_authentication():
+    """Adversarial: sem autenticação a listagem é negada.
+
+    SessionAuthentication não expõe WWW-Authenticate → DRF rebaixa
+    NotAuthenticated para PermissionDenied → 403 (não 401).
+    """
+    resp = APIClient().get("/api/solicitacoes/")
+    assert resp.status_code == 403
+
+
+def test_solicitacao_detail_de_outro_usuario_retorna_404(factory_solicitacao):
+    """Adversarial (escopo #1779): usuário comum não enxerga solicitação de outro.
+
+    Fora do queryset escopado → get_object levanta Http404 → 404-como-inexistente
+    (não vaza 200 nem sinaliza existência com 403).
+    """
+    solicitacao = factory_solicitacao()  # dono = usuário auto-gerado
+    outro = UsuarioFactory()
+
+    client = APIClient()
+    client.force_authenticate(user=outro)
+
+    resp = client.get(f"/api/solicitacoes/{solicitacao.id}/")
+    assert resp.status_code == 404
+
+
+def test_solicitacao_list_escopada_ao_dono(factory_solicitacao):
+    """Adversarial (escopo #1779): usuário comum vê apenas as próprias na listagem."""
+    dono = UsuarioFactory()
+    minha = factory_solicitacao(usuario=dono)
+    # Reutiliza as deps com unique constraint (municipio/tipo_evento/projeto);
+    # só o usuário difere (auto-gerado) → solicitação de "outro dono".
+    de_outro = factory_solicitacao(
+        municipio=minha.municipio,
+        tipo_evento=minha.tipo_evento,
+        projeto=minha.projeto,
+    )
+
+    client = APIClient()
+    client.force_authenticate(user=dono)
+
+    resp = client.get("/api/solicitacoes/")
+    assert resp.status_code == 200
+
+    content = resp.json()
+    results = content["results"] if "results" in content else content
+    ids = {item["id"] for item in results}
+
+    assert minha.id in ids
+    assert de_outro.id not in ids, "Listagem não deve vazar solicitação de outro usuário"


### PR DESCRIPTION
## Contexto

Auditoria da suíte de testes apontou 3 arquivos que exercitavam **apenas o caminho feliz** (sem 4xx/escopo/entrada inválida). Uma verificação adversarial (10 revisores independentes) confirmou os 3 como gaps reais — e derrubou 3 outros "gaps" que já tinham cobertura de falha (409/escopo).

Este PR adiciona os casos adversariais faltantes. São testes de **regressão** que fixam invariantes de segurança **já implementadas** — nenhum código de produção foi tocado (só arquivos de teste, +199 linhas).

## Casos adicionados

**`test_solicitacao_participations_api.py`**
- `test_solicitacao_list_requires_authentication` — sem auth → 403 (SessionAuth rebaixa 401→403).
- `test_solicitacao_detail_de_outro_usuario_retorna_404` — fora do escopo → 404-como-inexistente (#1779).
- `test_solicitacao_list_escopada_ao_dono` — usuário comum vê só as próprias.

**`test_import_job_integration.py`**
- `test_upload_requires_authentication` — sem auth → 403.
- `test_upload_forbidden_for_non_privileged_user` — sem policy `import_generic_spreadsheet` → 403.
- `test_upload_without_file_returns_400` — POST sem `file` → 400.
- `test_malformed_csv_pula_linhas_job_success` — CSV válido com dados ruins → 202 e job **SUCCESS com linhas puladas** (nunca FAILED); nada persistido.

**`test_fluxo_por_projeto.py`**
- `test_criar_sem_autenticacao_403` — criar sem auth → 403.
- `test_criar_sem_capability_403` — sem `create_solicitation` → 403.
- `test_criar_sem_compra_registrada_400` — par (municipio, projeto) sem `Compra` → 400 keyed em `municipio`.

## Validação

Overlay no container dev (`--no-migrations`, single-process): **23 passed, 1 skipped**. Contratos de status confirmados contra o código real antes de escrever os asserts.
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `56281dab`, slot `1` / projeto `aprender_staging_s1`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local-s1, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 403)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
