### PR TITLE
fix(frontend): exibe horário de evento/bloqueio em America/Fortaleza (RD-06)

### DIFF
--- a/v2/frontend/src/components/MyBlocksTable.tsx
+++ b/v2/frontend/src/components/MyBlocksTable.tsx
@@ -13,6 +13,7 @@ import { DeleteOutlined } from '@ant-design/icons';
 import dayjs from 'dayjs';
 import type { ColumnsType, ColumnType } from 'antd/es/table';
 import type { ID } from '../types';
+import { formatFortaleza } from '../utils/datetime';
 
 import type { JSX } from "react";
 
@@ -73,14 +74,14 @@ export default function MyBlocksTable({ blocks, onDelete, loading }: MyBlocksTab
       title: 'Início',
       dataIndex: 'inicio',
       key: 'inicio',
-      render: (text: string) => dayjs(text).format('DD/MM/YYYY HH:mm'),
+      render: (text: string) => formatFortaleza(text),
       sorter: (a, b) => dayjs(a.inicio).unix() - dayjs(b.inicio).unix(),
     },
     {
       title: 'Fim',
       dataIndex: 'fim',
       key: 'fim',
-      render: (text: string) => dayjs(text).format('DD/MM/YYYY HH:mm'),
+      render: (text: string) => formatFortaleza(text),
     },
     {
       title: 'Tipo',

--- a/v2/frontend/src/components/__tests__/MyBlocksTable.test.tsx
+++ b/v2/frontend/src/components/__tests__/MyBlocksTable.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+
+import MyBlocksTable, { type BlockRecord } from '../MyBlocksTable';
+
+function makeBlock(overrides: Partial<BlockRecord> = {}): BlockRecord {
+  return {
+    id: 1,
+    inicio: '2026-09-15T12:00:00Z',
+    fim: '2026-09-15T18:00:00Z',
+    tipo: 'T',
+    status: 'aprovado',
+    ...overrides,
+  };
+}
+
+describe('MyBlocksTable', () => {
+  // RD-06 (#1719): início/fim do bloqueio exibidos fixando America/Fortaleza,
+  // independente do fuso do navegador. 12:00Z/18:00Z → 09:00/15:00 (UTC-3).
+  test('exibe início e fim do bloqueio em America/Fortaleza, não em UTC', () => {
+    render(<MyBlocksTable blocks={[makeBlock()]} onDelete={vi.fn()} loading={false} />);
+
+    // horários no fuso de Fortaleza...
+    expect(screen.getByText('15/09/2026 09:00')).toBeInTheDocument();
+    expect(screen.getByText('15/09/2026 15:00')).toBeInTheDocument();
+    // ...e nunca os horários UTC crus (regressão RD-06)
+    expect(screen.queryByText('15/09/2026 12:00')).not.toBeInTheDocument();
+    expect(screen.queryByText('15/09/2026 18:00')).not.toBeInTheDocument();
+  });
+});

--- a/v2/frontend/src/pages/Dashboards/GCalDashboardPage.tsx
+++ b/v2/frontend/src/pages/Dashboards/GCalDashboardPage.tsx
@@ -52,6 +52,7 @@ import {
 } from '@ant-design/icons';
 import dayjs from 'dayjs';
 import logger from '../../utils/logger';
+import { formatFortaleza } from '../../utils/datetime';
 import { TIMING } from '../../constants';
 import {
   getDashboardMetrics,
@@ -398,7 +399,7 @@ export default function GCalDashboardPage(): JSX.Element {
       key: 'gcal_last_sync_at',
       width: 180,
       render: (datetime: string | null) =>
-        datetime ? dayjs(datetime).format('DD/MM/YYYY HH:mm') : '-',
+        datetime ? formatFortaleza(datetime) : '-',
     },
     {
       title: 'Erro',
@@ -587,7 +588,7 @@ export default function GCalDashboardPage(): JSX.Element {
                       <Text type="danger">{error.gcal_last_error}</Text>
                       <br />
                       <Text type="secondary" style={{ fontSize: 12 }}>
-                        {dayjs(error.updated_at).format('DD/MM/YYYY HH:mm')}
+                        {formatFortaleza(error.updated_at)}
                       </Text>
                     </div>
                   ))}
@@ -743,10 +744,10 @@ export default function GCalDashboardPage(): JSX.Element {
               <Descriptions.Item label="Projeto">{eventDetail.projeto_nome || '-'}</Descriptions.Item>
               <Descriptions.Item label="Tipo de Evento">{eventDetail.tipo_evento_nome || '-'}</Descriptions.Item>
               <Descriptions.Item label="Início">
-                {eventDetail.inicio ? dayjs(eventDetail.inicio).format('DD/MM/YYYY HH:mm') : '-'}
+                {eventDetail.inicio ? formatFortaleza(eventDetail.inicio) : '-'}
               </Descriptions.Item>
               <Descriptions.Item label="Fim">
-                {eventDetail.fim ? dayjs(eventDetail.fim).format('DD/MM/YYYY HH:mm') : '-'}
+                {eventDetail.fim ? formatFortaleza(eventDetail.fim) : '-'}
               </Descriptions.Item>
               <Descriptions.Item label="Usuário">{eventDetail.usuario_username || '-'}</Descriptions.Item>
               <Descriptions.Item label="Coordenador">{eventDetail.coordenador_username || '-'}</Descriptions.Item>
@@ -762,7 +763,7 @@ export default function GCalDashboardPage(): JSX.Element {
               </Descriptions.Item>
               <Descriptions.Item label="Event ID">{eventDetail.external_event_id || '-'}</Descriptions.Item>
               <Descriptions.Item label="Última Sincronização">
-                {eventDetail.gcal_last_sync_at ? dayjs(eventDetail.gcal_last_sync_at).format('DD/MM/YYYY HH:mm') : '-'}
+                {eventDetail.gcal_last_sync_at ? formatFortaleza(eventDetail.gcal_last_sync_at) : '-'}
               </Descriptions.Item>
               <Descriptions.Item label="Meet Link">
                 {eventDetail.meet_link ? (
@@ -784,7 +785,7 @@ export default function GCalDashboardPage(): JSX.Element {
                 )}
               </Descriptions.Item>
               <Descriptions.Item label="Atualizado em">
-                {eventDetail.updated_at ? dayjs(eventDetail.updated_at).format('DD/MM/YYYY HH:mm') : '-'}
+                {eventDetail.updated_at ? formatFortaleza(eventDetail.updated_at) : '-'}
               </Descriptions.Item>
             </Descriptions>
 
@@ -823,7 +824,7 @@ export default function GCalDashboardPage(): JSX.Element {
                       <Text strong>{log.action}</Text>
                       <br />
                       <Text type="secondary">
-                        {log.usuario_nome} - {dayjs(log.created_at).format('DD/MM/YYYY HH:mm:ss')}
+                        {log.usuario_nome} - {formatFortaleza(log.created_at, 'DD/MM/YYYY HH:mm:ss')}
                       </Text>
                       {log.details && Object.keys(log.details).length > 0 && (
                         <div className="mt-1">

--- a/v2/frontend/src/pages/MeusEventos/MeusEventosPage.tsx
+++ b/v2/frontend/src/pages/MeusEventos/MeusEventosPage.tsx
@@ -19,8 +19,8 @@ import Tag from 'antd/es/tag';
 import Typography from 'antd/es/typography';
 import message from 'antd/es/message';
 import type { ColumnsType, TablePaginationConfig } from 'antd/es/table';
-import dayjs from 'dayjs';
 
+import { formatFortaleza } from '../../utils/datetime';
 import { getMyEvents, type MeEvent } from '../../api/me';
 import { MeetLink } from '../../components/MeetLink';
 
@@ -62,14 +62,14 @@ export default function MeusEventosPage(): JSX.Element {
       title: 'Data',
       dataIndex: 'inicio',
       key: 'data',
-      render: (inicio: string) => dayjs(inicio).format('DD/MM/YYYY'),
+      render: (inicio: string) => formatFortaleza(inicio, 'DD/MM/YYYY'),
       width: 110,
     },
     {
       title: 'Horário',
       key: 'horario',
       render: (_, record: MeEvent) =>
-        `${dayjs(record.inicio).format('HH:mm')} – ${dayjs(record.fim).format('HH:mm')}`,
+        `${formatFortaleza(record.inicio, 'HH:mm')} – ${formatFortaleza(record.fim, 'HH:mm')}`,
       width: 130,
     },
     {

--- a/v2/frontend/src/pages/MeusEventos/__tests__/MeusEventosPage.test.tsx
+++ b/v2/frontend/src/pages/MeusEventos/__tests__/MeusEventosPage.test.tsx
@@ -114,4 +114,21 @@ describe('MeusEventosPage', () => {
       expect(getMyEventsMock).toHaveBeenCalledWith({ page: 1, page_size: 20 });
     });
   });
+
+  // RD-06 (#1719): horário do evento é exibido fixando America/Fortaleza,
+  // não no fuso do navegador nem em UTC cru.
+  test('exibe horário do evento em America/Fortaleza, não em UTC', async () => {
+    // 13:00Z / 17:00Z → 10:00 / 14:00 em America/Fortaleza (UTC-3, sem DST)
+    getMyEventsMock.mockResolvedValueOnce(
+      makePage([makeEvent({ id: 40, inicio: '2026-05-10T13:00:00Z', fim: '2026-05-10T17:00:00Z' })])
+    );
+    renderPage();
+
+    // horário no fuso de Fortaleza...
+    expect(await screen.findByText(/10:00/)).toBeInTheDocument();
+    expect(screen.getByText(/14:00/)).toBeInTheDocument();
+    // ...e nunca o horário UTC cru (regressão RD-06)
+    expect(screen.queryByText(/13:00/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/17:00/)).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Contexto

RD-06/CP-03: instantes são armazenados em UTC e exibidos em **America/Fortaleza**. Call-sites residuais ainda formatavam com `dayjs` cru (fuso do **navegador**), então dois usuários em fusos diferentes veriam horários diferentes.

Os 3 sites do corpo original do #1719 já haviam sido corrigidos pela #1720 (ficou OPEN só porque usou keyword pt-BR). Este PR cobre os **residuais**, roteando pelo helper já existente e testado `formatFortaleza` (`utils/datetime.ts`) — **reuso, não novo helper**.

## Mudanças

- **`MeusEventosPage`** — data + horário do evento.
- **`MyBlocksTable`** — início/fim do bloqueio (disponibilidade, RD-06). `dayjs` mantido só no sorter (`.unix()`).
- **`GCalDashboardPage`** — horário do evento + timestamps do mesmo painel (sync/atualização/log) e tabela de erros, normalizados para o mesmo fuso (evita metade Fortaleza / metade browser no mesmo painel). Date-pickers seguem com `dayjs` (precisam de objeto `Dayjs`).

## Testes (guard RD-06)

- `MeusEventosPage.test.tsx`: evento `13:00Z/17:00Z` → exibe `10:00/14:00` (Fortaleza), **nunca** `13:00/17:00` (UTC).
- `MyBlocksTable.test.tsx` (novo): bloqueio `12:00Z/18:00Z` → `09:00/15:00`, nunca `12:00/18:00`.
- Validado no container: **8 passed**; `tsc --noEmit` limpo.

Closes #1719
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `74ee512f`, slot `1` / projeto `aprender_staging_s1`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local-s1, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 403)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
