### PR TITLE
fix(availability): grade mensal não multiplica CH/código por participante (M14-02)

### DIFF
--- a/v2/backend/apps/core/services/monthly_grid_service.py
+++ b/v2/backend/apps/core/services/monthly_grid_service.py
@@ -163,7 +163,13 @@ def build_monthly_grid(
     # fetch participant ids in a single batched values_list query below,
     # which is cheaper than materializing the RelatedManager for each
     # event (#777 phase 2).
-    events_q = events_q.select_related("municipio", "tipo_evento")
+    # `.distinct()`: o filtro por `participations__...` faz JOIN com Participation
+    # e materializa uma linha por participante. Sem o DISTINCT, o mesmo evento
+    # apareceria N vezes em `events` e seria redistribuído N vezes abaixo,
+    # inflando CH, contagem de eventos (código "2" em vez de "E") e detalhes.
+    # As colunas do SELECT (Solicitacao + municipio/tipo_evento via select_related)
+    # são determinísticas por evento, então o DISTINCT colapsa só as cópias. (#1630)
+    events_q = events_q.select_related("municipio", "tipo_evento").distinct()
     events = list(events_q)
 
     # Batch fetch participants for every event in one query. Returns a flat

--- a/v2/backend/apps/core/tests/test_monthly_with_deslocamento.py
+++ b/v2/backend/apps/core/tests/test_monthly_with_deslocamento.py
@@ -499,3 +499,45 @@ class TestMonthlyWithDeslocamento:
 
         # Dia 6 deve ser ""
         assert cells[5] == ""
+
+    def test_evento_com_dois_participantes_nao_multiplica(self):
+        """M14-02 (#1630): evento com 2+ participantes não pode multiplicar CH,
+        código nem detalhes por participante.
+
+        O JOIN Solicitacao × Participation materializa o mesmo evento uma vez
+        por participante; sem `.distinct()` cada cópia era distribuída de novo,
+        inflando CH (×N), virando o código "2" em vez de "E" e duplicando os
+        detalhes. Invariante: um evento conta UMA vez para cada participante.
+        """
+        u2 = UsuarioFactory(
+            username="formador2",
+            email="formador2@example.com",
+            password="password123",
+        )
+
+        # 1 evento de 4h no dia 15, com DOIS formadores participantes.
+        sol = SolicitacaoFactory(
+            usuario=self.user_formador,
+            municipio=self.municipio,
+            projeto=self.projeto,
+            tipo_evento=self.tipo_evento,
+            inicio=timezone.make_aware(datetime(2025, 10, 15, 8, 0), self.tz),
+            fim=timezone.make_aware(datetime(2025, 10, 15, 12, 0), self.tz),
+            status="aprovado",
+        )
+        for u in (self.user_formador, u2):
+            Participation.objects.create(solicitacao=sol, usuario=u, role="FORMADOR")
+
+        result = build_monthly_grid(year=2025, month=10, role="FORMADOR")
+
+        assert len(result["people"]) == 2
+        row_of = {p["id"]: idx for idx, p in enumerate(result["people"])}
+
+        for uid in (self.user_formador.id, u2.id):
+            row = row_of[uid]
+            # Dia 15 (índice 14): UM evento → "E", nunca "2".
+            assert result["cells"][row][14] == "E"
+            # CH contada uma vez (4h), não 8h.
+            assert result["people"][row]["ch_month"] == 4.0
+            # Detalhes com uma entrada, não duplicada.
+            assert len(result["details_index"][f"{row}:14"]) == 1


### PR DESCRIPTION
## Bug (#1630 / M14-02)

Na grade mensal, um evento com **2+ participantes** (Participation) inflava as métricas: CH somava N×, o código do dia virava **"2"** em vez de **"E"**, e os detalhes apareciam duplicados.

## Causa-raiz

`monthly_grid_service.py` filtra os eventos por `participations__role` + `participations__usuario_id__in`, o que faz **JOIN Solicitacao × Participation** e materializa **uma linha por participante**. Sem `.distinct()`, `events = list(events_q)` continha o mesmo evento N vezes, e o loop de distribuição (por dia/pessoa) somava CH, contava eventos e anexava detalhes N vezes.

## Fix (1 linha)

`.distinct()` na queryset. As colunas do SELECT (Solicitacao + `municipio`/`tipo_evento` via `select_related`) são determinísticas por evento, então o DISTINCT colapsa apenas as cópias geradas pelo JOIN — sem afetar dias com eventos **distintos** múltiplos (que legitimamente viram "2").

## Teste (TDD, RED→GREEN)

`test_evento_com_dois_participantes_nao_multiplica`: evento de 4h com 2 formadores → `ch_month=4.0` (não 8.0), célula `"E"` (não "2"), 1 detalhe por participante.
- **RED provado** antes do fix (`'2' == 'E'` falhava).
- **GREEN** depois; 19 passed / 7 skipped nos 2 arquivos que exercem a grade (nenhuma regressão no caso legítimo de "2" com 2 eventos distintos).

Closes #1630
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `e193898a`, slot `1` / projeto `aprender_staging_s1`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local-s1, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 403)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
