### PR TITLE
fix(api): DEFAULT_PAGINATION_CLASS honra ?page_size (StandardPagination)

### DIFF
--- a/v2/backend/apps/core/tests/test_default_pagination_1653.py
+++ b/v2/backend/apps/core/tests/test_default_pagination_1653.py
@@ -1,4 +1,4 @@
-# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportAttributeAccessIssue=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportIndexIssue=false, reportMissingTypeArgument=false
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportAttributeAccessIssue=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportIndexIssue=false, reportMissingTypeArgument=false, reportOptionalCall=false
 
 """
 #1653: o DEFAULT_PAGINATION_CLASS global deve honrar `?page_size` (com teto),

--- a/v2/backend/apps/core/tests/test_default_pagination_1653.py
+++ b/v2/backend/apps/core/tests/test_default_pagination_1653.py
@@ -1,0 +1,61 @@
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportAttributeAccessIssue=false, reportOptionalMemberAccess=false, reportArgumentType=false, reportCallIssue=false, reportIndexIssue=false, reportMissingTypeArgument=false
+
+"""
+#1653: o DEFAULT_PAGINATION_CLASS global deve honrar `?page_size` (com teto),
+sem mudar a resposta sem o parâmetro.
+
+Antes era `rest_framework.pagination.PageNumberPagination` cru, que ignorava
+`?page_size` e truncava TODA listagem em `PAGE_SIZE` (100). A troca para
+`apps.core.pagination.StandardPagination` é aditiva: mesmo default de 100,
+mas `?page_size` passa a ser respeitado até `max_page_size=500`.
+"""
+
+from __future__ import annotations
+
+from rest_framework.request import Request
+from rest_framework.settings import api_settings
+from rest_framework.test import APIClient, APIRequestFactory
+
+import pytest
+
+from apps.core.pagination import StandardPagination
+from apps.core.tests.factories import MunicipioFactory, UsuarioFactory
+
+
+def test_default_pagination_honra_page_size_query_param():
+    """Sentinela: o default global aceita `?page_size` e tem teto."""
+    pager = api_settings.DEFAULT_PAGINATION_CLASS()
+    assert pager.page_size_query_param == "page_size"
+    assert pager.max_page_size is not None
+    # Aditivo: mesmo default de 100 por página (resposta sem-param inalterada).
+    assert pager.page_size == api_settings.PAGE_SIZE == 100
+
+
+def test_standard_pagination_limita_ao_max_page_size():
+    """`?page_size` acima do teto é limitado a `max_page_size` (500)."""
+    req = Request(APIRequestFactory().get("/", {"page_size": "99999"}))
+    assert StandardPagination().get_page_size(req) == 500
+
+
+@pytest.mark.django_db
+def test_list_endpoint_respeita_page_size():
+    """Um list endpoint que herda o default passa a devolver `?page_size` itens.
+
+    Antes (PageNumberPagination cru) truncava em 100 ignorando o parâmetro.
+    """
+    admin = UsuarioFactory(superuser=True)
+    for i in range(150):
+        MunicipioFactory(nome=f"Cidade Paginacao {i:03d}", uf="CE", ativo=True)
+
+    client = APIClient()
+    client.force_authenticate(user=admin)
+
+    # Sem parâmetro: comportamento inalterado (100 por página).
+    default_resp = client.get("/api/municipios/")
+    assert default_resp.status_code == 200
+    assert len(default_resp.data["results"]) == 100
+
+    # Com `?page_size`: honrado (150), não truncado em 100.
+    resp = client.get("/api/municipios/?page_size=150")
+    assert resp.status_code == 200
+    assert len(resp.data["results"]) == 150

--- a/v2/backend/config/settings.py
+++ b/v2/backend/config/settings.py
@@ -493,7 +493,11 @@ REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": [
         "rest_framework.authentication.SessionAuthentication",
     ],
-    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
+    # StandardPagination (apps.core.pagination): mesmo PAGE_SIZE default (100), mas
+    # honra `?page_size` com teto `max_page_size=500`. Troca ADITIVA — a resposta
+    # sem o parâmetro é idêntica; antes, o PageNumberPagination cru ignorava
+    # `?page_size` e truncava toda listagem em 100. (#1653)
+    "DEFAULT_PAGINATION_CLASS": "apps.core.pagination.StandardPagination",
     "PAGE_SIZE": 100,
     "DEFAULT_RENDERER_CLASSES": [
         "rest_framework.renderers.JSONRenderer",


### PR DESCRIPTION
## Bug (#1653)

O `DEFAULT_PAGINATION_CLASS` global era `rest_framework.pagination.PageNumberPagination` **cru** — sem `page_size_query_param`. Resultado: o servidor **ignorava `?page_size`** e truncava **toda** listagem em `PAGE_SIZE` (100). A #1781 corrigiu só o `usuarios-admin`; este PR corrige o default para todos os ~20 endpoints que o herdam (inclui as telas DAT).

## Fix (1 linha)

`config/settings.py`: `DEFAULT_PAGINATION_CLASS` → `apps.core.pagination.StandardPagination` (classe **já existente**). Ela mantém `page_size=100` (== `PAGE_SIZE`), adiciona `page_size_query_param="page_size"` e `max_page_size=500`.

## Por que é seguro (aditivo, não breaking)

`StandardPagination.page_size == 100 == PAGE_SIZE` atual → a resposta **sem** `?page_size` fica **idêntica** (mesmo envelope, 100/página). Só muda o que hoje é bug: `?page_size` passa a ser respeitado, com teto de 500. Não usei `LargePagination` justamente porque seu `page_size=200` mudaria a resposta sem-param (isso sim seria breaking).

## Testes (TDD, RED→GREEN)

- **Sentinela**: o default global aceita `?page_size` e tem `max_page_size`.
- **Cap**: `?page_size=99999` → 500 (não ilimitado).
- **Behavior**: 150 municípios → `?page_size=150` devolve 150 (antes truncava em 100); sem param → 100 (inalterado).
- **RED provado** antes do fix (`None == 'page_size'`, `100 == 150`).
- **Regressão global**: suíte `apps/core` inteira single-process = **3188 passed / 37 skipped**, zero quebra.

Closes #1653
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `ea08ef5d`, slot `1` / projeto `aprender_staging_s1`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local-s1, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 403)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
