### PR TITLE
fix(sec): resolver de IP do cliente honra NUM_PROXIES (anti-forja XFF) (#1660)

### DIFF
--- a/v2/backend/apps/core/services/solicitacao_approval.py
+++ b/v2/backend/apps/core/services/solicitacao_approval.py
@@ -20,6 +20,7 @@ from apps.core.exceptions import ValidationAPIError
 from apps.core.models import AuditLog, Solicitacao, Usuario
 from apps.core.services.db_retry import retry_on_deadlock
 from apps.core.services.solicitacao_availability import enforce_solicitacao_availability
+from apps.core.utils.net import get_client_ip
 
 logger = logging.getLogger(__name__)
 
@@ -42,17 +43,6 @@ class BatchApprovalResult:
     approved_count: int
     rejected_count: int
     errors: list[dict[str, Any]]
-
-
-def _get_client_ip(request: Any) -> str:
-    """Extract real client IP considering reverse proxies."""
-    x_forwarded_for = request.META.get("HTTP_X_FORWARDED_FOR")
-    if x_forwarded_for:
-        return x_forwarded_for.split(",")[0].strip()
-    x_real_ip = request.META.get("HTTP_X_REAL_IP")
-    if x_real_ip:
-        return x_real_ip.strip()
-    return request.META.get("REMOTE_ADDR", "unknown")
 
 
 def _raise_invalid_status_error(solicitacao: Solicitacao) -> None:
@@ -123,7 +113,7 @@ def approve_solicitacao(
         ValidationAPIError: If solicitacao is not pending, or if any participant has a
             conflict (#1452)
     """
-    client_ip = _get_client_ip(request)
+    client_ip = get_client_ip(request)
     with transaction.atomic():
         solicitacao = Solicitacao.objects.select_for_update().get(pk=solicitacao.pk)
         if solicitacao.status != "pendente":
@@ -200,7 +190,7 @@ def reject_solicitacao(
     Raises:
         ValidationAPIError: If solicitacao is not pending
     """
-    client_ip = _get_client_ip(request)
+    client_ip = get_client_ip(request)
     with transaction.atomic():
         solicitacao = Solicitacao.objects.select_for_update().get(pk=solicitacao.pk)
         if solicitacao.status != "pendente":
@@ -283,7 +273,7 @@ def batch_approve_solicitacoes(
 
     approved = 0
     errors: list[dict[str, Any]] = []
-    client_ip = _get_client_ip(request)
+    client_ip = get_client_ip(request)
 
     with transaction.atomic():
         # Fetch and lock pending solicitacoes to avoid double-approval races
@@ -382,7 +372,7 @@ def batch_reject_solicitacoes(
 
     rejected = 0
     errors: list[dict[str, Any]] = []
-    client_ip = _get_client_ip(request)
+    client_ip = get_client_ip(request)
 
     with transaction.atomic():
         # Fetch and lock pending solicitacoes to avoid double-reject races

--- a/v2/backend/apps/core/services/solicitacao_publish.py
+++ b/v2/backend/apps/core/services/solicitacao_publish.py
@@ -18,6 +18,7 @@ from django.utils import timezone
 
 from apps.core.exceptions import APIError, ConflictError, ValidationAPIError
 from apps.core.models import AuditLog, GoogleOAuthCredential, Solicitacao, Usuario
+from apps.core.utils.net import get_client_ip
 
 logger = logging.getLogger(__name__)
 
@@ -50,17 +51,6 @@ class PreviewResult:
     success: bool
     preview: dict[str, Any]
     message: str
-
-
-def _get_client_ip(request: Any) -> str:
-    """Extract real client IP considering reverse proxies."""
-    x_forwarded_for = request.META.get("HTTP_X_FORWARDED_FOR")
-    if x_forwarded_for:
-        return x_forwarded_for.split(",")[0].strip()
-    x_real_ip = request.META.get("HTTP_X_REAL_IP")
-    if x_real_ip:
-        return x_real_ip.strip()
-    return request.META.get("REMOTE_ADDR", "unknown")
 
 
 def _check_google_oauth(user: Usuario) -> int | None:
@@ -109,7 +99,7 @@ def preview_gcal(
 
     preview = build_preview_for_solicitacao(solicitacao)
 
-    client_ip = _get_client_ip(request)
+    client_ip = get_client_ip(request)
     AuditLog.objects.create(
         usuario=user,
         action=AuditLog.Action.PREVIEW_GCAL,
@@ -249,7 +239,7 @@ def publish_to_gcal(
         )
 
     # AuditLog
-    client_ip = _get_client_ip(request)
+    client_ip = get_client_ip(request)
     AuditLog.objects.create(
         usuario=user,
         action=AuditLog.Action.PUBLISH_GCAL_REQUESTED,
@@ -344,7 +334,7 @@ def resync_to_gcal(
         )
 
     # AuditLog
-    client_ip = _get_client_ip(request)
+    client_ip = get_client_ip(request)
     AuditLog.objects.create(
         usuario=user,
         action=AuditLog.Action.RESYNC_GCAL_REQUESTED,
@@ -432,7 +422,7 @@ def cancel_from_gcal(
         task = task_cancel_solicitacao_from_gcal.delay(solicitacao.id)
 
     # AuditLog
-    client_ip = _get_client_ip(request)
+    client_ip = get_client_ip(request)
     AuditLog.objects.create(
         usuario=user,
         action=AuditLog.Action.CANCEL_GCAL_REQUESTED,

--- a/v2/backend/apps/core/tests/test_client_ip_1660.py
+++ b/v2/backend/apps/core/tests/test_client_ip_1660.py
@@ -10,6 +10,7 @@ the resolver falls back to the unforgeable ``REMOTE_ADDR``.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 from django.test import Client, RequestFactory, override_settings
 
@@ -19,7 +20,7 @@ _FACTORY = RequestFactory()
 
 
 def _req(xff: str | None = None, remote_addr: str = "10.0.0.9"):
-    extra: dict[str, str] = {"REMOTE_ADDR": remote_addr}
+    extra: dict[str, Any] = {"REMOTE_ADDR": remote_addr}
     if xff is not None:
         extra["HTTP_X_FORWARDED_FOR"] = xff
     return _FACTORY.get("/", **extra)

--- a/v2/backend/apps/core/tests/test_client_ip_1660.py
+++ b/v2/backend/apps/core/tests/test_client_ip_1660.py
@@ -1,0 +1,169 @@
+"""Adversarial unit tests for the canonical client-IP resolver (issue #1660).
+
+Proves that a forged ``X-Forwarded-For`` header cannot change the resolved IP
+when ``NUM_PROXIES`` matches the real topology, and that with no trusted proxy
+the resolver falls back to the unforgeable ``REMOTE_ADDR``.
+"""
+
+# pyright: reportUnknownMemberType=false, reportUnknownArgumentType=false, reportMissingImports=false
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from django.test import Client, RequestFactory, override_settings
+
+from apps.core.utils.net import UNKNOWN_IP, get_client_ip
+
+_FACTORY = RequestFactory()
+
+
+def _req(xff: str | None = None, remote_addr: str = "10.0.0.9"):
+    extra: dict[str, str] = {"REMOTE_ADDR": remote_addr}
+    if xff is not None:
+        extra["HTTP_X_FORWARDED_FOR"] = xff
+    return _FACTORY.get("/", **extra)
+
+
+@override_settings(NUM_PROXIES=0)
+def test_num_proxies_zero_ignores_xff_entirely():
+    # Attacker sends a forged XFF; with 0 trusted proxies it is worthless.
+    req = _req(xff="1.2.3.4", remote_addr="203.0.113.7")
+    assert get_client_ip(req) == "203.0.113.7"
+
+
+@override_settings(NUM_PROXIES=0)
+def test_num_proxies_zero_no_xff_uses_remote_addr():
+    assert get_client_ip(_req(remote_addr="198.51.100.2")) == "198.51.100.2"
+
+
+@override_settings(NUM_PROXIES=2)
+def test_two_proxies_reads_client_from_the_right():
+    # Legit chain: client -> proxy1 -> proxy2 -> gunicorn.
+    # nginx appends, so XFF = "<client>, <proxy1>"; REMOTE_ADDR = proxy2.
+    req = _req(xff="203.0.113.50, 172.16.0.1", remote_addr="172.16.0.2")
+    assert get_client_ip(req) == "203.0.113.50"
+
+
+@override_settings(NUM_PROXIES=2)
+def test_two_proxies_forged_prefix_is_ignored():
+    # Attacker prepends a fake IP. Trusted proxies append the *real* client
+    # address, so the fake one is pushed left and never selected.
+    req = _req(xff="1.2.3.4, 203.0.113.50, 172.16.0.1", remote_addr="172.16.0.2")
+    resolved = get_client_ip(req)
+    assert resolved == "203.0.113.50"
+    assert resolved != "1.2.3.4"
+
+
+@override_settings(NUM_PROXIES=2)
+def test_two_proxies_no_xff_falls_back_to_remote_addr():
+    assert get_client_ip(_req(remote_addr="172.16.0.2")) == "172.16.0.2"
+
+
+@override_settings(NUM_PROXIES=1)
+def test_single_proxy_reads_last_entry():
+    # 1 proxy: XFF = "<client>"; a forged prefix is appended-past by the proxy.
+    req = _req(xff="1.2.3.4, 203.0.113.99", remote_addr="172.16.0.2")
+    assert get_client_ip(req) == "203.0.113.99"
+
+
+@override_settings(NUM_PROXIES=2)
+def test_whitespace_is_stripped():
+    req = _req(xff="  203.0.113.50 ,  172.16.0.1  ", remote_addr="172.16.0.2")
+    assert get_client_ip(req) == "203.0.113.50"
+
+
+@override_settings(NUM_PROXIES=2)
+def test_missing_remote_addr_returns_unknown():
+    req = _FACTORY.get("/")
+    # RequestFactory always sets REMOTE_ADDR=127.0.0.1; strip it to exercise
+    # the defensive fallback.
+    del req.META["REMOTE_ADDR"]
+    assert get_client_ip(req) == UNKNOWN_IP
+
+
+@override_settings(NUM_PROXIES=None)
+def test_legacy_none_trusts_whole_chain():
+    # Documents the insecure legacy mode: with NUM_PROXIES unset the whole
+    # forwarded chain is trusted. Prod MUST set an integer.
+    req = _req(xff="1.2.3.4, 203.0.113.50", remote_addr="172.16.0.2")
+    assert get_client_ip(req) == "1.2.3.4,203.0.113.50"
+
+
+# --- Wiring: the helper and DRF's throttle must read the SAME NUM_PROXIES -----
+
+
+def test_num_proxies_wired_to_drf_and_helper():
+    """settings.NUM_PROXIES (read by get_client_ip) and REST_FRAMEWORK's
+    NUM_PROXIES (read by DRF's throttle get_ident) must be the same value, so
+    throttle, lockout and audit all key off one client identity (#1660).
+    Also a sentinel: the deployed default matches the prod proxy topology (2)."""
+    from django.conf import settings
+    from rest_framework.settings import api_settings
+
+    assert settings.NUM_PROXIES == api_settings.NUM_PROXIES == 2
+
+
+def test_drf_throttle_get_ident_ignores_forged_xff():
+    """DRF's throttle identity uses the real client behind NUM_PROXIES hops, so a
+    rotated left-most X-Forwarded-For no longer buys a fresh throttle bucket."""
+    from rest_framework.throttling import AnonRateThrottle
+
+    req = _req(xff="1.2.3.4, 203.0.113.50, 172.16.0.1", remote_addr="172.16.0.2")
+    ident = AnonRateThrottle().get_ident(req)
+    assert ident == "203.0.113.50"
+    assert ident != "1.2.3.4"
+
+
+# --- Recon gates: /metrics and /healthz/detailed must reject a forged XFF -----
+
+
+@override_settings(NUM_PROXIES=2)
+def test_metrics_gate_rejects_forged_xff():
+    # Forged "127.0.0.1" prepended; the 2 trusted proxies append the real public
+    # client (8.8.8.8, globally routable) + peer, so get_client_ip resolves the
+    # public IP → not internal → 403. (Note: RFC 5737 doc ranges like 203.0.113.x
+    # are classified is_private by modern ipaddress, so a real public IP is used.)
+    resp = Client().get(
+        "/metrics",
+        HTTP_X_FORWARDED_FOR="127.0.0.1, 8.8.8.8, 172.16.0.2",
+    )
+    assert resp.status_code == 403
+
+
+@override_settings(NUM_PROXIES=2)
+def test_metrics_gate_allows_internal_direct_scrape():
+    # Direct internal scrape (Prometheus → web:8000, no XFF) with a private
+    # REMOTE_ADDR is still allowed through the gate.
+    resp = Client().get("/metrics", REMOTE_ADDR="10.0.0.5")
+    assert resp.status_code != 403
+
+
+@override_settings(NUM_PROXIES=2)
+def test_healthz_detailed_rejects_forged_xff():
+    resp = Client().get(
+        "/healthz/detailed/",
+        HTTP_X_FORWARDED_FOR="127.0.0.1, 8.8.8.8, 172.16.0.2",
+    )
+    assert resp.status_code == 403
+
+
+# --- DoD lint guard: no raw X-Forwarded-For read outside the canonical module -
+
+
+def test_no_raw_xff_read_outside_net_module():
+    """DoD (#1660): HTTP_X_FORWARDED_FOR may only be READ in the canonical
+    resolver (apps/core/utils/net.py) and in tests. A new call site reading the
+    raw header re-introduces the forgeable first-element pattern."""
+    backend_root = Path(__file__).resolve().parents[3]
+    offenders: list[str] = []
+    for base in ("apps", "config"):
+        for py in (backend_root / base).rglob("*.py"):
+            rel = py.relative_to(backend_root).as_posix()
+            if rel == "apps/core/utils/net.py":
+                continue
+            if "/tests/" in rel or py.name.startswith("test_"):
+                continue
+            if "HTTP_X_FORWARDED_FOR" in py.read_text(encoding="utf-8", errors="ignore"):
+                offenders.append(rel)
+    assert offenders == [], f"raw X-Forwarded-For read outside net.py: {offenders}"

--- a/v2/backend/apps/core/tests/test_security_hardening.py
+++ b/v2/backend/apps/core/tests/test_security_hardening.py
@@ -44,7 +44,7 @@ class TestHealthzMinimalPayload(TestCase):
         assert "timezone" not in data
 
     def test_healthz_detailed_anonymous_external_returns_403(self):
-        response = self.client.get("/healthz/detailed/", REMOTE_ADDR="203.0.113.1")
+        response = self.client.get("/healthz/detailed/", REMOTE_ADDR="8.8.8.8")
         assert response.status_code == 403
 
     def test_healthz_detailed_internal_ip_returns_200(self):
@@ -60,7 +60,7 @@ class TestHealthzMinimalPayload(TestCase):
         User = get_user_model()
         admin = User.objects.create_superuser("admin_health", "a@b.com", "pass1234")
         self.client.force_login(admin)
-        response = self.client.get("/healthz/detailed/", REMOTE_ADDR="203.0.113.1")
+        response = self.client.get("/healthz/detailed/", REMOTE_ADDR="8.8.8.8")
         assert response.status_code == 200
         data = response.json()
         assert "checks" in data
@@ -97,7 +97,7 @@ class TestMetricsAuthGate(TestCase):
     """SEC-RECON-02: /metrics must require staff or internal IP."""
 
     def test_metrics_anonymous_external_returns_403(self):
-        response = self.client.get("/metrics", REMOTE_ADDR="203.0.113.1")
+        response = self.client.get("/metrics", REMOTE_ADDR="8.8.8.8")
         assert response.status_code == 403
 
     def test_metrics_internal_ip_returns_200(self):
@@ -111,7 +111,7 @@ class TestMetricsAuthGate(TestCase):
         User = get_user_model()
         staff = User.objects.create_user("staff_metrics", "s@b.com", "pass1234", is_staff=True)
         self.client.force_login(staff)
-        response = self.client.get("/metrics", REMOTE_ADDR="203.0.113.1")
+        response = self.client.get("/metrics", REMOTE_ADDR="8.8.8.8")
         assert response.status_code != 403
 
 

--- a/v2/backend/apps/core/tests/test_views_solicitacao_coverage.py
+++ b/v2/backend/apps/core/tests/test_views_solicitacao_coverage.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 from datetime import date, timedelta
 from uuid import uuid4
 
+from django.test import override_settings
 from django.utils import timezone
 from rest_framework.test import APIClient
 
@@ -153,9 +154,10 @@ def compra_projeto_super(municipio, projeto_super):
 
 @pytest.mark.django_db
 class TestGetClientIP:
-    """Tests for _get_client_ip helper function."""
+    """Tests for the canonical client-IP resolver (get_client_ip / #1660)."""
 
-    def test_x_forwarded_for_header(
+    @override_settings(NUM_PROXIES=2)
+    def test_x_forwarded_for_forged_prefix_is_ignored(
         self,
         api_client,
         usuario_superintendencia,
@@ -164,7 +166,11 @@ class TestGetClientIP:
         projeto_super,
         tipo_evento,
     ):
-        """X-Forwarded-For header is correctly extracted (line 36)."""
+        """Forged left-most X-Forwarded-For is ignored; audit logs the real client (#1660).
+
+        With NUM_PROXIES=2 the resolver reads the client from the RIGHT, so an
+        attacker-prepended ``1.2.3.4`` never reaches the AuditLog.
+        """
         sol = SolicitacaoFactory(
             usuario=usuario_coordenador,
             municipio=municipio,
@@ -178,18 +184,21 @@ class TestGetClientIP:
         api_client.force_authenticate(user=usuario_superintendencia)
         AuditLog.objects.all().delete()
 
-        # Request with X-Forwarded-For header
+        # Attacker prepends "1.2.3.4"; the 2 trusted proxies append the real
+        # client + their peer, so the real client sits at position -2.
         response = api_client.patch(
             f"/api/solicitacoes/{sol.id}/approve/",
-            HTTP_X_FORWARDED_FOR="192.168.1.100, 10.0.0.1",
+            HTTP_X_FORWARDED_FOR="1.2.3.4, 192.168.1.100, 10.0.0.1",
         )
 
         assert response.status_code == 200
         audit = AuditLog.objects.filter(action="APPROVE").first()
         assert audit is not None
         assert audit.details["ip_address"] == "192.168.1.100"
+        assert audit.details["ip_address"] != "1.2.3.4"
 
-    def test_x_real_ip_header(
+    @override_settings(NUM_PROXIES=2)
+    def test_x_real_ip_no_longer_trusted_falls_back_to_remote_addr(
         self,
         api_client,
         usuario_superintendencia,
@@ -198,7 +207,11 @@ class TestGetClientIP:
         projeto_super,
         tipo_evento,
     ):
-        """X-Real-IP header is correctly extracted (line 39)."""
+        """X-Real-IP is client-controllable and no longer trusted (#1660).
+
+        With no X-Forwarded-For from a trusted proxy, the resolver uses the
+        unforgeable REMOTE_ADDR instead of the spoofable X-Real-IP header.
+        """
         sol = SolicitacaoFactory(
             usuario=usuario_coordenador,
             municipio=municipio,
@@ -212,16 +225,18 @@ class TestGetClientIP:
         api_client.force_authenticate(user=usuario_superintendencia)
         AuditLog.objects.all().delete()
 
-        # Request with X-Real-IP header (no X-Forwarded-For)
+        # X-Real-IP alone must NOT set the audit IP anymore; REMOTE_ADDR wins.
         response = api_client.patch(
             f"/api/solicitacoes/{sol.id}/approve/",
             HTTP_X_REAL_IP="10.0.0.50",
+            REMOTE_ADDR="203.0.113.5",
         )
 
         assert response.status_code == 200
         audit = AuditLog.objects.filter(action="APPROVE").first()
         assert audit is not None
-        assert audit.details["ip_address"] == "10.0.0.50"
+        assert audit.details["ip_address"] == "203.0.113.5"
+        assert audit.details["ip_address"] != "10.0.0.50"
 
 
 # ============================================================

--- a/v2/backend/apps/core/utils/net.py
+++ b/v2/backend/apps/core/utils/net.py
@@ -1,0 +1,64 @@
+"""Client IP resolution honouring the trusted-proxy count (SEC / issue #1660).
+
+Single source of truth for "what is the client's IP". Historically this logic
+was duplicated in 8 call sites, each trusting the *first* entry of
+``X-Forwarded-For`` — a value the client fully controls — so lockout, throttle
+and ``AuditLog`` keys could all be forged (``X-Forwarded-For: 1.2.3.4``).
+
+This helper mirrors DRF's ``BaseThrottle.get_ident`` so the throttle, the login
+lockout and the audit log all key off the *same* value:
+
+* ``settings.NUM_PROXIES`` — the number of trusted reverse proxies that append
+  to ``X-Forwarded-For`` between the public internet and gunicorn.
+* With ``N`` proxies we read the ``N``-th entry counting *from the right*, so a
+  forged left-most entry is ignored.
+* With ``0`` proxies (or no XFF) we trust only ``REMOTE_ADDR`` — the real TCP
+  peer, which the client cannot forge.
+
+Set ``NUM_PROXIES`` to match the real topology: too low collapses every client
+onto the proxy IP (breaking per-client throttle); too high re-opens forgery.
+In production the chain is NPM edge → nginx ``frontend`` container → gunicorn,
+so ``NUM_PROXIES = 2``.
+
+Usage:
+    from apps.core.utils.net import get_client_ip
+
+    ip = get_client_ip(request)
+"""
+
+# pyright: reportUnknownVariableType=false, reportUnknownMemberType=false, reportUnknownArgumentType=false
+
+from __future__ import annotations
+
+from django.conf import settings
+from django.http import HttpRequest
+
+# Preserved from the legacy helper contract: callers store this when neither a
+# trusted proxy header nor REMOTE_ADDR is available (e.g. synthetic requests).
+UNKNOWN_IP = "unknown"
+
+
+def get_client_ip(request: HttpRequest) -> str:
+    """Return the client IP, counting ``NUM_PROXIES`` trusted hops from the right.
+
+    A forged left-most ``X-Forwarded-For`` entry is ignored because we always
+    index the client position relative to the trusted proxies closest to the
+    server. Falls back to ``REMOTE_ADDR`` (the unforgeable TCP peer) whenever no
+    trusted proxy header applies.
+    """
+    xff = request.META.get("HTTP_X_FORWARDED_FOR")
+    remote_addr = request.META.get("REMOTE_ADDR") or UNKNOWN_IP
+    num_proxies = getattr(settings, "NUM_PROXIES", 0)
+
+    # NUM_PROXIES=None => legacy "trust the whole chain" (dev only, discouraged).
+    if num_proxies is None:
+        return "".join(xff.split()) if xff else remote_addr
+
+    # 0 proxies, or no XFF at all => the only trustworthy value is the TCP peer.
+    if num_proxies == 0 or not xff:
+        return remote_addr
+
+    addrs = [addr.strip() for addr in xff.split(",") if addr.strip()]
+    if not addrs:
+        return remote_addr
+    return addrs[-min(num_proxies, len(addrs))]

--- a/v2/backend/apps/core/utils/net.py
+++ b/v2/backend/apps/core/utils/net.py
@@ -32,13 +32,14 @@ from __future__ import annotations
 
 from django.conf import settings
 from django.http import HttpRequest
+from rest_framework.request import Request
 
 # Preserved from the legacy helper contract: callers store this when neither a
 # trusted proxy header nor REMOTE_ADDR is available (e.g. synthetic requests).
 UNKNOWN_IP = "unknown"
 
 
-def get_client_ip(request: HttpRequest) -> str:
+def get_client_ip(request: HttpRequest | Request) -> str:
     """Return the client IP, counting ``NUM_PROXIES`` trusted hops from the right.
 
     A forged left-most ``X-Forwarded-For`` entry is ignored because we always

--- a/v2/backend/apps/core/views/me.py
+++ b/v2/backend/apps/core/views/me.py
@@ -40,6 +40,7 @@ from apps.core.serializers.me import MeEventSerializer
 from apps.core.serializers.usuario import ChangePasswordSerializer
 from apps.core.services.audit import registrar_auditoria
 from apps.core.services.lgpd_export_service import build_lgpd_export_data, export_counts
+from apps.core.utils.net import get_client_ip
 
 
 @extend_schema_view(
@@ -176,10 +177,7 @@ class ChangePasswordView(APIView):
             action=AuditLog.Action.CHANGE_PASSWORD,
             model_name="Usuario",
             details={
-                "ip_address": (
-                    request.META.get("HTTP_X_FORWARDED_FOR", "").split(",")[0].strip()
-                    or request.META.get("REMOTE_ADDR", "")
-                ),
+                "ip_address": get_client_ip(request),
                 "user_agent": request.META.get("HTTP_USER_AGENT", "")[:200],
             },
         )

--- a/v2/backend/apps/core/views/utils.py
+++ b/v2/backend/apps/core/views/utils.py
@@ -10,30 +10,14 @@ from __future__ import annotations
 
 from django.http import HttpRequest, JsonResponse
 
+from apps.core.utils.net import get_client_ip
 
-def _get_client_ip(request: HttpRequest) -> str:
-    """
-    Extrai o IP real do cliente, considerando proxies reversos.
-
-    Prioridade:
-    1. HTTP_X_FORWARDED_FOR (primeiro IP da lista)
-    2. HTTP_X_REAL_IP
-    3. REMOTE_ADDR
-
-    Returns:
-        str: IP do cliente
-    """
-    x_forwarded_for = request.META.get("HTTP_X_FORWARDED_FOR")
-    if x_forwarded_for:
-        # X-Forwarded-For pode conter múltiplos IPs: "client, proxy1, proxy2"
-        # O primeiro é o IP real do cliente
-        return x_forwarded_for.split(",")[0].strip()
-
-    x_real_ip = request.META.get("HTTP_X_REAL_IP")
-    if x_real_ip:
-        return x_real_ip.strip()
-
-    return request.META.get("REMOTE_ADDR", "unknown")
+# Backwards-compatible alias. The client-IP logic used to be copy-pasted here
+# (and in 7 other places), each trusting the *first* X-Forwarded-For entry —
+# which the client fully controls. It now lives in a single canonical helper
+# that honours NUM_PROXIES and ignores forged entries (#1660). Kept under the
+# legacy name so the views facade and views_auth imports keep working.
+_get_client_ip = get_client_ip
 
 
 def api_root(request: HttpRequest) -> JsonResponse:

--- a/v2/backend/apps/core/views_deslocamento.py
+++ b/v2/backend/apps/core/views_deslocamento.py
@@ -39,7 +39,6 @@ from rest_framework.exceptions import PermissionDenied
 from rest_framework.filters import OrderingFilter
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import IsAuthenticated
-from rest_framework.request import Request
 
 from django_filters.rest_framework import DjangoFilterBackend
 
@@ -47,29 +46,7 @@ from .models import AuditLog, Deslocamento, EquipeGerencia
 from .rbac.helpers import user_has_any_perm
 from .rbac.policies import user_can_delegate_deslocamento
 from .serializers import DeslocamentoSerializer
-
-
-def _get_client_ip(request: Request) -> str:
-    """
-    Extrai o IP real do cliente, considerando proxies reversos.
-
-    Prioridade:
-    1. HTTP_X_FORWARDED_FOR (primeiro IP da lista)
-    2. HTTP_X_REAL_IP
-    3. REMOTE_ADDR
-
-    Returns:
-        str: IP do cliente
-    """
-    x_forwarded_for = request.META.get("HTTP_X_FORWARDED_FOR")
-    if x_forwarded_for:
-        return x_forwarded_for.split(",")[0].strip()
-
-    x_real_ip = request.META.get("HTTP_X_REAL_IP")
-    if x_real_ip:
-        return x_real_ip.strip()
-
-    return request.META.get("REMOTE_ADDR", "unknown")
+from .utils.net import get_client_ip
 
 
 class DeslocamentoPagination(PageNumberPagination):
@@ -235,7 +212,7 @@ class DeslocamentoViewSet(viewsets.ModelViewSet):
                 "end_date": deslocamento.end_date.isoformat(),
                 "observacao": deslocamento.observacao or "",
                 "delegated": delegated,
-                "ip_address": _get_client_ip(self.request),
+                "ip_address": get_client_ip(self.request),
                 "user_agent": self.request.META.get("HTTP_USER_AGENT", "")[:200],
             },
         )
@@ -301,7 +278,7 @@ class DeslocamentoViewSet(viewsets.ModelViewSet):
                     "changed_fields": list(changed_fields.keys()),
                     "prev_values": prev_values,
                     "new_values": new_values,
-                    "ip_address": _get_client_ip(self.request),
+                    "ip_address": get_client_ip(self.request),
                     "user_agent": self.request.META.get("HTTP_USER_AGENT", "")[:200],
                 },
             )
@@ -330,7 +307,7 @@ class DeslocamentoViewSet(viewsets.ModelViewSet):
                 "start_date": instance.start_date.isoformat(),
                 "end_date": instance.end_date.isoformat(),
                 "observacao": instance.observacao or "",
-                "ip_address": _get_client_ip(self.request),
+                "ip_address": get_client_ip(self.request),
                 "user_agent": self.request.META.get("HTTP_USER_AGENT", "")[:200],
             },
         )

--- a/v2/backend/apps/core/views_solicitacao.py
+++ b/v2/backend/apps/core/views_solicitacao.py
@@ -16,7 +16,6 @@ from rest_framework import serializers, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.filters import OrderingFilter, SearchFilter
 from rest_framework.permissions import IsAuthenticated
-from rest_framework.request import Request
 from rest_framework.response import Response
 
 from django_filters.rest_framework import DjangoFilterBackend
@@ -46,19 +45,9 @@ from .services.solicitacao_publish import cancel_from_gcal
 from .services.solicitacao_publish import preview_gcal as preview_gcal_service
 from .services.solicitacao_publish import publish_to_gcal, resync_to_gcal
 from .services.solicitacao_scope import scope_solicitacoes
+from .utils.net import get_client_ip
 
 logger = logging.getLogger(__name__)
-
-
-def _get_client_ip(request: Request) -> str:
-    """Extract real client IP considering reverse proxies."""
-    x_forwarded_for = request.META.get("HTTP_X_FORWARDED_FOR")
-    if x_forwarded_for:
-        return x_forwarded_for.split(",")[0].strip()
-    x_real_ip = request.META.get("HTTP_X_REAL_IP")
-    if x_real_ip:
-        return x_real_ip.strip()
-    return request.META.get("REMOTE_ADDR", "unknown")
 
 
 class _ExtraParticipantsSerializer(serializers.Serializer):
@@ -535,7 +524,7 @@ class SolicitacaoViewSet(viewsets.ModelViewSet):
 
         # Se houver alterações, registra no AuditLog
         if changed_fields:
-            client_ip = _get_client_ip(self.request)
+            client_ip = get_client_ip(self.request)
 
             # AuditLog persistente
             AuditLog.objects.create(
@@ -659,7 +648,7 @@ class SolicitacaoViewSet(viewsets.ModelViewSet):
             "status": instance.status,
         }
 
-        client_ip = _get_client_ip(self.request)
+        client_ip = get_client_ip(self.request)
 
         # Registrar exclusão no AuditLog ANTES de deletar
         AuditLog.objects.create(

--- a/v2/backend/config/settings.py
+++ b/v2/backend/config/settings.py
@@ -486,6 +486,14 @@ CSRF_COOKIE_HTTPONLY = True
 # ================================================================
 # REST FRAMEWORK
 # ================================================================
+# Trusted reverse-proxy count for client-IP resolution (SEC / #1660).
+# Production chain: NPM edge → nginx `frontend` container → gunicorn = 2 proxies,
+# both appending to X-Forwarded-For. DRF's throttle get_ident and
+# apps.core.utils.net.get_client_ip both read the (NUM_PROXIES)-th entry from the
+# RIGHT, so a forged left-most XFF entry is ignored. Override via env if the edge
+# topology differs (e.g. NPM set to OVERWRITE XFF → 1); 0 = trust only REMOTE_ADDR.
+NUM_PROXIES = int(os.getenv("NUM_PROXIES", "2"))
+
 REST_FRAMEWORK = {
     "DEFAULT_PERMISSION_CLASSES": [
         "rest_framework.permissions.IsAuthenticated",
@@ -529,6 +537,11 @@ REST_FRAMEWORK = {
         # OAuth connect (GAP-3): conectar conta Google no /pre-agenda, anti-abuso por usuario.
         "oauth": "10/hour",
     },
+    # Bind throttle identity to the real client behind NUM_PROXIES trusted hops
+    # (#1660). Without it, get_ident concatenates the whole X-Forwarded-For chain,
+    # so an attacker rotating the left-most XFF entry earned a fresh throttle
+    # bucket per request — defeating anon/user/login throttles.
+    "NUM_PROXIES": NUM_PROXIES,
     # Custom exception handler for standardized error responses
     "EXCEPTION_HANDLER": "apps.core.exceptions.custom_exception_handler",
     # API Schema (drf-spectacular)

--- a/v2/backend/config/urls.py
+++ b/v2/backend/config/urls.py
@@ -6,6 +6,7 @@ URL configuration for AS v2 project.
 
 from __future__ import annotations
 
+import ipaddress
 import logging
 from typing import Any
 
@@ -15,16 +16,32 @@ from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.urls import include, path
 
 from apps.core.admin_site import admin_site  # Custom admin site (superusers only)
+from apps.core.utils.net import get_client_ip
 
 logger = logging.getLogger(__name__)
 
 
+def _is_internal_ip(ip: str) -> bool:
+    """True only for RFC1918 / loopback addresses.
+
+    Uses ``ipaddress`` instead of a ``str.startswith`` prefix match: the old
+    check accepted spoofable strings such as ``"10.evil"`` and treated the whole
+    ``172.0.0.0/8`` as internal instead of just ``172.16.0.0/12``.
+    """
+    try:
+        addr = ipaddress.ip_address(ip)
+    except ValueError:
+        return False
+    return addr.is_private or addr.is_loopback
+
+
 def _metrics_gate(request: HttpRequest) -> HttpResponse:
     """SEC-RECON-02: Proxy to django_prometheus only for staff or internal IPs."""
-    ip = request.META.get("HTTP_X_FORWARDED_FOR", request.META.get("REMOTE_ADDR", ""))
-    if "," in ip:
-        ip = ip.split(",")[0].strip()
-    is_internal = ip.startswith(("127.", "10.", "172.", "192.168.", "::1"))
+    # SEC/#1660: resolve the client behind NUM_PROXIES trusted hops instead of
+    # trusting the first (client-controlled) X-Forwarded-For entry. A forged
+    # "X-Forwarded-For: 127.0.0.1" is pushed left by the trusted proxies and
+    # never selected, so it can no longer fake an internal origin.
+    is_internal = _is_internal_ip(get_client_ip(request))
     is_staff = hasattr(request, "user") and request.user.is_authenticated and request.user.is_staff  # type: ignore[union-attr]
 
     if not is_internal and not is_staff:
@@ -46,11 +63,10 @@ def healthz_detailed(request: HttpRequest) -> JsonResponse:
 
     Checks database, Redis cache, and GCal circuit breaker status.
     """
-    # SEC-RECON-01: restrict to superuser or internal network
-    ip = request.META.get("HTTP_X_FORWARDED_FOR", request.META.get("REMOTE_ADDR", ""))
-    if "," in ip:
-        ip = ip.split(",")[0].strip()
-    is_internal = ip.startswith(("127.", "10.", "172.", "192.168.", "::1"))
+    # SEC-RECON-01 / #1660: restrict to superuser or internal network, resolving
+    # the real client behind NUM_PROXIES trusted proxies. A forged
+    # X-Forwarded-For can no longer fake an internal IP.
+    is_internal = _is_internal_ip(get_client_ip(request))
     is_superuser = hasattr(request, "user") and request.user.is_authenticated and request.user.is_superuser  # type: ignore[union-attr]
 
     if not is_internal and not is_superuser:


### PR DESCRIPTION
## Problema (M01-01 do épico #1660)

O IP do cliente era resolvido lendo o **primeiro** elemento de `X-Forwarded-For` — a extremidade que o cliente controla — em **8 sites duplicados** (`views/utils.py`, `views/me.py`, `views_deslocamento.py`, `views_solicitacao.py`, `services/solicitacao_approval.py`, `services/solicitacao_publish.py`, e 2 gates em `config/urls.py`). Consequências:

- **Throttle evadível**: `NUM_PROXIES` não estava setado → `get_ident` do DRF concatenava a cadeia XFF inteira → rotacionar o 1º elemento dava um balde de throttle novo por request (fura `Anon/User/LoginThrottle`).
- **Lockout por-IP evadível**: mesma leitura forjável na chave `login_attempts:{bucket}:{ip}`.
- **AuditLog envenenável**: `ip_address` gravado a partir do valor forjado.
- 🔴 **Bypass de recon**: `/metrics` e `/healthz/detailed/` gateavam "IP interno" com `split(",")[0]` + `startswith` → `X-Forwarded-For: 127.0.0.1` passava como interno.

## Correção

- **`apps/core/utils/net.py::get_client_ip`** — resolver único que espelha o `BaseThrottle.get_ident` do DRF: lê o `(NUM_PROXIES)`-ésimo IP **da direita**, ignorando entrada forjada à esquerda; cai para `REMOTE_ADDR` (peer TCP, não-forjável) sem proxy confiável. As **8 cópias foram removidas**; `X-Real-IP` (também forjável) deixou de ser confiado.
- **`NUM_PROXIES = 2`** (env-configurável) em `settings.py` **e** `REST_FRAMEWORK` — uma só fonte para o helper e para o throttle do DRF. Fecha o bypass de throttle e de lockout de uma vez.
- **Gates `/metrics` e `/healthz/detailed/`** — `get_client_ip(...)` confiável + `ipaddress.is_private` (substitui o `startswith` frágil que aceitava `"10.evil"` e todo o `172.0.0.0/8` em vez de `172.16.0.0/12`).
- **Lint-guard** (teste): `HTTP_X_FORWARDED_FOR` só pode aparecer em `net.py` e em testes — qualquer novo call-site cru reprova.

### Topologia (base do `NUM_PROXIES=2`)
Prod: **NPM (borda) → nginx container `frontend` → gunicorn** = 2 proxies, ambos fazendo *append* ao XFF (`$proxy_add_x_forwarded_for`). Um XFF forjado é empurrado à esquerda pelos 2 hops e nunca é selecionado. `NUM_PROXIES` é env-override caso o NPM seja reconfigurado para *sobrescrever* o XFF (→ 1).

## Testes (TDD RED→GREEN)
- **Unit** (`test_client_ip_1660.py`): forja derrotada para 0/1/2/None proxies, whitespace, fallback REMOTE_ADDR, sentinela de wiring `settings.NUM_PROXIES == api_settings.NUM_PROXIES == 2`.
- **Throttle**: `AnonRateThrottle().get_ident` ignora o XFF forjado.
- **Gates recon**: 403 sob XFF forjado (`127.0.0.1, 8.8.8.8, ...`), 200 no scrape interno direto.
- **Auditoria** (`test_views_solicitacao_coverage.py`): endpoint `approve` grava o cliente real (`-2`), não o forjado; `X-Real-IP` sozinho não seta mais o IP.
- **RED provado** contra o gate antigo (`/metrics` retornava 200 sob `X-Forwarded-For: 127.0.0.1`).
- Regressão verde: `test_security_hardening`, `test_views_auth`, `test_login_throttle_*`, `test_deslocamento_*`, `test_me_change_password`, `test_solicitacao_*`, `test_modular_views` (facade). Black/isort/flake8 limpos.

> ℹ️ Os testes de segurança existentes usavam `203.0.113.1` (RFC 5737 TEST-NET-3) como "IP externo"; o `ipaddress` moderno classifica esse range como `is_private` → atualizados para `8.8.8.8` (público real), fortalecendo a intenção.

## Defense-in-depth (follow-up, fora deste PR)
Sanitizar o XFF na borda (`v2/frontend/nginx.conf`, hoje faz *append*) como o `configs/vm01/nginx.conf` legado já faz para `/healthz/`. Depende das CIDRs de proxy confiável e toca a imagem de prod — PR dedicado.

Closes #1660
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `bc095f65`, slot `1` / projeto `aprender_staging_s1`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local-s1, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 403)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
