### PR TITLE
fix(dat): fecha import DAT (PG por_aluno, seed canon-key, NK por data)

### DIFF
--- a/v2/backend/apps/core/management/commands/seed_projetos_canonicos.py
+++ b/v2/backend/apps/core/management/commands/seed_projetos_canonicos.py
@@ -21,7 +21,8 @@ from apps.core.models import Projeto
 
 _FLUXOS = {"SUPER", "NAO_SUPER"}
 
-# 33 projetos canonicos (11 SUPER). Nomes definitivos revisados pelo dono do dado.
+# 40 projetos canonicos (15 SUPER). Nomes definitivos revisados pelo dono do dado.
+# +7 variantes numeradas KEEP_NUMERADO do contrato DAT/v6 (Amma 1/2, Catavento 2 2/3 3, Gestao Escolar 4/5/8).
 PROJETOS_CANONICOS: list[tuple[str, str]] = [
     ("A Cor da Gente", "NAO_SUPER"),
     ("ACerta Matemática", "NAO_SUPER"),
@@ -37,6 +38,10 @@ PROJETOS_CANONICOS: list[tuple[str, str]] = [
     ("Fluir das Emoções 2", "NAO_SUPER"),
     ("Fluir das Emoções 3", "NAO_SUPER"),
     ("Gestão Escolar", "NAO_SUPER"),
+    # Variantes numeradas KEEP_NUMERADO do contrato DAT/v6 (herdam o fluxo do pai).
+    ("Gestão Escolar 4", "NAO_SUPER"),
+    ("Gestão Escolar 5", "NAO_SUPER"),
+    ("Gestão Escolar 8", "NAO_SUPER"),
     ("Leio, Escrevo e Calculo", "NAO_SUPER"),
     ("Lendo e Escrevendo", "SUPER"),
     ("Ler, Ouvir e Contar", "SUPER"),
@@ -44,8 +49,12 @@ PROJETOS_CANONICOS: list[tuple[str, str]] = [
     ("NL e AMMA Português e Matemática", "SUPER"),
     ("Novo Lendo", "SUPER"),
     ("Projeto Amma", "SUPER"),
+    ("Projeto Amma 1", "SUPER"),
+    ("Projeto Amma 2", "SUPER"),
     ("Projeto Catavento 2", "SUPER"),
+    ("Projeto Catavento 2 2", "SUPER"),
     ("Projeto Catavento 3", "SUPER"),
+    ("Projeto Catavento 3 3", "SUPER"),
     ("Projeto Miudezas e Descobertas", "SUPER"),
     ("Sou da Paz", "NAO_SUPER"),
     ("Superativar Linguagens", "NAO_SUPER"),
@@ -60,16 +69,34 @@ PROJETOS_CANONICOS: list[tuple[str, str]] = [
 
 
 def seed_projetos_canonicos(projetos: list[tuple[str, str]]) -> dict[str, int]:
-    """Cria projetos (create-only por nome). Retorna counts; NUNCA sobrescreve fluxo existente."""
-    stats = {"created": 0, "existing": 0, "rejected": 0}
+    """Cria projetos (create-only). Idempotencia pela CANON-KEY do resolver (#1372), NAO por
+    `nome` exato: evita quase-duplicata quando o catalogo ja tem o projeto sob outra grafia
+    (ex.: golden dev em UPPERCASE, canonico em Title Case) — que o resolver depois marcaria
+    como `ambiguous`. NUNCA sobrescreve fluxo de projeto existente."""
+    from apps.core.services.export_contract_projeto_resolver import (
+        build_projeto_index,
+        resolve_projeto_export,
+    )
+
+    stats = {"created": 0, "existing": 0, "ambiguous": 0, "rejected": 0}
+    index = build_projeto_index()
     for nome_raw, fluxo_raw in projetos:
         nome = (nome_raw or "").strip()
         fluxo = (fluxo_raw or "").strip().upper()
         if not nome or fluxo not in _FLUXOS:
             stats["rejected"] += 1
             continue
-        _, created = Projeto.objects.get_or_create(nome=nome, defaults={"fluxo": fluxo})
-        stats["created" if created else "existing"] += 1
+        res = resolve_projeto_export(nome, index=index)
+        if res.status == "matched":
+            stats["existing"] += 1
+            continue
+        if res.status == "ambiguous":
+            # Ja ha >1 projeto com essa canon-key: criar pioraria. Decisao humana.
+            stats["ambiguous"] += 1
+            continue
+        Projeto.objects.get_or_create(nome=nome, defaults={"fluxo": fluxo})
+        index = build_projeto_index()  # inclui o recem-criado nas proximas resolucoes (n pequeno)
+        stats["created"] += 1
     return stats
 
 
@@ -81,7 +108,7 @@ class Command(BaseCommand):
         self.stdout.write(
             self.style.SUCCESS(
                 f"Projetos: {stats['created']} criados, {stats['existing']} existentes, "
-                f"{stats['rejected']} rejeitados"
+                f"{stats['ambiguous']} ambiguos, {stats['rejected']} rejeitados"
             )
         )
         self.stdout.write(f"Total no banco: {Projeto.objects.count()}")

--- a/v2/backend/apps/core/migrations/0088_fix_projeto_geral_por_aluno.py
+++ b/v2/backend/apps/core/migrations/0088_fix_projeto_geral_por_aluno.py
@@ -1,0 +1,37 @@
+"""Data migration: corrige `tipo_calculo_codigos` dos 3 ProjetoGeral por-aluno.
+
+A migration 0045 semeia A COR DA GENTE / ECS / ED FINANCEIRA como `por_aluno` (get_or_create),
+mas em bancos onde esses PGs foram criados ANTES por outro caminho — o importer, quando a linha do
+contrato nao trazia `tipo_calculo_codigos` — eles herdaram o default do model (`por_professor`), e o
+get_or_create create-only da 0045 encontrou-os existentes e nunca corrigiu. O contrato v6
+(`projeto_geral.csv`) confirma o valor certo: `aluno_div_divisor`, divisor 20.
+
+Forward-only: `.update()` e idempotente e no-op num banco ja correto (fresh via 0045); corretivo
+onde o valor vazou como `por_professor` (ex.: golden dev). Reverse = noop (reverter reintroduziria o
+valor errado). Alinha com o calculo per-compra de nr_codigos (#1788): o metodo do PG gateia qual
+`compra.tipo` conta — PG so-de-aluno precisa ser `por_aluno` senao o calculo zera os codigos.
+"""
+
+from django.db import migrations
+
+# Nomes canonicos (uppercase) exatamente como a 0045 os semeia.
+PG_POR_ALUNO = ["A COR DA GENTE", "ECS", "ED FINANCEIRA"]
+
+
+def fix_por_aluno(apps, schema_editor):
+    ProjetoGeral = apps.get_model("core", "ProjetoGeral")
+    ProjetoGeral.objects.filter(nome__in=PG_POR_ALUNO).update(
+        tipo_calculo_codigos="por_aluno",
+        divisor_aluno=20,
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0087_add_dat_compra_tipo_conta_para_codigos"),
+    ]
+
+    operations = [
+        migrations.RunPython(fix_por_aluno, migrations.RunPython.noop),
+    ]

--- a/v2/backend/apps/core/services/export_contract_importer.py
+++ b/v2/backend/apps/core/services/export_contract_importer.py
@@ -475,7 +475,7 @@ class ExportContractImporter:
             mun_idx = self._municipio_index()
             existing = set(
                 DATCompra.objects.values_list(
-                    "municipio_id", "projeto_id", "descricao_produto", "tipo", "quantidade", "ano_uso"
+                    "municipio_id", "projeto_id", "descricao_produto", "tipo", "quantidade", "ano_uso", "data_compra"
                 )
             )
             for r in rows:
@@ -493,7 +493,12 @@ class ExportContractImporter:
 
     @staticmethod
     def _dat_compra_nk(r: dict[str, str], mun_id: int | None, proj_id: int | None) -> tuple[Any, ...]:
-        """NK existence-based da compra: (mun, proj, descricao, tipo, quantidade, ano_uso)."""
+        """NK existence-based da compra: (mun, proj, descricao, tipo, quantidade, ano_uso, data_compra).
+
+        `data_compra` faz parte da NK (alinhado ao dedupe_key do contrato): duas compras iguais em
+        tudo menos a data (ex.: mesmo kit de professor comprado em 15/05 e 25/05) sao DISTINTAS —
+        sem a data elas colidiam e a 2a era descartada, causando under-count de nr_codigos.
+        """
         return (
             mun_id,
             proj_id,
@@ -501,6 +506,7 @@ class ExportContractImporter:
             (r.get("tipo") or "").strip() or None,
             _parse_int(r.get("quantidade")),
             _parse_int(r.get("ano_uso")),
+            _parse_iso_date(r.get("data_compra")),
         )
 
     def run(self) -> dict[str, Any]:
@@ -681,7 +687,7 @@ class ExportContractImporter:
         prod_idx = {(c or "").strip().upper(): pid for pid, c in Produto.objects.values_list("id", "codigo")}
         existing = set(
             DATCompra.objects.values_list(
-                "municipio_id", "projeto_id", "descricao_produto", "tipo", "quantidade", "ano_uso"
+                "municipio_id", "projeto_id", "descricao_produto", "tipo", "quantidade", "ano_uso", "data_compra"
             )
         )
         created = 0
@@ -702,7 +708,7 @@ class ExportContractImporter:
                 conta_para_codigos=_to_bool(r.get("conta_para_codigos")),
                 quantidade=nk[4] or 0,
                 ano_uso=nk[5],
-                data_compra=_parse_iso_date(r.get("data_compra")),
+                data_compra=nk[6],
                 created_by=actor,
             )
             existing.add(nk)

--- a/v2/backend/apps/core/tests/test_export_contract_importer_dat_compra.py
+++ b/v2/backend/apps/core/tests/test_export_contract_importer_dat_compra.py
@@ -10,6 +10,7 @@ Segurança: apply exige allowlist + actor; create-only; idempotente; fixtures si
 from __future__ import annotations
 
 import json
+from datetime import date
 from decimal import Decimal
 from typing import Any
 
@@ -60,6 +61,7 @@ def test_classify_dat_compra_skip_create_reject(tmp_path):
         tipo="Professor",
         quantidade=41,
         ano_uso=2026,
+        data_compra=date(2026, 6, 8),  # parte da NK: precisa casar a data do row p/ skip
         created_by=actor,
     )
     rows = "\n".join(
@@ -95,6 +97,29 @@ def test_apply_dat_compra_creates_and_recomputes(tmp_path):
     assert r["applied"]["dat_compra"] == 2
     reg.refresh_from_db()
     assert reg.nr_codigos == 59  # ceil(41×1.1)+ceil(11×1.1) = 46+13, NÃO ceil(52×1.1)=58
+
+
+def test_apply_dat_compra_distinct_by_data_compra(tmp_path):
+    """NK inclui data_compra: 2 compras iguais em tudo menos a DATA são distintas (não dedup).
+    Regressão real (PACATUBA/Vida & Ciências 9): mesmo kit de professor comprado em 2 datas —
+    sem a data na NK, a 2ª colidia e era descartada, causando under-count de nr_codigos."""
+    actor = _actor()
+    MunicipioFactory(nome="Cidade X", uf="CE", ativo=True)
+    ProjetoFactory(nome="Proj X", fluxo="NAO_SUPER")
+    rows = "\n".join(
+        [
+            "Cidade X,CE,Proj X,99,Professor kit,Professor,true,5,2026,2026-05-15",
+            "Cidade X,CE,Proj X,99,Professor kit,Professor,true,5,2026,2026-05-25",
+        ]
+    )
+    r = ExportContractImporter(
+        path=_write_export(tmp_path, {"dat_compra": f"{COMPRA_HEADER}\n{rows}\n"}),
+        apply=True,
+        allow=("dat_compra",),
+        actor=actor,
+    ).run()
+    assert r["applied"]["dat_compra"] == 2  # sem data_compra na NK seria 1 (2ª colidiria)
+    assert DATCompra.objects.filter(descricao_produto="Professor kit", quantidade=5).count() == 2
 
 
 def test_apply_dat_compra_idempotent(tmp_path):

--- a/v2/backend/apps/core/tests/test_seed_projetos_canonicos.py
+++ b/v2/backend/apps/core/tests/test_seed_projetos_canonicos.py
@@ -40,6 +40,16 @@ def test_seed_create_only_no_fluxo_overwrite():
     assert Projeto.objects.get(nome="Proj Existe Seed").fluxo == "NAO_SUPER"  # nao sobrescreve
 
 
+def test_seed_skips_canonical_duplicate_different_casing():
+    # Regressao: golden dev tem os projetos em UPPERCASE; o catalogo canonico em Title Case.
+    # A idempotencia por canon-key (nao por `nome` exato) NAO pode criar quase-duplicata.
+    ProjetoFactory(nome="GESTÃO ESCOLAR", fluxo="NAO_SUPER")
+    stats = seed_projetos_canonicos([("Gestão Escolar", "NAO_SUPER")])
+    assert stats["created"] == 0
+    assert stats["existing"] == 1
+    assert Projeto.objects.filter(nome__iexact="gestão escolar").count() == 1, "nao pode duplicar por grafia"
+
+
 def test_seed_rejects_invalid_fluxo_and_empty_name():
     stats = seed_projetos_canonicos([("", "SUPER"), ("Proj Fluxo Ruim", "INVALIDO"), ("Proj Ok Seed", "SUPER")])
     assert stats["created"] == 1
@@ -48,11 +58,11 @@ def test_seed_rejects_invalid_fluxo_and_empty_name():
 
 
 def test_constant_well_formed():
-    assert len(PROJETOS_CANONICOS) == 33
+    assert len(PROJETOS_CANONICOS) == 40
     nomes = [n for n, _ in PROJETOS_CANONICOS]
-    assert len(set(nomes)) == 33, "nomes de projeto devem ser unicos"
+    assert len(set(nomes)) == 40, "nomes de projeto devem ser unicos"
     assert all(f in {"SUPER", "NAO_SUPER"} for _, f in PROJETOS_CANONICOS)
-    assert sum(1 for _, f in PROJETOS_CANONICOS if f == "SUPER") == 11
+    assert sum(1 for _, f in PROJETOS_CANONICOS if f == "SUPER") == 15
 
 
 def test_command_seeds_catalogo():
@@ -61,7 +71,7 @@ def test_command_seeds_catalogo():
     tema = Projeto.objects.get(nome="TEMA")
     assert tema.fluxo == "SUPER"
     assert Projeto.objects.get(nome="Superativar Matemática").fluxo == "NAO_SUPER"
-    assert Projeto.objects.filter(nome__in=[n for n, _ in PROJETOS_CANONICOS]).count() == 33
+    assert Projeto.objects.filter(nome__in=[n for n, _ in PROJETOS_CANONICOS]).count() == 40
 
 
 def test_command_idempotent():


### PR DESCRIPTION
## O que

Fecha o import da fatia **DAT** (`dat_registro`/`dat_compra`/`dat_cadastro`) do export-contract, com os
3 fixes que faltavam para a reconciliação `nr_codigos ↔ nr_codigos_planilha` bater **0 under-count**.

| Fix | Root-cause |
|-----|-----------|
| **migration 0088** — `.update()` os 3 ProjetoGeral por-aluno (A COR DA GENTE / ECS / ED FINANCEIRA) → `por_aluno`, divisor 20 | A 0045 já os semeia certo, mas o default `por_professor` do model vazava quando o *importer* os criava sem `tipo_calculo`; `get_or_create` create-only nunca corrige o existente. Forward-only, idempotente, no-op em DB já correto. |
| **seed_projetos_canonicos** — idempotência pela **canon-key** do resolver (#1372), não por `nome` exato; + 7 variantes KEEP_NUMERADO | `get_or_create(nome exato)` criava quase-duplicata quando o catálogo já tinha o projeto sob outra grafia (golden UPPERCASE × canônico Title Case) → o resolver marcava `ambiguous`. |
| **NK `dat_compra`** — inclui `data_compra` (classify + apply) | Duas compras iguais em tudo menos a data (mesmo kit de professor em 2 datas) colidiam na NK e a 2ª era descartada → under-count. Alinha ao `dedupe_key` do contrato. |

## Validação (clone isolado da golden dev, autorizado; v6 — idêntico ao v9 nas fatias DAT)

Prep: `migrate` (aplica 0088) → `seed_projetos_canonicos` (8 criados, **0 ambíguos**) → apply operacional
`--as-user` → recompute. Reconciliação sobre 993 registros com valor de planilha:

- **MATCH 954 · OVER (by-design, arredondamento per-compra) 39 · UNDER-count 0** ✅

Testes: **34 verdes** (incl. 2 novos: duplicata-canônica por grafia; NK distinta por `data_compra`).
Pyright: **0 errors**.

## Caveat de fidelidade (relay ao sheets.banco — não bloqueia o 0-under-count)

8 dat_registro não importam por colisão de NK no nível de ID resolvido: 4 são inócuas (só acento);
**4 pares são projetos distintos que o resolver funde** com Nº de Códigos divergente
(`SUPERATIVAR PORTUGUÊS 3/5` ↔ `LINGUAGENS 3/5`; `PROJETO UNI DUNI TÊ 4/5` ↔ `UNI DUNI TÊ 4/5`).
Pedido de **dedup no contrato** (1 linha por projeto resolvido) — análogo ao dedup do `dat_cadastro`.

## Escopo

- **Só código.** O import real (apply contra alvo definitivo) é passo separado, com autorização
  explícita do dono (regra pétrea). Nenhum dado real foi escrito.
- Sequência do prep real: `migrate` → `seed_projetos_canonicos` → `import_export_contract --apply
  --allow-entity … --as-user <cpf>` → recompute → reconciliar.

## Staging gate

- [x] `make staging-full` executado com sucesso (8/8 PASS)
- [x] Evidência anexada no PR
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `6eb3685b`, slot `2` / projeto `aprender_staging_s2`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local-s2, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 403)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
