### PR TITLE
fix(rbac): invalida cache por-usuário ao deletar Group (#1667)

### DIFF
--- a/v2/backend/apps/core/rbac_signals.py
+++ b/v2/backend/apps/core/rbac_signals.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
-from django.db.models.signals import m2m_changed, post_delete, post_save
+from django.db.models.signals import m2m_changed, post_delete, post_save, pre_delete
 from django.dispatch import receiver
 
 from apps.core.models import PermissaoFuncional
@@ -110,3 +110,20 @@ def _invalidate_funcperm_on_group_change(
     group_id = getattr(instance, "id", None)
     if isinstance(group_id, int):
         invalidate_group_functional_permissions_cache([group_id])
+
+
+@receiver(pre_delete, sender=Group)
+def _invalidate_funcperm_on_group_delete_members(
+    sender: type[Group],
+    instance: Group,
+    **kwargs: Any,
+) -> None:
+    # M05-03 (#1667): ao deletar um Group, o cascade que remove as linhas de
+    # User.groups.through NÃO emite m2m_changed, então
+    # _invalidate_funcperm_on_user_groups_change nunca dispara e o cache
+    # POR-USUÁRIO dos ex-membros fica stale até o TTL (300s) — mantendo em cache
+    # capabilities que a exclusão do grupo revogou. Snapshot dos membros ANTES do
+    # cascade (mesmo padrão do pre_clear acima) e invalida o cache por-usuário.
+    member_ids = list(instance.user_set.values_list("id", flat=True))
+    if member_ids:
+        invalidate_users_functional_permissions_cache(member_ids)

--- a/v2/backend/apps/core/tests/test_rbac_functional_permissions.py
+++ b/v2/backend/apps/core/tests/test_rbac_functional_permissions.py
@@ -95,6 +95,40 @@ def test_cache_invalidated_when_user_groups_change():
     assert permission.has_permission(request, _MockView()) is False
 
 
+def test_cache_invalidated_when_group_deleted():
+    # M05-03 (#1667): deletar o Group deve invalidar o cache POR-USUÁRIO dos
+    # ex-membros. O cascade de User.groups.through NÃO emite m2m_changed, então
+    # sem o receiver pre_delete a autorização revogada persistia em cache (300s).
+    # Grupo descartável (não o DAT semeado, que tem FK protegida).
+    cache.clear()
+    temp_group = GroupFactory(name="temp_group_del_1667")
+    user = UsuarioFactory(
+        username="invalidate_group_delete",
+        email="invalidate_group_delete@test.com",
+        password="test123",
+        cpf="10000000011",
+    )
+    user.groups.add(temp_group)
+
+    custom_perm, _ = PermissaoFuncional.objects.get_or_create(
+        codename="perm_temp_group_del",
+        defaults={
+            "label": "Permissão temporária delete de grupo",
+            "description": "Teste",
+            "category": "test",
+            "is_system": False,
+        },
+    )
+    custom_perm.groups.set([temp_group])
+
+    permission = HasPerm("perm_temp_group_del")()
+    request = _request_with_user(APIRequestFactory(), user)
+    assert permission.has_permission(request, _MockView()) is True
+
+    temp_group.delete()  # cascade em User.groups.through NÃO emite m2m_changed
+    assert permission.has_permission(request, _MockView()) is False
+
+
 def test_cache_invalidated_when_permission_m2m_changes():
     cache.clear()
     dat_group = GroupFactory(name="DAT")


### PR DESCRIPTION
## Problema (M05-03 do épico #1667)

Deletar um `Group` **não invalidava o cache funcional POR-USUÁRIO** dos ex-membros. O único handler de delete de Group (`_invalidate_funcperm_on_group_change`, `post_delete`) só invalida o cache **por-grupo** e o de grupos atribuíveis. O cascade que remove as linhas de `User.groups.through` **não emite `m2m_changed`**, então `_invalidate_funcperm_on_user_groups_change` nunca dispara → as capabilities que a exclusão do grupo revogou continuavam servidas do cache até o TTL (**300s**). Achado P2, **vivo em prod**.

## Correção

Novo receiver `pre_delete` em `Group` (`_invalidate_funcperm_on_group_delete_members`) que faz **snapshot dos IDs dos membros ANTES do cascade** (`instance.user_set.values_list("id", flat=True)`) e chama `invalidate_users_functional_permissions_cache(member_ids)`. Mesmo padrão do `pre_clear` já existente (invalidação síncrona).

## Testes (TDD RED→GREEN)
- Novo `test_cache_invalidated_when_group_deleted` (grupo descartável + permissão custom para evitar a FK protegida do DAT semeado): prima o cache com `HasPerm(...).has_permission → True`, deleta o grupo, assere `→ False`.
- **RED provado** contra o código antigo: o teste falha (cache stale mantém o perm `True` após o delete).
- Suíte `test_rbac_functional_permissions.py` 9/9 verde. pyright 0 erros, black/isort/flake8 limpos.

> M19-01 (o outro sub-achado do épico) já foi resolvido por #1642 (2026-08-11) e é do domínio DAT. Este PR fecha a metade restante.

Closes #1667
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `3af1933a`, slot `1` / projeto `aprender_staging_s1`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local-s1, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 403)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
