### PR TITLE
fix(grade): CH Ano soma o ano inteiro, não só o mês (#1663)

### DIFF
--- a/v2/backend/apps/core/services/monthly_grid_service.py
+++ b/v2/backend/apps/core/services/monthly_grid_service.py
@@ -236,13 +236,43 @@ def build_monthly_grid(
                 events_by_user_day[(uid, day_num)].append(event)
             current += timedelta(days=1)
 
-        # CH mês/ano por usuário. Calcula uma vez por evento e soma pra
-        # cada participant.
+        # CH mês por usuário (uma vez por evento, somada a cada participant).
+        # CH ano é agregada à parte, sobre a janela do ANO — `events` só
+        # intersecta o mês consultado (M14-03 / #1663).
         ch_month_hours = _calc_hours_in_range(event.inicio, event.fim, month_start, month_end)
-        ch_year_hours = _calc_hours_in_range(event.inicio, event.fim, year_start_dt, year_end_dt)
         for uid in event_users:
             if uid in user_ids_set:
                 ch_month_by_user[uid] += ch_month_hours
+
+    # 5.5. CH Ano por usuário — janela do ANO, independente do mês consultado.
+    # `events` acima só intersecta [month_start, month_end], então somar ch_year
+    # sobre ele contava um único mês (CH Ano ≈ CH Mês, repetindo o CH Mês). Query
+    # própria sobre a janela do ano alimenta ch_year (M14-03 / #1663).
+    year_events_q = Solicitacao.objects.filter(
+        status="aprovado",
+        participations__role=role,
+        participations__usuario_id__in=user_ids,
+        inicio__lt=year_end_dt,
+        fim__gt=year_start_dt,
+    )
+    if sector and sector.strip():
+        year_events_q = year_events_q.filter(projeto__nome__iexact=sector.strip())
+    year_rows = list(year_events_q.values_list("id", "inicio", "fim").distinct())
+
+    year_event_to_users: dict[int, list[int]] = defaultdict(list)
+    year_event_ids = [row[0] for row in year_rows]
+    if year_event_ids:
+        for sol_id, uid in Participation.objects.filter(
+            solicitacao_id__in=year_event_ids,
+            role=role,
+            usuario_id__in=user_ids,
+        ).values_list("solicitacao_id", "usuario_id"):
+            year_event_to_users[sol_id].append(uid)
+
+    for ev_id, ev_inicio, ev_fim in year_rows:
+        ch_year_hours = _calc_hours_in_range(ev_inicio, ev_fim, year_start_dt, year_end_dt)
+        for uid in year_event_to_users.get(ev_id, ()):
+            if uid in user_ids_set:
                 ch_year_by_user[uid] += ch_year_hours
 
     # 6. Distribuir bloqueios por dia/pessoa

--- a/v2/backend/apps/core/tests/test_monthly_grid_ch_year.py
+++ b/v2/backend/apps/core/tests/test_monthly_grid_ch_year.py
@@ -1,0 +1,74 @@
+"""M14-03 (#1663): CH Ano da grade mensal deve somar o ANO inteiro.
+
+O queryset `events` do serviço só intersecta o mês consultado, então acumular
+`ch_year` sobre ele contava um único mês (CH Ano ≈ CH Mês). Este teste fixa o
+contrato: CH Ano soma todos os eventos do ano; CH Mês, só os do mês.
+"""
+
+# pyright: reportUnknownMemberType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportMissingParameterType=false, reportAttributeAccessIssue=false, reportOptionalMemberAccess=false, reportIndexIssue=false, reportArgumentType=false
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from django.utils import timezone
+
+import pytest
+
+from apps.core.models import Participation
+from apps.core.services.monthly_grid_service import build_monthly_grid
+from apps.core.tests.factories import (
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
+
+
+@pytest.mark.django_db
+class TestMonthlyGridChYear:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.tz = timezone.get_current_timezone()
+        self.user_formador = UsuarioFactory(
+            username="formador_chyear",
+            email="formador_chyear@example.com",
+            password="password123",
+        )
+        self.municipio = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+        # fluxo=SUPER é obrigatório: o fallback de população da grade só considera
+        # participações em eventos SUPER (senão a grade volta vazia — falso verde).
+        self.projeto = ProjetoFactory(nome="Projeto ChYear", ativo=True, fluxo="SUPER")
+        self.tipo_evento = TipoEventoFactory(nome="Formação", cor="#FF0000")
+
+    def _evento_4h(self, mes: int, dia: int):
+        sol = SolicitacaoFactory(
+            usuario=self.user_formador,
+            municipio=self.municipio,
+            projeto=self.projeto,
+            tipo_evento=self.tipo_evento,
+            inicio=timezone.make_aware(datetime(2026, mes, dia, 8, 0), self.tz),
+            fim=timezone.make_aware(datetime(2026, mes, dia, 12, 0), self.tz),
+            status="aprovado",
+        )
+        Participation.objects.create(
+            solicitacao=sol,
+            usuario=self.user_formador,
+            role="FORMADOR",
+        )
+        return sol
+
+    def test_ch_year_soma_o_ano_inteiro_nao_so_o_mes(self):
+        # Mesmo formador, 2 eventos de 4h: um em março (mês consultado) e outro
+        # em janeiro (fora do mês, dentro do ano).
+        self._evento_4h(mes=3, dia=10)
+        self._evento_4h(mes=1, dia=15)
+
+        result = build_monthly_grid(year=2026, month=3, role="FORMADOR")
+        person = next(p for p in result["people"] if p["id"] == self.user_formador.id)
+
+        # CH Mês = só março (4h). CH Ano = março + janeiro (8h).
+        assert person["ch_month"] == 4.0
+        assert person["ch_year"] == 8.0
+        assert person["ch_year"] > person["ch_month"]


### PR DESCRIPTION
## Problema (M14-03 do épico #1663)

Na grade mensal, `ch_year` (CH Ano) era acumulado dentro do loop que percorre `events` — mas `events` é filtrado **só pela interseção com o mês consultado** (`inicio < month_end AND fim > month_start`). Resultado: **CH Ano só somava os eventos do mês consultado**, cada um clampado à janela do ano (que, para eventos de um mês, é igual ao clamp do mês) → CH Ano ≈ CH Mês, repetindo o número.

## Correção

`ch_year` passa a ser agregada por uma **query própria com escopo de ANO** (`inicio < year_end AND fim > year_start`, `.distinct()`), independente da lista do mês. `ch_month` e a distribuição diária permanecem intactos (ainda vêm de `events`, month-scoped). Participantes do ano são batcheados numa consulta só (`values_list("id", "inicio", "fim")` + participação por role).

## Testes (TDD RED→GREEN)
- Novo `test_monthly_grid_ch_year.py`: mesmo formador com **4h em março** (consultado) + **4h em janeiro** (fora do mês). Consulta março → `ch_month == 4.0`, `ch_year == 8.0`, `ch_year > ch_month`.
- **RED provado**: código antigo dá `ch_year == 4.0` (só março).
- Regressão `test_monthly_with_deslocamento.py` 7/7 verde. pyright 0 erros, black/isort/flake8 limpos.

> Escopo: só M14-03. M14-02 já foi feito (#1785, `.distinct()`); M14-05 (população da grade) tem issue própria #1631 (gated por decisão). Este PR **não fecha** o épico.

Refs #1663
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `40f22627`, slot `1` / projeto `aprender_staging_s1`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local-s1, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 403)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
