### PR TITLE
fix(dr): restore_db.sh aborta em falha e verifica linhas (#1645)

### DIFF
--- a/v2/infra/scripts/restore_db.sh
+++ b/v2/infra/scripts/restore_db.sh
@@ -129,6 +129,24 @@ psql -h $DB_HOST -U postgres -c "
     WHERE datname = '$DB_NAME' AND pid <> pg_backend_pid();
 " 2>/dev/null || true
 
+# Step 2.5: Safety dump do banco atual ANTES do DROP destrutivo (M26-02 / #1645).
+# Se o restore falhar, o estado anterior ainda existe. Best-effort: banco novo ou
+# pg_dump ausente apenas avisa (nao aborta o restore).
+SAFETY_DUMP="$BACKUP_DIR/pre-restore-safety-$(date +%Y%m%d_%H%M%S).sql.gz"
+if command -v pg_dump > /dev/null 2>&1; then
+    echo "[$(date)] Dump de seguranca do banco atual -> $SAFETY_DUMP"
+    if ( set -o pipefail; pg_dump -h $DB_HOST -U postgres -d $DB_NAME 2>/dev/null | gzip > "$SAFETY_DUMP" ); then
+        echo -e "${GREEN}Dump de seguranca salvo.${NC}"
+    else
+        echo -e "${YELLOW}AVISO: dump de seguranca falhou (banco novo?); prosseguindo.${NC}"
+        rm -f "$SAFETY_DUMP"
+        SAFETY_DUMP=""
+    fi
+else
+    echo -e "${YELLOW}AVISO: pg_dump indisponivel; sem dump de seguranca.${NC}"
+    SAFETY_DUMP=""
+fi
+
 # Step 3: Drop and recreate database
 echo "[$(date)] Recreating database..."
 psql -h $DB_HOST -U postgres -c "DROP DATABASE IF EXISTS $DB_NAME;"
@@ -136,21 +154,62 @@ psql -h $DB_HOST -U postgres -c "CREATE DATABASE $DB_NAME OWNER $DB_USER;"
 
 # Step 4: Restore backup
 echo "[$(date)] Restoring backup (this may take a while)..."
+# M26-02 (#1645): `-v ON_ERROR_STOP=1` faz o psql ABORTAR no primeiro erro de SQL —
+# sem isso ele seguia apos falhas e "restaurava" um banco com tabelas faltando, saindo 0.
+# pipefail LOCAL captura falha de age/gunzip (o branch plaintext tambem passa a ter).
+# Capturamos o exit do pipeline; se != 0, abortamos VERMELHO (o banner verde so sai no fim).
 # SEC-017: Support encrypted backups (.age extension)
+RESTORE_OK=0
 if echo "$BACKUP_FILE" | grep -q '\.age$'; then
     BACKUP_AGE_KEY="${BACKUP_AGE_KEY:-/etc/backup-key.txt}"
     echo "[$(date)] Decrypting encrypted backup with age..."
-    # pipefail LOCAL: uma falha do `age` (chave errada, arquivo truncado) deve abortar o
-    # restore — sem isso, o psql receberia stream vazio e "restauraria" um banco incompleto.
-    ( set -o pipefail; age -d -i "$BACKUP_AGE_KEY" "$BACKUP_FILE" | gunzip | psql -h $DB_HOST -U postgres -d $DB_NAME -q )
+    if ( set -o pipefail; age -d -i "$BACKUP_AGE_KEY" "$BACKUP_FILE" | gunzip | psql -v ON_ERROR_STOP=1 -h $DB_HOST -U postgres -d $DB_NAME -q ); then
+        RESTORE_OK=1
+    fi
 else
-    gunzip -c "$BACKUP_FILE" | psql -h $DB_HOST -U postgres -d $DB_NAME -q
+    if ( set -o pipefail; gunzip -c "$BACKUP_FILE" | psql -v ON_ERROR_STOP=1 -h $DB_HOST -U postgres -d $DB_NAME -q ); then
+        RESTORE_OK=1
+    fi
+fi
+if [ "$RESTORE_OK" -ne 1 ]; then
+    echo -e "${RED}ERROR: restore falhou (erro de SQL, decifragem ou descompressao). Banco pode estar incompleto.${NC}"
+    [ -n "$SAFETY_DUMP" ] && echo -e "${RED}Estado anterior preservado em: $SAFETY_DUMP${NC}"
+    exit 1
 fi
 
-# Step 5: Verify restore
+# Step 5: Verify restore — M26-02 (#1645). Exige piso de tabelas E linhas nas
+# tabelas-chave. Um restore que perdeu tabelas ou veio vazio NAO declara sucesso.
 echo "[$(date)] Verifying restore..."
-TABLE_COUNT=$(psql -h $DB_HOST -U postgres -d $DB_NAME -t -c "SELECT count(*) FROM information_schema.tables WHERE table_schema = 'public';")
+_count() { psql -h $DB_HOST -U postgres -d $DB_NAME -tAc "$1" 2>/dev/null | tr -d '[:space:]'; }
+TABLE_COUNT=$(_count "SELECT count(*) FROM information_schema.tables WHERE table_schema='public';")
+[[ "$TABLE_COUNT" =~ ^[0-9]+$ ]] || TABLE_COUNT=0
 echo "Tables restored: $TABLE_COUNT"
+
+MIN_TABLES="${RESTORE_MIN_TABLES:-20}"
+VERIFY_FAIL=0
+if [ "$TABLE_COUNT" -lt "$MIN_TABLES" ]; then
+    echo -e "${RED}ERROR: apenas $TABLE_COUNT tabelas (< piso $MIN_TABLES) — restore incompleto.${NC}"
+    VERIFY_FAIL=1
+fi
+for tbl in core_usuario core_solicitacao; do
+    ROWS=$(_count "SELECT count(*) FROM $tbl;")
+    [[ "$ROWS" =~ ^[0-9]+$ ]] || ROWS=0
+    if [ "$ROWS" -eq 0 ]; then
+        echo -e "${RED}ERROR: tabela-chave '$tbl' ausente ou vazia (linhas=$ROWS).${NC}"
+        VERIFY_FAIL=1
+    else
+        echo "  $tbl: $ROWS linhas"
+    fi
+done
+
+if [ "$VERIFY_FAIL" -ne 0 ]; then
+    echo ""
+    echo -e "${RED}========================================${NC}"
+    echo -e "${RED}  Restore FALHOU na verificacao!       ${NC}"
+    echo -e "${RED}========================================${NC}"
+    [ -n "$SAFETY_DUMP" ] && echo -e "${RED}Estado anterior preservado em: $SAFETY_DUMP${NC}"
+    exit 1
+fi
 
 echo ""
 echo -e "${GREEN}========================================${NC}"

--- a/v2/infra/scripts/tests/restore_db.bats
+++ b/v2/infra/scripts/tests/restore_db.bats
@@ -29,9 +29,17 @@ setup() {
 #!/usr/bin/env bash
 echo "psql $*" >> "$PSQL_LOG"
 cat >/dev/null 2>&1 || true   # dreno do pipe (age|gunzip|psql); EOF imediato nos -c
+# A chamada de RESTORE (Step 4) e' a unica com -q: falha sob STUB_RESTORE_EXIT (M26-02).
+for a in "$@"; do
+  if [ "$a" = "-q" ] && [ -n "$STUB_RESTORE_EXIT" ]; then exit "$STUB_RESTORE_EXIT"; fi
+done
+# Contagens da Step 5 sao ajustaveis por env (default 42) p/ simular tabela vazia/faltando.
 for a in "$@"; do
   case "$a" in
-    *information_schema*|*"count("*|*"COUNT("*) echo 42 ;;
+    *core_usuario*)        echo "${STUB_CORE_USUARIO_ROWS:-42}" ;;
+    *core_solicitacao*)    echo "${STUB_CORE_SOLICITACAO_ROWS:-42}" ;;
+    *information_schema*)   echo "${STUB_TABLE_COUNT:-42}" ;;
+    *"count("*|*"COUNT("*)  echo 42 ;;
   esac
 done
 exit 0
@@ -121,4 +129,24 @@ run_restore() { printf 'yes\n' | bash "$SCRIPT" "$@"; }
   run run_restore --latest
   [ "$status" -eq 0 ]
   [[ "$output" == *"Backup integrity OK"* ]]
+}
+
+# 6) M26-02 (#1645): um erro de SQL no restore (psql sai != 0 sob ON_ERROR_STOP)
+# deve ABORTAR — nada de "Restore completed successfully!" com exit 0.
+@test "restore com erro no meio NAO declara sucesso" {
+  export STUB_RESTORE_EXIT=3
+  run run_restore "$PLAIN_GZ"
+  [ "$status" -ne 0 ]
+  [[ "$output" != *"Restore completed successfully"* ]]
+  [[ "$output" == *"restore falhou"* ]]
+}
+
+# 7) M26-02 (#1645): restore "sucesso" mas tabela-chave vazia -> a verificacao final
+# reprova e NAO imprime o banner verde.
+@test "verificacao final reprova banco com tabela-chave vazia" {
+  export STUB_CORE_USUARIO_ROWS=0
+  run run_restore "$PLAIN_GZ"
+  [ "$status" -ne 0 ]
+  [[ "$output" != *"Restore completed successfully"* ]]
+  [[ "$output" == *"core_usuario"* ]]
 }


### PR DESCRIPTION
## Problema (M26-02)

`restore_db.sh` imprimia **"Restore completed successfully!" com exit 0** mesmo depois de um restore que perdeu tabelas:
- os dois `psql` de restauração rodavam **sem `-v ON_ERROR_STOP=1`** → o psql seguia após erros de SQL e "restaurava" um banco incompleto, saindo 0;
- o branch plaintext (`gunzip | psql`) não tinha `pipefail` → falha do gunzip mascarada;
- a Step 5 só **contava tabelas** e imprimia o banner verde **incondicionalmente**.

## Correção

- **`ON_ERROR_STOP=1`** nos dois `psql` de restauração + **`pipefail` local** também no branch plaintext; o exit do pipeline é capturado e, se `!= 0`, aborta **vermelho** (o banner verde só sai no fim).
- **Step 5 real**: piso de tabelas (`RESTORE_MIN_TABLES`, default 20) **E** `linhas > 0` em `core_usuario`/`core_solicitacao`; reprova → exit 1, sem banner verde.
- **Safety dump** best-effort do banco atual **antes** do `DROP DATABASE` (banco novo/pg_dump ausente apenas avisa).

## Testes (TDD RED→GREEN — bats hermético)
- 2 testes novos no `restore_db.bats` (stub psql estendido com contagens ajustáveis + `STUB_RESTORE_EXIT`): (6) erro no meio do restore → aborta sem banner; (7) tabela-chave vazia → verificação reprova.
- **RED provado**: ambos falham contra o script antigo (banner verde + exit 0).
- Suíte `restore_db.bats` **7/7 verde**. shellcheck sem novos findings.

> Escopo M26-02. O par M26-03 (`test_dr.sh` exercitar o round-trip `.age`) vai em PR separado (#1646). Ambos são do épico #1662.

Closes #1645
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `ebec512e`, slot `1` / projeto `aprender_staging_s1`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local-s1, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 403)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
