### PR TITLE
fix(disponibilidade): CONVIDADO nao ocupa a agenda (#1664)

### DIFF
--- a/v2/backend/apps/core/services/availability_service.py
+++ b/v2/backend/apps/core/services/availability_service.py
@@ -26,10 +26,20 @@ from django.conf import settings
 from django.db.models import Q
 from django.utils import timezone
 
-from apps.core.models import AvailabilityBlock, Municipio, Solicitacao, Usuario
+from apps.core.models import AvailabilityBlock, Municipio, Participation, Solicitacao, Usuario
 from apps.core.services.config_service import get_cfg
 from apps.core.types import ConflictCode
 from apps.core.utils.cache_utils import cache_availability_check
+
+# SSOT dos papéis OCUPANTES (RD): quem, participando de um evento aprovado, ocupa a
+# agenda para efeito de conflito/capacidade. CONVIDADO não ocupa. Usado tanto no
+# enforcement (solicitacao_availability) quanto na query de eventos existentes aqui —
+# um único predicado, sem lista de papéis duplicada fora deste módulo. (M08-07 / #1664)
+ENFORCED_ROLES: tuple[str, ...] = (
+    Participation.Role.COORDENADOR.value,
+    Participation.Role.FORMADOR.value,
+    Participation.Role.COORD_ACOMPANHA.value,
+)
 
 
 @dataclass
@@ -163,8 +173,11 @@ def _check_conflicts_impl(
     )
 
     conflicts: list[Conflict] = []
+    # M08-07 (#1664): só papéis OCUPANTES (ENFORCED_ROLES) bloqueiam. Antes qualquer
+    # participação casava, então um CONVIDADO bloqueava indevidamente o FORMADOR. O
+    # filtro por role vai na ORIGEM da query (events_qs), não em Python depois.
     events_qs = Solicitacao.objects.filter(status=Solicitacao.Status.APROVADO).filter(
-        Q(usuario=usuario) | Q(participations__usuario=usuario)
+        Q(usuario=usuario) | Q(participations__usuario=usuario, participations__role__in=ENFORCED_ROLES)
     )
     if exclude_solicitacao_id is not None:
         events_qs = events_qs.exclude(pk=exclude_solicitacao_id)

--- a/v2/backend/apps/core/services/solicitacao_availability.py
+++ b/v2/backend/apps/core/services/solicitacao_availability.py
@@ -21,20 +21,13 @@ from django.db import connection
 
 from apps.core.exceptions import ValidationAPIError
 from apps.core.models import Participation, Solicitacao, Usuario
-from apps.core.services.availability_service import Conflict, check_conflicts_uncached
+from apps.core.services.availability_service import ENFORCED_ROLES, Conflict, check_conflicts_uncached
 
 logger = logging.getLogger(__name__)
 
-# Papéis que ocupam a agenda da pessoa e por isso entram na checagem.
-#
-# CONVIDADO fica de fora de propósito: é audiência, não recurso alocado. Checá-lo
-# estouraria a capacidade diária (RD-05) de quem é convidado a vários eventos no mesmo
-# dia — um diretor convidado a 5 eventos bloquearia os 5.
-ENFORCED_ROLES: tuple[str, ...] = (
-    Participation.Role.COORDENADOR,
-    Participation.Role.FORMADOR,
-    Participation.Role.COORD_ACOMPANHA,
-)
+# ENFORCED_ROLES (papéis ocupantes; CONVIDADO fica de fora — é audiência, não recurso
+# alocado) é SSOT do motor: definido em availability_service e importado acima, para o
+# enforcement e a query de eventos existentes usarem o MESMO predicado (M08-07 / #1664).
 
 # Namespace do advisory lock (classid), para não colidir com outros locks da aplicação.
 _LOCK_NAMESPACE = 1452

--- a/v2/backend/apps/core/tests/test_availability_convidado_1664.py
+++ b/v2/backend/apps/core/tests/test_availability_convidado_1664.py
@@ -1,0 +1,72 @@
+"""M08-07 (#1664): participação CONVIDADO não ocupa a agenda da pessoa.
+
+A `events_qs` do motor de disponibilidade casava qualquer participação da pessoa,
+sem filtrar por papel ocupante — então uma participação CONVIDADO (audiência)
+bloqueava a pessoa para uma alocação real (FORMADOR) no mesmo horário. O filtro
+por `role__in=ENFORCED_ROLES` vai na origem da query.
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportOptionalMemberAccess=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportIndexIssue=false
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from django.utils import timezone
+
+import pytest
+
+from apps.core.models import Participation, Solicitacao
+from apps.core.services.availability_service import check_conflicts_uncached
+from apps.core.tests.factories import (
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+def _setup():
+    tz = timezone.get_current_timezone()
+    municipio = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+    projeto = ProjetoFactory(nome="Projeto Conv 1664", ativo=True, fluxo="SUPER")
+    tipo = TipoEventoFactory(nome="Formação", cor="#FF0000")
+    dono = UsuarioFactory(username="dono_e1_1664", email="dono_e1_1664@x.com", password="p")
+    pessoa = UsuarioFactory(username="pessoa_conv_1664", email="pessoa_conv_1664@x.com", password="p")
+    inicio = timezone.make_aware(datetime(2026, 5, 10, 9, 0), tz)
+    fim = timezone.make_aware(datetime(2026, 5, 10, 11, 0), tz)
+    # Evento aprovado E1 pertence ao `dono`; `pessoa` entra como participante.
+    e1 = SolicitacaoFactory(
+        usuario=dono,
+        municipio=municipio,
+        projeto=projeto,
+        tipo_evento=tipo,
+        inicio=inicio,
+        fim=fim,
+        status=Solicitacao.Status.APROVADO,
+    )
+    return municipio, pessoa, e1, inicio, fim
+
+
+def test_participacao_convidado_nao_bloqueia_a_pessoa():
+    municipio, pessoa, e1, inicio, fim = _setup()
+    Participation.objects.create(solicitacao=e1, usuario=pessoa, role=Participation.Role.CONVIDADO)
+
+    # Checar `pessoa` no MESMO horário (como se fosse alocá-la de FORMADOR).
+    result = check_conflicts_uncached(usuario=pessoa, inicio=inicio, fim=fim, municipio=municipio)
+
+    assert result.ok, [c.code for c in result.conflicts]
+
+
+def test_participacao_formador_ainda_bloqueia_a_pessoa():
+    # Controle positivo: papel OCUPANTE (FORMADOR) continua bloqueando — o fix
+    # exclui só os não-ocupantes, não afrouxa a regra.
+    municipio, pessoa, e1, inicio, fim = _setup()
+    Participation.objects.create(solicitacao=e1, usuario=pessoa, role=Participation.Role.FORMADOR)
+
+    result = check_conflicts_uncached(usuario=pessoa, inicio=inicio, fim=fim, municipio=municipio)
+
+    assert not result.ok


### PR DESCRIPTION
## Problema (M08-07 do épico #1664)

A `events_qs` do motor de disponibilidade (`availability_service.py`) casava **qualquer** participação da pessoa — `Q(participations__usuario=usuario)` sem `role__in` — então uma participação **CONVIDADO** (audiência, não recurso alocado) bloqueava a pessoa para uma alocação real (FORMADOR) no mesmo horário. Achado P2, vivo em prod.

## Correção
- **`ENFORCED_ROLES` vira SSOT do motor**: movido para `availability_service.py` (módulo base) e importado por `solicitacao_availability.py`, para o enforcement **e** a query de eventos existentes usarem o **mesmo predicado** — sem lista de papéis ocupantes duplicada.
- **`events_qs` filtra `role__in=ENFORCED_ROLES` na origem** da query.

## Testes (TDD RED→GREEN)
- `test_participacao_convidado_nao_bloqueia_a_pessoa` (CONVIDADO não bloqueia) + controle positivo `test_participacao_formador_ainda_bloqueia_a_pessoa` (FORMADOR ainda bloqueia).
- **RED provado**: código antigo gera `Conflict(code='X')` para o CONVIDADO.
- Regressão `test_availability_per_formador_1452` + `test_availability_service` **35/35** verde. pyright/black/isort/flake8 limpos.

> Escopo M08-07. O par M08-09 (RD-05 meia-noite) fica em PR separado. Não fecha o épico.

Refs #1664
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `e0914baa`, slot `1` / projeto `aprender_staging_s1`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local-s1, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 403)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
