### PR TITLE
fix(sec): CSP script-src sem unsafe-inline + connect-src sem github (#1462)

### DIFF
--- a/v2/backend/apps/core/middleware_security.py
+++ b/v2/backend/apps/core/middleware_security.py
@@ -61,11 +61,14 @@ class SecurityHeadersMiddleware:
         is_api_docs = request.path.startswith("/api/docs") or request.path.startswith("/api/redoc")
 
         # - 'self': Permite recursos do mesmo domínio
-        # - 'unsafe-inline': Necessário para Ant Design inline styles
+        # - 'unsafe-inline' (SÓ em style-src): Ant Design injeta estilos inline
         # - data:: Necessário para imagens base64 (ícones, avatars)
         # - blob:: Necessário para download de arquivos
-        # SEC-CSP-01: only allow unsafe-eval in development (React hot reload needs it)
-        script_src = "script-src 'self' 'unsafe-inline'"
+        # SEC-004 (#1462): script-src SEM 'unsafe-inline' — corta a superfície de XSS por
+        # injeção de <script>/handler inline. Nenhum template Django do projeto usa script
+        # inline e o admin 5.2 é CSP-compatível; o SPA React é servido pelo nginx (sem esta
+        # CSP). unsafe-eval fica só em dev (hot reload do React).
+        script_src = "script-src 'self'"
         if settings.ENVIRONMENT != "production":
             script_src += " 'unsafe-eval'"
         style_src = "style-src 'self' 'unsafe-inline'"
@@ -87,7 +90,7 @@ class SecurityHeadersMiddleware:
             style_src,  # Ant Design usa inline styles
             img_src,  # Imagens de qualquer HTTPS
             font_src,  # Fontes locais e data URIs
-            "connect-src 'self' https://api.github.com",  # APIs permitidas
+            "connect-src 'self'",  # APIs permitidas (G8 #1462: api.github.com removido — sem consumidor)
             "frame-ancestors 'none'",  # Previne clickjacking (como X-Frame-Options)
             "base-uri 'self'",  # Previne ataques de base tag
             "form-action 'self'",  # Forms só podem submeter para o mesmo domínio

--- a/v2/backend/apps/core/tests/test_middleware_security.py
+++ b/v2/backend/apps/core/tests/test_middleware_security.py
@@ -39,11 +39,20 @@ class TestCSPUnsafeEval(TestCase):
         assert "style-src 'self' 'unsafe-inline'" in csp, f"style-src missing unsafe-inline: {csp}"
 
     @override_settings(ENVIRONMENT="production")
-    def test_production_csp_has_unsafe_inline_for_scripts(self):
-        """script-src must still have unsafe-inline (needed for inline scripts)."""
+    def test_production_csp_script_src_has_no_unsafe_inline(self):
+        """SEC-004 (#1462): script-src must NOT contain unsafe-inline."""
         response = self.client.get("/healthz/")
         csp = response.get("Content-Security-Policy", "") or response.get("Content-Security-Policy-Report-Only", "")
-        assert "script-src 'self' 'unsafe-inline'" in csp, f"script-src missing unsafe-inline: {csp}"
+        # Isola a diretiva script-src (style-src legitimamente mantém 'unsafe-inline').
+        script_directive = next((d for d in csp.split(";") if d.strip().startswith("script-src")), "")
+        assert script_directive, f"script-src directive missing: {csp}"
+        assert "unsafe-inline" not in script_directive, f"script-src should not have unsafe-inline: {csp}"
+
+    def test_csp_connect_src_has_no_github(self):
+        """G8 (#1462): connect-src must not allowlist api.github.com (sem consumidor)."""
+        response = self.client.get("/healthz/")
+        csp = response.get("Content-Security-Policy", "") or response.get("Content-Security-Policy-Report-Only", "")
+        assert "api.github.com" not in csp, f"connect-src should not have api.github.com: {csp}"
 
 
 class TestCSPMode(TestCase):


### PR DESCRIPTION
## Problema (#1462)

- **G6 (regressão do SEC-004 #802)**: `script-src` reintroduziu `'unsafe-inline'` — superfície de XSS por `<script>`/handler inline.
- **G8**: `connect-src` allowlista `https://api.github.com` sem nenhum consumidor (backend nem frontend).

## Correção
- **`script-src 'self'`** (sem `'unsafe-inline'`; `'unsafe-eval'` fica só em dev p/ hot reload). Seguro: (a) é a **reversão de uma regressão** — já rodou em prod sem `unsafe-inline` no SEC-004; (b) **zero** `<script>` inline nos templates Django do projeto (grep); (c) admin Django 5.2 é CSP-compatível; (d) o SPA React é servido pelo **nginx** (sem esta CSP — ela cobre `/admin/` e respostas Django). `style-src` **mantém** `'unsafe-inline'` (Ant Design).
- **`connect-src 'self'`** (removido `api.github.com`).

## Testes (TDD RED→GREEN)
- `test_production_csp_script_src_has_no_unsafe_inline` (isola a diretiva script-src) + `test_csp_connect_src_has_no_github`.
- **RED provado**: ambos falham contra o CSP antigo. Suíte `test_middleware_security` **9/9** verde. pyright/black/isort/flake8 limpos.

> `report-uri` (3º item do issue) fica p/ PR dedicado — precisa de um endpoint receptor com throttle (evitar 4xx log-flood). Este PR entrega as 2 remoções de hardening. **Não fecha** o issue.

Refs #1462
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `6613ca22`, slot `1` / projeto `aprender_staging_s1`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local-s1, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 403)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
