### PR TITLE
fix(disponibilidade): RD-05 recorta evento pela janela do dia (#1664)

### DIFF
--- a/v2/backend/apps/core/services/availability_service.py
+++ b/v2/backend/apps/core/services/availability_service.py
@@ -122,6 +122,18 @@ def _fmt_interval_local(start: datetime, end: datetime) -> str:
     return f"{s:%H:%M %d/%m}–{e:%H:%M %d/%m}"
 
 
+def _clip_minutes(start: datetime, end: datetime, window_start: datetime, window_end: datetime) -> int:
+    """Minutos de [start, end] que caem dentro de [window_start, window_end] (>= 0).
+
+    Usado pela RD-05 para recortar tanto os eventos existentes quanto o novo pela
+    janela de UM dia local — assim um evento que cruza a meia-noite contribui só a
+    fração correta em cada dia (M08-09 / #1664).
+    """
+    lo = max(start, window_start)
+    hi = min(end, window_end)
+    return max(int((hi - lo).total_seconds() // 60), 0)
+
+
 def _check_conflicts_impl(
     *,
     usuario: Usuario,
@@ -289,46 +301,42 @@ def _check_conflicts_impl(
     # ================================================================
     # RD-05: CAPACIDADE DIÁRIA
     # ================================================================
-    # Buscar eventos aprovados no mesmo dia local do início
-    inicio_local: datetime = to_local(inicio)
-    inicio_date = inicio_local.date()
-
-    # Issue #249: Usar range de datetime ao invés de .date() para evitar
-    # problemas de timezone (RD-06). Eventos próximos da meia-noite podem
-    # ter data diferente em UTC vs America/Fortaleza.
+    # M08-09 (#1664): checa CADA dia LOCAL que o novo evento toca. Eventos
+    # existentes E o novo são recortados pela janela do dia (`_clip_minutes`),
+    # então um evento que cruza a meia-noite (ex.: 22h→02h) contribui só a fração
+    # certa em D e em D+1 — antes, o novo evento entrava com a duração CHEIA no dia
+    # do início e o dia seguinte nunca era checado.
+    # Issue #249: ranges de datetime (não `.date()`) por causa de UTC vs local (RD-06).
     tz_name: str = getattr(settings, "TZ_PROJECT", "America/Fortaleza")
     local_tz = ZoneInfo(tz_name)
-
-    # Início e fim do dia no timezone local, convertidos para UTC para query
-    day_start: datetime = datetime.combine(inicio_date, time.min, tzinfo=local_tz)
-    day_end: datetime = datetime.combine(inicio_date, time.max, tzinfo=local_tz)
-
-    # Seleção ampla: eventos que tocam o dia do início (usando ranges UTC)
-    same_day_events = events_qs.filter(inicio__lt=day_end, fim__gt=day_start).distinct()
-
-    # Somar duração dos eventos existentes no dia
-    total_minutes: int = 0
-    for ev in same_day_events:
-        overlap_start = max(ev.inicio, day_start)
-        overlap_end = min(ev.fim, day_end)
-        dur: int = int((overlap_end - overlap_start).total_seconds() // 60)
-        total_minutes += max(dur, 0)
-
-    # Somar duração do novo intervalo
-    new_duration: int = int((fim - inicio).total_seconds() // 60)
-    total_minutes += new_duration
-
-    # Verificar limite diário
     daily_limit_minutes: int = int(daily_limit_h * 60)
-    if total_minutes > daily_limit_minutes:
-        conflicts.append(
-            Conflict(
-                "M",
-                "Capacidade diária excedida",
-                f"Total do dia {inicio_local:%d/%m}: {total_minutes} min > "
-                f"limite {daily_limit_minutes} min ({daily_limit_h}h)",
-            )
-        )
+
+    first_day = to_local(inicio).date()
+    last_day = to_local(fim).date()
+    day = first_day
+    while day <= last_day:
+        day_start: datetime = datetime.combine(day, time.min, tzinfo=local_tz)
+        day_end: datetime = datetime.combine(day, time.max, tzinfo=local_tz)
+
+        # Só checa dias onde o novo evento realmente ocupa tempo (evita falso M num
+        # dia adjacente onde o evento apenas toca a fronteira).
+        new_minutes = _clip_minutes(inicio, fim, day_start, day_end)
+        if new_minutes > 0:
+            total_minutes = new_minutes
+            for ev in events_qs.filter(inicio__lt=day_end, fim__gt=day_start).distinct():
+                total_minutes += _clip_minutes(ev.inicio, ev.fim, day_start, day_end)
+
+            if total_minutes > daily_limit_minutes:
+                conflicts.append(
+                    Conflict(
+                        "M",
+                        "Capacidade diária excedida",
+                        f"Total do dia {day:%d/%m}: {total_minutes} min > "
+                        f"limite {daily_limit_minutes} min ({daily_limit_h}h)",
+                    )
+                )
+
+        day += timedelta(days=1)
 
     # ================================================================
     # RD-07: Retornar todos os conflitos encontrados

--- a/v2/backend/apps/core/tests/test_availability_rd05_midnight_1664.py
+++ b/v2/backend/apps/core/tests/test_availability_rd05_midnight_1664.py
@@ -1,0 +1,91 @@
+"""M08-09 (#1664): RD-05 recorta pela janela do dia — eventos que cruzam a
+meia-noite contribuem a fração certa em D e em D+1.
+
+Antes: o evento NOVO entrava com a duração CHEIA no dia do início (falso M) e o
+dia seguinte nunca era checado (M real passava batido).
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportOptionalMemberAccess=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportIndexIssue=false
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from django.utils import timezone
+
+import pytest
+
+from apps.core.models import Solicitacao
+from apps.core.services.availability_service import check_conflicts_uncached
+from apps.core.tests.factories import (
+    MunicipioFactory,
+    ProjetoFactory,
+    SolicitacaoFactory,
+    TipoEventoFactory,
+    UsuarioFactory,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+def _ctx():
+    tz = timezone.get_current_timezone()
+    municipio = MunicipioFactory(nome="Fortaleza", uf="CE", ativo=True)
+    projeto = ProjetoFactory(nome="Projeto RD05", ativo=True, fluxo="SUPER")
+    tipo = TipoEventoFactory(nome="Formação", cor="#FF0000")
+    pessoa = UsuarioFactory(username="pessoa_rd05", email="pessoa_rd05@x.com", password="p")
+    return tz, municipio, projeto, tipo, pessoa
+
+
+def _evento(pessoa, municipio, projeto, tipo, ini: datetime, fim: datetime):
+    return SolicitacaoFactory(
+        usuario=pessoa,
+        municipio=municipio,
+        projeto=projeto,
+        tipo_evento=tipo,
+        inicio=ini,
+        fim=fim,
+        status=Solicitacao.Status.APROVADO,
+    )
+
+
+def test_evento_cruzando_meia_noite_nao_conta_duracao_cheia_no_dia_do_inicio():
+    # Limite diário padrão = 8h. Evento existente de 5h (08–13) em D.
+    # Novo evento 22h(D)→02h(D+1) = 4h, mas só 2h caem em D.
+    # Antigo: D = 5h + 4h(cheia) = 9h > 8h → falso M. Novo: D = 5h + ~2h = ~7h → ok.
+    tz, municipio, projeto, tipo, pessoa = _ctx()
+    _evento(
+        pessoa,
+        municipio,
+        projeto,
+        tipo,
+        timezone.make_aware(datetime(2026, 5, 10, 8, 0), tz),
+        timezone.make_aware(datetime(2026, 5, 10, 13, 0), tz),
+    )
+    inicio = timezone.make_aware(datetime(2026, 5, 10, 22, 0), tz)
+    fim = timezone.make_aware(datetime(2026, 5, 11, 2, 0), tz)
+
+    result = check_conflicts_uncached(usuario=pessoa, inicio=inicio, fim=fim, municipio=municipio)
+
+    assert result.ok, [(c.code, c.detail) for c in result.conflicts]
+
+
+def test_evento_cruzando_meia_noite_conta_capacidade_no_dia_seguinte():
+    # Evento existente de 6h (05–11) em D+1. Novo 22h(D)→04h(D+1) = 6h; 4h caem em D+1.
+    # Antigo: só checa D → 6h < 8h → ok (perde o estouro). Novo: D+1 = 6h + 4h = 10h > 8h → M.
+    tz, municipio, projeto, tipo, pessoa = _ctx()
+    _evento(
+        pessoa,
+        municipio,
+        projeto,
+        tipo,
+        timezone.make_aware(datetime(2026, 5, 11, 5, 0), tz),
+        timezone.make_aware(datetime(2026, 5, 11, 11, 0), tz),
+    )
+    inicio = timezone.make_aware(datetime(2026, 5, 10, 22, 0), tz)
+    fim = timezone.make_aware(datetime(2026, 5, 11, 4, 0), tz)
+
+    result = check_conflicts_uncached(usuario=pessoa, inicio=inicio, fim=fim, municipio=municipio)
+
+    assert not result.ok
+    assert any(c.code == "M" for c in result.conflicts), [(c.code, c.detail) for c in result.conflicts]


### PR DESCRIPTION
## Problema (M08-09 do épico #1664)

A capacidade diária (RD-05) em `availability_service.py` só checava **o dia do `inicio`** e somava a **duração cheia** do novo evento, mesmo quando ele **cruzava a meia-noite**:
- **falso M** no dia do início (contava horas que na verdade caem no dia seguinte);
- **M real** no dia seguinte **passava batido** (D+1 nunca era checado).

Os eventos *existentes* já eram recortados pela janela do dia; só o **novo** entrava inteiro.

## Correção
- Helper `_clip_minutes(start, end, window_start, window_end)` — minutos de um intervalo dentro da janela de **um** dia local.
- RD-05 itera por **cada dia local que o novo evento toca**; **eventos existentes e o novo** são recortados pela janela do dia. Um evento 22h→02h contribui a fração certa em D e em D+1. Eventos de um só dia ficam idênticos (recorte == cheio) — sem regressão.

## Testes (TDD RED→GREEN)
- `..._nao_conta_duracao_cheia_no_dia_do_inicio`: 22h→02h com 5h já em D → **ok** (antigo dava falso M).
- `..._conta_capacidade_no_dia_seguinte`: 22h→04h com 6h em D+1 → **M** (antigo perdia o estouro).
- **RED provado** para ambos. Regressão `test_availability_service` + `per_formador_1452` + `cache_availability` **46/46** verde. pyright/black/isort/flake8 limpos.

> Escopo M08-09. Junto com #1794 (M08-07: CONVIDADO + SSOT ENFORCED_ROLES) completam o épico #1664. **Não fecha** sozinho.

Refs #1664
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `a35e7103`, slot `1` / projeto `aprender_staging_s1`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local-s1, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 403)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
