### PR TITLE
docs(rbac): ADR-019 formaliza composition OR de metrics (#1268)

### DIFF
--- a/v2/backend/apps/core/views/metrics/dashboard_metrics.py
+++ b/v2/backend/apps/core/views/metrics/dashboard_metrics.py
@@ -33,6 +33,7 @@ from apps.core.permissions import HasPerm
     #   run_daily_operations    → Controle (operar)
     #   supervise_operations    → Diretoria (supervisionar)
     #   manage_admin_registries → DAT (validar/suportar)
+    # Racional completo + guard-rail: ADR-019 (v2/docs/adr/ADR-019-metrics-composition-or.md).
     [HasPerm("run_daily_operations") | HasPerm("supervise_operations") | HasPerm("manage_admin_registries")]
 )
 @throttle_classes([ScopedRateThrottle])
@@ -132,6 +133,7 @@ productivity_metrics.throttle_scope = "metrics"  # type: ignore[attr-defined]
     #   run_daily_operations    → Controle (operar)
     #   supervise_operations    → Diretoria (supervisionar)
     #   manage_admin_registries → DAT (validar/suportar)
+    # Racional completo + guard-rail: ADR-019 (v2/docs/adr/ADR-019-metrics-composition-or.md).
     [HasPerm("run_daily_operations") | HasPerm("supervise_operations") | HasPerm("manage_admin_registries")]
 )
 @throttle_classes([ScopedRateThrottle])

--- a/v2/backend/apps/core/views/metrics/formador_metrics.py
+++ b/v2/backend/apps/core/views/metrics/formador_metrics.py
@@ -28,7 +28,7 @@ from apps.core.permissions import HasPerm
     # Onda 2 A3 (β, 2026-04-27): adicionado `manage_admin_registries` para DAT
     # como ator transversal (validar/suportar). Mesma decisão dos demais
     # endpoints metrics — preserva Lote 4.2.b2 (composition OR ad-hoc por
-    # objetos semanticamente diferentes).
+    # objetos semanticamente diferentes). Ver ADR-019 (v2/docs/adr/ADR-019-metrics-composition-or.md).
     [HasPerm("run_daily_operations") | HasPerm("supervise_operations") | HasPerm("manage_admin_registries")]
 )
 @throttle_classes([ScopedRateThrottle])

--- a/v2/docs/adr/ADR-019-metrics-composition-or.md
+++ b/v2/docs/adr/ADR-019-metrics-composition-or.md
@@ -1,0 +1,57 @@
+# ADR-019 — Métricas: composition OR de 3 vias em vez de policy unificada
+
+| Field        | Value                                                                                  |
+| ------------ | -------------------------------------------------------------------------------------- |
+| **Status**   | Accepted                                                                               |
+| **Date**     | 2026-04-27                                                                             |
+| **Deciders** | Backend (Aprender Sistema) — RBAC Onda 2 A3 / Lote 4.2.b2                               |
+| **Issue**    | [#1268](https://github.com/matheusnorjosa/aprender_sistema/issues/1268) — RBAC C3 metrics semantic review |
+| **Related**  | [RBAC_NAMING.md](../RBAC_NAMING.md), [rbac_authorization_matrix.md](../rbac_authorization_matrix.md) |
+
+## Contexto
+
+Três endpoints de métricas de gestão precisam ser acessíveis a **três setores por
+motivos legítimos distintos**:
+
+| Capability                | Setor       | Motivo legítimo   |
+| ------------------------- | ----------- | ----------------- |
+| `run_daily_operations`    | Controle    | operar            |
+| `supervise_operations`    | Diretoria   | supervisionar     |
+| `manage_admin_registries` | DAT         | validar / suportar|
+
+Os endpoints são:
+
+- `apps/core/views/metrics/dashboard_metrics.py::productivity_metrics`
+- `apps/core/views/metrics/dashboard_metrics.py::quality_metrics`
+- `apps/core/views/metrics/formador_metrics.py::formadores_metrics`
+
+Na Onda 2 A3 (β, 2026-04-27) adicionou-se `manage_admin_registries` (DAT como ator
+transversal) à composição já existente. A pergunta de revisão (C3, #1268): **consolidar
+os três `HasPerm(...) | ...` numa policy única?**
+
+## Decisão
+
+**Manter a composition OR ad-hoc** em cada endpoint:
+
+```python
+[HasPerm("run_daily_operations") | HasPerm("supervise_operations") | HasPerm("manage_admin_registries")]
+```
+
+**Não** consolidar numa policy única. Os três endpoints protegem **objetos
+semanticamente diferentes** (produtividade de pessoas × qualidade de fluxo × registros
+administrativos); uma policy única (ex.: `can_view_management_metrics`) daria a impressão
+de um único intent de autorização quando na verdade são três motivos legítimos que hoje
+coincidem no conjunto de capabilities, mas podem divergir. Ver o critério de "match de
+intent vs. capability" em [RBAC_NAMING.md](../RBAC_NAMING.md).
+
+Precedente: **Lote 4.2.b2** — composition OR é tática e aceitável para ≤ 3 capabilities
+quando os objetos protegidos são distintos.
+
+## Consequências
+
+- **Aceito**: os três endpoints repetem o predicado OR. É duplicação de *forma*, não de
+  *intent* — não deve ser "DRY-forçado" numa policy.
+- **Guard-rail**: uma futura consolidação em policy única exige revisão semântica
+  (confirmar que os três objetos passaram a compartilhar o mesmo intent). Sem isso,
+  conflaria intenções distintas.
+- Os comentários inline nos três endpoints referenciam este ADR.


### PR DESCRIPTION
## Contexto (#1268 — RBAC C3, label `ready`)

A decisão **A3 / Lote 4.2.b2** — três endpoints de métricas protegidos por `HasPerm("run_daily_operations") | HasPerm("supervise_operations") | HasPerm("manage_admin_registries")` (composition OR), **sem** consolidar numa policy única porque protegem objetos semanticamente distintos — vivia **só em comentários inline**. Nenhum ADR a documentava.

## Mudança
- Novo **`v2/docs/adr/ADR-019-metrics-composition-or.md`** (formato ADR-012): contexto, decisão, consequências e guard-rail (uma consolidação futura exige revisão semântica).
- Os 3 comentários inline (`productivity_metrics`, `quality_metrics`, `formadores_metrics`) passam a referenciar o ADR-019.

## Verificação
- `scripts/check_doc_links.py` → 0 links quebrados (o ADR resolve p/ `RBAC_NAMING.md` + `rbac_authorization_matrix.md`).
- `scripts/check_doc_frontmatter.py` OK. black/flake8 limpos nos 2 `.py` (só comentário).

> Sem mudança funcional (o issue diz "Nenhum funcional (apenas doc)"). O código já implementava a decisão; este PR a torna rastreável.

Closes #1268
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `4f9a7524`, slot `1` / projeto `aprender_staging_s1`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local-s1, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 403)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
