### PR TITLE
fix(import): importer lê ano_uso_colecao do contrato v12

### DIFF
--- a/v2/backend/apps/core/services/export_contract_importer.py
+++ b/v2/backend/apps/core/services/export_contract_importer.py
@@ -505,7 +505,9 @@ class ExportContractImporter:
             (r.get("descricao_produto") or "").strip(),
             (r.get("tipo") or "").strip() or None,
             _parse_int(r.get("quantidade")),
-            _parse_int(r.get("ano_uso")),
+            # Contrato v12 renomeou `ano_uso` -> `ano_uso_colecao` (ano de USO da coleção,
+            # distinto de `ano_compra`). Prefere o nome novo; cai no antigo p/ contratos <=v11.
+            _parse_int(r.get("ano_uso_colecao") or r.get("ano_uso")),
             _parse_iso_date(r.get("data_compra")),
         )
 

--- a/v2/backend/apps/core/tests/test_export_contract_importer_dat_compra.py
+++ b/v2/backend/apps/core/tests/test_export_contract_importer_dat_compra.py
@@ -25,6 +25,8 @@ pytestmark = pytest.mark.django_db
 COMPRA_HEADER = (
     "municipio,uf,projeto,produto_codigo,descricao_produto,tipo,conta_para_codigos,quantidade,ano_uso,data_compra"
 )
+# Contrato v12 renomeou `ano_uso` -> `ano_uso_colecao` (ano de USO da coleção != ano_compra).
+COMPRA_HEADER_V12 = COMPRA_HEADER.replace("ano_uso", "ano_uso_colecao")
 PG_HEADER = (
     "nome,nome_norm,usa_avaliar,tipo_calculo_codigos,divisor_aluno,multiplicador_professor,precisa_config,visto_na_dat"
 )
@@ -97,6 +99,24 @@ def test_apply_dat_compra_creates_and_recomputes(tmp_path):
     assert r["applied"]["dat_compra"] == 2
     reg.refresh_from_db()
     assert reg.nr_codigos == 59  # ceil(41×1.1)+ceil(11×1.1) = 46+13, NÃO ceil(52×1.1)=58
+
+
+def test_apply_dat_compra_reads_ano_uso_colecao_v12(tmp_path):
+    """Regressão de drift: o contrato v12 renomeou a coluna `ano_uso` -> `ano_uso_colecao`.
+    Se o importer lesse só o nome antigo, `ano_uso` viria None e TODA compra seria descartada
+    como 'ano_uso ausente' (applied=0, silencioso). Aqui o header só tem o nome NOVO."""
+    actor = _actor()
+    MunicipioFactory(nome="Cidade X", uf="CE", ativo=True)
+    ProjetoFactory(nome="Proj X", fluxo="NAO_SUPER")
+    row = "Cidade X,CE,Proj X,99,Professor kit,Professor,true,41,2026,2026-06-08"
+    r = ExportContractImporter(
+        path=_write_export(tmp_path, {"dat_compra": f"{COMPRA_HEADER_V12}\n{row}\n"}),
+        apply=True,
+        allow=("dat_compra",),
+        actor=actor,
+    ).run()
+    assert r["applied"]["dat_compra"] == 1
+    assert DATCompra.objects.get().ano_uso == 2026
 
 
 def test_apply_dat_compra_distinct_by_data_compra(tmp_path):


### PR DESCRIPTION
## O quê

O importer do export-contract passa a ler a coluna `ano_uso_colecao` (contrato v12) com fallback para o nome antigo `ano_uso` (contratos ≤v11).

## Por quê (bug de drift, silencioso)

O contrato **v12** renomeou `ano_uso` → `ano_uso_colecao` (ano de **uso** da coleção, distinto de `ano_compra`). O importer lia só `r.get("ano_uso")` → no v12 a coluna não existe → `_parse_int(None)=None` → a guarda "ano_uso ausente" descartava **TODAS as compras** (`applied=0`, **sem erro**).

Provado num clone do golden: **com** o fix, as 2160 compras válidas do v12 entram e reconciliam célula-a-célula com o `nr_codigos_por_ano.csv` do sheets.banco (2026=64.151, 2027=263, exatos); **sem** o fix, 0.

## Teste

`test_apply_dat_compra_reads_ano_uso_colecao_v12` — header só com o nome novo, prova `applied==1` + `ano_uso==2026`. Regressão contra o drift voltar.

## Escopo

Import-layer, ortogonal ao modelo (branch `feat/dat-registro-ano`). Aterrissa sozinho; pré-requisito para qualquer apply do contrato v12+.
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `c998e98e`, slot `1` / projeto `aprender_staging_s1`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local-s1, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 403)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
