### PR TITLE
feat(dat): DATRegistro.ano — nr_codigos por ano de uso

### DIFF
--- a/v2/backend/apps/core/migrations/0089_dat_registro_ano.py
+++ b/v2/backend/apps/core/migrations/0089_dat_registro_ano.py
@@ -1,0 +1,54 @@
+"""Adiciona `ano` (ano de uso da coleção) ao DATRegistro + backfill pelo ano dominante das compras.
+
+Primeiro passo da dimensão temporal por ano (cohort anual): `nr_codigos` passa a contar só as
+compras cujo `ano_uso` bate com `registro.ano`, em vez de somar 2026 + 2027 + sem-ano no mesmo balde.
+Campo NULLABLE nesta fase (transição segura); o backfill preenche pelo ano_uso DOMINANTE das compras
+do par (municipio, projeto). Registros sem compras ficam com ano=NULL (mantêm o cálculo somando tudo).
+
+A chave natural passa a incluir `ano` (split de registros per-year) num PR seguinte — junto do import
+per-year e da reconciliação contra o Nº de Códigos por ano. Após esta migration, rodar
+`recalcular_nr_codigos_dat` recomputa `nr_codigos` já por ano (o cálculo filtra por `ano` quando setado).
+"""
+
+from django.db import migrations, models
+from django.db.models import Count
+
+
+def backfill_ano(apps, schema_editor):
+    DATRegistro = apps.get_model("core", "DATRegistro")
+    DATCompra = apps.get_model("core", "DATCompra")
+    updates = []
+    for reg in DATRegistro.objects.all().only("id", "municipio_id", "projeto_id"):
+        dom = (
+            DATCompra.objects.filter(municipio_id=reg.municipio_id, projeto_id=reg.projeto_id, ativo=True)
+            .values("ano_uso")
+            .annotate(n=Count("id"))
+            .order_by("-n", "-ano_uso")
+            .first()
+        )
+        if dom and dom["ano_uso"] is not None:
+            reg.ano = dom["ano_uso"]
+            updates.append(reg)
+    if updates:
+        DATRegistro.objects.bulk_update(updates, ["ano"], batch_size=500)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0088_fix_projeto_geral_por_aluno"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="datregistro",
+            name="ano",
+            field=models.PositiveSmallIntegerField(
+                blank=True,
+                null=True,
+                help_text="Ano de uso da coleção — nr_codigos conta apenas as compras deste ano.",
+                verbose_name="Ano de uso",
+            ),
+        ),
+        migrations.RunPython(backfill_ano, migrations.RunPython.noop),
+    ]

--- a/v2/backend/apps/core/models/dat_registro.py
+++ b/v2/backend/apps/core/models/dat_registro.py
@@ -81,6 +81,15 @@ class DATRegistro(models.Model):
         verbose_name="Projeto Específico",
         help_text="Ex: VIDA E LINGUAGEM 6, ACERTA BRASIL MATEMATICA",
     )
+    # Ano de uso da coleção (cohort anual). nr_codigos conta SÓ as compras deste ano
+    # (DATCompra.ano_uso). Nullable na transição: o backfill preenche pelo ano dominante
+    # das compras; a chave natural passa a incluir `ano` num PR seguinte (split per-year).
+    ano = models.PositiveSmallIntegerField(
+        null=True,
+        blank=True,
+        verbose_name="Ano de uso",
+        help_text="Ano de uso da coleção — nr_codigos conta apenas as compras deste ano.",
+    )
     aluno_qtde = models.PositiveIntegerField(
         null=True,
         blank=True,

--- a/v2/backend/apps/core/services/dat_codigos.py
+++ b/v2/backend/apps/core/services/dat_codigos.py
@@ -10,7 +10,7 @@ Aritmética `Decimal` (nunca `float`): `float(Decimal("1.1")) == 1.1000000000000
 faz o `ceil` estourar +1. Ver `REGRA-10-PORCENTO-CODIGOS.md` §6.
 """
 
-# pyright: reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportOperatorIssue=false, reportCallIssue=false
+# pyright: reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportOperatorIssue=false, reportCallIssue=false, reportUnnecessaryComparison=false
 
 from __future__ import annotations
 
@@ -45,6 +45,11 @@ def calcular_nr_codigos(registro: DATRegistro) -> int | None:
     """
     Soma dos códigos das compras do registro (município × projeto, ativas).
 
+    Cohort anual (decisão do dono): quando `registro.ano` está definido, conta SÓ as
+    compras cujo `ano_uso` bate — cada ano tem seu número, sem inflar o total somando
+    2026 + 2027 + sem-ano no mesmo balde. `ano` nulo (transição) mantém o comportamento
+    antigo (soma todos os anos).
+
     `None` quando o projeto_geral não gera códigos (`nao_aplicavel`) ou não existe —
     preserva a semântica de "em branco" da planilha. A regra vem SEMPRE do
     `registro.projeto_geral` (FK NOT NULL), nunca da compra.
@@ -58,6 +63,8 @@ def calcular_nr_codigos(registro: DATRegistro) -> int | None:
     from apps.core.models.dat_compra import DATCompra
 
     compras = DATCompra.objects.filter(municipio_id=registro.municipio_id, projeto_id=registro.projeto_id, ativo=True)
+    if registro.ano is not None:
+        compras = compras.filter(ano_uso=registro.ano)
     return sum(codigos_da_compra(c, pg) for c in compras)
 
 

--- a/v2/backend/apps/core/tests/test_dat_codigos.py
+++ b/v2/backend/apps/core/tests/test_dat_codigos.py
@@ -92,26 +92,41 @@ class CalcularNrCodigosTest(TestCase):
         )
         cls.projeto = ProjetoFactory(nome="NOVO LENDO 1", codigo="NL1", fluxo="NAO_SUPER", projeto_geral=cls.pg_prof)
 
-    def _registro(self, projeto, pg, aluno=None, prof=None):
+    def _registro(self, projeto, pg, aluno=None, prof=None, ano=None):
         return DATRegistro.objects.create(
             municipio=self.municipio,
             projeto_geral=pg,
             projeto=projeto,
             aluno_qtde=aluno,
             professor_qtde=prof,
+            ano=ano,
             created_by=self.user,
         )
 
-    def _compra_db(self, projeto, tipo, qtde, conta=True):
+    def _compra_db(self, projeto, tipo, qtde, conta=True, ano=2026):
         return DATCompra.objects.create(
             municipio=self.municipio,
             projeto=projeto,
             tipo=tipo,
             quantidade=qtde,
             conta_para_codigos=conta,
-            ano_uso=2026,
+            ano_uso=ano,
             created_by=self.user,
         )
+
+    def test_conta_so_o_ano_do_registro(self):
+        """Cohort anual: registro de 2026 conta só as compras ano_uso=2026, não as de 2027."""
+        reg = self._registro(self.projeto, self.pg_prof, prof=20, ano=2026)
+        self._compra_db(self.projeto, "Professor", 20, ano=2026)  # ceil(22.0) = 22
+        self._compra_db(self.projeto, "Professor", 100, ano=2027)  # outro ano → não conta
+        self.assertEqual(calcular_nr_codigos(reg), 22)
+
+    def test_ano_nulo_soma_todos_os_anos(self):
+        """Transição (ano=NULL): mantém o comportamento antigo, somando todos os anos."""
+        reg = self._registro(self.projeto, self.pg_prof, prof=20, ano=None)
+        self._compra_db(self.projeto, "Professor", 20, ano=2026)  # 22
+        self._compra_db(self.projeto, "Professor", 20, ano=2027)  # 22
+        self.assertEqual(calcular_nr_codigos(reg), 44)
 
     def test_soma_arredonda_cada_compra_nao_o_agregado(self):
         """O caso 41+11 do REGRA-10: per-compra = 46+13 = 59 (NÃO ceil(52×1.1)=58)."""


### PR DESCRIPTION
## O quê

`DATRegistro.ano` (PositiveSmallInteger nullable) + `calcular_nr_codigos` passa a contar só as compras do ano do registro (`ano_uso == registro.ano`); `ano` nulo mantém o comportamento antigo (soma todos os anos — transição). Migration **0089**: AddField + backfill do `ano` pelo `ano_uso` dominante das compras do registro.

## Por quê

Decisão do dono (domínio temporal por ano): a plataforma somava 2026 + 2027 + sem-ano no mesmo balde → o total inflava. Cada ano passa a ter o seu número; des-infla os registros existentes.

## Evidência — reconciliação no clone (dado real)

Clone do golden + apply do contrato v12 (DATCompra=2160, DATRegistro=1003) + backfill + recompute, reconciliado **por chave FK** contra `nr_codigos_por_ano.csv` (sheets.banco):

- Totais por ano **exatos**: **2026 = 64.151 · 2027 = 263** (Django == sheets.banco).
- Célula (município, projeto, ano): **996 batem · 0 valor difere · 0 só-Django · 0 projeto irresolvível**.
- **22 testes verdes** na infra real (2 novos: conta só o ano do registro; ano nulo soma todos).

## Próximo (não neste PR)

O **split** (NK ganha `ano` → 1 registro por ano + gravar NÃO_CLASSIFICADO como pendente-de-ano) é o PR2. Este PR é o passo 1 — campo + cálculo por ano + des-inflação — e é independente. Depende só da migration 0088 (já na main).
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `6f977f68`, slot `2` / projeto `aprender_staging_s2`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local-s2, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 403)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
