### PR TITLE
test(frontend): liga o gate de cobertura no baseline (ratchet)

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -62,8 +62,8 @@ jobs:
     - name: Build with Vite
       run: npm run build
 
-    - name: Run tests
-      run: npm run test
+    - name: Run tests (gate de cobertura — ratchet no baseline)
+      run: npm run test:coverage
 
     - name: Check bundle sizes
       run: npm run size

--- a/v2/frontend/vitest.config.ts
+++ b/v2/frontend/vitest.config.ts
@@ -48,11 +48,16 @@ export default defineConfig({
         '**/e2e/**',
         'src/main.tsx',
       ],
+      // Ratchet de cobertura fixado no baseline REAL medido (2026-08), não numa meta
+      // aspiracional. O gate estava DORMENTE — o CI rodava `vitest` sem `--coverage`,
+      // então os 70% nunca eram avaliados e a cobertura real caiu para ~42%. Ligar em
+      // 70% reprovaria o CI na hora; fixar no piso atual TRAVA a regressão (nenhum PR
+      // baixa a cobertura) e sobe por ratchet conforme os testes entram.
       thresholds: {
-        statements: 70,
-        branches: 70,
-        functions: 70,
-        lines: 70,
+        statements: 40,
+        branches: 31,
+        functions: 29,
+        lines: 41,
       },
     },
   },


### PR DESCRIPTION
## Problema

O frontend tem um threshold de cobertura de **70%** definido em `vitest.config.ts` — mas ele estava **dormente**: o `frontend-ci.yml` rodava `npm run test` (sem `--coverage`), então o threshold **nunca era avaliado**. Resultado: a cobertura real caiu para **~42% linhas / 30% funções** sem nada barrar. (Auditoria de robustez do frontend, frente 03.)

## Correção — ligar o gate no baseline (ratchet)

- **`frontend-ci.yml`**: o step de testes passa a rodar `npm run test:coverage` → o gate de cobertura passa a bloquear o job `[required] build/lint do frontend`.
- **`vitest.config.ts`**: thresholds fixados no **baseline real medido** (não na meta aspiracional de 70%, que reprovaria o CI imediatamente): `statements 40 · branches 31 · functions 29 · lines 41`. Isso **trava a regressão** — nenhum PR pode baixar a cobertura — e sobe por **ratchet** conforme testes entram.

## Verificação (toolchain real, imagem `aprender-frontend`)
- `npm run test:coverage`: **592 testes verdes** (65 arquivos), coverage `41.6 / 32.8 / 30.1 / 42.1` → **passa o gate (exit 0)** com a margem escolhida.
- Já demonstrado que **reprova acima do baseline** (o 70% original falhava) → o gate é significativo.
- `tsc --noEmit` exit 0, `eslint` limpo.

> Primeiro passo da Fase 0 do roadmap de robustez do frontend (enforcement). Próximos: guard anti-JS-legado e conversão dos 6 testes `.js`→`.ts`.
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `0d9ffc6c`, slot `1` / projeto `aprender_staging_s1`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local-s1, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 403)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
