### PR TITLE
ci(frontend): guard trava .js/.jsx de produção em src/ (migração TS)

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -56,6 +56,9 @@ jobs:
 
     - uses: ./.github/actions/setup-node-deps
 
+    - name: Guard — migração TS (sem .js/.jsx de produção)
+      run: npm run check:ts-only
+
     - name: Run ESLint
       run: npm run lint
 

--- a/v2/frontend/package.json
+++ b/v2/frontend/package.json
@@ -8,6 +8,7 @@
     "build": "tsc --noEmit && vite build",
     "build:analyze": "ANALYZE=true vite build",
     "lint": "eslint .",
+    "check:ts-only": "node scripts/check-no-legacy-js.mjs",
     "typecheck": "tsc --noEmit",
     "preview": "vite preview",
     "test": "vitest",

--- a/v2/frontend/scripts/check-no-legacy-js.mjs
+++ b/v2/frontend/scripts/check-no-legacy-js.mjs
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+/**
+ * Guard de migração TypeScript (#477).
+ *
+ * A migração está concluída — código de produção em src/ é 100% .ts/.tsx.
+ * Este guard TRAVA a regressão: falha o CI se aparecer QUALQUER .js/.jsx de
+ * produção em src/. Testes e infra de teste ficam na allowlist até serem
+ * convertidos (arquivos *.test.* / *.spec.*, diretórios __tests__/, e src/test/).
+ *
+ * Uso: node scripts/check-no-legacy-js.mjs   (exit 1 se achar legado)
+ */
+import { readdirSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SRC = fileURLToPath(new URL('../src', import.meta.url));
+
+/** @param {string} name */
+const isTestFile = (name) => /\.(test|spec)\.[jt]sx?$/.test(name);
+/** @param {string} rel */
+const inTestInfra = (rel) => rel === 'test' || rel.startsWith('test/');
+
+/** @type {string[]} */
+const offenders = [];
+
+/** @param {string} dir */
+function walk(dir) {
+  for (const name of readdirSync(dir)) {
+    const abs = join(dir, name);
+    const rel = relative(SRC, abs).split('\\').join('/');
+    if (statSync(abs).isDirectory()) {
+      if (name === '__tests__' || name === 'node_modules') continue;
+      walk(abs);
+      continue;
+    }
+    if (isTestFile(name) || inTestInfra(rel)) continue;
+    if (/\.(js|jsx)$/.test(name)) offenders.push('src/' + rel);
+  }
+}
+
+walk(SRC);
+
+if (offenders.length > 0) {
+  console.error('\u274c Migracao TS (#477): .js/.jsx de PRODUCAO encontrados em src/:');
+  for (const f of offenders.sort()) console.error('   ' + f);
+  console.error('\nProducao deve ser 100% TypeScript. Renomeie para .ts/.tsx.');
+  process.exit(1);
+}
+
+console.log('\u2705 Nenhum .js/.jsx de producao em src/ (migracao TS trancada).');


### PR DESCRIPTION
## Contexto

A migração TypeScript (#477) está **concluída** — o código de produção em `src/` é 100% `.ts`/`.tsx` (0 `.jsx`). Mas **nada impede reintroduzir JS legado**: o `tsc --noEmit` e o ESLint passam mesmo se alguém criar um `.js`/`.jsx` novo em produção. A migração não é irreversível. (Auditoria de robustez do frontend, frente 01.)

## Correção — ratchet anti-regressão

- **`scripts/check-no-legacy-js.mjs`**: varre `src/` e **falha (exit 1)** se achar `.js`/`.jsx` de produção. Allowlist: diretórios `__tests__/`, arquivos `*.test.*`/`*.spec.*`, e `src/test/` (os 6 `.js` de teste restantes — que serão convertidos num PR seguinte).
- **`npm run check:ts-only`** + step no `frontend-ci.yml` (antes do ESLint) → o guard bloqueia o job `[required] build/lint do frontend`.

## Verificação (toolchain real)
- **GREEN**: no código atual → `✅ Nenhum .js/.jsx de produção`, exit 0.
- **RED**: com `src/__proof.jsx` + `src/__proof.js` → lista os dois e **exit 1**.
- `npm run lint` do projeto: **0 erros** (o script não introduz nada).

> Fase 0 do roadmap de robustez (enforcement), 2/3. Próximo: converter os 6 testes `.js`→`.ts` (fecha os 100% e liga type-check neles). Independente do #1800 (linhas distintas do `frontend-ci.yml`).
