### PR TITLE
feat(dat): command split_dat_registros_por_ano (split per-year)

### DIFF
--- a/v2/backend/apps/core/management/commands/split_dat_registros_por_ano.py
+++ b/v2/backend/apps/core/management/commands/split_dat_registros_por_ano.py
@@ -1,0 +1,26 @@
+"""Command: split per-year de DATRegistro. Roda APÓS o import das compras. Ver
+`apps/core/services/dat_registro_split.py`."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from django.core.management.base import BaseCommand
+
+from apps.core.services.dat_registro_split import split_dat_registros
+
+
+class Command(BaseCommand):
+    help = "Divide os DATRegistro flat em um registro por ano de uso das compras (split per-year)."
+
+    def add_arguments(self, parser: Any) -> None:
+        parser.add_argument("--dry-run", action="store_true", help="Não grava; só reporta o que faria.")
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        dry_run = bool(options["dry_run"])
+        r = split_dat_registros(dry_run=dry_run)
+        sufixo = " (DRY-RUN, nada gravado)" if dry_run else ""
+        self.stdout.write(
+            f"Pares processados: {r['pares']} | registros criados: {r['criados']} | "
+            f"reatribuídos: {r['reatribuidos']} | compras sem registro: {r['compras_sem_registro']}{sufixo}"
+        )

--- a/v2/backend/apps/core/services/dat_registro_split.py
+++ b/v2/backend/apps/core/services/dat_registro_split.py
@@ -1,0 +1,100 @@
+"""
+Split per-year de DATRegistro: deriva um registro por ano de uso a partir das compras.
+
+O import cria um registro "flat" por (município, projeto) sem ano — no ENTITY_ORDER
+`dat_registro` vem antes de `dat_compra`, então o ano só se conhece depois. Este passo,
+rodado APÓS o import das compras, faz o fan-out do flat em um registro por ano de uso
+(`DATCompra.ano_uso`), com um bucket pendente (`ano=None`) para as compras NÃO_CLASSIFICADAS.
+Idempotente.
+
+Os atributos do flat (aluno_qtde/professor_qtde) ficam no ano PRIMÁRIO (2026 se houver, senão
+o maior ano real); os anos secundários nascem sem esses campos. `nr_codigos` é recomputado por
+ano no `save()` (ver `dat_codigos.calcular_nr_codigos`, que filtra por `ano_uso=registro.ano`).
+"""
+
+# pyright: reportUnknownMemberType=false, reportUnknownVariableType=false, reportUnknownArgumentType=false, reportAttributeAccessIssue=false, reportArgumentType=false
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+from django.db import transaction
+
+from apps.core.models.dat_compra import DATCompra
+from apps.core.models.dat_registro import DATRegistro
+
+
+def _primary_ano(anos: set[int | None]) -> int | None:
+    """Ano que carrega os atributos do flat: 2026 se presente, senão o maior ano real, senão None."""
+    reais = sorted(a for a in anos if a is not None)
+    if 2026 in reais:
+        return 2026
+    return reais[-1] if reais else None
+
+
+@transaction.atomic
+def split_dat_registros(dry_run: bool = False) -> dict[str, int]:
+    """
+    Garante um DATRegistro por (município, projeto, ano de uso das compras).
+
+    Para cada par (município, projeto) que tem registro: lê os `ano_uso` distintos das compras
+    ativas (inclui None = NÃO_CLASSIFICADO); reatribui o registro-flat ao ano primário (preservando
+    atributos) e cria os anos que faltam. Pares sem compra ficam como estão (não deleta). Retorna
+    contadores (pares, criados, reatribuidos).
+    """
+    compra_anos: dict[tuple[int, int], set[int | None]] = defaultdict(set)
+    for mid, pid, ano in DATCompra.objects.filter(ativo=True).values_list("municipio_id", "projeto_id", "ano_uso"):
+        compra_anos[(mid, pid)].add(ano)
+
+    pares = criados = reatribuidos = 0
+    par_registro = set(DATRegistro.objects.values_list("municipio_id", "projeto_id").distinct())
+    for mid, pid in sorted(par_registro):
+        target = compra_anos.get((mid, pid))
+        if not target:
+            continue  # sem compras: registro pendente/órfão fica como está (não deleta)
+        pares += 1
+        regs = list(DATRegistro.objects.filter(municipio_id=mid, projeto_id=pid))
+        existing: dict[int | None, DATRegistro] = {r.ano: r for r in regs}
+        primary = _primary_ano(target)
+
+        # 1. Garante o registro PRIMÁRIO (carrega os atributos do flat).
+        if primary not in existing:
+            anchor = max(regs, key=lambda r: ((r.aluno_qtde or 0) + (r.professor_qtde or 0), int(r.pk)))
+            reatribuidos += 1
+            existing.pop(anchor.ano, None)
+            if not dry_run:
+                anchor.ano = primary
+                anchor.save()  # recomputa nr_codigos para o ano primário
+            existing[primary] = anchor
+        primary_reg = existing[primary]
+
+        # 2. Cria um registro para cada OUTRO ano de uso (atributos só no primário).
+        for ano in sorted(target, key=lambda a: (a is None, a or 0)):
+            if ano in existing:
+                continue
+            criados += 1
+            if not dry_run:
+                novo = DATRegistro(
+                    municipio_id=mid,
+                    projeto_id=pid,
+                    projeto_geral_id=primary_reg.projeto_geral_id,
+                    ano=ano,
+                    aluno_qtde=None,
+                    professor_qtde=None,
+                    created_by_id=primary_reg.created_by_id,
+                )
+                novo.save()  # recomputa nr_codigos para o ano
+                existing[ano] = novo
+            else:
+                existing[ano] = primary_reg  # placeholder só p/ a contagem do dry-run
+
+    # Pares com compra ativa mas SEM nenhum registro (anomalia de origem: a planilha dat_registro
+    # não tem linha para o par, então o split não tem o que fan-out e a compra fica sem rastreamento).
+    # Reportados para reconciliação — nunca criados em silêncio.
+    orfaos = sorted(par for par in compra_anos if par not in par_registro)
+    return {
+        "pares": pares,
+        "criados": criados,
+        "reatribuidos": reatribuidos,
+        "compras_sem_registro": len(orfaos),
+    }

--- a/v2/backend/apps/core/tests/test_split_dat_registros.py
+++ b/v2/backend/apps/core/tests/test_split_dat_registros.py
@@ -1,0 +1,145 @@
+"""
+Testes do split per-year de DATRegistro (serviço `split_dat_registros` + command
+`split_dat_registros_por_ano`). Deriva um registro por ano de uso a partir das compras.
+"""
+
+# pyright: reportMissingParameterType=false, reportUnknownParameterType=false, reportUnknownArgumentType=false, reportUnknownVariableType=false, reportUnknownMemberType=false, reportAttributeAccessIssue=false, reportArgumentType=false, reportCallIssue=false, reportOptionalMemberAccess=false
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from apps.core.models import DATRegistro, ProjetoGeral
+from apps.core.models.dat_compra import DATCompra
+from apps.core.services.dat_registro_split import split_dat_registros
+from apps.core.tests.factories import MunicipioFactory, ProjetoFactory, UsuarioFactory
+
+
+class SplitDatRegistrosTest(TestCase):
+    """`split_dat_registros` — fan-out de um registro flat em um por ano de uso das compras."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.municipio = MunicipioFactory(nome="Split City", uf="CE")
+        cls.user = UsuarioFactory(username="split_user")
+        cls.pg = ProjetoGeral.objects.create(
+            nome="PG Split",
+            usa_avaliar=False,
+            tipo_calculo_codigos="por_professor",
+            multiplicador_professor=Decimal("1.1"),
+        )
+        cls.projeto = ProjetoFactory(nome="SPLIT 1", codigo="SPL1", fluxo="NAO_SUPER", projeto_geral=cls.pg)
+
+    def _flat(self, ano=None, aluno=None, prof=None):
+        return DATRegistro.objects.create(
+            municipio=self.municipio,
+            projeto_geral=self.pg,
+            projeto=self.projeto,
+            ano=ano,
+            aluno_qtde=aluno,
+            professor_qtde=prof,
+            created_by=self.user,
+        )
+
+    def _compra(self, qtde, ano, tipo="Professor", conta=True):
+        return DATCompra.objects.create(
+            municipio=self.municipio,
+            projeto=self.projeto,
+            tipo=tipo,
+            quantidade=qtde,
+            conta_para_codigos=conta,
+            ano_uso=ano,
+            created_by=self.user,
+        )
+
+    def _regs(self):
+        return {r.ano: r for r in DATRegistro.objects.filter(municipio=self.municipio, projeto=self.projeto)}
+
+    def test_cria_um_registro_por_ano(self):
+        """Flat + compras 2026 e 2027 → dois registros, cada um com o nr_codigos do SEU ano."""
+        self._flat(prof=40)
+        self._compra(20, 2026)  # ceil(20×1.1)=22
+        self._compra(100, 2027)  # ceil(100×1.1)=110
+        split_dat_registros()
+        regs = self._regs()
+        self.assertEqual(set(regs), {2026, 2027})
+        self.assertEqual(regs[2026].nr_codigos, 22)
+        self.assertEqual(regs[2027].nr_codigos, 110)
+
+    def test_bucket_pendente_para_nao_classificado(self):
+        """Compras 2026 + NÃO_CLASSIFICADO (ano_uso=None) → registro 2026 + pendente(None)."""
+        self._flat(prof=20)
+        self._compra(20, 2026)  # 22
+        self._compra(50, None)  # ceil(50×1.1)=55 no bucket pendente
+        split_dat_registros()
+        regs = self._regs()
+        self.assertEqual(set(regs), {2026, None})
+        self.assertEqual(regs[2026].nr_codigos, 22)
+        self.assertEqual(regs[None].nr_codigos, 55)
+
+    def test_idempotente(self):
+        """Rodar duas vezes não duplica nem cria de novo."""
+        self._flat(prof=20)
+        self._compra(20, 2026)
+        self._compra(20, 2027)
+        split_dat_registros()
+        n1 = DATRegistro.objects.filter(municipio=self.municipio, projeto=self.projeto).count()
+        r2 = split_dat_registros()
+        n2 = DATRegistro.objects.filter(municipio=self.municipio, projeto=self.projeto).count()
+        self.assertEqual(n1, n2)
+        self.assertEqual(r2["criados"], 0)
+
+    def test_preserva_atributos_no_primario(self):
+        """Os atributos do flat (aluno/professor) ficam no ano primário (2026); outros anos = None."""
+        self._flat(aluno=100, prof=40)
+        self._compra(20, 2026)
+        self._compra(20, 2027)
+        split_dat_registros()
+        regs = self._regs()
+        self.assertEqual((regs[2026].aluno_qtde, regs[2026].professor_qtde), (100, 40))
+        self.assertEqual((regs[2027].aluno_qtde, regs[2027].professor_qtde), (None, None))
+
+    def test_registro_sem_compras_intocado(self):
+        """Registro sem nenhuma compra fica como está (não vira pendente nem some)."""
+        reg = self._flat(ano=2026, prof=10)
+        split_dat_registros()
+        self.assertEqual(DATRegistro.objects.filter(municipio=self.municipio, projeto=self.projeto).count(), 1)
+        reg.refresh_from_db()
+        self.assertEqual(reg.ano, 2026)
+
+    def test_compra_sem_registro_reportada(self):
+        """Compra para um par SEM registro (anomalia de origem: planilha dat_registro não tem a
+        linha) não é splitada nem inventada — é reportada em `compras_sem_registro`."""
+        outro = ProjetoFactory(nome="SPLIT 2", codigo="SPL2", fluxo="NAO_SUPER", projeto_geral=self.pg)
+        DATCompra.objects.create(
+            municipio=self.municipio,
+            projeto=outro,
+            tipo="Professor",
+            quantidade=20,
+            conta_para_codigos=True,
+            ano_uso=2026,
+            created_by=self.user,
+        )
+        res = split_dat_registros()  # nenhum DATRegistro para (municipio, outro)
+        self.assertEqual(res["compras_sem_registro"], 1)
+        self.assertEqual(DATRegistro.objects.filter(municipio=self.municipio, projeto=outro).count(), 0)
+
+    def test_dry_run_nao_grava(self):
+        """--dry-run reporta o que faria mas não cria nada."""
+        self._flat(prof=20)
+        self._compra(20, 2026)
+        self._compra(20, 2027)
+        res = split_dat_registros(dry_run=True)
+        self.assertEqual(res["criados"], 1)
+        self.assertEqual(DATRegistro.objects.filter(municipio=self.municipio, projeto=self.projeto).count(), 1)
+
+    def test_command_roda(self):
+        """O command envelopa o serviço e grava (smoke de integração)."""
+        self._flat(prof=20)
+        self._compra(20, 2026)
+        self._compra(20, 2027)
+        call_command("split_dat_registros_por_ano")
+        self.assertEqual(set(self._regs()), {2026, 2027})


### PR DESCRIPTION
## O quê

Command **`split_dat_registros_por_ano`** — após o import das compras, deriva um DATRegistro por ano de uso a partir de `DATCompra.ano_uso`: reatribui o registro-flat ao ano primário (2026, preservando aluno/professor) e cria os anos que faltam + o bucket pendente (ano=None). Idempotente, com `--dry-run`, e **reporta compras sem registro** (nunca dropa em silêncio).

## Por quê

Fecha o split per-year (decisão A): cada ano com o seu número. No `ENTITY_ORDER`, `dat_registro` vem antes de `dat_compra`, então o ano só se conhece depois — daí a passada pós-import.

## Evidência — validação no clone (dado real, stack completo A+B+C)

Clone do golden + import v12 (fix1+fix2) + split, reconciliado por chave FK contra `nr_codigos_por_ano.csv` (sheets.banco), nos **dois lados** (compras e registros):

- **2026 = 64.151 · 2027 = 263 — EXATOS** (compras e registros).
- Célula (município, projeto, ano): **1019 batem · 0 valor difere · 0 só-Django**.
- **Idempotente** no dado real (2ª execução: 0 criados).
- **8 testes unitários** do split + regressão DAT (1141) verdes; Black/flake8/isort limpos.

### Gap conhecido (fora do escopo do PR)

NC: 341 (Django) vs 350 (CSV) = **9 códigos**, de **4 pares com compra mas SEM registro na planilha** (o split reporta: "compras sem registro: 4"). 3 têm valor 0 (benignos); 1 real — CATOLÉ/BRINCANDO E APRENDENDO 3 — está **ausente do `dat_registro.csv`** e o projeto foi semeado sem `projeto_geral` no clone (seed mínimo). Resolve com o import do master `projeto` (Onda A) + a linha na planilha. **Não é bug do split** — ele reporta a anomalia em vez de inventar registro.

## Stack (3/3 — split per-year)

Base: **#B** (NK com `ano`). Requer #A e #B mergeados.
<!-- staging-gate-auto -->
## Staging gate

- [x] make staging-full executado com sucesso (8/8 PASS)
- [x] Evidencia anexada no PR

Evidencia (gate local, commit `190be1c7`, slot `3` / projeto `aprender_staging_s3`):

```
   STAGING GATE SMOKE TEST RESULTS
==============================================
[1/8] Backend readyz: PASS
[2/8] Backend version: PASS (v=staging-local-s3, sha=unknown)
[3/8] CSRF endpoint: PASS
[4/8] Auth pipeline: PASS (HTTP 403)
[5/8] Celery worker: PASS
[6/8] Celery beat: PASS
[7/8] Frontend HTTP: PASS
[8/8] Frontend health: PASS

ALL 8 CHECKS PASSED
```
